### PR TITLE
[codex] Add MCP team context discovery

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,15 @@
+name: CI Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  go-unit:
+    name: Go unit tests
+    uses: ./.github/workflows/ci-shared.yml

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,15 @@
+name: CI Push
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  go-unit:
+    name: Go unit tests
+    uses: ./.github/workflows/ci-shared.yml

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -1,14 +1,7 @@
-name: CI
+name: CI Shared
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -3,7 +3,7 @@ name: Release prerelease
 on:
   workflow_run:
     workflows:
-      - CI
+      - CI Push
     types:
       - completed
     branches:

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -64,7 +64,12 @@ func (h *MCPHandler) HandlePost(c echo.Context) error {
 		return httperr.New(httperr.VALIDATION_ERROR, "request body is required")
 	}
 
-	server := mcp.NewServerWithScopes(h.reg, profileID.String(), principal.Scopes, h.logger)
+	team := mcp.TeamContext{}
+	if resolvedTeam, ok := middleware.GetResolvedTeamContext(ctx); ok {
+		team.Name = resolvedTeam.Name
+		team.Description = resolvedTeam.Description
+	}
+	server := mcp.NewServerWithScopesAndTeamContext(h.reg, profileID.String(), principal.Scopes, team, h.logger)
 	responsePayload := server.HandlePayload(ctx, payload)
 
 	if acceptsEventStream(c.Request().Header.Get("Accept")) {

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -42,6 +42,35 @@ func TestMCPHandlerPostInitializeJSON(t *testing.T) {
 	require.Equal(t, "2024-11-05", result["protocolVersion"])
 }
 
+func TestMCPHandlerPostInitializeUsesResolvedTeamContext(t *testing.T) {
+	h := NewMCPHandler(registry.New(), testMCPLogger())
+	e := echo.New()
+	profileID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	ctx := middleware.SetResolvedTeamContextForTest(req.Context(), middleware.ResolvedTeamContext{
+		ID:          profileID,
+		Name:        "Dense-Mem Project",
+		Description: "Project memory only",
+	})
+	ctx = middleware.SetPrincipalForTest(ctx, &middleware.Principal{TeamID: profileID, Scopes: []string{"read"}})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.HandlePost(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	result := resp["result"].(map[string]any)
+	serverInfo := result["serverInfo"].(map[string]any)
+	require.Equal(t, "dense-mem-dense-mem-project", serverInfo["name"])
+	require.Contains(t, serverInfo["description"], "Project memory only")
+	require.Contains(t, result["instructions"], "Dense-Mem Project")
+}
+
 func TestMCPHandlerPostToolCallUsesAuthenticatedProfile(t *testing.T) {
 	reg := registry.New()
 	profileID := uuid.New()

--- a/internal/http/middleware/profile_resolution.go
+++ b/internal/http/middleware/profile_resolution.go
@@ -24,6 +24,18 @@ type ProfileResolutionServiceInterface interface {
 // Using a typed context key prevents accidental overwrites from other packages.
 type ResolvedProfileKey struct{}
 
+// ResolvedTeamContextKey is the typed context key for storing the resolved team
+// metadata needed by downstream MCP surfaces.
+type ResolvedTeamContextKey struct{}
+
+// ResolvedTeamContext contains non-secret team metadata resolved from the
+// authenticated API key or route. It is safe to expose to authenticated callers.
+type ResolvedTeamContext struct {
+	ID          uuid.UUID
+	Name        string
+	Description string
+}
+
 // TeamIDHeader is the HTTP header for explicit team ID overrides in legacy clients.
 const TeamIDHeader = "X-Team-ID"
 
@@ -128,9 +140,14 @@ func ProfileResolutionMiddleware(svc ProfileResolutionServiceInterface) echo.Mid
 				return httperr.New(httperr.NOT_FOUND, "profile not found")
 			}
 
-			// Store resolved profile ID in context
-			// Use a dedicated typed key to prevent collisions
+			// Store resolved team ID and metadata in context.
+			// Use dedicated typed keys to prevent collisions.
 			resolvedCtx := context.WithValue(ctx, ResolvedProfileKey{}, profileID)
+			resolvedCtx = context.WithValue(resolvedCtx, ResolvedTeamContextKey{}, ResolvedTeamContext{
+				ID:          profileID,
+				Name:        profile.Name,
+				Description: profile.Description,
+			})
 			c.SetRequest(c.Request().WithContext(resolvedCtx))
 
 			// Continue to next handler
@@ -154,6 +171,12 @@ func GetResolvedProfileID(ctx context.Context) (uuid.UUID, bool) {
 // GetResolvedTeamID retrieves the resolved team ID from the context.
 func GetResolvedTeamID(ctx context.Context) (uuid.UUID, bool) {
 	return GetResolvedProfileID(ctx)
+}
+
+// GetResolvedTeamContext retrieves the resolved team metadata from the context.
+func GetResolvedTeamContext(ctx context.Context) (ResolvedTeamContext, bool) {
+	team, ok := ctx.Value(ResolvedTeamContextKey{}).(ResolvedTeamContext)
+	return team, ok
 }
 
 // MustGetResolvedProfileID retrieves the resolved profile ID from the context.
@@ -180,4 +203,12 @@ func SetResolvedProfileIDForTest(ctx context.Context, profileID uuid.UUID) conte
 // SetResolvedTeamIDForTest sets a resolved team ID in context for testing.
 func SetResolvedTeamIDForTest(ctx context.Context, teamID uuid.UUID) context.Context {
 	return SetResolvedProfileIDForTest(ctx, teamID)
+}
+
+// SetResolvedTeamContextForTest sets resolved team metadata in context for tests.
+func SetResolvedTeamContextForTest(ctx context.Context, team ResolvedTeamContext) context.Context {
+	if team.ID != uuid.Nil {
+		ctx = SetResolvedProfileIDForTest(ctx, team.ID)
+	}
+	return context.WithValue(ctx, ResolvedTeamContextKey{}, team)
 }

--- a/internal/http/middleware/profile_resolution_test.go
+++ b/internal/http/middleware/profile_resolution_test.go
@@ -333,10 +333,11 @@ func TestProfileResolution_StoresInContext(t *testing.T) {
 
 	profileID := uuid.New()
 	profile := &domain.Profile{
-		ID:        profileID,
-		Name:      "test-profile",
-		CreatedAt: time.Now().UTC(),
-		UpdatedAt: time.Now().UTC(),
+		ID:          profileID,
+		Name:        "test-profile",
+		Description: "Profile resolution test scope",
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
 	}
 
 	mockSvc := &mockProfileResolutionService{
@@ -346,11 +347,14 @@ func TestProfileResolution_StoresInContext(t *testing.T) {
 	}
 
 	var capturedID uuid.UUID
+	var capturedTeam ResolvedTeamContext
 	var found bool
+	var teamFound bool
 
 	e.GET("/api/v1/profiles/:profileId/test", func(c echo.Context) error {
 		ctx := c.Request().Context()
 		capturedID, found = GetResolvedProfileID(ctx)
+		capturedTeam, teamFound = GetResolvedTeamContext(ctx)
 		return c.String(http.StatusOK, "ok")
 	}, ProfileResolutionMiddleware(mockSvc))
 
@@ -362,6 +366,12 @@ func TestProfileResolution_StoresInContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.True(t, found, "profile ID should be found in context")
 	assert.Equal(t, profileID, capturedID)
+	assert.True(t, teamFound, "team context should be found in context")
+	assert.Equal(t, ResolvedTeamContext{
+		ID:          profileID,
+		Name:        "test-profile",
+		Description: "Profile resolution test scope",
+	}, capturedTeam)
 }
 
 // TestProfileResolution_ProfileNotFound tests that a non-existent profile
@@ -493,4 +503,23 @@ func TestProfileResolution_SetResolvedProfileIDForTest(t *testing.T) {
 	got, ok := GetResolvedProfileID(ctx)
 	require.True(t, ok)
 	assert.Equal(t, profileID, got)
+}
+
+func TestProfileResolution_SetResolvedTeamContextForTest(t *testing.T) {
+	teamID := uuid.New()
+	team := ResolvedTeamContext{
+		ID:          teamID,
+		Name:        "Dense-Mem Project",
+		Description: "Project memory only",
+	}
+
+	ctx := SetResolvedTeamContextForTest(context.Background(), team)
+
+	gotID, ok := GetResolvedProfileID(ctx)
+	require.True(t, ok)
+	assert.Equal(t, teamID, gotID)
+
+	gotTeam, ok := GetResolvedTeamContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, team, gotTeam)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/tools"
@@ -41,17 +42,37 @@ type Server struct {
 	registry  registry.Registry
 	profileID string
 	scopes    []string
+	team      TeamContext
 	logger    observability.LogProvider
+}
+
+// TeamContext is non-secret team metadata made visible in MCP discovery so
+// clients can distinguish multiple API-key-scoped Dense-Mem connections.
+type TeamContext struct {
+	Name        string
+	Description string
 }
 
 // NewServer constructs a Server bound to a registry and a fixed profile ID.
 func NewServer(reg registry.Registry, profileID string, logger observability.LogProvider) *Server {
-	return &Server{registry: reg, profileID: profileID, logger: logger}
+	return NewServerWithScopesAndTeamContext(reg, profileID, nil, TeamContext{}, logger)
 }
 
 // NewServerWithScopes constructs a Server that filters visible/callable tools by scope.
 func NewServerWithScopes(reg registry.Registry, profileID string, scopes []string, logger observability.LogProvider) *Server {
-	return &Server{registry: reg, profileID: profileID, scopes: append([]string(nil), scopes...), logger: logger}
+	return NewServerWithScopesAndTeamContext(reg, profileID, scopes, TeamContext{}, logger)
+}
+
+// NewServerWithScopesAndTeamContext constructs a Server with request-scoped team
+// metadata for MCP discovery surfaces.
+func NewServerWithScopesAndTeamContext(reg registry.Registry, profileID string, scopes []string, team TeamContext, logger observability.LogProvider) *Server {
+	return &Server{
+		registry:  reg,
+		profileID: profileID,
+		scopes:    append([]string(nil), scopes...),
+		team:      normalizeTeamContext(team),
+		logger:    logger,
+	}
 }
 
 // rpcRequest mirrors the incoming JSON-RPC 2.0 envelope.
@@ -107,16 +128,28 @@ func (s *Server) dispatch(ctx context.Context, req rpcRequest) rpcResponse {
 
 // handleInitialize returns the server's capability block.
 func (s *Server) handleInitialize() map[string]any {
-	return map[string]any{
+	serverInfo := map[string]any{
+		"name":    s.serverName(),
+		"version": ServerVersion,
+	}
+	if s.team.Name != "" {
+		serverInfo["title"] = fmt.Sprintf("Dense-Mem: %s", s.team.Name)
+	}
+	if description := s.serverDescription(); description != "" {
+		serverInfo["description"] = description
+	}
+
+	out := map[string]any{
 		"protocolVersion": ProtocolVersion,
 		"capabilities": map[string]any{
 			"tools": map[string]any{},
 		},
-		"serverInfo": map[string]any{
-			"name":    ServerName,
-			"version": ServerVersion,
-		},
+		"serverInfo": serverInfo,
 	}
+	if instructions := s.instructions(); instructions != "" {
+		out["instructions"] = instructions
+	}
+	return out
 }
 
 // handleToolsList returns registered tools mapped to MCP tool descriptors.
@@ -134,7 +167,7 @@ func (s *Server) handleToolsList() map[string]any {
 		}
 		out = append(out, map[string]any{
 			"name":        t.Name,
-			"description": t.Description,
+			"description": s.toolDescription(t.Description),
 			"inputSchema": schema,
 		})
 	}
@@ -221,6 +254,100 @@ func (s *Server) canUseTool(tool registry.Tool) bool {
 		}
 	}
 	return true
+}
+
+func (s *Server) serverName() string {
+	if s.team.Name == "" {
+		return ServerName
+	}
+	slug := slugifyMCPName(s.team.Name)
+	if slug == "" {
+		return ServerName
+	}
+	return ServerName + "-" + slug
+}
+
+func (s *Server) serverDescription() string {
+	if s.team.Name == "" && s.team.Description == "" {
+		return ""
+	}
+	name := s.teamDisplayName()
+	if s.team.Description == "" {
+		return fmt.Sprintf("Dense-Mem MCP server for team %q.", name)
+	}
+	return fmt.Sprintf("Dense-Mem MCP server for team %q. Scope description: %s", name, s.team.Description)
+}
+
+func (s *Server) instructions() string {
+	if s.team.Name == "" && s.team.Description == "" {
+		return ""
+	}
+	name := s.teamDisplayName()
+	parts := []string{
+		fmt.Sprintf("Use this Dense-Mem MCP connection only for memories, evidence, claims, facts, recall, and knowledge operations that belong to the %q team.", name),
+		"Use a personal memory MCP for unrelated personal identity, private-life facts, and cross-project preferences.",
+		"If a memory could belong to both this team and a personal memory, ask before writing.",
+	}
+	if s.team.Description != "" {
+		parts = append(parts, "Team scope description: "+s.team.Description)
+	}
+	return strings.Join(parts, " ")
+}
+
+func (s *Server) toolDescription(description string) string {
+	if s.team.Name == "" && s.team.Description == "" {
+		return description
+	}
+
+	prefixParts := []string{
+		fmt.Sprintf("Dense-Mem team scope: %s.", s.teamDisplayName()),
+		"Use this MCP only for memory and knowledge belonging to this team; use personal memory MCPs for unrelated personal facts.",
+	}
+	if s.team.Description != "" {
+		prefixParts = append(prefixParts, "Scope description: "+s.team.Description)
+	}
+	prefix := strings.Join(prefixParts, " ")
+	if strings.TrimSpace(description) == "" {
+		return prefix
+	}
+	return prefix + " " + description
+}
+
+func (s *Server) teamDisplayName() string {
+	if s.team.Name != "" {
+		return s.team.Name
+	}
+	return "this team"
+}
+
+func normalizeTeamContext(team TeamContext) TeamContext {
+	return TeamContext{
+		Name:        normalizeMCPText(team.Name),
+		Description: normalizeMCPText(team.Description),
+	}
+}
+
+func normalizeMCPText(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func slugifyMCPName(value string) string {
+	value = strings.ToLower(value)
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range value {
+		isAlnum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlnum {
+			b.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen && b.Len() > 0 {
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func okResponse(id json.RawMessage, result any) rpcResponse {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -140,6 +140,49 @@ func TestMCP_Initialize(t *testing.T) {
 	if info["name"] != ServerName {
 		t.Errorf("serverInfo.name = %v; want %v", info["name"], ServerName)
 	}
+	if _, ok := result["instructions"]; ok {
+		t.Errorf("legacy initialize unexpectedly included team instructions: %v", result["instructions"])
+	}
+}
+
+func TestMCP_InitializeIncludesTeamContext(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	s := NewServerWithScopesAndTeamContext(reg, "pA", nil, TeamContext{
+		Name:        "Dense-Mem Project",
+		Description: "Project memory only",
+	}, logger)
+
+	out := runRPC(t, s, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	var resp rpcResp
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v — out=%q", err, out)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result unmarshal: %v", err)
+	}
+
+	info, _ := result["serverInfo"].(map[string]any)
+	if info["name"] != "dense-mem-dense-mem-project" {
+		t.Errorf("serverInfo.name = %v; want dense-mem-dense-mem-project", info["name"])
+	}
+	if info["title"] != "Dense-Mem: Dense-Mem Project" {
+		t.Errorf("serverInfo.title = %v", info["title"])
+	}
+	description, _ := info["description"].(string)
+	if !strings.Contains(description, "Project memory only") {
+		t.Errorf("serverInfo.description missing team description: %q", description)
+	}
+	instructions, _ := result["instructions"].(string)
+	for _, want := range []string{"Dense-Mem Project", "personal memory MCP", "ask before writing"} {
+		if !strings.Contains(instructions, want) {
+			t.Errorf("instructions missing %q: %q", want, instructions)
+		}
+	}
 }
 
 func TestMCP_ToolsListMirrorsRegistry(t *testing.T) {
@@ -184,6 +227,50 @@ func TestMCP_ToolsListMirrorsRegistry(t *testing.T) {
 	}
 	if _, ok := payload.Tools[0]["inputSchema"]; !ok {
 		t.Errorf("missing inputSchema")
+	}
+}
+
+func TestMCP_ToolsListIncludesTeamContextWithoutMutatingRegistry(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	_ = reg.Register(registry.Tool{
+		Name:        "remember",
+		Description: "Store durable memory.",
+		InputSchema: map[string]any{"type": "object"},
+	})
+	s := NewServerWithScopesAndTeamContext(reg, "pA", nil, TeamContext{
+		Name:        "Dense-Mem Project",
+		Description: "Project memory only",
+	}, logger)
+
+	out := runRPC(t, s, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	var resp rpcResp
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var payload struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Result, &payload); err != nil {
+		t.Fatalf("result unmarshal: %v", err)
+	}
+	if len(payload.Tools) != 1 {
+		t.Fatalf("tools count = %d; want 1", len(payload.Tools))
+	}
+
+	description, _ := payload.Tools[0]["description"].(string)
+	for _, want := range []string{"Dense-Mem team scope: Dense-Mem Project", "Project memory only", "Store durable memory."} {
+		if !strings.Contains(description, want) {
+			t.Errorf("tool description missing %q: %q", want, description)
+		}
+	}
+
+	tool, ok := reg.Get("remember")
+	if !ok {
+		t.Fatal("remember not registered")
+	}
+	if tool.Description != "Store durable memory." {
+		t.Fatalf("registry description was mutated: %q", tool.Description)
 	}
 }
 

--- a/packages/mcp-proxy/README.md
+++ b/packages/mcp-proxy/README.md
@@ -42,8 +42,12 @@ redact Authorization headers and Dense-Mem API keys.
 
 ## Codex Desktop
 
+Use a team-specific config key when one client connects to multiple Dense-Mem
+teams. Dense-Mem also returns the authenticated team name and description through
+MCP discovery, but many clients display or namespace tools by this local key.
+
 ```toml
-[mcp_servers.dense_mem]
+[mcp_servers.dense_mem_primary_memory]
 command = "npx"
 args = ["-y", "dense-mem-mcp-proxy"]
 env = { DENSE_MEM_MCP_URL = "http://127.0.0.1:8080/mcp", DENSE_MEM_API_KEY = "dm_live_..." }
@@ -56,7 +60,7 @@ enabled = true
 ```json
 {
   "mcpServers": {
-    "dense_mem": {
+    "dense_mem_primary_memory": {
       "command": "npx",
       "args": ["-y", "dense-mem-mcp-proxy"],
       "env": {


### PR DESCRIPTION
## Summary

- Expose API-key-scoped team name and description through MCP `initialize` metadata and instructions.
- Prefix `tools/list` descriptions with the authenticated Dense-Mem team scope so LLM clients can route memory writes more accurately.
- Keep registry tool definitions immutable and add proxy docs recommending team-specific MCP config keys for multiple Dense-Mem connections.

## Why

When a client has multiple memory MCP servers, Dense-Mem needs to make the authenticated team boundary visible to the LLM before tool selection. The team description already exists in the API model, but it was not previously surfaced through MCP discovery.

## Validation

- `go test ./internal/mcp ./internal/http/handler ./internal/http/middleware`
- `npm test --prefix packages/mcp-proxy`
- `go test ./...`
- `git diff --check`
- Pre-push checks passed, including repository coverage threshold.