### PR TITLE
[codex] Fix prerelease trigger for CI Push

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -3,7 +3,6 @@ name: Release prerelease
 on:
   workflow_run:
     workflows:
-      - CI
       - CI Push
     types:
       - completed

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - CI
+      - CI Push
     types:
       - completed
     branches:


### PR DESCRIPTION
## Summary

- Update the default-branch prerelease workflow listener to match the current `CI Push` workflow name.
- Remove the old `CI` listener to avoid duplicate prerelease triggers if both old and new CI workflows ever exist on `dev` at the same time.

## Why

`Release prerelease` is triggered by `workflow_run`, and GitHub registers that trigger from the default branch. `main` was still listening for `CI`, while `dev` merge/direct-push validation now runs as `CI Push`, so successful pushes to `dev` did not create a prerelease run.

## Expected behavior after merge

- Merging a feature PR into `dev` runs `CI Push`, then triggers `Release prerelease`.
- Direct pushes to `dev` run `CI Push`, then triggers `Release prerelease`.
- Merging a PR into `main` does not create a prerelease because the workflow_run branch filter remains `dev`.

## Validation

- `git diff --check`
- Pre-push checks passed, including textlint, Go tests, and coverage threshold.