### PR TITLE
Address post-merge review fixes

### DIFF
--- a/internal/http/handler/openapi_handler.go
+++ b/internal/http/handler/openapi_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/labstack/echo/v4"
 
@@ -14,8 +15,11 @@ import (
 // variant and full runtime variant to protected routes, so whoever reaches
 // this handler is already authorized for the requested variant.
 type OpenAPIHandler struct {
-	gen     openapi.Generator
-	variant openapi.SpecVariant
+	gen       openapi.Generator
+	variant   openapi.SpecVariant
+	cacheOnce sync.Once
+	cacheSpec map[string]any
+	cacheErr  error
 }
 
 // OpenAPIHandlerInterface is the companion interface for OpenAPIHandler.
@@ -32,9 +36,11 @@ func NewOpenAPIHandler(gen openapi.Generator, variant openapi.SpecVariant) *Open
 
 // Handle returns the OpenAPI document as JSON.
 func (h *OpenAPIHandler) Handle(c echo.Context) error {
-	spec, err := h.gen.Generate(h.variant)
-	if err != nil {
+	h.cacheOnce.Do(func() {
+		h.cacheSpec, h.cacheErr = h.gen.Generate(h.variant)
+	})
+	if h.cacheErr != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to generate openapi spec")
 	}
-	return c.JSON(http.StatusOK, spec)
+	return c.JSON(http.StatusOK, h.cacheSpec)
 }

--- a/internal/http/handler/openapi_handler_test.go
+++ b/internal/http/handler/openapi_handler_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,20 @@ import (
 	"github.com/markhuangai/dense-mem/internal/openapi"
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
 )
+
+type countingOpenAPIGenerator struct {
+	calls int
+	spec  map[string]any
+	err   error
+}
+
+func (g *countingOpenAPIGenerator) Generate(_ openapi.SpecVariant) (map[string]any, error) {
+	g.calls++
+	if g.err != nil {
+		return nil, g.err
+	}
+	return g.spec, nil
+}
 
 func buildTestGenerator(t *testing.T) openapi.Generator {
 	t.Helper()
@@ -67,6 +82,50 @@ func TestOpenAPIHandler_ServesFullVariant(t *testing.T) {
 	paths := body["paths"].(map[string]any)
 	if _, has := paths["/api/v1/teams/{teamId}/query/stream"]; !has {
 		t.Errorf("full response missing runtime-only path")
+	}
+}
+
+func TestOpenAPIHandler_CachesGeneratedSpec(t *testing.T) {
+	gen := &countingOpenAPIGenerator{
+		spec: map[string]any{"openapi": "3.0.3", "paths": map[string]any{}},
+	}
+	h := NewOpenAPIHandler(gen, openapi.SpecVariantFull)
+
+	e := echo.New()
+	e.GET("/api/v1/openapi.json", h.Handle)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/openapi.json", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d; want 200. body=%s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	if gen.calls != 1 {
+		t.Fatalf("Generate calls = %d; want 1", gen.calls)
+	}
+}
+
+func TestOpenAPIHandler_CachesGenerationError(t *testing.T) {
+	gen := &countingOpenAPIGenerator{err: errors.New("boom")}
+	h := NewOpenAPIHandler(gen, openapi.SpecVariantFull)
+
+	e := echo.New()
+	e.GET("/api/v1/openapi.json", h.Handle)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/openapi.json", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("request %d status = %d; want 500. body=%s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	if gen.calls != 1 {
+		t.Fatalf("Generate calls = %d; want 1", gen.calls)
 	}
 }
 

--- a/internal/http/handler/tool_execute_handler.go
+++ b/internal/http/handler/tool_execute_handler.go
@@ -77,10 +77,10 @@ func (h *ToolExecuteHandler) Handle(c echo.Context) error {
 			return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
 		}
 	}
+	registry.StripTenantOverrideArgs(args)
 	if err := registry.ValidateInput(tool, args); err != nil {
 		return httperr.New(httperr.VALIDATION_ERROR, err.Error())
 	}
-	delete(args, "team_id")
 
 	out, err := tool.Invoke(ctx, profileID.String(), args)
 	if err != nil {

--- a/internal/http/handler/tool_execute_handler_test.go
+++ b/internal/http/handler/tool_execute_handler_test.go
@@ -71,7 +71,7 @@ func TestToolExecuteHandler_RejectsMissingRequiredField(t *testing.T) {
 	assert.Contains(t, apiErr.Message, "content is required")
 }
 
-func TestToolExecuteHandler_RejectsUnknownFieldWhenAdditionalPropertiesFalse(t *testing.T) {
+func TestToolExecuteHandler_RejectsUnknownNonTenantFieldWhenAdditionalPropertiesFalse(t *testing.T) {
 	reg := registry.New()
 	called := false
 	err := reg.Register(registry.Tool{
@@ -104,7 +104,7 @@ func TestToolExecuteHandler_RejectsUnknownFieldWhenAdditionalPropertiesFalse(t *
 
 	e.POST("/api/v1/tools/:name", h.Handle)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/get_memory", strings.NewReader(`{"id":"frag-1","team_id":"forged"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/get_memory", strings.NewReader(`{"id":"frag-1","unexpected":"forged"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Profile-ID", profileID.String())
 	rec := httptest.NewRecorder()
@@ -116,7 +116,51 @@ func TestToolExecuteHandler_RejectsUnknownFieldWhenAdditionalPropertiesFalse(t *
 
 	var apiErr httperr.APIError
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &apiErr))
-	assert.Contains(t, apiErr.Message, "unknown field: team_id")
+	assert.Contains(t, apiErr.Message, "unknown field: unexpected")
+}
+
+func TestToolExecuteHandler_StripsTenantFieldsBeforeStrictValidation(t *testing.T) {
+	reg := registry.New()
+	var gotInput map[string]any
+	err := reg.Register(registry.Tool{
+		Name:           "get_memory",
+		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"id": map[string]any{"type": "string"}}, "additionalProperties": false},
+		RequiredScopes: []string{"read"},
+		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
+			gotInput = input
+			return map[string]any{"ok": true}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	h := NewToolExecuteHandler(reg)
+	e := newTestEcho()
+	profileID := uuid.New()
+
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := middleware.SetResolvedProfileIDForTest(c.Request().Context(), profileID)
+			ctx = middleware.SetPrincipalForTest(ctx, &middleware.Principal{
+				KeyID:  uuid.New(),
+				Role:   "user",
+				Scopes: []string{"read"},
+			})
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+
+	e.POST("/api/v1/tools/:name", h.Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/get_memory", strings.NewReader(`{"id":"frag-1","team_id":"forged","profile_id":"forged-profile"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Profile-ID", profileID.String())
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, map[string]any{"id": "frag-1"}, gotInput)
 }
 
 func TestToolExecuteHandler_MapsEmbeddingFailureToServiceUnavailable(t *testing.T) {
@@ -249,7 +293,7 @@ func TestToolExecuteHandler_AdditionalBranches(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, rec.Code)
 	})
 
-	t.Run("success strips forged team_id", func(t *testing.T) {
+	t.Run("success strips forged tenant fields", func(t *testing.T) {
 		reg := registry.New()
 		var gotInput map[string]any
 		require.NoError(t, reg.Register(registry.Tool{
@@ -274,12 +318,13 @@ func TestToolExecuteHandler_AdditionalBranches(t *testing.T) {
 		})
 		e.POST("/api/v1/tools/:name", h.Handle)
 
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/probe", strings.NewReader(`{"team_id":"attacker","x":1}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/probe", strings.NewReader(`{"team_id":"attacker","profile_id":"attacker-profile","x":1}`))
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)
 
 		require.Equal(t, http.StatusOK, rec.Code)
 		require.NotContains(t, gotInput, "team_id")
+		require.NotContains(t, gotInput, "profile_id")
 	})
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -179,8 +179,7 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 	// Strip tenant IDs to prevent callers from overriding the fixed server
 	// team. The HTTP API derives scope from the bearer key; local registries
 	// may still receive a construction-time team for tests.
-	delete(args, "team_id")
-	delete(args, "profile_id")
+	registry.StripTenantOverrideArgs(args)
 	if err := registry.ValidateInput(tool, args); err != nil {
 		return nil, &rpcError{Code: errCodeInvalidParams, Message: err.Error()}
 	}

--- a/internal/service/audit_service.go
+++ b/internal/service/audit_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -86,21 +87,27 @@ func NewAuditServiceWithLogger(db *gorm.DB, logger *slog.Logger) *AuditServiceIm
 	return &AuditServiceImpl{db: db, logger: logger, rls: postgres.NewRLS()}
 }
 
-// sensitiveFields contains the list of fields that must be redacted from audit payloads.
-var sensitiveFields = map[string]bool{
-	"key_hash":         true,
-	"encrypted_secret": true,
-	"api_key":          true,
-	"raw_key":          true,
-	"secret":           true,
-	"password":         true,
-	"token":            true,
-	"embedding":        true,
-	"embeddings":       true,
-	"ai_api_key":       true,
+// sensitiveFields contains exact normalized field names redacted from audit data.
+var sensitiveFields = map[string]struct{}{
+	"access_token":     {},
+	"accesstoken":      {},
+	"ai_api_key":       {},
+	"api_key":          {},
+	"apikey":           {},
+	"authorization":    {},
+	"encrypted_secret": {},
+	"embedding":        {},
+	"embeddings":       {},
+	"key_hash":         {},
+	"password":         {},
+	"raw_key":          {},
+	"refresh_token":    {},
+	"refreshtoken":     {},
+	"secret":           {},
+	"token":            {},
 }
 
-// redactPayload removes sensitive fields from a payload map.
+// redactPayload removes sensitive fields from audit maps.
 // It returns a new map and does not modify the original.
 func redactPayload(payload map[string]interface{}) map[string]interface{} {
 	if payload == nil {
@@ -109,17 +116,69 @@ func redactPayload(payload map[string]interface{}) map[string]interface{} {
 
 	redacted := make(map[string]interface{}, len(payload))
 	for key, value := range payload {
-		if sensitiveFields[key] {
+		if isSensitiveAuditField(key) {
 			continue
 		}
-		// Recursively redact nested maps
-		if nestedMap, ok := value.(map[string]interface{}); ok {
-			redacted[key] = redactPayload(nestedMap)
-		} else {
-			redacted[key] = value
-		}
+		redacted[key] = redactAuditValue(value)
 	}
 	return redacted
+}
+
+func isSensitiveAuditField(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	if _, ok := sensitiveFields[normalized]; ok {
+		return true
+	}
+	compact := strings.ReplaceAll(normalized, "_", "")
+	if _, ok := sensitiveFields[compact]; ok {
+		return true
+	}
+	return strings.HasSuffix(normalized, "_api_key") ||
+		strings.HasSuffix(normalized, "_password") ||
+		strings.HasSuffix(normalized, "_secret") ||
+		strings.HasSuffix(normalized, "_token") ||
+		strings.HasSuffix(compact, "apikey") ||
+		strings.HasSuffix(compact, "password") ||
+		strings.HasSuffix(compact, "secret") ||
+		strings.HasSuffix(compact, "token")
+}
+
+func redactAuditValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return redactPayload(typed)
+	case []interface{}:
+		redacted := make([]interface{}, len(typed))
+		for i, child := range typed {
+			redacted[i] = redactAuditValue(child)
+		}
+		return redacted
+	}
+
+	reflected := reflect.ValueOf(value)
+	if !reflected.IsValid() {
+		return value
+	}
+	if reflected.Kind() == reflect.Map && reflected.Type().Key().Kind() == reflect.String {
+		fields := make(map[string]interface{}, reflected.Len())
+		iter := reflected.MapRange()
+		for iter.Next() {
+			fields[iter.Key().String()] = iter.Value().Interface()
+		}
+		return redactPayload(fields)
+	}
+	if reflected.Kind() == reflect.Slice || reflected.Kind() == reflect.Array {
+		if reflected.Type().Elem().Kind() == reflect.Uint8 {
+			return value
+		}
+		redacted := make([]interface{}, reflected.Len())
+		for i := 0; i < reflected.Len(); i++ {
+			redacted[i] = redactAuditValue(reflected.Index(i).Interface())
+		}
+		return redacted
+	}
+	return value
 }
 
 func auditClientIPValue(ctx context.Context, entry AuditLogEntry) any {
@@ -160,7 +219,7 @@ func (s *AuditServiceImpl) Append(ctx context.Context, entry AuditLogEntry) erro
 	// Convert metadata to JSON
 	metadataJSON := []byte("{}")
 	if entry.Metadata != nil {
-		data, err := json.Marshal(entry.Metadata)
+		data, err := json.Marshal(redactPayload(entry.Metadata))
 		if err != nil {
 			return fmt.Errorf("failed to marshal metadata: %w", err)
 		}

--- a/internal/service/audit_service_test.go
+++ b/internal/service/audit_service_test.go
@@ -406,12 +406,22 @@ func TestAuditServiceRedactsSecrets(t *testing.T) {
 			"token":            "bearer-token-abc",
 			"embedding":        []float32{0.1, 0.2, 0.3},
 			"embeddings":       [][]float32{{0.1, 0.2}, {0.3, 0.4}},
+			"Authorization":    "Bearer payload-token",
+			"nested":           map[string]interface{}{"access_token": "payload-access-token", "refreshToken": "payload-refresh-token", "safe": "keep"},
+			"clientSecret":     "payload-client-secret",
 			"team_id":          profileID,    // This should be preserved
 			"label":            "test-label", // This should be preserved
 		},
 		ActorRole:     "system",
 		ClientIP:      "192.168.1.1",
 		CorrelationID: "corr-redact-789",
+		Metadata: map[string]interface{}{
+			"source":        "unit",
+			"apiKey":        "metadata-api-key",
+			"Authorization": "Bearer metadata-token",
+			"clientSecret":  "metadata-client-secret",
+			"nested":        map[string]interface{}{"refresh_token": "metadata-refresh-token", "refreshToken": "metadata-refresh-token-camel", "safe": "keep"},
+		},
 	}
 
 	err = auditService.Append(ctx, entry)
@@ -419,11 +429,12 @@ func TestAuditServiceRedactsSecrets(t *testing.T) {
 
 	// Verify the entry was written and check the payload
 	var afterPayload string
+	var metadataPayload string
 	err = sqlDB.QueryRowContext(ctx, `
-		SELECT after_payload::text
-		FROM audit_log
-		WHERE entity_id = 'test-redaction-123'
-	`).Scan(&afterPayload)
+			SELECT after_payload::text, metadata::text
+			FROM audit_log
+			WHERE entity_id = 'test-redaction-123'
+		`).Scan(&afterPayload, &metadataPayload)
 	require.NoError(t, err, "should retrieve audit log entry")
 
 	// Verify sensitive fields are NOT present
@@ -434,13 +445,24 @@ func TestAuditServiceRedactsSecrets(t *testing.T) {
 	assert.NotContains(t, afterPayload, "secret-value", "secret should be redacted")
 	assert.NotContains(t, afterPayload, "password123", "password should be redacted")
 	assert.NotContains(t, afterPayload, "bearer-token-abc", "token should be redacted")
+	assert.NotContains(t, afterPayload, "Bearer payload-token", "authorization should be redacted")
+	assert.NotContains(t, afterPayload, "payload-access-token", "nested access token should be redacted")
+	assert.NotContains(t, afterPayload, "payload-refresh-token", "nested refreshToken should be redacted")
+	assert.NotContains(t, afterPayload, "payload-client-secret", "clientSecret should be redacted")
 	assert.NotContains(t, afterPayload, "0.1", "embedding should be redacted")
 	assert.NotContains(t, afterPayload, "embeddings", "embeddings field should be redacted")
+	assert.NotContains(t, metadataPayload, "metadata-api-key", "metadata apiKey should be redacted")
+	assert.NotContains(t, metadataPayload, "Bearer metadata-token", "metadata authorization should be redacted")
+	assert.NotContains(t, metadataPayload, "metadata-client-secret", "metadata clientSecret should be redacted")
+	assert.NotContains(t, metadataPayload, "metadata-refresh-token", "nested metadata refresh token should be redacted")
+	assert.NotContains(t, metadataPayload, "metadata-refresh-token-camel", "nested metadata refreshToken should be redacted")
 
 	// Verify legitimate fields ARE present
 	assert.Contains(t, afterPayload, "Test Key", "name should be preserved")
 	assert.Contains(t, afterPayload, profileID, "team_id should be preserved")
 	assert.Contains(t, afterPayload, "test-label", "label should be preserved")
+	assert.Contains(t, metadataPayload, "unit", "metadata source should be preserved")
+	assert.Contains(t, metadataPayload, "keep", "safe nested metadata should be preserved")
 }
 
 // verifyAuditEntry is a helper to verify audit log entries were created

--- a/internal/service/audit_service_unit_test.go
+++ b/internal/service/audit_service_unit_test.go
@@ -153,11 +153,11 @@ func TestAuditAppendRedactsPayloadsAndWritesInsert(t *testing.T) {
 		"entity-1",
 		auditJSONArg{
 			present: map[string]interface{}{"name": "before"},
-			absent:  []string{"secret", "token"},
+			absent:  []string{"secret", "token", "Authorization", "refreshToken"},
 		},
 		auditJSONArg{
 			present: map[string]interface{}{"name": "after"},
-			absent:  []string{"api_key", "embedding"},
+			absent:  []string{"api_key", "embedding", "access_token", "clientSecret"},
 		},
 		sqlmock.AnyArg(),
 		"admin",
@@ -165,6 +165,7 @@ func TestAuditAppendRedactsPayloadsAndWritesInsert(t *testing.T) {
 		"corr-1",
 		auditJSONArg{
 			present: map[string]interface{}{"source": "unit"},
+			absent:  []string{"password", "apiKey", "refresh_token", "clientSecret", "refreshToken"},
 		},
 	).WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -176,22 +177,28 @@ func TestAuditAppendRedactsPayloadsAndWritesInsert(t *testing.T) {
 		EntityType: "secret_entity",
 		EntityID:   "entity-1",
 		BeforePayload: map[string]interface{}{
-			"name":   "before",
-			"secret": "remove",
-			"nested": map[string]interface{}{"token": "remove", "safe": "keep"},
+			"name":          "before",
+			"secret":        "remove",
+			"Authorization": "remove",
+			"nested":        map[string]interface{}{"token": "remove", "refreshToken": "remove", "safe": "keep"},
 		},
 		AfterPayload: map[string]interface{}{
-			"name":      "after",
-			"api_key":   "remove",
-			"embedding": []float64{1, 2, 3},
+			"name":         "after",
+			"api_key":      "remove",
+			"access_token": "remove",
+			"clientSecret": "remove",
+			"embedding":    []float64{1, 2, 3},
 		},
 		ActorKeyID:    &actorKeyID,
 		ActorRole:     "admin",
 		ClientIP:      "203.0.113.10",
 		CorrelationID: "corr-1",
 		Metadata: map[string]interface{}{
-			"source":   "unit",
-			"password": "remove",
+			"source":         "unit",
+			"password":       "remove",
+			"apiKey":         "remove",
+			"nested":         map[string]string{"refresh_token": "remove", "refreshToken": "remove", "safe": "keep"},
+			"array_payloads": []map[string]interface{}{{"client_secret": "remove", "clientSecret": "remove", "name": "kept"}},
 		},
 	})
 

--- a/internal/service/claimservice/create_test.go
+++ b/internal/service/claimservice/create_test.go
@@ -51,6 +51,7 @@ type stubClaimWriter struct {
 	written []map[string]any
 	queries []string
 	err     error
+	summary neo4j.ResultSummary
 }
 
 func (s *stubClaimWriter) ScopedWrite(
@@ -64,11 +65,50 @@ func (s *stubClaimWriter) ScopedWrite(
 	}
 	s.queries = append(s.queries, query)
 	s.written = append(s.written, params)
-	return nil, nil
+	if s.summary != nil {
+		return s.summary, nil
+	}
+	return stubResultSummary{counters: stubCounters{containsUpdates: true, propertiesSet: 1}}, nil
 }
 
 // Compile-time check: stubClaimWriter satisfies the package-internal interface.
 var _ claimWriter = (*stubClaimWriter)(nil)
+
+type stubResultSummary struct {
+	counters neo4j.Counters
+}
+
+func (s stubResultSummary) Server() neo4j.ServerInfo                  { return nil }
+func (s stubResultSummary) Query() neo4j.Query                        { return nil }
+func (s stubResultSummary) StatementType() neo4j.StatementType        { return neo4j.StatementTypeUnknown }
+func (s stubResultSummary) Counters() neo4j.Counters                  { return s.counters }
+func (s stubResultSummary) Plan() neo4j.Plan                          { return nil }
+func (s stubResultSummary) Profile() neo4j.ProfiledPlan               { return nil }
+func (s stubResultSummary) Notifications() []neo4j.Notification       { return nil }
+func (s stubResultSummary) GqlStatusObjects() []neo4j.GqlStatusObject { return nil }
+func (s stubResultSummary) ResultAvailableAfter() time.Duration       { return 0 }
+func (s stubResultSummary) ResultConsumedAfter() time.Duration        { return 0 }
+func (s stubResultSummary) Database() neo4j.DatabaseInfo              { return nil }
+
+type stubCounters struct {
+	containsUpdates bool
+	propertiesSet   int
+}
+
+func (c stubCounters) ContainsUpdates() bool       { return c.containsUpdates }
+func (c stubCounters) NodesCreated() int           { return 0 }
+func (c stubCounters) NodesDeleted() int           { return 0 }
+func (c stubCounters) RelationshipsCreated() int   { return 0 }
+func (c stubCounters) RelationshipsDeleted() int   { return 0 }
+func (c stubCounters) PropertiesSet() int          { return c.propertiesSet }
+func (c stubCounters) LabelsAdded() int            { return 0 }
+func (c stubCounters) LabelsRemoved() int          { return 0 }
+func (c stubCounters) IndexesAdded() int           { return 0 }
+func (c stubCounters) IndexesRemoved() int         { return 0 }
+func (c stubCounters) ConstraintsAdded() int       { return 0 }
+func (c stubCounters) ConstraintsRemoved() int     { return 0 }
+func (c stubCounters) SystemUpdates() int          { return 0 }
+func (c stubCounters) ContainsSystemUpdates() bool { return false }
 
 // TestCreateClaimDedupeAndDefaults covers AC-11 (deduplicate by idempotency key
 // and content hash) and AC-13 (server-side default population).

--- a/internal/service/claimservice/verify.go
+++ b/internal/service/claimservice/verify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/ownership"
 	"github.com/markhuangai/dense-mem/internal/verifier"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
 // verifyClaimCypher updates a Claim node's verification fields after a
@@ -212,7 +213,7 @@ func (s *verifyClaimServiceImpl) Verify(ctx context.Context, profileID string, c
 	now := time.Now().UTC()
 
 	// Persist the updated fields.
-	_, err = s.writer.ScopedWrite(ctx, profileID, verifyClaimCypher, map[string]any{
+	summary, err := s.writer.ScopedWrite(ctx, profileID, verifyClaimCypher, map[string]any{
 		"claimId":              claimID,
 		"status":               string(newStatus),
 		"entailmentVerdict":    string(newVerdict),
@@ -223,6 +224,10 @@ func (s *verifyClaimServiceImpl) Verify(ctx context.Context, profileID string, c
 	if err != nil {
 		s.incVerifyMetric(ctx, "error")
 		return nil, fmt.Errorf("claim verify: persist: %w", err)
+	}
+	if !writeSummaryContainsUpdates(summary) {
+		s.incVerifyMetric(ctx, "error")
+		return nil, ErrClaimNotFound
 	}
 
 	// Step 8: emit metric for the successful verification path.
@@ -245,6 +250,10 @@ func (s *verifyClaimServiceImpl) Verify(ctx context.Context, profileID string, c
 // backend is wired. Nil-safe: if metrics is nil the call is a no-op.
 func (s *verifyClaimServiceImpl) incVerifyMetric(ctx context.Context, outcome string) {
 	observability.RecordVerifyVerdict(ctx, s.metrics, s.verifierModel, outcome)
+}
+
+func writeSummaryContainsUpdates(summary neo4j.ResultSummary) bool {
+	return summary != nil && summary.Counters() != nil && summary.Counters().ContainsUpdates()
 }
 
 // emitVerifyAudit writes a claim.verify audit entry. Any error is logged and

--- a/internal/service/claimservice/verify_test.go
+++ b/internal/service/claimservice/verify_test.go
@@ -275,6 +275,41 @@ func TestVerifyClaimNotFound(t *testing.T) {
 	require.Empty(t, writer.written, "no write must occur when claim is missing")
 }
 
+func TestVerifyClaimReturnsNotFoundWhenPersistMatchesNoRows(t *testing.T) {
+	ctx := context.Background()
+
+	claimRows := map[string][]map[string]any{
+		verifyTestProfileA: {baseVerifyClaimRow(verifyTestClaimID, verifyTestProfileA)},
+	}
+	fragRows := map[string][]map[string]any{
+		verifyTestProfileA: {},
+	}
+	writer := &stubClaimWriter{
+		summary: stubResultSummary{counters: stubCounters{}},
+	}
+	verif := &stubVerifier{
+		resp: verifier.Response{
+			Verdict:    "entailed",
+			Confidence: 0.95,
+			Reasoning:  "clear match",
+			RawJSON:    `{"verdict":"entailed"}`,
+		},
+	}
+	metrics := observability.NewInMemoryDiscoverabilityMetrics()
+	audit := &capturingAudit{}
+
+	svc := buildVerifyService(claimRows, fragRows, writer, verif, "gpt-4o-mini", audit, metrics)
+
+	_, err := svc.Verify(ctx, verifyTestProfileA, verifyTestClaimID)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrClaimNotFound)
+	require.Len(t, writer.written, 1, "the persist attempt still happens after the initial read")
+	require.Equal(t, 1, metrics.VerifyVerdictCount("error"))
+	require.Equal(t, 0, metrics.VerifyVerdictCount("verified"))
+	require.Empty(t, audit.entries, "successful verification audit must not emit when persistence matched no rows")
+}
+
 // TestVerifyClaimVerifierError verifies that a verifier failure propagates as
 // an error, leaves the claim unchanged, and emits the "error" metric.
 func TestVerifyClaimVerifierError(t *testing.T) {

--- a/internal/service/factservice/promote.go
+++ b/internal/service/factservice/promote.go
@@ -656,8 +656,7 @@ func (s *promoteClaimServiceImpl) createNewFact(
 		if err != nil {
 			return fmt.Errorf("create fact node: %w", err)
 		}
-		_, err = result.Consume(ctx)
-		return err
+		return consumeRequiredPromotionWrite(ctx, result)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("promote: persist new fact: %w", err)
@@ -689,9 +688,26 @@ func (s *promoteClaimServiceImpl) linkClaimToExistingFact(
 		if err != nil {
 			return fmt.Errorf("link claim to existing fact: %w", err)
 		}
-		_, err = result.Consume(ctx)
-		return err
+		return consumeRequiredPromotionWrite(ctx, result)
 	})
+}
+
+func consumeRequiredPromotionWrite(ctx context.Context, result neo4j.ResultWithContext) error {
+	if result == nil {
+		return ErrClaimNotFound
+	}
+	summary, err := result.Consume(ctx)
+	if err != nil {
+		return err
+	}
+	if !promotionSummaryContainsUpdates(summary) {
+		return ErrClaimNotFound
+	}
+	return nil
+}
+
+func promotionSummaryContainsUpdates(summary neo4j.ResultSummary) bool {
+	return summary != nil && summary.Counters() != nil && summary.Counters().ContainsUpdates()
 }
 
 // loadClaim retrieves a Claim from Neo4j, including its supporting fragment

--- a/internal/service/factservice/promote_test.go
+++ b/internal/service/factservice/promote_test.go
@@ -64,6 +64,43 @@ func (s *stubPromoteDB) ScopedWriteTx(
 
 var _ promoteDB = (*stubPromoteDB)(nil)
 
+type promotionStubResultSummary struct {
+	counters neo4j.Counters
+}
+
+func (s promotionStubResultSummary) Server() neo4j.ServerInfo { return nil }
+func (s promotionStubResultSummary) Query() neo4j.Query       { return nil }
+func (s promotionStubResultSummary) StatementType() neo4j.StatementType {
+	return neo4j.StatementTypeUnknown
+}
+func (s promotionStubResultSummary) Counters() neo4j.Counters                  { return s.counters }
+func (s promotionStubResultSummary) Plan() neo4j.Plan                          { return nil }
+func (s promotionStubResultSummary) Profile() neo4j.ProfiledPlan               { return nil }
+func (s promotionStubResultSummary) Notifications() []neo4j.Notification       { return nil }
+func (s promotionStubResultSummary) GqlStatusObjects() []neo4j.GqlStatusObject { return nil }
+func (s promotionStubResultSummary) ResultAvailableAfter() time.Duration       { return 0 }
+func (s promotionStubResultSummary) ResultConsumedAfter() time.Duration        { return 0 }
+func (s promotionStubResultSummary) Database() neo4j.DatabaseInfo              { return nil }
+
+type promotionStubCounters struct {
+	containsUpdates bool
+}
+
+func (c promotionStubCounters) ContainsUpdates() bool       { return c.containsUpdates }
+func (c promotionStubCounters) NodesCreated() int           { return 0 }
+func (c promotionStubCounters) NodesDeleted() int           { return 0 }
+func (c promotionStubCounters) RelationshipsCreated() int   { return 0 }
+func (c promotionStubCounters) RelationshipsDeleted() int   { return 0 }
+func (c promotionStubCounters) PropertiesSet() int          { return 0 }
+func (c promotionStubCounters) LabelsAdded() int            { return 0 }
+func (c promotionStubCounters) LabelsRemoved() int          { return 0 }
+func (c promotionStubCounters) IndexesAdded() int           { return 0 }
+func (c promotionStubCounters) IndexesRemoved() int         { return 0 }
+func (c promotionStubCounters) ConstraintsAdded() int       { return 0 }
+func (c promotionStubCounters) ConstraintsRemoved() int     { return 0 }
+func (c promotionStubCounters) SystemUpdates() int          { return 0 }
+func (c promotionStubCounters) ContainsSystemUpdates() bool { return false }
+
 // stubClaimLocker implements postgresstorage.ClaimLocker for unit tests.
 //
 // It immediately invokes fn with a nil *gorm.DB — the promotion algorithm
@@ -359,6 +396,17 @@ func TestPromoteQueriesUseJSONClassificationStorage(t *testing.T) {
 	require.Contains(t, loadClaimForPromoteCypher, "c.classification_json             AS classification_json")
 	require.Contains(t, idempotencyCheckCypher, "f.classification_json            AS classification_json")
 	require.Contains(t, createFactAndEdgeCypher, "classification_json:           $classificationJSON")
+}
+
+func TestPromotionSummaryContainsUpdates(t *testing.T) {
+	require.False(t, promotionSummaryContainsUpdates(nil))
+	require.False(t, promotionSummaryContainsUpdates(promotionStubResultSummary{}))
+	require.False(t, promotionSummaryContainsUpdates(promotionStubResultSummary{
+		counters: promotionStubCounters{},
+	}))
+	require.True(t, promotionSummaryContainsUpdates(promotionStubResultSummary{
+		counters: promotionStubCounters{containsUpdates: true},
+	}))
 }
 
 func TestConfirmMemoryDecisionBranches(t *testing.T) {

--- a/internal/service/telemetry_service.go
+++ b/internal/service/telemetry_service.go
@@ -89,6 +89,7 @@ type TelemetryPoint struct {
 type PrometheusTelemetryService struct {
 	baseURL string
 	client  *http.Client
+	timeout time.Duration
 	now     func() time.Time
 }
 
@@ -99,6 +100,7 @@ func NewPrometheusTelemetryService(baseURL string, timeout time.Duration) *Prome
 	return &PrometheusTelemetryService{
 		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
 		client:  &http.Client{Timeout: timeout},
+		timeout: timeout,
 		now:     time.Now,
 	}
 }
@@ -141,11 +143,14 @@ func (s *PrometheusTelemetryService) Snapshot(ctx context.Context, filter Teleme
 		return snapshot, nil
 	}
 
+	queryCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
 	selector := telemetrySelector(scope, nil)
 	cardSpecs := telemetryCardSpecs(scope, windowKey)
 	cards := make([]TelemetryCard, 0, len(cardSpecs))
 	for _, spec := range cardSpecs {
-		value, queryErr := s.queryInstant(ctx, spec.Query)
+		value, queryErr := s.queryInstant(queryCtx, spec.Query)
 		if queryErr != nil {
 			snapshot.Message = "telemetry backend query failed"
 			return snapshot, nil
@@ -156,7 +161,7 @@ func (s *PrometheusTelemetryService) Snapshot(ctx context.Context, filter Teleme
 	seriesSpecs := telemetrySeriesSpecs(selector, windowDef.Rate)
 	series := make([]TelemetrySeries, 0, len(seriesSpecs))
 	for _, spec := range seriesSpecs {
-		points, queryErr := s.queryRange(ctx, spec.Query, from, to, windowDef.Step)
+		points, queryErr := s.queryRange(queryCtx, spec.Query, from, to, windowDef.Step)
 		if queryErr != nil {
 			snapshot.Message = "telemetry backend query failed"
 			return snapshot, nil

--- a/internal/service/telemetry_service_test.go
+++ b/internal/service/telemetry_service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -88,10 +89,41 @@ func TestPrometheusTelemetryService_RejectsInvalidWindow(t *testing.T) {
 	require.Contains(t, err.Error(), "window must be one of")
 }
 
+func TestPrometheusTelemetryService_SnapshotTimeoutBoundsSequentialQueries(t *testing.T) {
+	var requests atomic.Int32
+	prom := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		time.Sleep(25 * time.Millisecond)
+		switch r.URL.Path {
+		case "/api/v1/query":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"result":[{"value":[1770000000,"42"]}]}}`))
+		case "/api/v1/query_range":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"result":[{"values":[[1770000000,"0.5"]]}]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer prom.Close()
+
+	svc := NewPrometheusTelemetryService(prom.URL, 60*time.Millisecond)
+	svc.now = func() time.Time { return time.Unix(1770000060, 0).UTC() }
+
+	start := time.Now()
+	snapshot, err := svc.Snapshot(context.Background(), TelemetryFilter{Window: "15m", Scope: "system"})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.False(t, snapshot.Available)
+	require.Equal(t, "telemetry backend query failed", snapshot.Message)
+	require.Less(t, elapsed, 250*time.Millisecond)
+	require.Less(t, requests.Load(), int32(len(telemetryCardSpecs(TelemetryScope{Type: "system"}, "15m"))))
+}
+
 func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 	svc := NewPrometheusTelemetryService(" https://prom.example.test/ ", 0)
 	require.Equal(t, "https://prom.example.test", svc.baseURL)
 	require.Equal(t, 5*time.Second, svc.client.Timeout)
+	require.Equal(t, 5*time.Second, svc.timeout)
 
 	snapshot, err := (*PrometheusTelemetryService)(nil).Snapshot(context.Background(), TelemetryFilter{})
 	require.NoError(t, err)

--- a/internal/tools/registry/validation.go
+++ b/internal/tools/registry/validation.go
@@ -42,6 +42,14 @@ func ValidateInput(tool Tool, args map[string]any) error {
 	return nil
 }
 
+// StripTenantOverrideArgs removes caller-supplied tenant selectors from tool
+// arguments. Transports derive scope from authenticated context, not request
+// bodies.
+func StripTenantOverrideArgs(args map[string]any) {
+	delete(args, "team_id")
+	delete(args, "profile_id")
+}
+
 func validateSchemaValue(name string, value any, schema map[string]any) error {
 	expected, _ := schema["type"].(string)
 	switch expected {


### PR DESCRIPTION
## Summary

- Cache generated OpenAPI specs per handler instance.
- Strip tenant override fields before strict tool input validation in HTTP and MCP transports.
- Expand audit redaction to nested payloads, metadata, camelCase/suffixed secret fields, and array/map values.
- Treat Neo4j writes that report no updates as not-found paths for claim verification and promotion.
- Bound Prometheus telemetry snapshot queries with the configured timeout.

## Validation

- `git diff --check`
- `go test ./...`
- `npm run --prefix .lint lint:lines`
- Pre-push hook passed with coverage at 90.0% against the 90.0% requirement.