### PR TITLE
[codex] Add granular MCP memory entry validation

### DIFF
--- a/docs/standalone-mcp-memory-architecture.md
+++ b/docs/standalone-mcp-memory-architecture.md
@@ -58,6 +58,13 @@ older comparable facts so audit and history remain intact.
 
 Normal chat-session insertion.
 
+MCP callers should send one granular evidence entry per call. Each entry is
+validated to stay under 1000 characters; larger scenarios should be split by
+decision, fact, correction, preference, project milestone, or another
+claim-worthy unit. Typed claims should point at the smallest supporting entry,
+using multiple supporting fragment IDs only when one claim needs evidence from
+more than one entry.
+
 1. Save source evidence as a fragment.
 2. Embed the fragment through the configured provider.
 3. Create typed claims from host-supplied candidate memories.

--- a/internal/service/skillpackservice/artifact.go
+++ b/internal/service/skillpackservice/artifact.go
@@ -8,7 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
 )
 
 const (
@@ -85,6 +88,13 @@ func validatePack(pack SkillPack) error {
 			return fmt.Errorf("%w: items[%d]: %v", ErrInvalidArtifact, i, err)
 		}
 	}
+	claimsByID, fragmentsByID, err := validateSupport(pack.Support)
+	if err != nil {
+		return err
+	}
+	if err := validateItemSupportReferences(pack.Items, claimsByID, fragmentsByID); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -110,7 +120,163 @@ func validateItem(item SkillPackItem) error {
 	if !allowedSourceKind(item.SourceKind) {
 		return fmt.Errorf("source_kind %q is not allowed", item.SourceKind)
 	}
+	if len(item.SourceID) > 128 {
+		return errors.New("source_id exceeds 128 characters")
+	}
+	if err := validateIDList("support_claim_ids", item.SupportClaimIDs); err != nil {
+		return err
+	}
+	if err := validateIDList("support_fragment_ids", item.SupportFragmentIDs); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateSupport(support *SkillPackSupport) (map[string]SkillPackSupportClaim, map[string]struct{}, error) {
+	claimsByID := map[string]SkillPackSupportClaim{}
+	fragmentsByID := map[string]struct{}{}
+	if support == nil {
+		return claimsByID, fragmentsByID, nil
+	}
+	for i, fragment := range support.Fragments {
+		if err := validateSupportFragment(fragment); err != nil {
+			return nil, nil, fmt.Errorf("%w: support.fragments[%d]: %v", ErrInvalidArtifact, i, err)
+		}
+		if _, exists := fragmentsByID[fragment.FragmentID]; exists {
+			return nil, nil, fmt.Errorf("%w: support.fragments[%d]: duplicate fragment_id %q", ErrInvalidArtifact, i, fragment.FragmentID)
+		}
+		fragmentsByID[fragment.FragmentID] = struct{}{}
+	}
+	for i, claim := range support.Claims {
+		if err := validateSupportClaim(claim); err != nil {
+			return nil, nil, fmt.Errorf("%w: support.claims[%d]: %v", ErrInvalidArtifact, i, err)
+		}
+		if _, exists := claimsByID[claim.ClaimID]; exists {
+			return nil, nil, fmt.Errorf("%w: support.claims[%d]: duplicate claim_id %q", ErrInvalidArtifact, i, claim.ClaimID)
+		}
+		for _, fragmentID := range claim.SupportedBy {
+			if _, exists := fragmentsByID[fragmentID]; !exists {
+				return nil, nil, fmt.Errorf("%w: support.claims[%d]: supported_by references missing fragment %q", ErrInvalidArtifact, i, fragmentID)
+			}
+		}
+		claimsByID[claim.ClaimID] = claim
+	}
+	return claimsByID, fragmentsByID, nil
+}
+
+func validateSupportClaim(claim SkillPackSupportClaim) error {
+	if strings.TrimSpace(claim.ClaimID) == "" {
+		return errors.New("claim_id is required")
+	}
+	if len(claim.ClaimID) > 128 {
+		return errors.New("claim_id exceeds 128 characters")
+	}
+	if err := validateTripleFields(claim.Subject, claim.Predicate, claim.Object); err != nil {
+		return err
+	}
+	return validateIDList("supported_by", claim.SupportedBy)
+}
+
+func validateSupportFragment(fragment SkillPackSupportFragment) error {
+	if strings.TrimSpace(fragment.FragmentID) == "" {
+		return errors.New("fragment_id is required")
+	}
+	if len(fragment.FragmentID) > 128 {
+		return errors.New("fragment_id exceeds 128 characters")
+	}
+	if strings.TrimSpace(fragment.Content) == "" {
+		return errors.New("content is required")
+	}
+	if len(fragment.Content) > 8192 {
+		return errors.New("content exceeds 8192 bytes")
+	}
+	if len(fragment.Source) > 256 {
+		return errors.New("source exceeds 256 characters")
+	}
+	if fragment.SourceType != "" && !domain.SourceType(fragment.SourceType).IsValid() {
+		return fmt.Errorf("source_type %q is not allowed", fragment.SourceType)
+	}
+	if fragment.Authority != "" && !domain.Authority(fragment.Authority).IsValid() {
+		return fmt.Errorf("authority %q is not allowed", fragment.Authority)
+	}
+	if len(fragment.Labels) > 20 {
+		return errors.New("labels exceeds 20 items")
+	}
+	for i, label := range fragment.Labels {
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("labels[%d] is required", i)
+		}
+		if len(label) > 64 {
+			return fmt.Errorf("labels[%d] exceeds 64 characters", i)
+		}
+	}
+	if !validConfidence(fragment.SourceQuality) {
+		return errors.New("source_quality must be in [0,1]")
+	}
+	return nil
+}
+
+func validateTripleFields(subject, predicate, object string) error {
+	if strings.TrimSpace(subject) == "" {
+		return errors.New("subject is required")
+	}
+	if len(subject) > 256 {
+		return errors.New("subject exceeds 256 characters")
+	}
+	if strings.TrimSpace(predicate) == "" {
+		return errors.New("predicate is required")
+	}
+	if !allowedPredicate(predicate) {
+		return fmt.Errorf("predicate %q is not allowed", predicate)
+	}
+	if strings.TrimSpace(object) == "" {
+		return errors.New("object is required")
+	}
+	if len(object) > 1024 {
+		return errors.New("object exceeds 1024 characters")
+	}
+	return nil
+}
+
+func validateIDList(field string, values []string) error {
+	seen := map[string]struct{}{}
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s[%d] is required", field, i)
+		}
+		if len(value) > 128 {
+			return fmt.Errorf("%s[%d] exceeds 128 characters", field, i)
+		}
+		if _, exists := seen[value]; exists {
+			return fmt.Errorf("%s[%d] duplicates %q", field, i, value)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+func validateItemSupportReferences(items []SkillPackItem, claimsByID map[string]SkillPackSupportClaim, fragmentsByID map[string]struct{}) error {
+	for i, item := range items {
+		for _, claimID := range item.SupportClaimIDs {
+			claim, exists := claimsByID[claimID]
+			if !exists {
+				return fmt.Errorf("%w: items[%d]: support_claim_ids references missing claim %q", ErrInvalidArtifact, i, claimID)
+			}
+			if claim.Subject != item.Subject || claim.Predicate != item.Predicate || claim.Object != item.Object {
+				return fmt.Errorf("%w: items[%d]: support claim %q does not match item triple", ErrInvalidArtifact, i, claimID)
+			}
+		}
+		for _, fragmentID := range item.SupportFragmentIDs {
+			if _, exists := fragmentsByID[fragmentID]; !exists {
+				return fmt.Errorf("%w: items[%d]: support_fragment_ids references missing fragment %q", ErrInvalidArtifact, i, fragmentID)
+			}
+		}
+	}
+	return nil
+}
+
+func validConfidence(value float64) bool {
+	return value >= 0 && value <= 1
 }
 
 func allowedPredicate(predicate string) bool {
@@ -135,13 +301,68 @@ func normalizePack(pack SkillPack) SkillPack {
 	pack.SchemaVersion = strings.TrimSpace(pack.SchemaVersion)
 	pack.Name = strings.TrimSpace(pack.Name)
 	pack.Description = strings.TrimSpace(pack.Description)
+	if pack.ExportedAt != nil {
+		exportedAt := pack.ExportedAt.UTC()
+		if exportedAt.IsZero() {
+			pack.ExportedAt = nil
+		} else {
+			pack.ExportedAt = &exportedAt
+		}
+	}
 	for i := range pack.Items {
 		pack.Items[i].Subject = strings.TrimSpace(pack.Items[i].Subject)
 		pack.Items[i].Predicate = strings.TrimSpace(pack.Items[i].Predicate)
 		pack.Items[i].Object = strings.TrimSpace(pack.Items[i].Object)
 		pack.Items[i].SourceKind = strings.TrimSpace(pack.Items[i].SourceKind)
+		pack.Items[i].SourceID = strings.TrimSpace(pack.Items[i].SourceID)
+		normalizeIDList(pack.Items[i].SupportClaimIDs)
+		normalizeIDList(pack.Items[i].SupportFragmentIDs)
+	}
+	if pack.Support != nil {
+		for i := range pack.Support.Claims {
+			normalizeSupportClaim(&pack.Support.Claims[i])
+		}
+		for i := range pack.Support.Fragments {
+			normalizeSupportFragment(&pack.Support.Fragments[i])
+		}
+		sort.Slice(pack.Support.Claims, func(i, j int) bool {
+			return pack.Support.Claims[i].ClaimID < pack.Support.Claims[j].ClaimID
+		})
+		sort.Slice(pack.Support.Fragments, func(i, j int) bool {
+			return pack.Support.Fragments[i].FragmentID < pack.Support.Fragments[j].FragmentID
+		})
+		if len(pack.Support.Claims) == 0 && len(pack.Support.Fragments) == 0 {
+			pack.Support = nil
+		}
 	}
 	return pack
+}
+
+func normalizeIDList(values []string) {
+	for i := range values {
+		values[i] = strings.TrimSpace(values[i])
+	}
+	sort.Strings(values)
+}
+
+func normalizeSupportClaim(claim *SkillPackSupportClaim) {
+	claim.ClaimID = strings.TrimSpace(claim.ClaimID)
+	claim.Subject = strings.TrimSpace(claim.Subject)
+	claim.Predicate = strings.TrimSpace(claim.Predicate)
+	claim.Object = strings.TrimSpace(claim.Object)
+	normalizeIDList(claim.SupportedBy)
+}
+
+func normalizeSupportFragment(fragment *SkillPackSupportFragment) {
+	fragment.FragmentID = strings.TrimSpace(fragment.FragmentID)
+	fragment.Content = strings.TrimSpace(fragment.Content)
+	fragment.Source = strings.TrimSpace(fragment.Source)
+	fragment.SourceType = strings.TrimSpace(fragment.SourceType)
+	fragment.Authority = strings.TrimSpace(fragment.Authority)
+	for i := range fragment.Labels {
+		fragment.Labels[i] = strings.TrimSpace(fragment.Labels[i])
+	}
+	sort.Strings(fragment.Labels)
 }
 
 func validateExpectedHash(actual, expected string) error {

--- a/internal/service/skillpackservice/artifact.go
+++ b/internal/service/skillpackservice/artifact.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	maxArtifactBytes = 1 << 20
-	maxPackItems     = 100
 )
 
 var (
@@ -80,9 +79,6 @@ func validatePack(pack SkillPack) error {
 	}
 	if len(pack.Items) == 0 {
 		return fmt.Errorf("%w: items is required", ErrInvalidArtifact)
-	}
-	if len(pack.Items) > maxPackItems {
-		return fmt.Errorf("%w: items exceeds maximum of %d", ErrInvalidArtifact, maxPackItems)
 	}
 	for i, item := range pack.Items {
 		if err := validateItem(item); err != nil {

--- a/internal/service/skillpackservice/graph.go
+++ b/internal/service/skillpackservice/graph.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/markhuangai/dense-mem/internal/service/fragmentcodec"
 	neo4jstorage "github.com/markhuangai/dense-mem/internal/storage/neo4j"
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
@@ -111,6 +112,51 @@ func candidateFromRow(row map[string]any, sourceKind string) Candidate {
 		},
 		Snippet:    stringState(row, "object"),
 		RecordedAt: recordedAt,
+	}
+}
+
+func (g *graphOps) loadSupportFragments(ctx context.Context, profileID string, fragmentIDs []string) (map[string]SkillPackSupportFragment, error) {
+	out := map[string]SkillPackSupportFragment{}
+	fragmentIDs = uniqueStrings(fragmentIDs)
+	if len(fragmentIDs) == 0 {
+		return out, nil
+	}
+	if !g.available() {
+		return nil, fmt.Errorf("skill pack export: graph store is required to export support fragments")
+	}
+	_, rows, err := g.graph.ScopedRead(ctx, profileID, `
+		MATCH (sf:SourceFragment {team_id: $profileId})
+		WHERE sf.fragment_id IN $fragmentIds
+		  AND (sf.status IS NULL OR sf.status = 'active')
+		RETURN sf.fragment_id AS fragment_id,
+		       sf.content AS content,
+		       sf.source AS source,
+		       sf.source_type AS source_type,
+		       sf.authority AS authority,
+		       sf.labels AS labels,
+		       sf.source_quality AS source_quality
+	`, map[string]any{"fragmentIds": fragmentIDs})
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		fragment := supportFragmentFromRow(row)
+		if fragment.FragmentID != "" {
+			out[fragment.FragmentID] = fragment
+		}
+	}
+	return out, nil
+}
+
+func supportFragmentFromRow(row map[string]any) SkillPackSupportFragment {
+	return SkillPackSupportFragment{
+		FragmentID:    stringState(row, "fragment_id"),
+		Content:       stringState(row, "content"),
+		Source:        stringState(row, "source"),
+		SourceType:    stringState(row, "source_type"),
+		Authority:     stringState(row, "authority"),
+		Labels:        stringSliceState(row, "labels"),
+		SourceQuality: floatState(row, "source_quality"),
 	}
 }
 
@@ -421,6 +467,51 @@ func stringState(m map[string]any, key string) string {
 		return v
 	}
 	return ""
+}
+
+func stringSliceState(m map[string]any, key string) []string {
+	raw, ok := m[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch values := raw.(type) {
+	case []string:
+		return values
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if s, ok := value.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func floatState(m map[string]any, key string) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	default:
+		return 0
+	}
+}
+
+func optionalMapState(m map[string]any, keys ...string) map[string]any {
+	for _, key := range keys {
+		if decoded := fragmentcodec.DecodeOptionalMap(m[key]); decoded != nil {
+			return decoded
+		}
+	}
+	return nil
 }
 
 func nullableStringState(m map[string]any, key string) any {

--- a/internal/service/skillpackservice/import_item.go
+++ b/internal/service/skillpackservice/import_item.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (s *service) importItem(ctx context.Context, profileID, importID, artifactHash, fragmentID, mode string, item SkillPackItem, inspected InspectItem, decision string) ImportItemResult {
+	return s.importItemWithSupport(ctx, profileID, importID, artifactHash, fragmentID, mode, item, inspected, decision, itemSupportInput{})
+}
+
+func (s *service) importItemWithSupport(ctx context.Context, profileID, importID, artifactHash, fragmentID, mode string, item SkillPackItem, inspected InspectItem, decision string, support itemSupportInput) ImportItemResult {
 	result := ImportItemResult{Index: inspected.Index, Item: item, Conflicts: inspected.ConflictingFacts, Decision: decision}
 	if decision == DecisionSkip {
 		result.Status = "skipped"
@@ -19,21 +23,7 @@ func (s *service) importItem(ctx context.Context, profileID, importID, artifactH
 	if decision == DecisionDemoteToClaim && item.SourceKind != SourceKindFact {
 		return itemError(result, fmt.Errorf("%s is only valid for %s items", DecisionDemoteToClaim, SourceKindFact))
 	}
-	claim := &domain.Claim{
-		Subject:           item.Subject,
-		Predicate:         item.Predicate,
-		Object:            item.Object,
-		Modality:          domain.ModalityAssertion,
-		Polarity:          domain.PolarityPlus,
-		Speaker:           "skill_pack",
-		ExtractConf:       confidenceFor(mode, item.SourceKind),
-		ResolutionConf:    confidenceFor(mode, item.SourceKind),
-		IdempotencyKey:    fmt.Sprintf("skill-pack:%s:%d", artifactHash, inspected.Index),
-		SupportedBy:       []string{fragmentID},
-		ExtractionModel:   "skill_pack_import",
-		ExtractionVersion: SchemaVersion,
-		PipelineRunID:     importID,
-	}
+	claim := claimFromItem(item, mode, artifactHash, inspected.Index, importID, support, fragmentID)
 	createRes, err := s.deps.ClaimCreate.Create(ctx, profileID, claim)
 	if err != nil {
 		result.Status = "error"

--- a/internal/service/skillpackservice/service.go
+++ b/internal/service/skillpackservice/service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/factservice"
 )
 
+const skillPackListPageLimit = 100
+
 type service struct {
 	deps     Dependencies
 	graphOps *graphOps
@@ -34,7 +36,7 @@ func New(deps Dependencies) Service {
 }
 
 func (s *service) FindCandidates(ctx context.Context, profileID string, req FindCandidatesRequest) (*FindCandidatesResult, error) {
-	limit := clampLimit(req.Limit, 20, maxPackItems)
+	limit := clampLimit(req.Limit, 20, skillPackListPageLimit)
 	query := strings.ToLower(strings.TrimSpace(req.Query))
 	if query == "" {
 		return nil, errors.New("skill pack candidates: query is required")
@@ -48,7 +50,7 @@ func (s *service) FindCandidates(ctx context.Context, profileID string, req Find
 
 	out := &FindCandidatesResult{Candidates: []Candidate{}}
 	if s.deps.FactList != nil {
-		facts, _, err := s.deps.FactList.List(ctx, profileID, factservice.FactListFilters{Status: domain.FactStatusActive}, maxPackItems, "")
+		facts, _, err := s.deps.FactList.List(ctx, profileID, factservice.FactListFilters{Status: domain.FactStatusActive}, skillPackListPageLimit, "")
 		if err != nil {
 			return nil, err
 		}
@@ -75,7 +77,7 @@ func (s *service) FindCandidates(ctx context.Context, profileID string, req Find
 	}
 
 	if s.deps.ClaimList != nil && len(out.Candidates) < limit {
-		claims, _, err := s.deps.ClaimList.List(ctx, profileID, maxPackItems, 0)
+		claims, _, err := s.deps.ClaimList.List(ctx, profileID, skillPackListPageLimit, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +485,7 @@ func (s *service) inspectItem(ctx context.Context, profileID string, idx int, it
 			Subject:   item.Subject,
 			Predicate: item.Predicate,
 			Status:    domain.FactStatusActive,
-		}, maxPackItems, "")
+		}, skillPackListPageLimit, "")
 		if err != nil {
 			return out, err
 		}
@@ -499,7 +501,7 @@ func (s *service) inspectItem(ctx context.Context, profileID string, idx int, it
 			Subject:   item.Subject,
 			Predicate: item.Predicate,
 			Status:    domain.FactStatusSuperseded,
-		}, maxPackItems, "")
+		}, skillPackListPageLimit, "")
 		if err != nil {
 			return out, err
 		}
@@ -510,7 +512,7 @@ func (s *service) inspectItem(ctx context.Context, profileID string, idx int, it
 		}
 	}
 	if s.deps.ClaimList != nil {
-		claims, _, err := s.deps.ClaimList.List(ctx, profileID, maxPackItems, 0)
+		claims, _, err := s.deps.ClaimList.List(ctx, profileID, skillPackListPageLimit, 0)
 		if err != nil {
 			return out, err
 		}

--- a/internal/service/skillpackservice/service.go
+++ b/internal/service/skillpackservice/service.go
@@ -109,12 +109,16 @@ func (s *service) Export(ctx context.Context, profileID string, req ExportReques
 	if strings.TrimSpace(req.Name) == "" {
 		return nil, errors.New("skill pack export: name is required")
 	}
+	exportedAt := time.Now().UTC()
 	pack := SkillPack{
 		SchemaVersion: SchemaVersion,
 		Name:          req.Name,
 		Description:   req.Description,
+		ExportedAt:    &exportedAt,
 		Items:         []SkillPackItem{},
 	}
+	withSupport := includeSupport(req)
+	support := newSupportBuilder()
 
 	for _, factID := range req.FactIDs {
 		if s.deps.FactGet == nil {
@@ -124,15 +128,25 @@ func (s *service) Export(ctx context.Context, profileID string, req ExportReques
 		if err != nil {
 			return nil, err
 		}
+		if fact == nil {
+			return nil, fmt.Errorf("skill pack export: fact %s not found", factID)
+		}
 		if !allowedPredicate(fact.Predicate) {
 			return nil, fmt.Errorf("skill pack export: fact %s predicate %q is not supported", factID, fact.Predicate)
 		}
-		pack.Items = append(pack.Items, SkillPackItem{
+		item := SkillPackItem{
 			Subject:    fact.Subject,
 			Predicate:  fact.Predicate,
 			Object:     fact.Object,
 			SourceKind: SourceKindFact,
-		})
+			SourceID:   fact.FactID,
+		}
+		if withSupport {
+			if err := s.addFactSupport(ctx, profileID, &item, fact, support); err != nil {
+				return nil, err
+			}
+		}
+		pack.Items = append(pack.Items, item)
 	}
 
 	for _, claimID := range req.ClaimIDs {
@@ -143,18 +157,28 @@ func (s *service) Export(ctx context.Context, profileID string, req ExportReques
 		if err != nil {
 			return nil, err
 		}
+		if claim == nil {
+			return nil, fmt.Errorf("skill pack export: claim %s not found", claimID)
+		}
 		if claim.Status != domain.StatusValidated {
 			return nil, fmt.Errorf("skill pack export: claim %s must be validated", claimID)
 		}
 		if !allowedPredicate(claim.Predicate) {
 			return nil, fmt.Errorf("skill pack export: claim %s predicate %q is not supported", claimID, claim.Predicate)
 		}
-		pack.Items = append(pack.Items, SkillPackItem{
+		item := SkillPackItem{
 			Subject:    claim.Subject,
 			Predicate:  claim.Predicate,
 			Object:     claim.Object,
 			SourceKind: SourceKindValidatedClaim,
-		})
+			SourceID:   claim.ClaimID,
+		}
+		if withSupport {
+			if err := s.addClaimSupport(ctx, profileID, &item, claim, support); err != nil {
+				return nil, err
+			}
+		}
+		pack.Items = append(pack.Items, item)
 	}
 
 	for _, item := range req.ManualItems {
@@ -164,6 +188,9 @@ func (s *service) Export(ctx context.Context, profileID string, req ExportReques
 		pack.Items = append(pack.Items, item)
 	}
 
+	if withSupport {
+		pack.Support = support.build()
+	}
 	pack = normalizePack(pack)
 	canonical, hash, err := canonicalArtifact(pack)
 	if err != nil {
@@ -174,6 +201,8 @@ func (s *service) Export(ctx context.Context, profileID string, req ExportReques
 		CanonicalJSON: string(canonical),
 		SHA256:        hash,
 		ItemCount:     len(pack.Items),
+		Filename:      skillPackFilename(pack.Name),
+		ContentType:   "application/json",
 	}, nil
 }
 
@@ -209,6 +238,7 @@ func (s *service) Import(ctx context.Context, profileID string, req ImportReques
 	}
 	selected := selectedIndexSet(req.SelectedItems, len(pack.Items))
 	decisionByIndex := conflictDecisionMap(req.ConflictDecisions)
+	supportState := newSupportImportState(pack)
 	if req.Mode == ModeTrusted && req.AutoDecideConflicts {
 		s.recommendMissingDecisions(ctx, profileID, hash, sourceURL, req.Mode, inspection, selected, decisionByIndex, true)
 	}
@@ -258,6 +288,24 @@ func (s *service) Import(ctx context.Context, profileID string, req ImportReques
 			"mode":          req.Mode,
 			"artifact_hash": hash,
 			"error":         out.Error,
+		}); err != nil {
+			out.Error = fmt.Sprintf("%s; skill pack import status update failed: %v", out.Error, err)
+		}
+		return out, nil
+	}
+	failItem := func(result ImportItemResult) (*ImportResult, error) {
+		out.Items = append(out.Items, result)
+		out.Status = domain.SkillPackImportStatusFailed
+		if result.Error == "" {
+			out.Error = fmt.Sprintf("skill pack import: item %d failed", result.Index)
+		} else {
+			out.Error = fmt.Sprintf("skill pack import: item %d: %s", result.Index, result.Error)
+		}
+		if err := s.deps.Ledger.UpdateImportStatus(ctx, profileID, importID, out.Status, out.AppliedCount, out.SkippedCount, map[string]any{
+			"mode":              req.Mode,
+			"artifact_hash":     hash,
+			"failed_item_index": result.Index,
+			"error":             out.Error,
 		}); err != nil {
 			out.Error = fmt.Sprintf("%s; skill pack import status update failed: %v", out.Error, err)
 		}
@@ -313,24 +361,26 @@ func (s *service) Import(ctx context.Context, profileID string, req ImportReques
 			out.SkippedCount++
 			continue
 		}
-		result := s.importItem(ctx, profileID, importID, hash, fragmentID, req.Mode, item, inspection.Items[idx], decisionByIndex[idx])
+		if decisionByIndex[idx] == DecisionSkip {
+			result := s.importItemWithSupport(ctx, profileID, importID, hash, fragmentID, req.Mode, item, inspection.Items[idx], DecisionSkip, itemSupportInput{})
+			out.Items = append(out.Items, result)
+			out.SkippedCount++
+			continue
+		}
+		itemSupport, err := s.importSupportForItem(ctx, profileID, importID, hash, sourceURL, req.Mode, pack, supportState, item)
+		if err != nil {
+			return failItem(itemError(ImportItemResult{
+				Index:     idx,
+				Item:      item,
+				Conflicts: inspection.Items[idx].ConflictingFacts,
+				Decision:  decisionByIndex[idx],
+			}, err))
+		}
+		result := s.importItemWithSupport(ctx, profileID, importID, hash, fragmentID, req.Mode, item, inspection.Items[idx], decisionByIndex[idx], itemSupport)
 		out.Items = append(out.Items, result)
 		if result.Status == "error" {
-			out.Status = domain.SkillPackImportStatusFailed
-			if result.Error == "" {
-				out.Error = fmt.Sprintf("skill pack import: item %d failed", result.Index)
-			} else {
-				out.Error = fmt.Sprintf("skill pack import: item %d: %s", result.Index, result.Error)
-			}
-			if err := s.deps.Ledger.UpdateImportStatus(ctx, profileID, importID, out.Status, out.AppliedCount, out.SkippedCount, map[string]any{
-				"mode":              req.Mode,
-				"artifact_hash":     hash,
-				"failed_item_index": result.Index,
-				"error":             out.Error,
-			}); err != nil {
-				out.Error = fmt.Sprintf("%s; skill pack import status update failed: %v", out.Error, err)
-			}
-			return out, nil
+			out.Items = out.Items[:len(out.Items)-1]
+			return failItem(result)
 		}
 		if result.Status == "imported" || result.Status == "promoted" || result.Status == "validated" {
 			out.AppliedCount++
@@ -452,6 +502,12 @@ func (s *service) inspectPack(ctx context.Context, profileID string, pack SkillP
 		ItemCount:    len(pack.Items),
 		SourceURL:    sourceURL,
 		Items:        make([]InspectItem, 0, len(pack.Items)),
+	}
+	if pack.Support != nil {
+		out.SupportSummary = &SupportSummary{
+			ClaimCount:    len(pack.Support.Claims),
+			FragmentCount: len(pack.Support.Fragments),
+		}
 	}
 	for idx, item := range pack.Items {
 		inspected, err := s.inspectItem(ctx, profileID, idx, item)

--- a/internal/service/skillpackservice/service_fakes_test.go
+++ b/internal/service/skillpackservice/service_fakes_test.go
@@ -3,6 +3,7 @@ package skillpackservice
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -116,21 +117,41 @@ func (g *factCandidateGraph) ScopedWriteTx(_ context.Context, _ string, _ func(n
 }
 
 type recordingGraph struct {
-	states        map[string]map[string]any
-	promotedFacts map[string]string
-	writeCount    int
-	writeErr      error
-	writeErrAfter int
-	writeQueries  []string
-	writeParams   []map[string]any
-	txCount       int
-	txErr         error
-	readErr       error
+	states           map[string]map[string]any
+	promotedFacts    map[string]string
+	supportFragments map[string]SkillPackSupportFragment
+	writeCount       int
+	writeErr         error
+	writeErrAfter    int
+	writeQueries     []string
+	writeParams      []map[string]any
+	txCount          int
+	txErr            error
+	readErr          error
 }
 
 func (g *recordingGraph) ScopedRead(_ context.Context, _ string, _ string, params map[string]any) (neo4jdriver.ResultSummary, []map[string]any, error) {
 	if g.readErr != nil {
 		return nil, nil, g.readErr
+	}
+	if fragmentIDs, _ := params["fragmentIds"].([]string); len(fragmentIDs) > 0 {
+		rows := []map[string]any{}
+		for _, fragmentID := range fragmentIDs {
+			fragment, exists := g.supportFragments[fragmentID]
+			if !exists {
+				continue
+			}
+			rows = append(rows, map[string]any{
+				"fragment_id":    fragment.FragmentID,
+				"content":        fragment.Content,
+				"source":         fragment.Source,
+				"source_type":    fragment.SourceType,
+				"authority":      fragment.Authority,
+				"labels":         fragment.Labels,
+				"source_quality": fragment.SourceQuality,
+			})
+		}
+		return nil, rows, nil
 	}
 	if claimID, _ := params["claimId"].(string); claimID != "" {
 		if factID := g.promotedFacts[claimID]; factID != "" {
@@ -249,19 +270,22 @@ type fakeFragmentCreate struct {
 	calls     int
 	duplicate bool
 	err       error
+	requests  []*dto.CreateFragmentRequest
 }
 
 func (f *fakeFragmentCreate) Create(_ context.Context, profileID string, req *dto.CreateFragmentRequest) (*fragmentservice.CreateResult, error) {
 	f.calls++
+	f.requests = append(f.requests, req)
 	if f.err != nil {
 		return nil, f.err
 	}
+	fragmentID := fmt.Sprintf("fragment-%d", f.calls)
 	return &fragmentservice.CreateResult{
 		Fragment: &domain.Fragment{
-			FragmentID:  "fragment-1",
+			FragmentID:  fragmentID,
 			ProfileID:   profileID,
 			Content:     req.Content,
-			ContentHash: "hash",
+			ContentHash: "hash-" + fragmentID,
 			CreatedAt:   time.Now().UTC(),
 		},
 		Duplicate: f.duplicate,
@@ -273,10 +297,12 @@ type fakeClaimCreate struct {
 	duplicate bool
 	claimID   string
 	err       error
+	claims    []*domain.Claim
 }
 
 func (f *fakeClaimCreate) Create(_ context.Context, profileID string, claim *domain.Claim) (*claimservice.CreateResult, error) {
 	f.calls++
+	f.claims = append(f.claims, claim)
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/internal/service/skillpackservice/service_support_workflow_test.go
+++ b/internal/service/skillpackservice/service_support_workflow_test.go
@@ -1,0 +1,212 @@
+package skillpackservice
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestImportRebuildsSelectedSupportLineage(t *testing.T) {
+	fragmentCreate := &fakeFragmentCreate{}
+	claimCreate := &fakeClaimCreate{}
+	ledger := &fakeLedger{}
+	graph := &recordingGraph{}
+	pack := &SkillPack{
+		SchemaVersion: SchemaVersion,
+		Name:          "Supported pack",
+		Items: []SkillPackItem{{
+			Subject:            "assistant",
+			Predicate:          "has_skill",
+			Object:             "writes useful blog outlines",
+			SourceKind:         SourceKindValidatedClaim,
+			SourceID:           "claim-source",
+			SupportClaimIDs:    []string{"claim-source", "claim-source-2"},
+			SupportFragmentIDs: []string{"fragment-source"},
+		}},
+		Support: &SkillPackSupport{
+			Claims: []SkillPackSupportClaim{{
+				ClaimID:     "claim-source",
+				Subject:     "assistant",
+				Predicate:   "has_skill",
+				Object:      "writes useful blog outlines",
+				SupportedBy: []string{"fragment-source"},
+			}, {
+				ClaimID:     "claim-source-2",
+				Subject:     "assistant",
+				Predicate:   "has_skill",
+				Object:      "writes useful blog outlines",
+				SupportedBy: []string{"fragment-source-2"},
+			}},
+			Fragments: []SkillPackSupportFragment{{
+				FragmentID:    "fragment-source",
+				Content:       "Good blog outlines define audience, thesis, supporting claims, and success checks.",
+				Source:        "conversation",
+				SourceType:    string(domain.SourceTypeConversation),
+				Authority:     string(domain.AuthorityPrimary),
+				SourceQuality: 0.93,
+			}, {
+				FragmentID:    "fragment-source-2",
+				Content:       "Strong outlines turn each supporting claim into a section with an acceptance check.",
+				Source:        "conversation",
+				SourceType:    string(domain.SourceTypeConversation),
+				Authority:     string(domain.AuthorityPrimary),
+				SourceQuality: 0.93,
+			}},
+		},
+	}
+	svc := New(Dependencies{
+		FragmentCreate: fragmentCreate,
+		ClaimCreate:    claimCreate,
+		Graph:          graph,
+		Ledger:         ledger,
+	})
+
+	res, err := svc.Import(context.Background(), "team-1", ImportRequest{
+		Artifact: pack,
+		Mode:     ModeReview,
+	})
+	if err != nil {
+		t.Fatalf("Import supported pack: %v", err)
+	}
+	if res.Status != domain.SkillPackImportStatusApplied || res.Items[0].Status != "imported" {
+		t.Fatalf("result = %+v, want applied imported", res)
+	}
+	if fragmentCreate.calls != 3 {
+		t.Fatalf("fragmentCreate calls = %d, want artifact fragment plus two support fragments", fragmentCreate.calls)
+	}
+	if claimCreate.calls != 1 || len(claimCreate.claims) != 1 {
+		t.Fatalf("claimCreate calls/claims = %d/%d, want one claim", claimCreate.calls, len(claimCreate.claims))
+	}
+	createdClaim := claimCreate.claims[0]
+	if len(createdClaim.SupportedBy) != 2 ||
+		!slices.Contains(createdClaim.SupportedBy, "fragment-2") ||
+		!slices.Contains(createdClaim.SupportedBy, "fragment-3") {
+		t.Fatalf("created claim supported_by = %+v, want recreated support fragments", createdClaim.SupportedBy)
+	}
+	if createdClaim.Speaker != "skill_pack" || createdClaim.ExtractConf != 0.8 || !strings.HasPrefix(createdClaim.IdempotencyKey, "skill-pack:claim:") {
+		t.Fatalf("created claim = %+v, want import defaults and support claim idempotency", createdClaim)
+	}
+	if len(ledger.changes) != 4 {
+		t.Fatalf("ledger changes = %d, want artifact fragment + two support fragments + claim", len(ledger.changes))
+	}
+}
+
+func TestSupportHelpersNormalizeAndDedupe(t *testing.T) {
+	claimIDs := supportFragmentIDsForClaim(&domain.Claim{
+		SupportedBy: []string{" fragment-a ", "fragment-a", ""},
+		Evidence: []domain.Evidence{
+			{FragmentID: "fragment-b"},
+			{FragmentID: "fragment-b"},
+			{FragmentID: ""},
+		},
+	})
+	if !slices.Equal(claimIDs, []string{"fragment-a", "fragment-b"}) {
+		t.Fatalf("claim support ids = %+v, want deduped claim and evidence fragments", claimIDs)
+	}
+	factIDs := supportFragmentIDsForFact(&domain.Fact{
+		Evidence: []domain.Evidence{
+			{FragmentID: "fragment-c"},
+			{FragmentID: "fragment-c"},
+			{FragmentID: ""},
+		},
+	})
+	if !slices.Equal(factIDs, []string{"fragment-c"}) {
+		t.Fatalf("fact support ids = %+v, want deduped evidence fragments", factIDs)
+	}
+	missing := missingSupportFragments([]string{"fragment-a", "fragment-b"}, map[string]SkillPackSupportFragment{
+		"fragment-a": {FragmentID: "fragment-a"},
+	})
+	if !slices.Equal(missing, []string{"fragment-b"}) {
+		t.Fatalf("missing fragments = %+v, want fragment-b", missing)
+	}
+	labels := appendImportLabel([]string{" a ", "a", "", "b"})
+	if !slices.Equal(labels, []string{"a", "b", "skill_pack_import"}) {
+		t.Fatalf("labels = %+v, want trimmed dedupe plus import label", labels)
+	}
+	fullLabels := []string{}
+	for i := 0; i < 20; i++ {
+		fullLabels = append(fullLabels, "label"+string(rune('a'+i)))
+	}
+	if got := appendImportLabel(fullLabels); len(got) != 20 || slices.Contains(got, "skill_pack_import") {
+		t.Fatalf("full labels = %+v, want no extra import label", got)
+	}
+}
+
+func TestGraphRowStateHelpersDecodeTypes(t *testing.T) {
+	row := map[string]any{
+		"strings":       []string{"a", "b"},
+		"mixed":         []any{"c", 12, "d", ""},
+		"float32":       float32(1.25),
+		"int":           int(2),
+		"int64":         int64(3),
+		"metadata_json": `{"topic":"testing"}`,
+		"bad_json":      "{",
+	}
+	if !slices.Equal(stringSliceState(row, "strings"), []string{"a", "b"}) {
+		t.Fatalf("stringSliceState strings = %+v", stringSliceState(row, "strings"))
+	}
+	if !slices.Equal(stringSliceState(row, "mixed"), []string{"c", "d"}) {
+		t.Fatalf("stringSliceState mixed = %+v", stringSliceState(row, "mixed"))
+	}
+	if stringSliceState(row, "missing") != nil || stringSliceState(map[string]any{"x": 1}, "x") != nil {
+		t.Fatal("stringSliceState should return nil for missing or unsupported values")
+	}
+	if floatState(row, "float32") != 1.25 || floatState(row, "int") != 2 || floatState(row, "int64") != 3 || floatState(row, "missing") != 0 {
+		t.Fatalf("floatState decoded unexpected values")
+	}
+	decoded := optionalMapState(row, "bad_json", "metadata_json")
+	if decoded["topic"] != "testing" {
+		t.Fatalf("optionalMapState = %+v, want decoded metadata_json", decoded)
+	}
+	if optionalMapState(row, "bad_json", "missing") != nil {
+		t.Fatal("optionalMapState should return nil when no map value decodes")
+	}
+}
+
+func TestSupportValidationRejectsMalformedFields(t *testing.T) {
+	claimCases := []struct {
+		name  string
+		claim SkillPackSupportClaim
+		want  string
+	}{
+		{name: "missing claim id", claim: SkillPackSupportClaim{Subject: "assistant", Predicate: "has_skill", Object: "testing"}, want: "claim_id"},
+		{name: "long claim id", claim: SkillPackSupportClaim{ClaimID: strings.Repeat("c", 129), Subject: "assistant", Predicate: "has_skill", Object: "testing"}, want: "claim_id exceeds"},
+		{name: "bad triple", claim: SkillPackSupportClaim{ClaimID: "claim-1", Predicate: "has_skill", Object: "testing"}, want: "subject"},
+		{name: "bad support id", claim: SkillPackSupportClaim{ClaimID: "claim-1", Subject: "assistant", Predicate: "has_skill", Object: "testing", SupportedBy: []string{""}}, want: "supported_by"},
+	}
+	for _, tc := range claimCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateSupportClaim(tc.claim); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateSupportClaim err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	fragmentCases := []struct {
+		name     string
+		fragment SkillPackSupportFragment
+		want     string
+	}{
+		{name: "missing id", fragment: SkillPackSupportFragment{Content: "content"}, want: "fragment_id"},
+		{name: "long id", fragment: SkillPackSupportFragment{FragmentID: strings.Repeat("f", 129), Content: "content"}, want: "fragment_id exceeds"},
+		{name: "missing content", fragment: SkillPackSupportFragment{FragmentID: "fragment-1"}, want: "content"},
+		{name: "long content", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: strings.Repeat("x", 8193)}, want: "content exceeds"},
+		{name: "long source", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", Source: strings.Repeat("s", 257)}, want: "source exceeds"},
+		{name: "bad source type", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", SourceType: "bad"}, want: "source_type"},
+		{name: "bad authority", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", Authority: "bad"}, want: "authority"},
+		{name: "too many labels", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", Labels: make([]string, 21)}, want: "labels exceeds"},
+		{name: "empty label", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", Labels: []string{""}}, want: "labels[0]"},
+		{name: "long label", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", Labels: []string{strings.Repeat("l", 65)}}, want: "labels[0] exceeds"},
+		{name: "bad quality", fragment: SkillPackSupportFragment{FragmentID: "fragment-1", Content: "content", SourceQuality: 2}, want: "source_quality"},
+	}
+	for _, tc := range fragmentCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateSupportFragment(tc.fragment); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateSupportFragment err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/skillpackservice/service_test.go
+++ b/internal/service/skillpackservice/service_test.go
@@ -51,6 +51,9 @@ func TestExportProducesMinimalCanonicalArtifactAndHash(t *testing.T) {
 	if res.Artifact.SchemaVersion != SchemaVersion {
 		t.Fatalf("schema_version = %q", res.Artifact.SchemaVersion)
 	}
+	if res.Artifact.ExportedAt == nil {
+		t.Fatal("exported_at is required on exported artifacts")
+	}
 	if len(res.Artifact.Items) != 3 {
 		t.Fatalf("items len = %d, want 3", len(res.Artifact.Items))
 	}
@@ -93,6 +96,74 @@ func TestExportAllowsMoreThanOneHundredFacts(t *testing.T) {
 	}
 	if len(res.Artifact.Items) != len(factIDs) {
 		t.Fatalf("items len = %d, want %d", len(res.Artifact.Items), len(factIDs))
+	}
+}
+
+func TestExportIncludesSelectedFactSupportGraph(t *testing.T) {
+	fact := &domain.Fact{
+		FactID:              "fact-1",
+		Subject:             "assistant",
+		Predicate:           "has_skill",
+		Object:              "writes useful blog outlines",
+		Status:              domain.FactStatusActive,
+		PromotedFromClaimID: "claim-1",
+	}
+	claim := &domain.Claim{
+		ClaimID:        "claim-1",
+		Subject:        fact.Subject,
+		Predicate:      fact.Predicate,
+		Object:         fact.Object,
+		Status:         domain.StatusSuperseded,
+		Modality:       domain.ModalityAssertion,
+		Polarity:       domain.PolarityPlus,
+		Speaker:        "user",
+		ExtractConf:    0.91,
+		ResolutionConf: 0.92,
+		SupportedBy:    []string{"fragment-1"},
+	}
+	graph := &recordingGraph{supportFragments: map[string]SkillPackSupportFragment{
+		"fragment-1": {
+			FragmentID:    "fragment-1",
+			Content:       "A blog outline should define audience, thesis, claims, and success checks.",
+			Source:        "conversation",
+			SourceType:    "conversation",
+			Authority:     string(domain.AuthorityPrimary),
+			SourceQuality: 0.95,
+		},
+	}}
+	svc := New(Dependencies{
+		FactGet:  fakeFactGet{facts: map[string]*domain.Fact{"fact-1": fact}},
+		ClaimGet: fakeClaimGet{claims: map[string]*domain.Claim{"claim-1": claim}},
+		Graph:    graph,
+	})
+
+	res, err := svc.Export(context.Background(), "team-1", ExportRequest{
+		Name:    "Blog writing",
+		FactIDs: []string{"fact-1"},
+	})
+	if err != nil {
+		t.Fatalf("Export with support: %v", err)
+	}
+	if res.Filename != "blog-writing.skill-pack.json" || res.ContentType != "application/json" {
+		t.Fatalf("file metadata = %q/%q, want blog-writing.skill-pack.json/application/json", res.Filename, res.ContentType)
+	}
+	if len(res.Artifact.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(res.Artifact.Items))
+	}
+	item := res.Artifact.Items[0]
+	if item.SourceID != "fact-1" || len(item.SupportClaimIDs) != 1 || item.SupportClaimIDs[0] != "claim-1" {
+		t.Fatalf("item support = %+v, want source fact and support claim", item)
+	}
+	if res.Artifact.Support == nil || len(res.Artifact.Support.Claims) != 1 || len(res.Artifact.Support.Fragments) != 1 {
+		t.Fatalf("support = %+v, want one claim and one fragment", res.Artifact.Support)
+	}
+	if res.Artifact.Support.Fragments[0].Content == "" ||
+		strings.Contains(res.CanonicalJSON, "team_id") ||
+		strings.Contains(res.CanonicalJSON, "extract_conf") ||
+		strings.Contains(res.CanonicalJSON, "resolution_conf") ||
+		strings.Contains(res.CanonicalJSON, "extraction_model") ||
+		strings.Contains(res.CanonicalJSON, "extraction_version") {
+		t.Fatalf("canonical support JSON = %s", res.CanonicalJSON)
 	}
 }
 

--- a/internal/service/skillpackservice/service_test.go
+++ b/internal/service/skillpackservice/service_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -61,6 +62,37 @@ func TestExportProducesMinimalCanonicalArtifactAndHash(t *testing.T) {
 	sum := sha256.Sum256([]byte(res.CanonicalJSON))
 	if got := res.SHA256; got != hex.EncodeToString(sum[:]) {
 		t.Fatalf("sha256 = %s, want hash of canonical JSON", got)
+	}
+}
+
+func TestExportAllowsMoreThanOneHundredFacts(t *testing.T) {
+	facts := make(map[string]*domain.Fact)
+	factIDs := make([]string, 0, 101)
+	for i := 0; i < 101; i++ {
+		factID := fmt.Sprintf("fact-%03d", i)
+		factIDs = append(factIDs, factID)
+		facts[factID] = &domain.Fact{
+			FactID:    factID,
+			Subject:   "assistant",
+			Predicate: "has_skill",
+			Object:    fmt.Sprintf("skill %03d", i),
+			Status:    domain.FactStatusActive,
+		}
+	}
+	svc := New(Dependencies{FactGet: fakeFactGet{facts: facts}})
+
+	res, err := svc.Export(context.Background(), "team-1", ExportRequest{
+		Name:    "Large pack",
+		FactIDs: factIDs,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if res.ItemCount != len(factIDs) {
+		t.Fatalf("item_count = %d, want %d", res.ItemCount, len(factIDs))
+	}
+	if len(res.Artifact.Items) != len(factIDs) {
+		t.Fatalf("items len = %d, want %d", len(res.Artifact.Items), len(factIDs))
 	}
 }
 

--- a/internal/service/skillpackservice/service_workflow_test.go
+++ b/internal/service/skillpackservice/service_workflow_test.go
@@ -201,6 +201,18 @@ func TestParseArtifactJSONValidationBranches(t *testing.T) {
 	if _, err := parseArtifactJSON([]byte(strings.Repeat("x", maxArtifactBytes+1))); !errors.Is(err, ErrInvalidArtifact) {
 		t.Fatalf("oversized parse err = %v, want ErrInvalidArtifact", err)
 	}
+	supported := `{"schema_version":"dense-mem.skill_pack.v1","name":"Pack","items":[{"subject":"assistant","predicate":"has_skill","object":"testing","source_kind":"source_validated_claim","source_id":"claim-1","support_claim_ids":["claim-1"],"support_fragment_ids":["fragment-1"]}],"support":{"claims":[{"claim_id":"claim-1","subject":"assistant","predicate":"has_skill","object":"testing","supported_by":["fragment-1"]}],"fragments":[{"fragment_id":"fragment-1","content":"testing evidence","source_type":"conversation"}]}}`
+	if pack, err := parseArtifactJSON([]byte(supported)); err != nil || pack.Support == nil || len(pack.Support.Claims) != 1 {
+		t.Fatalf("parse supported artifact pack=%+v err=%v, want support", pack, err)
+	}
+	danglingItemClaim := `{"schema_version":"dense-mem.skill_pack.v1","name":"Pack","items":[{"subject":"assistant","predicate":"has_skill","object":"testing","source_kind":"source_validated_claim","support_claim_ids":["missing"]}],"support":{"fragments":[{"fragment_id":"fragment-1","content":"testing evidence"}]}}`
+	if _, err := parseArtifactJSON([]byte(danglingItemClaim)); !errors.Is(err, ErrInvalidArtifact) || !strings.Contains(err.Error(), "missing claim") {
+		t.Fatalf("dangling item claim err = %v, want missing claim ErrInvalidArtifact", err)
+	}
+	danglingClaimFragment := `{"schema_version":"dense-mem.skill_pack.v1","name":"Pack","items":[{"subject":"assistant","predicate":"has_skill","object":"testing","source_kind":"source_validated_claim","support_claim_ids":["claim-1"]}],"support":{"claims":[{"claim_id":"claim-1","subject":"assistant","predicate":"has_skill","object":"testing","supported_by":["missing"]}]}}`
+	if _, err := parseArtifactJSON([]byte(danglingClaimFragment)); !errors.Is(err, ErrInvalidArtifact) || !strings.Contains(err.Error(), "missing fragment") {
+		t.Fatalf("dangling claim fragment err = %v, want missing fragment ErrInvalidArtifact", err)
+	}
 	if err := validateItem(SkillPackItem{Subject: strings.Repeat("x", 257), Predicate: "has_skill", Object: "x", SourceKind: SourceKindManual}); err == nil {
 		t.Fatal("long subject should fail")
 	}
@@ -771,16 +783,33 @@ func TestTrustedImportConflictDecisions(t *testing.T) {
 
 	t.Run("skip selected conflict", func(t *testing.T) {
 		ledger := &fakeLedger{}
+		fragmentCreate := &fakeFragmentCreate{}
 		claimCreate := &fakeClaimCreate{}
+		pack := packWithItem(SourceKindManual)
+		pack.Items[0].SupportClaimIDs = []string{"claim-skip"}
+		pack.Items[0].SupportFragmentIDs = []string{"fragment-skip"}
+		pack.Support = &SkillPackSupport{
+			Claims: []SkillPackSupportClaim{{
+				ClaimID:     "claim-skip",
+				Subject:     pack.Items[0].Subject,
+				Predicate:   pack.Items[0].Predicate,
+				Object:      pack.Items[0].Object,
+				SupportedBy: []string{"fragment-skip"},
+			}},
+			Fragments: []SkillPackSupportFragment{{
+				FragmentID: "fragment-skip",
+				Content:    "Skipped support evidence should not be imported.",
+			}},
+		}
 		svc := New(Dependencies{
-			FragmentCreate: &fakeFragmentCreate{},
+			FragmentCreate: fragmentCreate,
 			ClaimCreate:    claimCreate,
 			FactList:       fakeFactList{facts: []*domain.Fact{conflictingFact}},
 			Graph:          &recordingGraph{},
 			Ledger:         ledger,
 		})
 		res, err := svc.Import(context.Background(), "team-1", ImportRequest{
-			Artifact: packWithItem(SourceKindManual),
+			Artifact: pack,
 			Mode:     ModeTrusted,
 			ConflictDecisions: []ConflictDecision{{
 				Index:  0,
@@ -795,6 +824,9 @@ func TestTrustedImportConflictDecisions(t *testing.T) {
 		}
 		if claimCreate.calls != 0 {
 			t.Fatalf("claimCreate calls = %d, want 0", claimCreate.calls)
+		}
+		if fragmentCreate.calls != 1 {
+			t.Fatalf("fragmentCreate calls = %d, want only artifact summary fragment", fragmentCreate.calls)
 		}
 	})
 

--- a/internal/service/skillpackservice/service_workflow_test.go
+++ b/internal/service/skillpackservice/service_workflow_test.go
@@ -236,14 +236,14 @@ func TestParseArtifactJSONValidationBranches(t *testing.T) {
 	if err := validatePack(longNamePack); err == nil {
 		t.Fatal("long name should fail")
 	}
-	tooManyItemsPack := longNamePack
-	tooManyItemsPack.Name = "Pack"
-	tooManyItemsPack.Items = make([]SkillPackItem, maxPackItems+1)
-	for i := range tooManyItemsPack.Items {
-		tooManyItemsPack.Items[i] = SkillPackItem{Subject: "assistant", Predicate: "has_skill", Object: "testing", SourceKind: SourceKindManual}
+	manyItemsPack := longNamePack
+	manyItemsPack.Name = "Pack"
+	manyItemsPack.Items = make([]SkillPackItem, 101)
+	for i := range manyItemsPack.Items {
+		manyItemsPack.Items[i] = SkillPackItem{Subject: "assistant", Predicate: "has_skill", Object: "testing", SourceKind: SourceKindManual}
 	}
-	if err := validatePack(tooManyItemsPack); err == nil {
-		t.Fatal("too many items should fail")
+	if err := validatePack(manyItemsPack); err != nil {
+		t.Fatalf("many items should pass: %v", err)
 	}
 	if err := validateExpectedHash("abc", "not-64"); !errors.Is(err, ErrInvalidArtifact) {
 		t.Fatalf("invalid expected hash err = %v, want ErrInvalidArtifact", err)

--- a/internal/service/skillpackservice/support.go
+++ b/internal/service/skillpackservice/support.go
@@ -1,0 +1,367 @@
+package skillpackservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/http/dto"
+)
+
+type supportBuilder struct {
+	claims    map[string]SkillPackSupportClaim
+	fragments map[string]SkillPackSupportFragment
+}
+
+type itemSupportInput struct {
+	Claim       *SkillPackSupportClaim
+	FragmentIDs []string
+}
+
+type supportImportState struct {
+	claimsByID       map[string]SkillPackSupportClaim
+	fragmentsByID    map[string]SkillPackSupportFragment
+	localFragmentIDs map[string]string
+}
+
+func includeSupport(req ExportRequest) bool {
+	return req.IncludeSupport == nil || *req.IncludeSupport
+}
+
+func newSupportBuilder() *supportBuilder {
+	return &supportBuilder{
+		claims:    map[string]SkillPackSupportClaim{},
+		fragments: map[string]SkillPackSupportFragment{},
+	}
+}
+
+func (b *supportBuilder) addClaim(claim *domain.Claim) []string {
+	if claim == nil || claim.ClaimID == "" {
+		return nil
+	}
+	b.claims[claim.ClaimID] = supportClaimFromDomain(claim)
+	return supportFragmentIDsForClaim(claim)
+}
+
+func (b *supportBuilder) addFragments(fragments map[string]SkillPackSupportFragment) {
+	for id, fragment := range fragments {
+		if id != "" {
+			b.fragments[id] = fragment
+		}
+	}
+}
+
+func (b *supportBuilder) build() *SkillPackSupport {
+	if b == nil || (len(b.claims) == 0 && len(b.fragments) == 0) {
+		return nil
+	}
+	support := &SkillPackSupport{
+		Claims:    make([]SkillPackSupportClaim, 0, len(b.claims)),
+		Fragments: make([]SkillPackSupportFragment, 0, len(b.fragments)),
+	}
+	for _, claim := range b.claims {
+		support.Claims = append(support.Claims, claim)
+	}
+	for _, fragment := range b.fragments {
+		support.Fragments = append(support.Fragments, fragment)
+	}
+	return support
+}
+
+func supportClaimFromDomain(claim *domain.Claim) SkillPackSupportClaim {
+	return SkillPackSupportClaim{
+		ClaimID:     claim.ClaimID,
+		Subject:     claim.Subject,
+		Predicate:   claim.Predicate,
+		Object:      claim.Object,
+		SupportedBy: supportFragmentIDsForClaim(claim),
+	}
+}
+
+func supportFragmentIDsForClaim(claim *domain.Claim) []string {
+	if claim == nil {
+		return nil
+	}
+	ids := append([]string(nil), claim.SupportedBy...)
+	for _, evidence := range claim.Evidence {
+		if evidence.FragmentID != "" {
+			ids = append(ids, evidence.FragmentID)
+		}
+	}
+	return uniqueStrings(ids)
+}
+
+func supportFragmentIDsForFact(fact *domain.Fact) []string {
+	if fact == nil {
+		return nil
+	}
+	ids := []string{}
+	for _, evidence := range fact.Evidence {
+		if evidence.FragmentID != "" {
+			ids = append(ids, evidence.FragmentID)
+		}
+	}
+	return uniqueStrings(ids)
+}
+
+func (s *service) addFactSupport(ctx context.Context, profileID string, item *SkillPackItem, fact *domain.Fact, builder *supportBuilder) error {
+	item.SourceID = fact.FactID
+	fragmentIDs := supportFragmentIDsForFact(fact)
+	if fact.PromotedFromClaimID != "" {
+		if s.deps.ClaimGet == nil {
+			return fmt.Errorf("skill pack export: claim get service is required to export support for fact %s", fact.FactID)
+		}
+		claim, err := s.deps.ClaimGet.Get(ctx, profileID, fact.PromotedFromClaimID)
+		if err != nil {
+			return err
+		}
+		if claim == nil {
+			return fmt.Errorf("skill pack export: promoted claim %s not found for fact %s", fact.PromotedFromClaimID, fact.FactID)
+		}
+		item.SupportClaimIDs = append(item.SupportClaimIDs, claim.ClaimID)
+		fragmentIDs = append(fragmentIDs, builder.addClaim(claim)...)
+	}
+	return s.addSupportFragments(ctx, profileID, item, builder, fragmentIDs)
+}
+
+func (s *service) addClaimSupport(ctx context.Context, profileID string, item *SkillPackItem, claim *domain.Claim, builder *supportBuilder) error {
+	item.SourceID = claim.ClaimID
+	item.SupportClaimIDs = append(item.SupportClaimIDs, claim.ClaimID)
+	fragmentIDs := builder.addClaim(claim)
+	return s.addSupportFragments(ctx, profileID, item, builder, fragmentIDs)
+}
+
+func (s *service) addSupportFragments(ctx context.Context, profileID string, item *SkillPackItem, builder *supportBuilder, fragmentIDs []string) error {
+	fragmentIDs = uniqueStrings(fragmentIDs)
+	if len(fragmentIDs) == 0 {
+		return nil
+	}
+	fragments, err := s.graphOps.loadSupportFragments(ctx, profileID, fragmentIDs)
+	if err != nil {
+		return err
+	}
+	if missing := missingSupportFragments(fragmentIDs, fragments); len(missing) > 0 {
+		return fmt.Errorf("skill pack export: support fragments not found or retracted: %s", strings.Join(missing, ", "))
+	}
+	builder.addFragments(fragments)
+	item.SupportFragmentIDs = uniqueStrings(append(item.SupportFragmentIDs, fragmentIDs...))
+	return nil
+}
+
+func missingSupportFragments(ids []string, fragments map[string]SkillPackSupportFragment) []string {
+	missing := []string{}
+	for _, id := range uniqueStrings(ids) {
+		if _, exists := fragments[id]; !exists {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}
+
+func newSupportImportState(pack SkillPack) *supportImportState {
+	state := &supportImportState{
+		claimsByID:       map[string]SkillPackSupportClaim{},
+		fragmentsByID:    map[string]SkillPackSupportFragment{},
+		localFragmentIDs: map[string]string{},
+	}
+	if pack.Support == nil {
+		return state
+	}
+	for _, claim := range pack.Support.Claims {
+		state.claimsByID[claim.ClaimID] = claim
+	}
+	for _, fragment := range pack.Support.Fragments {
+		state.fragmentsByID[fragment.FragmentID] = fragment
+	}
+	return state
+}
+
+func (s *service) importSupportForItem(ctx context.Context, profileID, importID, artifactHash, sourceURL, mode string, pack SkillPack, state *supportImportState, item SkillPackItem) (itemSupportInput, error) {
+	if state == nil || (len(item.SupportClaimIDs) == 0 && len(item.SupportFragmentIDs) == 0) {
+		return itemSupportInput{}, nil
+	}
+	support := itemSupportInput{}
+	for _, claimID := range item.SupportClaimIDs {
+		claim, exists := state.claimsByID[claimID]
+		if !exists {
+			return support, fmt.Errorf("support claim %s not found", claimID)
+		}
+		if support.Claim == nil {
+			firstClaim := claim
+			support.Claim = &firstClaim
+		}
+		support.FragmentIDs = append(support.FragmentIDs, claim.SupportedBy...)
+	}
+	support.FragmentIDs = append(support.FragmentIDs, item.SupportFragmentIDs...)
+	originalFragmentIDs := uniqueStrings(support.FragmentIDs)
+	localFragmentIDs := make([]string, 0, len(originalFragmentIDs))
+	for _, originalID := range originalFragmentIDs {
+		localID, err := s.importSupportFragment(ctx, profileID, importID, artifactHash, sourceURL, mode, pack, state, originalID)
+		if err != nil {
+			return support, err
+		}
+		localFragmentIDs = append(localFragmentIDs, localID)
+	}
+	support.FragmentIDs = uniqueStrings(localFragmentIDs)
+	return support, nil
+}
+
+func (s *service) importSupportFragment(ctx context.Context, profileID, importID, artifactHash, sourceURL, mode string, pack SkillPack, state *supportImportState, originalID string) (string, error) {
+	if localID := state.localFragmentIDs[originalID]; localID != "" {
+		return localID, nil
+	}
+	fragment, exists := state.fragmentsByID[originalID]
+	if !exists {
+		return "", fmt.Errorf("support fragment %s not found", originalID)
+	}
+	sourceType := fragment.SourceType
+	if sourceType == "" {
+		sourceType = string(domain.SourceTypeManual)
+	}
+	authority := fragment.Authority
+	if authority == "" {
+		authority = importAuthority(mode)
+	}
+	source := fragment.Source
+	if source == "" {
+		source = importSource(pack, sourceURL)
+	}
+	metadata := map[string]any{}
+	metadata["imported"] = true
+	metadata["import_id"] = importID
+	metadata["skill_pack_hash"] = artifactHash
+	metadata["skill_pack_schema"] = pack.SchemaVersion
+	metadata["source_fragment_id"] = originalID
+	fragmentRes, err := s.deps.FragmentCreate.Create(ctx, profileID, &dto.CreateFragmentRequest{
+		Content:        fragment.Content,
+		SourceType:     sourceType,
+		Source:         source,
+		Authority:      authority,
+		IdempotencyKey: skillPackImportKey("fragment", artifactHash, originalID),
+		Labels:         appendImportLabel(fragment.Labels),
+		Metadata:       metadata,
+		SourceQuality:  importSourceQuality(mode, fragment.SourceQuality),
+	})
+	if err != nil {
+		return "", err
+	}
+	localID := fragmentRes.Fragment.FragmentID
+	state.localFragmentIDs[originalID] = localID
+	if fragmentRes.Duplicate {
+		return localID, nil
+	}
+	if err := s.graphOps.tagFragment(ctx, profileID, localID, importID, artifactHash); err != nil {
+		return "", s.cleanupCreatedEntity(ctx, profileID, "fragment", localID, err)
+	}
+	if err := s.appendChange(ctx, profileID, importID, "fragment", localID, domain.SkillPackChangeActionCreated, nil, map[string]any{
+		"fragment_id":  localID,
+		"content_hash": fragmentRes.Fragment.ContentHash,
+		"import_id":    importID,
+	}); err != nil {
+		return "", s.cleanupCreatedEntity(ctx, profileID, "fragment", localID, err)
+	}
+	return localID, nil
+}
+
+func importSourceQuality(mode string, exported float64) float64 {
+	if exported > 0 {
+		return exported
+	}
+	return sourceQuality(mode)
+}
+
+func claimFromItem(item SkillPackItem, mode, artifactHash string, idx int, importID string, support itemSupportInput, fallbackFragmentID string) *domain.Claim {
+	supportedBy := append([]string(nil), support.FragmentIDs...)
+	if len(supportedBy) == 0 && fallbackFragmentID != "" {
+		supportedBy = []string{fallbackFragmentID}
+	}
+	claim := &domain.Claim{
+		Subject:           item.Subject,
+		Predicate:         item.Predicate,
+		Object:            item.Object,
+		Modality:          domain.ModalityAssertion,
+		Polarity:          domain.PolarityPlus,
+		Speaker:           "skill_pack",
+		ExtractConf:       confidenceFor(mode, item.SourceKind),
+		ResolutionConf:    confidenceFor(mode, item.SourceKind),
+		IdempotencyKey:    fmt.Sprintf("skill-pack:%s:%d", artifactHash, idx),
+		SupportedBy:       supportedBy,
+		ExtractionModel:   "skill_pack_import",
+		ExtractionVersion: SchemaVersion,
+		PipelineRunID:     importID,
+	}
+	if support.Claim == nil {
+		return claim
+	}
+	source := support.Claim
+	claim.IdempotencyKey = skillPackImportKey("claim", artifactHash, source.ClaimID)
+	return claim
+}
+
+func skillPackImportKey(kind, artifactHash, sourceID string) string {
+	sum := sha256.Sum256([]byte(kind + ":" + artifactHash + ":" + sourceID))
+	return "skill-pack:" + kind + ":" + hex.EncodeToString(sum[:])
+}
+
+func skillPackFilename(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range name {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash && b.Len() > 0 {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		slug = "skill-pack"
+	}
+	return slug + ".skill-pack.json"
+}
+
+func appendImportLabel(labels []string) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		if _, exists := seen[label]; exists {
+			continue
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	if _, exists := seen["skill_pack_import"]; !exists && len(out) < 20 {
+		out = append(out, "skill_pack_import")
+	}
+	return out
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/service/skillpackservice/types.go
+++ b/internal/service/skillpackservice/types.go
@@ -65,17 +65,45 @@ type ConflictDecider interface {
 }
 
 type SkillPack struct {
-	SchemaVersion string          `json:"schema_version"`
-	Name          string          `json:"name"`
-	Description   string          `json:"description,omitempty"`
-	Items         []SkillPackItem `json:"items"`
+	SchemaVersion string            `json:"schema_version"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description,omitempty"`
+	ExportedAt    *time.Time        `json:"exported_at,omitempty"`
+	Items         []SkillPackItem   `json:"items"`
+	Support       *SkillPackSupport `json:"support,omitempty"`
 }
 
 type SkillPackItem struct {
-	Subject    string `json:"subject"`
-	Predicate  string `json:"predicate"`
-	Object     string `json:"object"`
-	SourceKind string `json:"source_kind"`
+	Subject            string   `json:"subject"`
+	Predicate          string   `json:"predicate"`
+	Object             string   `json:"object"`
+	SourceKind         string   `json:"source_kind"`
+	SourceID           string   `json:"source_id,omitempty"`
+	SupportClaimIDs    []string `json:"support_claim_ids,omitempty"`
+	SupportFragmentIDs []string `json:"support_fragment_ids,omitempty"`
+}
+
+type SkillPackSupport struct {
+	Claims    []SkillPackSupportClaim    `json:"claims,omitempty"`
+	Fragments []SkillPackSupportFragment `json:"fragments,omitempty"`
+}
+
+type SkillPackSupportClaim struct {
+	ClaimID     string   `json:"claim_id"`
+	Subject     string   `json:"subject"`
+	Predicate   string   `json:"predicate"`
+	Object      string   `json:"object"`
+	SupportedBy []string `json:"supported_by,omitempty"`
+}
+
+type SkillPackSupportFragment struct {
+	FragmentID    string   `json:"fragment_id"`
+	Content       string   `json:"content"`
+	Source        string   `json:"source,omitempty"`
+	SourceType    string   `json:"source_type,omitempty"`
+	Authority     string   `json:"authority,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	SourceQuality float64  `json:"source_quality,omitempty"`
 }
 
 type Candidate struct {
@@ -96,11 +124,12 @@ type FindCandidatesResult struct {
 }
 
 type ExportRequest struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	FactIDs     []string        `json:"fact_ids,omitempty"`
-	ClaimIDs    []string        `json:"claim_ids,omitempty"`
-	ManualItems []SkillPackItem `json:"manual_items,omitempty"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description,omitempty"`
+	FactIDs        []string        `json:"fact_ids,omitempty"`
+	ClaimIDs       []string        `json:"claim_ids,omitempty"`
+	ManualItems    []SkillPackItem `json:"manual_items,omitempty"`
+	IncludeSupport *bool           `json:"include_support,omitempty"`
 }
 
 type ExportResult struct {
@@ -108,6 +137,8 @@ type ExportResult struct {
 	CanonicalJSON string    `json:"canonical_json"`
 	SHA256        string    `json:"sha256"`
 	ItemCount     int       `json:"item_count"`
+	Filename      string    `json:"filename"`
+	ContentType   string    `json:"content_type"`
 }
 
 type InspectRequest struct {
@@ -123,9 +154,15 @@ type InspectResult struct {
 	Name              string           `json:"name"`
 	Description       string           `json:"description,omitempty"`
 	ItemCount         int              `json:"item_count"`
+	SupportSummary    *SupportSummary  `json:"support_summary,omitempty"`
 	Items             []InspectItem    `json:"items"`
 	DecisionsRequired []ConflictPrompt `json:"decisions_required,omitempty"`
 	SourceURL         string           `json:"source_url,omitempty"`
+}
+
+type SupportSummary struct {
+	ClaimCount    int `json:"claim_count"`
+	FragmentCount int `json:"fragment_count"`
 }
 
 type InspectItem struct {

--- a/internal/tools/registry/memory_tools.go
+++ b/internal/tools/registry/memory_tools.go
@@ -11,12 +11,12 @@ import (
 func rememberTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "remember",
-		Description: "Store chat-session memory evidence, create host-extracted typed personal-memory claims, verify them, and promote non-conflicting validated claims to facts.",
+		Description: "Store one granular chat-session memory evidence entry, create host-extracted typed personal-memory claims, verify them, and promote non-conflicting validated claims to facts. Keep each entry under 1000 characters and split large scenarios into precise supporting evidence pieces.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"content"},
 			"properties": map[string]any{
-				"content":         schemaString("Evidence text from the current conversation.", 8192),
+				"content":         memoryEntryString("Evidence text from the current conversation."),
 				"source":          schemaString("Free-form provenance.", 256),
 				"idempotency_key": schemaString("Dedupe key scoped to profile.", 128),
 				"labels":          map[string]any{"type": "array", "items": map[string]any{"type": "string", "maxLength": 64}, "maxItems": 20},
@@ -48,12 +48,12 @@ func rememberTool(deps Dependencies) Tool {
 func importMemoriesTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "import_memories",
-		Description: "Import summarized historical conversations as evidence and optional typed personal-memory claims. Bulk imports do not auto-promote unless auto_promote is true.",
+		Description: "Import one granular summarized historical memory entry as evidence and optional typed personal-memory claims. Split bulk history into entries under 1000 characters so claims can attach to precise support. Bulk imports do not auto-promote unless auto_promote is true.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"summary"},
 			"properties": map[string]any{
-				"summary":         schemaString("Summarized historical conversation or memory bundle.", 8192),
+				"summary":         memoryEntryString("Summarized historical conversation or memory bundle."),
 				"source":          schemaString("Free-form provenance.", 256),
 				"idempotency_key": schemaString("Dedupe key scoped to profile.", 128),
 				"labels":          map[string]any{"type": "array", "items": map[string]any{"type": "string", "maxLength": 64}, "maxItems": 20},

--- a/internal/tools/registry/skill_pack_tools.go
+++ b/internal/tools/registry/skill_pack_tools.go
@@ -47,11 +47,12 @@ func exportSkillPackTool(deps Dependencies) Tool {
 			"type":     "object",
 			"required": []string{"name"},
 			"properties": map[string]any{
-				"name":         schemaString("Skill pack name.", 256),
-				"description":  schemaString("Short skill pack description.", 1024),
-				"fact_ids":     map[string]any{"type": "array", "items": schemaString("Fact ID.", 128)},
-				"claim_ids":    map[string]any{"type": "array", "items": schemaString("Claim ID.", 128)},
-				"manual_items": skillPackItemsSchema(),
+				"name":            schemaString("Skill pack name.", 256),
+				"description":     schemaString("Short skill pack description.", 1024),
+				"fact_ids":        map[string]any{"type": "array", "items": schemaString("Fact ID.", 128)},
+				"claim_ids":       map[string]any{"type": "array", "items": schemaString("Claim ID.", 128)},
+				"manual_items":    skillPackItemsSchema(),
+				"include_support": map[string]any{"type": "boolean", "description": "Include selected fact/claim support claims and source fragments. Defaults to true."},
 			},
 			"additionalProperties": false,
 		},
@@ -192,7 +193,9 @@ func skillPackSchema() map[string]any {
 			"schema_version": schemaEnum([]string{"dense-mem.skill_pack.v1"}),
 			"name":           schemaString("Skill pack name.", 256),
 			"description":    schemaString("Short skill pack description.", 1024),
+			"exported_at":    schemaString("RFC3339 export timestamp.", 64),
 			"items":          skillPackItemsSchema(),
+			"support":        skillPackSupportSchema(),
 		},
 		"additionalProperties": false,
 	}
@@ -206,13 +209,65 @@ func skillPackItemsSchema() map[string]any {
 			"type":     "object",
 			"required": []string{"subject", "predicate", "object", "source_kind"},
 			"properties": map[string]any{
-				"subject":     schemaString("Triple subject.", 256),
-				"predicate":   schemaEnum([]string{"has_skill", "knows", "uses"}),
-				"object":      schemaString("Triple object.", 1024),
-				"source_kind": schemaEnum([]string{"source_fact", "source_validated_claim", "manual"}),
+				"subject":              schemaString("Triple subject.", 256),
+				"predicate":            schemaEnum([]string{"has_skill", "knows", "uses"}),
+				"object":               schemaString("Triple object.", 1024),
+				"source_kind":          schemaEnum([]string{"source_fact", "source_validated_claim", "manual"}),
+				"source_id":            schemaString("Original source fact or claim ID.", 128),
+				"support_claim_ids":    map[string]any{"type": "array", "items": schemaString("Supporting claim ID.", 128)},
+				"support_fragment_ids": map[string]any{"type": "array", "items": schemaString("Supporting fragment ID.", 128)},
 			},
 			"additionalProperties": false,
 		},
+	}
+}
+
+func skillPackSupportSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"claims": map[string]any{
+				"type":  "array",
+				"items": skillPackSupportClaimSchema(),
+			},
+			"fragments": map[string]any{
+				"type":  "array",
+				"items": skillPackSupportFragmentSchema(),
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func skillPackSupportClaimSchema() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"claim_id", "subject", "predicate", "object"},
+		"properties": map[string]any{
+			"claim_id":     schemaString("Original supporting claim ID.", 128),
+			"subject":      schemaString("Claim subject.", 256),
+			"predicate":    schemaEnum([]string{"has_skill", "knows", "uses"}),
+			"object":       schemaString("Claim object.", 1024),
+			"supported_by": map[string]any{"type": "array", "items": schemaString("Supporting fragment ID.", 128)},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func skillPackSupportFragmentSchema() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"fragment_id", "content"},
+		"properties": map[string]any{
+			"fragment_id":    schemaString("Original source fragment ID.", 128),
+			"content":        schemaString("Source fragment content.", 8192),
+			"source":         schemaString("Source identifier.", 256),
+			"source_type":    schemaEnum([]string{"conversation", "document", "observation", "manual"}),
+			"authority":      schemaEnum([]string{"authoritative", "primary", "secondary", "inferred", "unknown"}),
+			"labels":         map[string]any{"type": "array", "items": schemaString("Fragment label.", 64)},
+			"source_quality": map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+		},
+		"additionalProperties": false,
 	}
 }
 

--- a/internal/tools/registry/skill_pack_tools.go
+++ b/internal/tools/registry/skill_pack_tools.go
@@ -49,8 +49,8 @@ func exportSkillPackTool(deps Dependencies) Tool {
 			"properties": map[string]any{
 				"name":         schemaString("Skill pack name.", 256),
 				"description":  schemaString("Short skill pack description.", 1024),
-				"fact_ids":     map[string]any{"type": "array", "items": schemaString("Fact ID.", 128), "maxItems": 100},
-				"claim_ids":    map[string]any{"type": "array", "items": schemaString("Claim ID.", 128), "maxItems": 100},
+				"fact_ids":     map[string]any{"type": "array", "items": schemaString("Fact ID.", 128)},
+				"claim_ids":    map[string]any{"type": "array", "items": schemaString("Claim ID.", 128)},
 				"manual_items": skillPackItemsSchema(),
 			},
 			"additionalProperties": false,
@@ -121,7 +121,7 @@ func importSkillPackTool(deps Dependencies) Tool {
 				"url":                   schemaString("HTTPS URL to a skill pack JSON artifact.", 2048),
 				"expected_sha256":       schemaString("Expected canonical artifact SHA-256.", 64),
 				"mode":                  schemaEnum([]string{"review", "trusted"}),
-				"selected_items":        map[string]any{"type": "array", "items": map[string]any{"type": "integer", "minimum": 0}, "maxItems": 100},
+				"selected_items":        map[string]any{"type": "array", "items": map[string]any{"type": "integer", "minimum": 0}},
 				"conflict_decisions":    conflictDecisionsSchema(),
 				"auto_decide_conflicts": map[string]any{"type": "boolean", "description": "Allow the configured LLM decider to fill missing conflict decisions before trusted import writes."},
 			},
@@ -202,7 +202,6 @@ func skillPackItemsSchema() map[string]any {
 	return map[string]any{
 		"type":     "array",
 		"minItems": 1,
-		"maxItems": 100,
 		"items": map[string]any{
 			"type":     "object",
 			"required": []string{"subject", "predicate", "object", "source_kind"},
@@ -219,8 +218,7 @@ func skillPackItemsSchema() map[string]any {
 
 func conflictDecisionsSchema() map[string]any {
 	return map[string]any{
-		"type":     "array",
-		"maxItems": 100,
+		"type": "array",
 		"items": map[string]any{
 			"type":     "object",
 			"required": []string{"index", "action"},

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -108,12 +108,12 @@ func defaultTools(deps Dependencies) []Tool {
 func saveMemoryTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "save_memory",
-		Description: "Persist a new SourceFragment for the caller's profile. The server produces the embedding; text and metadata are stored with an audit entry. Supports idempotency via idempotency_key or content hash.",
+		Description: "Persist one granular SourceFragment for the caller's profile. Keep each entry under 1000 characters and split large scenarios into claim-worthy evidence pieces so future claims can attach to precise support. The server produces the embedding; text and metadata are stored with an audit entry. Supports idempotency via idempotency_key or content hash.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"content"},
 			"properties": map[string]any{
-				"content":         schemaString("Fragment text.", 8192),
+				"content":         memoryEntryString("Fragment text."),
 				"source_type":     schemaEnum([]string{"conversation", "document", "observation", "manual"}),
 				"source":          schemaString("Free-form provenance.", 256),
 				"authority":       schemaEnum([]string{"authoritative", "primary", "secondary", "inferred", "unknown"}),
@@ -467,6 +467,17 @@ func graphQueryTool(deps Dependencies) Tool {
 }
 
 // --- schema + marshaling helpers ------------------------------------------
+
+const (
+	memoryEntryMaxLength = 999
+	memoryEntryGuidance  = "Split large scenarios into multiple semantic entries under 1000 characters. Store one decision, fact, correction, preference, project milestone, or other claim-worthy unit per entry; attach typed claims to the smallest supporting entry and use multiple supported_by IDs only when one claim needs cross-entry evidence."
+)
+
+func memoryEntryString(description string) map[string]any {
+	s := schemaString(description+" "+memoryEntryGuidance, memoryEntryMaxLength)
+	s["x-validation-hint"] = memoryEntryGuidance
+	return s
+}
 
 func schemaString(description string, maxLen int) map[string]any {
 	s := map[string]any{"type": "string"}

--- a/internal/tools/registry/toolset_knowledge_test.go
+++ b/internal/tools/registry/toolset_knowledge_test.go
@@ -130,6 +130,39 @@ func TestBuildDefaultMemoryTools_InvalidInputBranches(t *testing.T) {
 	}
 }
 
+func TestBuildDefaultMemoryTools_GranularEntryValidation(t *testing.T) {
+	reg, _ := BuildDefault(Dependencies{Memory: &stubMemory{}})
+
+	cases := []struct {
+		toolName string
+		field    string
+	}{
+		{toolName: "remember", field: "content"},
+		{toolName: "import_memories", field: "summary"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.toolName, func(t *testing.T) {
+			tool, ok := reg.Get(tc.toolName)
+			if !ok {
+				t.Fatalf("%s not registered", tc.toolName)
+			}
+			properties := tool.InputSchema["properties"].(map[string]any)
+			fieldSchema := properties[tc.field].(map[string]any)
+			if got, want := fieldSchema["maxLength"], memoryEntryMaxLength; got != want {
+				t.Fatalf("%s.%s maxLength = %v; want %d", tc.toolName, tc.field, got, want)
+			}
+
+			err := ValidateInput(tool, map[string]any{
+				tc.field: strings.Repeat("x", memoryEntryMaxLength+1),
+			})
+			if err == nil || !strings.Contains(err.Error(), "Split large scenarios") {
+				t.Fatalf("ValidateInput long %s error = %v; want split guidance", tc.field, err)
+			}
+		})
+	}
+}
+
 func TestBuildDefault_RecallInvokerErrorBranches(t *testing.T) {
 	t.Run("nil fragment hit returns mapping error", func(t *testing.T) {
 		reg, _ := BuildDefault(Dependencies{Recall: stubRecallNilFragment{}})

--- a/internal/tools/registry/toolset_test.go
+++ b/internal/tools/registry/toolset_test.go
@@ -179,6 +179,17 @@ func TestValidateInputRejectsNestedSaveMemoryFields(t *testing.T) {
 		t.Fatal("save_memory tool not registered")
 	}
 
+	properties := tool.InputSchema["properties"].(map[string]any)
+	contentSchema := properties["content"].(map[string]any)
+	if got, want := contentSchema["maxLength"], memoryEntryMaxLength; got != want {
+		t.Fatalf("save_memory content maxLength = %v; want %d", got, want)
+	}
+	if err := ValidateInput(tool, map[string]any{
+		"content": strings.Repeat("x", memoryEntryMaxLength+1),
+	}); err == nil || !strings.Contains(err.Error(), "Split large scenarios") {
+		t.Fatalf("ValidateInput long content error = %v; want split guidance", err)
+	}
+
 	if err := ValidateInput(tool, map[string]any{
 		"content":     "hello",
 		"source_type": "webhook",

--- a/internal/tools/registry/toolset_test.go
+++ b/internal/tools/registry/toolset_test.go
@@ -522,6 +522,52 @@ func TestSkillPackSchemasDoNotCapItemsAtOneHundred(t *testing.T) {
 	}
 }
 
+func TestSkillPackSchemasAcceptSupportGraph(t *testing.T) {
+	reg, _ := BuildDefault(Dependencies{SkillPack: &stubSkillPackService{}})
+	artifact := map[string]any{
+		"schema_version": "dense-mem.skill_pack.v1",
+		"name":           "Supported pack",
+		"items": []any{map[string]any{
+			"subject":              "assistant",
+			"predicate":            "has_skill",
+			"object":               "testing",
+			"source_kind":          "source_validated_claim",
+			"source_id":            "claim-1",
+			"support_claim_ids":    []any{"claim-1"},
+			"support_fragment_ids": []any{"fragment-1"},
+		}},
+		"support": map[string]any{
+			"claims": []any{map[string]any{
+				"claim_id":     "claim-1",
+				"subject":      "assistant",
+				"predicate":    "has_skill",
+				"object":       "testing",
+				"supported_by": []any{"fragment-1"},
+			}},
+			"fragments": []any{map[string]any{
+				"fragment_id":    "fragment-1",
+				"content":        "testing evidence",
+				"source_type":    "conversation",
+				"authority":      "primary",
+				"source_quality": 0.9,
+			}},
+		},
+	}
+
+	exportTool, _ := reg.Get("export_skill_pack")
+	if err := ValidateInput(exportTool, map[string]any{"name": "Pack", "claim_ids": []any{"claim-1"}, "include_support": false}); err != nil {
+		t.Fatalf("export_skill_pack support flag ValidateInput: %v", err)
+	}
+	inspectTool, _ := reg.Get("inspect_skill_pack")
+	if err := ValidateInput(inspectTool, map[string]any{"artifact": artifact}); err != nil {
+		t.Fatalf("inspect_skill_pack support artifact ValidateInput: %v", err)
+	}
+	importTool, _ := reg.Get("import_skill_pack")
+	if err := ValidateInput(importTool, map[string]any{"artifact": artifact, "mode": "review"}); err != nil {
+		t.Fatalf("import_skill_pack support artifact ValidateInput: %v", err)
+	}
+}
+
 func TestImportSkillPackReturnsRecoverableResultOnPartialError(t *testing.T) {
 	skillPack := &stubSkillPackService{
 		importResult: &skillpackservice.ImportResult{
@@ -868,6 +914,8 @@ func (s *stubSkillPackService) Export(ctx context.Context, profileID string, req
 		CanonicalJSON: "{}",
 		SHA256:        strings.Repeat("a", 64),
 		ItemCount:     1,
+		Filename:      "pack.skill-pack.json",
+		ContentType:   "application/json",
 	}, nil
 }
 

--- a/internal/tools/registry/toolset_test.go
+++ b/internal/tools/registry/toolset_test.go
@@ -479,6 +479,49 @@ func TestBuildDefaultSkillPackTools_InvokeSuccessAndInvalidInput(t *testing.T) {
 	}
 }
 
+func TestSkillPackSchemasDoNotCapItemsAtOneHundred(t *testing.T) {
+	reg, _ := BuildDefault(Dependencies{SkillPack: &stubSkillPackService{}})
+
+	factIDs := make([]any, 101)
+	selectedItems := make([]any, 101)
+	conflictDecisions := make([]any, 101)
+	items := make([]any, 101)
+	for i := 0; i < 101; i++ {
+		factIDs[i] = "fact-1"
+		selectedItems[i] = i
+		conflictDecisions[i] = map[string]any{"index": i, "action": "skip"}
+		items[i] = map[string]any{
+			"subject":     "assistant",
+			"predicate":   "has_skill",
+			"object":      "testing",
+			"source_kind": "manual",
+		}
+	}
+	artifact := map[string]any{
+		"schema_version": "dense-mem.skill_pack.v1",
+		"name":           "Pack",
+		"items":          items,
+	}
+
+	exportTool, _ := reg.Get("export_skill_pack")
+	if err := ValidateInput(exportTool, map[string]any{"name": "Pack", "fact_ids": factIDs}); err != nil {
+		t.Fatalf("export_skill_pack ValidateInput: %v", err)
+	}
+	inspectTool, _ := reg.Get("inspect_skill_pack")
+	if err := ValidateInput(inspectTool, map[string]any{"artifact": artifact}); err != nil {
+		t.Fatalf("inspect_skill_pack ValidateInput: %v", err)
+	}
+	importTool, _ := reg.Get("import_skill_pack")
+	if err := ValidateInput(importTool, map[string]any{
+		"artifact":           artifact,
+		"mode":               "review",
+		"selected_items":     selectedItems,
+		"conflict_decisions": conflictDecisions,
+	}); err != nil {
+		t.Fatalf("import_skill_pack ValidateInput: %v", err)
+	}
+}
+
 func TestImportSkillPackReturnsRecoverableResultOnPartialError(t *testing.T) {
 	skillPack := &stubSkillPackService{
 		importResult: &skillpackservice.ImportResult{

--- a/internal/tools/registry/validation.go
+++ b/internal/tools/registry/validation.go
@@ -53,7 +53,11 @@ func validateSchemaValue(name string, value any, schema map[string]any) error {
 			return fmt.Errorf("%s must be at least %d characters", name, int(minLen))
 		}
 		if maxLen, ok := schemaNumber(schema["maxLength"]); ok && len(s) > int(maxLen) {
-			return fmt.Errorf("%s exceeds maximum length of %d", name, int(maxLen))
+			message := fmt.Sprintf("%s exceeds maximum length of %d", name, int(maxLen))
+			if hint, ok := schema["x-validation-hint"].(string); ok && hint != "" {
+				message = message + ": " + hint
+			}
+			return fmt.Errorf("%s", message)
 		}
 	case "integer":
 		number, ok := schemaNumber(value)

--- a/internal/tools/registry/validation.go
+++ b/internal/tools/registry/validation.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
+	"unicode/utf8"
 )
 
 func ValidateInput(tool Tool, args map[string]any) error {
@@ -49,10 +50,11 @@ func validateSchemaValue(name string, value any, schema map[string]any) error {
 		if !ok {
 			return fmt.Errorf("%s must be a string", name)
 		}
-		if minLen, ok := schemaNumber(schema["minLength"]); ok && len(s) < int(minLen) {
+		charLen := utf8.RuneCountInString(s)
+		if minLen, ok := schemaNumber(schema["minLength"]); ok && charLen < int(minLen) {
 			return fmt.Errorf("%s must be at least %d characters", name, int(minLen))
 		}
-		if maxLen, ok := schemaNumber(schema["maxLength"]); ok && len(s) > int(maxLen) {
+		if maxLen, ok := schemaNumber(schema["maxLength"]); ok && charLen > int(maxLen) {
 			message := fmt.Sprintf("%s exceeds maximum length of %d", name, int(maxLen))
 			if hint, ok := schema["x-validation-hint"].(string); ok && hint != "" {
 				message = message + ": " + hint

--- a/internal/tools/registry/validation_test.go
+++ b/internal/tools/registry/validation_test.go
@@ -51,6 +51,19 @@ func TestValidateInputSchemaBranches(t *testing.T) {
 		t.Fatalf("ValidateInput valid input: %v", err)
 	}
 
+	nonASCIIValid := map[string]any{
+		"name":    strings.Repeat("界", 5),
+		"count":   json.Number("2"),
+		"ratio":   float32(0.5),
+		"enabled": true,
+		"mode":    "fast",
+		"nested":  map[string]string{"id": "n1"},
+		"items":   []any{json.Number("1"), float64(2)},
+	}
+	if err := ValidateInput(tool, nonASCIIValid); err != nil {
+		t.Fatalf("ValidateInput non-ASCII exact max input: %v", err)
+	}
+
 	cases := []struct {
 		name string
 		args map[string]any
@@ -60,7 +73,9 @@ func TestValidateInputSchemaBranches(t *testing.T) {
 		{"unknown field", map[string]any{"name": "ok", "count": 1, "extra": true}, "unknown field: extra"},
 		{"string type", map[string]any{"name": 3, "count": 1}, "name must be a string"},
 		{"string min length", map[string]any{"name": "a", "count": 1}, "at least 2"},
+		{"string min length non-ASCII", map[string]any{"name": "界", "count": 1}, "at least 2"},
 		{"string max length", map[string]any{"name": "abcdef", "count": 1}, "maximum length"},
+		{"string max length non-ASCII", map[string]any{"name": strings.Repeat("界", 6), "count": 1}, "maximum length"},
 		{"integer type", map[string]any{"name": "ok", "count": 1.2}, "count must be an integer"},
 		{"integer finite", map[string]any{"name": "ok", "count": math.Inf(1)}, "count must be an integer"},
 		{"integer min", map[string]any{"name": "ok", "count": 0}, "greater than or equal to 1"},


### PR DESCRIPTION
## Summary

This PR adds a granular-entry policy for MCP/tool-layer memory writes.

- Adds a shared memory-entry schema helper that caps `save_memory`, `remember`, and `import_memories` inputs below 1000 characters.
- Adds validation guidance so overlong entries tell callers how to split large scenarios into semantic evidence units.
- Updates focused registry tests for the new schema and validation behavior.
- Documents the MCP memory-entry guidance in the standalone MCP architecture docs.

## Why

Large memory chunks blur embeddings, verification context, and `SUPPORTED_BY` relationships. Focused evidence entries make claims easier to attach to the smallest supporting fragment and should improve future recall and graph relationship quality.

## Validation

- `go test ./internal/tools/registry`
- `go test ./internal/tools/registry ./internal/mcp`
- `go test ./internal/http/handler`
- `go test ./...`
- Pre-push checks completed successfully, including coverage at 90.1% against the 90.0% threshold.