### PR TITLE
[codex] Redesign dashboard portals

### DIFF
--- a/tests/uat/control-portal-live.spec.ts
+++ b/tests/uat/control-portal-live.spec.ts
@@ -6,7 +6,7 @@
  * backend, with API cleanup for the disposable team.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const CONTROL_BASE_URL = process.env.CONTROL_BASE_URL || 'http://127.0.0.1:8090';
 const CONTROL_PORTAL_TOKEN = process.env.CONTROL_PORTAL_TOKEN || '';
@@ -54,6 +54,7 @@ test('control portal creates, displays, and deletes a read-only team profile', a
     await page.getByLabel('Control token').fill(CONTROL_PORTAL_TOKEN);
     await page.getByRole('button', { name: 'Unlock' }).click();
     await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+    await expectNoShellOverlap(page);
 
     await page.getByLabel('Name').first().fill(teamName);
     await page.getByLabel('Description').first().fill('live portal UAT team');
@@ -65,6 +66,7 @@ test('control portal creates, displays, and deletes a read-only team profile', a
 
     await page.getByRole('button', { name: /Profiles & API Keys/ }).click();
     await expect(page.getByRole('heading', { name: 'Profiles' })).toBeVisible();
+    await expectNoShellOverlap(page);
     await page.getByLabel('Profile name').fill(profileName);
     await page.getByLabel('Permission').selectOption('read');
     await page.getByLabel('Rate limit').fill('120');
@@ -91,3 +93,36 @@ test('control portal creates, displays, and deletes a read-only team profile', a
     }
   }
 });
+
+async function expectNoShellOverlap(page: Page) {
+  const boxes = await page.locator('.topbar, .control-sidebar, .detail-pane').evaluateAll((elements) => (
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        className: element.className,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+  ));
+  for (const box of boxes) {
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+  }
+  for (let i = 0; i < boxes.length; i += 1) {
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      expect(rectanglesOverlap(boxes[i], boxes[j]), `${boxes[i].className} overlaps ${boxes[j].className}`).toBe(false);
+    }
+  }
+}
+
+function rectanglesOverlap(
+  first: { left: number; top: number; right: number; bottom: number },
+  second: { left: number; top: number; right: number; bottom: number },
+) {
+  return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import { TeamProfile, ControlApi, CreatedTeamProfile, ProfileRole, Team } from "
 import { MetricsPanel } from "./control/MetricsPanel";
 import { SecurityPanel } from "./control/SecurityPanel";
 import { displayKeySuffix, formatDate, profilePermissionLabel, profileRoleLabel, readError, shortId } from "./control/utils";
+import { AuthShell, PortalShell, SectionHeading } from "./ui/components";
 
 const TOKEN_STORAGE_KEY = "denseMem.controlToken";
 const THEME_STORAGE_KEY = "denseMem.controlTheme";
@@ -71,35 +72,36 @@ export function App() {
 
   if (!api) {
     return (
-      <main className="auth-shell" data-theme={theme}>
-        <form className="auth-panel" onSubmit={submitToken}>
-          <div className="brand-row">
-            <span className="brand-mark"><ShieldCheck size={20} aria-hidden="true" /></span>
-            <h1>Dense-Mem Control</h1>
-            <button
-              className="icon-button theme-toggle"
-              type="button"
-              aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-              onClick={toggleTheme}
-            >
-              {theme === "dark" ? <Sun size={17} aria-hidden="true" /> : <Moon size={17} aria-hidden="true" />}
-            </button>
-          </div>
-          <label htmlFor="portal-token">Control token</label>
-          <input
-            id="portal-token"
-            type="password"
-            value={draftToken}
-            onChange={(event) => setDraftToken(event.target.value)}
-            autoComplete="current-password"
-          />
-          {authError && <p className="field-error" role="alert">{authError}</p>}
-          <button className="primary-button" type="submit">
-            <ShieldCheck size={17} aria-hidden="true" />
-            Unlock
+      <AuthShell
+        theme={theme}
+        title="Dense-Mem Control"
+        icon={<ShieldCheck size={20} aria-hidden="true" />}
+        onSubmit={submitToken}
+        actions={(
+          <button
+            className="icon-button theme-toggle"
+            type="button"
+            aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            onClick={toggleTheme}
+          >
+            {theme === "dark" ? <Sun size={17} aria-hidden="true" /> : <Moon size={17} aria-hidden="true" />}
           </button>
-        </form>
-      </main>
+        )}
+      >
+        <label htmlFor="portal-token">Control token</label>
+        <input
+          id="portal-token"
+          type="password"
+          value={draftToken}
+          onChange={(event) => setDraftToken(event.target.value)}
+          autoComplete="current-password"
+        />
+        {authError && <p className="field-error" role="alert">{authError}</p>}
+        <button className="primary-button" type="submit">
+          <ShieldCheck size={17} aria-hidden="true" />
+          Unlock
+        </button>
+      </AuthShell>
     );
   }
 
@@ -149,13 +151,12 @@ function Portal({
   const selectedTeam = teams.find((team) => team.id === selectedTeamId) ?? null;
 
   return (
-    <main className="app-shell" data-theme={theme}>
-      <header className="topbar">
-        <div className="brand-row">
-          <span className="brand-mark"><ShieldCheck size={20} aria-hidden="true" /></span>
-          <h1>Dense-Mem Control</h1>
-        </div>
-        <div className="topbar-actions">
+    <PortalShell
+      theme={theme}
+      title="Dense-Mem Control"
+      icon={<ShieldCheck size={20} aria-hidden="true" />}
+      topbarActions={(
+        <>
           <button
             className="icon-button"
             type="button"
@@ -172,96 +173,79 @@ function Portal({
             <LogOut size={17} aria-hidden="true" />
             Sign out
           </button>
-        </div>
-      </header>
-
-      {error && <div className="banner error" role="alert">{error}</div>}
-
-      <section className="workspace">
-        <aside className="control-sidebar" aria-label="Control navigation">
-          <nav className="portal-tabs" aria-label="Portal sections">
-            <button
-              className={activeTab === "teams" ? "tab-button active" : "tab-button"}
-              type="button"
-              aria-current={activeTab === "teams" ? "page" : undefined}
-              onClick={() => setActiveTab("teams")}
-            >
-              <Users size={17} aria-hidden="true" />
-              Teams
-            </button>
-            <button
-              className={activeTab === "metrics" ? "tab-button active" : "tab-button"}
-              type="button"
-              aria-current={activeTab === "metrics" ? "page" : undefined}
-              onClick={() => setActiveTab("metrics")}
-            >
-              <BarChart3 size={17} aria-hidden="true" />
-              Metrics
-            </button>
-            <button
-              className={activeTab === "profiles" ? "tab-button active" : "tab-button"}
-              type="button"
-              aria-current={activeTab === "profiles" ? "page" : undefined}
-              disabled={!selectedTeam}
-              onClick={() => setActiveTab("profiles")}
-            >
-              <KeyRound size={17} aria-hidden="true" />
-              Profiles & API Keys
-            </button>
-            <button
-              className={activeTab === "security" ? "tab-button active" : "tab-button"}
-              type="button"
-              aria-current={activeTab === "security" ? "page" : undefined}
-              onClick={() => setActiveTab("security")}
-            >
-              <Ban size={17} aria-hidden="true" />
-              IP Bans
-            </button>
-          </nav>
-
-          <div className="section-heading">
-            <h2>Teams</h2>
-            <span>{teams.length}</span>
-          </div>
-          <TeamSelectList
-            teams={teams}
-            selectedTeamId={selectedTeamId}
-            loading={loadState === "loading"}
-            onSelect={setSelectedTeamId}
-          />
-        </aside>
-
-        <section className="detail-pane" aria-label="Team details">
-          {activeTab === "teams" && (
-            <>
-              <section className="surface">
-                <div className="section-heading">
-                  <h2>Create team</h2>
-                </div>
-                <TeamCreateForm api={api} onCreated={(team) => void loadTeams(team.id)} />
-              </section>
-              {selectedTeam ? (
-                <TeamEditor
-                  api={api}
-                  team={selectedTeam}
-                  onUpdated={(team) => {
-                    setTeams((current) => current.map((item) => (item.id === team.id ? team : item)));
-                  }}
-                  onDeleted={() => void loadTeams()}
-                />
-              ) : (
-                <div className="empty-state">{loadState === "loading" ? "Loading" : "No teams"}</div>
-              )}
-            </>
+        </>
+      )}
+      navLabel="Control navigation"
+      navItems={[
+        {
+          id: "teams",
+          label: "Teams",
+          icon: <Users size={17} aria-hidden="true" />,
+          active: activeTab === "teams",
+          onClick: () => setActiveTab("teams"),
+        },
+        {
+          id: "metrics",
+          label: "Metrics",
+          icon: <BarChart3 size={17} aria-hidden="true" />,
+          active: activeTab === "metrics",
+          onClick: () => setActiveTab("metrics"),
+        },
+        {
+          id: "profiles",
+          label: "Profiles & API Keys",
+          icon: <KeyRound size={17} aria-hidden="true" />,
+          active: activeTab === "profiles",
+          disabled: !selectedTeam,
+          onClick: () => setActiveTab("profiles"),
+        },
+        {
+          id: "security",
+          label: "IP Bans",
+          icon: <Ban size={17} aria-hidden="true" />,
+          active: activeTab === "security",
+          onClick: () => setActiveTab("security"),
+        },
+      ]}
+      sidebarTitle="Teams"
+      sidebarMeta={teams.length}
+      sidebarBody={(
+        <TeamSelectList
+          teams={teams}
+          selectedTeamId={selectedTeamId}
+          loading={loadState === "loading"}
+          onSelect={setSelectedTeamId}
+        />
+      )}
+      detailLabel="Team details"
+      error={error}
+    >
+      {activeTab === "teams" && (
+        <>
+          <section className="surface">
+            <SectionHeading title="Create team" />
+            <TeamCreateForm api={api} onCreated={(team) => void loadTeams(team.id)} />
+          </section>
+          {selectedTeam ? (
+            <TeamEditor
+              api={api}
+              team={selectedTeam}
+              onUpdated={(team) => {
+                setTeams((current) => current.map((item) => (item.id === team.id ? team : item)));
+              }}
+              onDeleted={() => void loadTeams()}
+            />
+          ) : (
+            <div className="empty-state">{loadState === "loading" ? "Loading" : "No teams"}</div>
           )}
-          {activeTab === "profiles" && (
-            selectedTeam ? <TeamProfilesPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
-          )}
-          {activeTab === "metrics" && <MetricsPanel api={api} teams={teams} />}
-          {activeTab === "security" && <SecurityPanel api={api} />}
-        </section>
-      </section>
-    </main>
+        </>
+      )}
+      {activeTab === "profiles" && (
+        selectedTeam ? <TeamProfilesPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
+      )}
+      {activeTab === "metrics" && <MetricsPanel api={api} teams={teams} />}
+      {activeTab === "security" && <SecurityPanel api={api} />}
+    </PortalShell>
   );
 }
 
@@ -403,10 +387,7 @@ function TeamEditor({
 
   return (
     <section className="surface">
-      <div className="section-heading">
-        <h2>{team.name}</h2>
-        <span>{shortId(team.id)}</span>
-      </div>
+      <SectionHeading title={team.name} meta={shortId(team.id)} />
       <form className="edit-grid" onSubmit={save}>
         <label htmlFor="team-name">Name</label>
         <input id="team-name" value={name} onChange={(event) => setName(event.target.value)} />
@@ -532,10 +513,7 @@ function TeamProfilesPanel({ api, team }: { api: ControlApi; team: Team }) {
 
   return (
     <section className="surface">
-      <div className="section-heading">
-        <h2>Profiles</h2>
-        <span>{keys.length}</span>
-      </div>
+      <SectionHeading title="Profiles" meta={keys.length} />
       {createdKey && <CreatedKeyNotice createdKey={createdKey} onDismiss={() => setCreatedKey(null)} />}
       {error && <div className="banner error" role="alert">{error}</div>}
       <TeamProfileCreateForm

--- a/web/src/control/MetricsPanel.tsx
+++ b/web/src/control/MetricsPanel.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { ControlApi, ControlMetrics, Team, TeamProfile } from "../api";
 import { TelemetryDashboard } from "../telemetry/TelemetryDashboard";
 import { TelemetrySnapshot, TelemetryWindowKey } from "../telemetry/types";
+import { SectionHeading, SummaryCard } from "../ui/components";
 import { dependencyStatusClass, formatCount, formatDate, formatLatency, formatPercent, readError, shortId } from "./utils";
 
 type TelemetryControlScope = "system" | "team" | "profile";
@@ -154,15 +155,15 @@ export function MetricsPanel({ api, teams }: { api: ControlApi; teams: Team[] })
         )}
       />
 
-      <div className="section-heading">
-        <div>
-          <h2>Usage Rollup</h2>
-          {metrics && <p className="section-subtitle">{formatDate(metrics.window.from)} - {formatDate(metrics.window.to)}</p>}
-        </div>
-        <button className="icon-button" type="button" aria-label="Refresh metrics" onClick={() => void loadMetrics()} disabled={loading}>
-          <RefreshCw size={16} aria-hidden="true" />
-        </button>
-      </div>
+      <SectionHeading
+        title="Usage Rollup"
+        subtitle={metrics ? `${formatDate(metrics.window.from)} - ${formatDate(metrics.window.to)}` : undefined}
+        actions={(
+          <button className="icon-button" type="button" aria-label="Refresh metrics" onClick={() => void loadMetrics()} disabled={loading}>
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+        )}
+      />
       {error && <div className="banner error" role="alert">{error}</div>}
 
       <div className="metrics-toolbar">
@@ -203,26 +204,11 @@ export function MetricsPanel({ api, teams }: { api: ControlApi; teams: Team[] })
 function MetricsSummary({ metrics }: { metrics: ControlMetrics }) {
   return (
     <div className="metrics-summary" aria-label="Request metrics">
-      <div className="summary-item">
-        <span>Requests</span>
-        <strong>{formatCount(metrics.system.requests)}</strong>
-      </div>
-      <div className="summary-item">
-        <span>Errors</span>
-        <strong>{formatCount(metrics.system.errors)}</strong>
-      </div>
-      <div className="summary-item">
-        <span>Error rate</span>
-        <strong>{formatPercent(metrics.system.errors, metrics.system.requests)}</strong>
-      </div>
-      <div className="summary-item">
-        <span>Avg latency</span>
-        <strong>{formatLatency(metrics.system.avg_latency_ms)}</strong>
-      </div>
-      <div className="summary-item">
-        <span>Max latency</span>
-        <strong>{formatLatency(metrics.system.max_latency_ms)}</strong>
-      </div>
+      <SummaryCard label="Requests" value={formatCount(metrics.system.requests)} />
+      <SummaryCard label="Errors" value={formatCount(metrics.system.errors)} tone={metrics.system.errors > 0 ? "warning" : "neutral"} />
+      <SummaryCard label="Error rate" value={formatPercent(metrics.system.errors, metrics.system.requests)} />
+      <SummaryCard label="Avg latency" value={formatLatency(metrics.system.avg_latency_ms)} />
+      <SummaryCard label="Max latency" value={formatLatency(metrics.system.max_latency_ms)} />
     </div>
   );
 }
@@ -241,11 +227,13 @@ function DependencySummary({ dependencies }: { dependencies: ControlMetrics["dep
       </div>
       <div className="dependency-grid">
         {dependencies.map((dep) => (
-          <div className="summary-item" key={dep.name}>
-            <span>{dep.name}</span>
-            <strong><span className={`status-pill ${dependencyStatusClass(dep.status)}`}>{dep.status}</span></strong>
-            <small>{dep.latency_ms === null || dep.latency_ms === undefined ? "n/a" : formatLatency(dep.latency_ms)}</small>
-          </div>
+          <SummaryCard
+            key={dep.name}
+            label={dep.name}
+            value={<span className={`status-pill ${dependencyStatusClass(dep.status)}`}>{dep.status}</span>}
+            detail={dep.latency_ms === null || dep.latency_ms === undefined ? "n/a" : formatLatency(dep.latency_ms)}
+            tone={dep.status === "error" ? "danger" : dep.status === "degraded" ? "warning" : "neutral"}
+          />
         ))}
       </div>
     </div>

--- a/web/src/control/SecurityPanel.tsx
+++ b/web/src/control/SecurityPanel.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import { Ban, RefreshCw, Trash2 } from "lucide-react";
 import { ControlApi, SecurityBan, SecuritySettings } from "../api";
+import { SectionHeading, SummaryCard } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
 export function SecurityPanel({ api }: { api: ControlApi }) {
@@ -77,36 +78,24 @@ export function SecurityPanel({ api }: { api: ControlApi }) {
 
   return (
     <section className="surface security-panel">
-      <div className="section-heading">
-        <div>
-          <h2>IP Bans</h2>
-          <p className="section-subtitle">Review failed-auth bans, add manual bans, and clear strikes.</p>
-        </div>
-        <button className="icon-button" type="button" aria-label="Refresh security" onClick={() => void loadSecurity()} disabled={busy}>
-          <RefreshCw size={16} aria-hidden="true" />
-        </button>
-      </div>
+      <SectionHeading
+        title="IP Bans"
+        subtitle="Review failed-auth bans, add manual bans, and clear strikes."
+        actions={(
+          <button className="icon-button" type="button" aria-label="Refresh security" onClick={() => void loadSecurity()} disabled={busy}>
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+        )}
+      />
       {error && <div className="banner error" role="alert">{error}</div>}
 
       <div className="security-summary" aria-label="IP ban rules">
         {settings ? (
           <>
-            <div className="summary-item">
-              <span>Protection</span>
-              <strong>{settings.enabled ? "On" : "Off"}</strong>
-            </div>
-            <div className="summary-item">
-              <span>Threshold</span>
-              <strong>{settings.failure_threshold} failures</strong>
-            </div>
-            <div className="summary-item">
-              <span>Window</span>
-              <strong>{settings.failure_window_seconds}s</strong>
-            </div>
-            <div className="summary-item">
-              <span>Ban duration</span>
-              <strong>{settings.ban_duration_seconds === 0 ? "Permanent" : `${settings.ban_duration_seconds}s`}</strong>
-            </div>
+            <SummaryCard label="Protection" value={settings.enabled ? "On" : "Off"} />
+            <SummaryCard label="Threshold" value={`${settings.failure_threshold} failures`} />
+            <SummaryCard label="Window" value={`${settings.failure_window_seconds}s`} />
+            <SummaryCard label="Ban duration" value={settings.ban_duration_seconds === 0 ? "Permanent" : `${settings.ban_duration_seconds}s`} />
           </>
         ) : (
           <div className="table-placeholder compact">Loading rules</div>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
+import "./responsive.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -1,0 +1,144 @@
+@media (max-width: 1180px) {
+  .topbar,
+  .workspace,
+  .app-shell > .banner {
+    width: min(100% - 32px, 1040px);
+  }
+
+  .workspace {
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  }
+
+  .telemetry-card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    padding: 14px 0 28px;
+  }
+
+  .topbar,
+  .workspace {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .control-sidebar {
+    position: static;
+  }
+
+  .portal-tabs {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .tab-button {
+    justify-content: center;
+  }
+
+  .topbar-actions {
+    justify-content: start;
+  }
+
+  .edit-grid,
+  .key-form,
+  .security-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .security-summary,
+  .metrics-summary,
+  .dependency-grid,
+  .telemetry-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metrics-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .search-form,
+  .key-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .topbar,
+  .workspace,
+  .app-shell > .banner {
+    width: calc(100vw - 28px);
+  }
+
+  .auth-panel,
+  .surface,
+  .control-sidebar {
+    padding: 14px;
+  }
+
+  .brand-row h1 {
+    font-size: 19px;
+  }
+
+  .topbar-actions,
+  .list-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .portal-tabs,
+  .security-summary,
+  .metrics-summary,
+  .dependency-grid,
+  .metrics-toolbar,
+  .telemetry-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tab-button {
+    justify-content: flex-start;
+  }
+
+  .secret-box {
+    grid-template-columns: 1fr;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 9px 8px;
+  }
+
+  .key-table {
+    min-width: 0;
+  }
+
+  .key-table thead {
+    display: none;
+  }
+
+  .key-table,
+  .key-table tbody,
+  .key-table tr,
+  .key-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .key-table tr {
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .key-table td {
+    border-bottom: 0;
+  }
+
+  .key-table .actions-cell {
+    width: 100%;
+    text-align: left;
+  }
+
+  .profile-name-cell {
+    align-items: stretch;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -193,6 +193,16 @@ button {
   padding: 18px;
 }
 
+.surface-section {
+  min-width: 0;
+}
+
+.team-management-surface .surface-section + .surface-section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
 .portal-tabs {
   display: grid;
   gap: 6px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -28,52 +28,55 @@ button {
 
 .auth-shell,
 .app-shell {
-  --bg: #eef2f4;
+  --bg: #f4f7f5;
   --panel: #ffffff;
-  --panel-strong: #f8faf9;
-  --panel-muted: #edf3f1;
-  --border: #d7e0de;
-  --border-strong: #bdcbc8;
-  --text: #172222;
-  --muted: #627170;
-  --subtle: #7b8987;
+  --panel-strong: #f8fbf9;
+  --panel-muted: #eef4f1;
+  --panel-hover: #e7efec;
+  --border: #dce5e1;
+  --border-strong: #b9c8c2;
+  --text: #141f1d;
+  --muted: #5b6965;
+  --subtle: #7a8782;
   --accent: #0f766e;
-  --accent-strong: #0b5f59;
-  --accent-soft: #dff3ef;
-  --danger: #9f241b;
+  --accent-strong: #0a5f58;
+  --accent-soft: #dbf1ed;
+  --danger: #b02a1f;
+  --danger-strong: #8f2018;
   --danger-soft: #fff0ed;
-  --warning: #9a6300;
-  --warning-soft: #fff5d6;
-  --shadow: 0 18px 50px rgba(20, 31, 32, 0.10);
+  --warning: #946200;
+  --warning-soft: #fff4d6;
+  --focus: rgba(15, 118, 110, 0.2);
+  --shadow: 0 18px 44px rgba(23, 35, 34, 0.08);
+  --shadow-soft: 0 1px 2px rgba(23, 35, 34, 0.07);
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top left, rgba(15, 118, 110, 0.08), transparent 320px),
-    var(--bg);
+  background: var(--bg);
   color: var(--text);
 }
 
 .auth-shell[data-theme="dark"],
 .app-shell[data-theme="dark"] {
-  --bg: #0b0f12;
-  --panel: #12181c;
-  --panel-strong: #171f24;
-  --panel-muted: #1d272c;
-  --border: #26333a;
-  --border-strong: #3a4b52;
-  --text: #edf5f2;
-  --muted: #9aa9a6;
-  --subtle: #748481;
-  --accent: #33c7b6;
-  --accent-strong: #58dacb;
-  --accent-soft: rgba(51, 199, 182, 0.14);
-  --danger: #ff897b;
-  --danger-soft: rgba(255, 137, 123, 0.12);
+  --bg: #0c1110;
+  --panel: #121917;
+  --panel-strong: #17201d;
+  --panel-muted: #1e2a26;
+  --panel-hover: #24332e;
+  --border: #273630;
+  --border-strong: #3c5149;
+  --text: #ecf4f1;
+  --muted: #a0afa9;
+  --subtle: #788b84;
+  --accent: #37c5b3;
+  --accent-strong: #7ee4d5;
+  --accent-soft: rgba(55, 197, 179, 0.14);
+  --danger: #ff8a7d;
+  --danger-strong: #ffafa6;
+  --danger-soft: rgba(255, 138, 125, 0.13);
   --warning: #f4bd53;
-  --warning-soft: rgba(244, 189, 83, 0.13);
-  --shadow: 0 20px 60px rgba(0, 0, 0, 0.34);
-  background:
-    radial-gradient(circle at top left, rgba(51, 199, 182, 0.09), transparent 340px),
-    var(--bg);
+  --warning-soft: rgba(244, 189, 83, 0.14);
+  --focus: rgba(55, 197, 179, 0.24);
+  --shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.26);
 }
 
 .auth-shell {
@@ -104,7 +107,7 @@ button {
 .topbar,
 .workspace,
 .app-shell > .banner {
-  width: min(1180px, calc(100vw - 40px));
+  width: min(1420px, calc(100vw - 40px));
   margin-inline: auto;
 }
 
@@ -113,32 +116,33 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 4px 0 18px;
+  padding: 0 0 18px;
 }
 
 .brand-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 11px;
   min-width: 0;
 }
 
 .brand-row h1 {
   margin: 0;
+  color: var(--text);
   font-size: 22px;
   line-height: 1.15;
-  font-weight: 760;
+  font-weight: 780;
 }
 
 .brand-mark {
-  width: 36px;
-  height: 36px;
+  width: 38px;
+  height: 38px;
   display: inline-grid;
   place-items: center;
   flex: 0 0 auto;
-  color: var(--accent);
+  color: var(--accent-strong);
   background: var(--accent-soft);
-  border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--border));
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
   border-radius: 8px;
 }
 
@@ -152,7 +156,7 @@ button {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(260px, 300px) minmax(0, 1fr);
+  grid-template-columns: minmax(250px, 294px) minmax(0, 1fr);
   gap: 18px;
   align-items: start;
 }
@@ -163,15 +167,20 @@ button {
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-soft);
 }
 
 .control-sidebar {
   position: sticky;
   top: 20px;
   display: grid;
-  gap: 18px;
+  gap: 16px;
   padding: 14px;
+}
+
+.sidebar-panel {
+  display: grid;
+  gap: 12px;
 }
 
 .detail-pane {
@@ -181,7 +190,7 @@ button {
 }
 
 .surface {
-  padding: 16px;
+  padding: 18px;
 }
 
 .portal-tabs {
@@ -196,8 +205,7 @@ button {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 9px;
-  min-height: 40px;
+  min-width: 0;
   border-radius: 8px;
   color: var(--muted);
   background: transparent;
@@ -206,15 +214,24 @@ button {
 }
 
 .tab-button {
+  gap: 9px;
+  min-height: 40px;
   padding: 0 10px;
   font-size: 14px;
-  font-weight: 730;
+  font-weight: 740;
+}
+
+.tab-button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tab-button:hover,
 .team-list-item:hover {
   color: var(--text);
-  background: var(--panel-muted);
+  background: var(--panel-hover);
 }
 
 .tab-button.active,
@@ -235,12 +252,14 @@ button {
 
 .team-list-item {
   justify-content: space-between;
+  gap: 10px;
+  min-height: 42px;
   padding: 8px 10px;
   border: 1px solid transparent;
 }
 
 .team-list-item.selected {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
 }
 
 .team-list-item span {
@@ -250,7 +269,7 @@ button {
   white-space: nowrap;
   color: inherit;
   font-size: 14px;
-  font-weight: 740;
+  font-weight: 760;
 }
 
 .team-list-item small {
@@ -267,18 +286,24 @@ button {
   margin-bottom: 14px;
 }
 
+.section-title-stack {
+  min-width: 0;
+}
+
 .section-heading h2,
 .list-toolbar h3 {
   margin: 0;
+  color: var(--text);
   font-size: 17px;
   line-height: 1.25;
+  font-weight: 780;
 }
 
 .section-heading span,
 .list-toolbar span {
   color: var(--subtle);
   font-size: 12px;
-  font-weight: 760;
+  font-weight: 780;
   text-transform: uppercase;
 }
 
@@ -293,13 +318,14 @@ label,
 legend {
   color: var(--muted);
   font-size: 12px;
-  font-weight: 720;
+  font-weight: 740;
 }
 
 input,
 select,
 textarea {
   width: 100%;
+  min-width: 0;
   border: 1px solid var(--border-strong);
   border-radius: 7px;
   background: var(--panel-strong);
@@ -310,7 +336,7 @@ textarea {
 }
 
 textarea {
-  min-height: 78px;
+  min-height: 82px;
   resize: vertical;
 }
 
@@ -318,7 +344,11 @@ input:focus,
 select:focus,
 textarea:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+.field-control {
+  min-width: 0;
 }
 
 .inline-form,
@@ -355,7 +385,7 @@ textarea:focus {
   min-height: 38px;
   border-radius: 7px;
   font-size: 14px;
-  font-weight: 720;
+  font-weight: 740;
   cursor: pointer;
   transition: background 140ms ease, border-color 140ms ease, color 140ms ease, transform 140ms ease;
 }
@@ -383,7 +413,7 @@ textarea:focus {
 
 .ghost-button:hover,
 .icon-button:hover {
-  background: var(--panel-muted);
+  background: var(--panel-hover);
 }
 
 .danger-button {
@@ -395,7 +425,8 @@ textarea:focus {
 
 .danger-button:hover,
 .icon-button.danger:hover {
-  background: color-mix(in srgb, var(--danger-soft) 72%, var(--danger) 14%);
+  color: var(--danger-strong);
+  background: color-mix(in srgb, var(--danger-soft) 70%, var(--danger) 12%);
 }
 
 .icon-button {
@@ -449,6 +480,7 @@ button:disabled {
   overflow-x: auto;
   border: 1px solid var(--border);
   border-radius: 8px;
+  background: var(--panel);
 }
 
 .data-table {
@@ -476,14 +508,14 @@ button:disabled {
   color: var(--subtle);
   background: var(--panel-strong);
   font-size: 12px;
-  font-weight: 760;
+  font-weight: 780;
 }
 
 .row-button {
   color: var(--text);
   background: transparent;
   padding: 0;
-  font-weight: 720;
+  font-weight: 740;
   text-align: left;
   cursor: pointer;
 }
@@ -494,7 +526,7 @@ button:disabled {
 }
 
 .key-table {
-  min-width: 840px;
+  min-width: 860px;
 }
 
 .key-table th:nth-child(1),
@@ -509,15 +541,15 @@ button:disabled {
 
 .key-table th:nth-child(5),
 .key-table td:nth-child(5) {
-  width: 86px;
-}
-
-.key-table .actions-cell {
   width: 104px;
 }
 
+.key-table .actions-cell {
+  width: 108px;
+}
+
 .security-table {
-  min-width: 840px;
+  min-width: 860px;
 }
 
 .security-table th:nth-child(1),
@@ -529,11 +561,11 @@ button:disabled {
 .security-table td:nth-child(2),
 .security-table th:nth-child(3),
 .security-table td:nth-child(3) {
-  width: 120px;
+  width: 124px;
 }
 
 .metrics-table {
-  min-width: 760px;
+  min-width: 780px;
 }
 
 .metrics-table th:not(:first-child),
@@ -542,18 +574,19 @@ button:disabled {
 }
 
 .route-metrics-table {
-  min-width: 820px;
+  min-width: 840px;
 }
 
 .route-metrics-table th:first-child,
 .route-metrics-table td:first-child {
-  width: 420px;
+  width: 430px;
 }
 
 .profile-name-cell,
 .table-actions {
   display: flex;
   align-items: center;
+  min-width: 0;
   gap: 8px;
 }
 
@@ -576,6 +609,7 @@ button:disabled {
   color: var(--muted);
   border: 1px dashed var(--border-strong);
   border-radius: 8px;
+  background: var(--panel-strong);
 }
 
 .table-placeholder.compact {
@@ -589,7 +623,9 @@ button:disabled {
   border-bottom: 1px solid var(--border);
 }
 
-.security-summary {
+.security-summary,
+.metrics-summary,
+.telemetry-card-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 10px;
@@ -597,15 +633,12 @@ button:disabled {
 }
 
 .metrics-summary {
-  display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 10px;
-  margin-bottom: 16px;
 }
 
 .metrics-toolbar {
   display: grid;
-  grid-template-columns: 72px minmax(130px, 170px) 52px minmax(160px, 220px);
+  grid-template-columns: max-content minmax(130px, 180px) max-content minmax(160px, 230px);
   gap: 10px;
   align-items: center;
   padding: 12px 0 16px;
@@ -622,7 +655,39 @@ button:disabled {
   gap: 10px;
 }
 
-.dependency-grid .summary-item small {
+.summary-item {
+  min-width: 0;
+  padding: 12px;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.summary-item.warning {
+  border-color: color-mix(in srgb, var(--warning) 34%, var(--border));
+}
+
+.summary-item.danger {
+  border-color: color-mix(in srgb, var(--danger) 34%, var(--border));
+}
+
+.summary-item > span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--subtle);
+  font-size: 12px;
+  font-weight: 740;
+}
+
+.summary-item strong {
+  display: block;
+  color: var(--text);
+  font-size: 16px;
+  line-height: 1.2;
+  font-weight: 780;
+}
+
+.summary-item small {
   display: block;
   margin-top: 7px;
   color: var(--muted);
@@ -643,7 +708,7 @@ button:disabled {
   overflow: hidden;
   color: var(--text);
   font-size: 14px;
-  font-weight: 740;
+  font-weight: 760;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -687,7 +752,7 @@ button:disabled {
 .knowledge-item-head small {
   color: var(--subtle);
   font-size: 12px;
-  font-weight: 720;
+  font-weight: 740;
 }
 
 .knowledge-item h3 {
@@ -695,6 +760,7 @@ button:disabled {
   color: var(--text);
   font-size: 15px;
   line-height: 1.25;
+  font-weight: 780;
 }
 
 .knowledge-item p {
@@ -724,7 +790,7 @@ button:disabled {
   margin-bottom: 6px;
   color: var(--subtle);
   font-size: 12px;
-  font-weight: 720;
+  font-weight: 740;
 }
 
 .key-detail-grid dd {
@@ -733,29 +799,6 @@ button:disabled {
   font-size: 14px;
   line-height: 1.35;
   overflow-wrap: anywhere;
-}
-
-.summary-item {
-  min-width: 0;
-  padding: 12px;
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.summary-item span {
-  display: block;
-  margin-bottom: 6px;
-  color: var(--subtle);
-  font-size: 12px;
-  font-weight: 720;
-}
-
-.summary-item strong {
-  display: block;
-  color: var(--text);
-  font-size: 15px;
-  line-height: 1.2;
 }
 
 .security-ban-form {
@@ -798,7 +841,7 @@ fieldset {
   gap: 6px;
   color: var(--muted);
   font-size: 14px;
-  font-weight: 640;
+  font-weight: 660;
 }
 
 .check-row input {
@@ -827,7 +870,7 @@ code {
   padding: 0 8px;
   border-radius: 999px;
   font-size: 12px;
-  font-weight: 760;
+  font-weight: 780;
 }
 
 .status-pill.warning {
@@ -861,137 +904,4 @@ code {
   display: block;
   margin-bottom: 6px;
   font-size: 14px;
-}
-
-@media (max-width: 980px) {
-  .app-shell {
-    padding: 14px 0 28px;
-  }
-
-  .topbar,
-  .workspace,
-  .app-shell > .banner {
-    width: min(100% - 28px, 760px);
-  }
-
-  .topbar,
-  .workspace {
-    display: grid;
-    grid-template-columns: 1fr;
-  }
-
-  .control-sidebar {
-    position: static;
-  }
-
-  .portal-tabs {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .tab-button {
-    justify-content: center;
-  }
-
-  .topbar-actions {
-    justify-content: start;
-  }
-
-  .edit-grid,
-  .key-form,
-  .security-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .security-summary,
-  .metrics-summary,
-  .dependency-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .metrics-toolbar {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .search-form,
-  .key-detail-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 620px) {
-  .topbar,
-  .workspace,
-  .app-shell > .banner {
-    width: calc(100vw - 28px);
-  }
-
-  .auth-panel,
-  .surface,
-  .control-sidebar {
-    padding: 14px;
-  }
-
-  .brand-row h1 {
-    font-size: 19px;
-  }
-
-  .topbar-actions,
-  .list-toolbar {
-    flex-wrap: wrap;
-  }
-
-  .portal-tabs,
-  .security-summary,
-  .metrics-summary,
-  .dependency-grid,
-  .metrics-toolbar {
-    grid-template-columns: 1fr;
-  }
-
-  .tab-button {
-    justify-content: flex-start;
-  }
-
-  .secret-box {
-    grid-template-columns: 1fr;
-  }
-
-  .data-table th,
-  .data-table td {
-    padding: 9px 8px;
-  }
-
-  .key-table {
-    min-width: 0;
-  }
-
-  .key-table thead {
-    display: none;
-  }
-
-  .key-table,
-  .key-table tbody,
-  .key-table tr,
-  .key-table td {
-    display: block;
-    width: 100%;
-  }
-
-  .key-table tr {
-    padding: 8px 0;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .key-table td {
-    border-bottom: 0;
-  }
-
-  .key-table .actions-cell {
-    width: 100%;
-    text-align: left;
-  }
-
-  .profile-name-cell {
-    align-items: stretch;
-  }
 }

--- a/web/src/telemetry/TelemetryDashboard.tsx
+++ b/web/src/telemetry/TelemetryDashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import { RefreshCw } from "lucide-react";
 import { TelemetrySnapshot, TelemetryWindowKey, telemetryWindowOptions } from "./types";
+import { SectionHeading, SummaryCard } from "../ui/components";
 import "./telemetry.css";
 
 type TelemetryDashboardProps = {
@@ -35,19 +36,15 @@ export function TelemetryDashboard({
 }: TelemetryDashboardProps) {
   return (
     <div className="telemetry-dashboard">
-      <div className="section-heading">
-        <div>
-          <h2>{title}</h2>
-          {snapshot && (
-            <p className="section-subtitle">
-              {formatTelemetryTime(snapshot.window.from)} - {formatTelemetryTime(snapshot.window.to)}
-            </p>
-          )}
-        </div>
-        <button className="icon-button" type="button" aria-label="Refresh telemetry" onClick={onRefresh} disabled={loading}>
-          <RefreshCw size={16} aria-hidden="true" />
-        </button>
-      </div>
+      <SectionHeading
+        title={title}
+        subtitle={snapshot ? `${formatTelemetryTime(snapshot.window.from)} - ${formatTelemetryTime(snapshot.window.to)}` : undefined}
+        actions={(
+          <button className="icon-button" type="button" aria-label="Refresh telemetry" onClick={onRefresh} disabled={loading}>
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+        )}
+      />
 
       <div className="metrics-toolbar telemetry-toolbar">
         <label htmlFor={`${title}-telemetry-window`}>Telemetry range</label>
@@ -71,10 +68,7 @@ export function TelemetryDashboard({
         <>
           <div className="telemetry-card-grid" aria-label={`${title} totals`}>
             {snapshot.cards.map((card) => (
-              <div className="summary-item" key={card.id}>
-                <span>{card.label}</span>
-                <strong>{formatTelemetryValue(card.value, card.unit)}</strong>
-              </div>
+              <SummaryCard key={card.id} label={card.label} value={formatTelemetryValue(card.value, card.unit)} />
             ))}
           </div>
           <div className="telemetry-chart-grid" aria-label={`${title} charts`}>

--- a/web/src/telemetry/telemetry.css
+++ b/web/src/telemetry/telemetry.css
@@ -1,29 +1,33 @@
 .telemetry-dashboard {
-  margin-bottom: 20px;
-  padding-bottom: 18px;
+  margin-bottom: 22px;
+  padding-bottom: 20px;
   border-bottom: 1px solid var(--border);
 }
 
 .telemetry-toolbar {
-  grid-template-columns: 122px minmax(130px, 170px) 62px minmax(150px, 210px) 52px minmax(150px, 210px) 62px minmax(150px, 210px);
+  grid-template-columns:
+    max-content minmax(130px, 170px)
+    max-content minmax(150px, 210px)
+    max-content minmax(150px, 210px)
+    max-content minmax(150px, 210px);
 }
 
 .telemetry-card-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 10px;
   margin-bottom: 16px;
 }
 
 .telemetry-chart-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 12px;
 }
 
 .telemetry-chart {
   min-width: 0;
-  height: 270px;
+  height: 260px;
   padding: 12px;
   background: var(--panel-strong);
   border: 1px solid var(--border);
@@ -67,10 +71,6 @@
 }
 
 @media (max-width: 980px) {
-  .telemetry-card-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .telemetry-toolbar {
     grid-template-columns: 1fr 1fr;
   }
@@ -82,7 +82,12 @@
 
 @media (max-width: 620px) {
   .telemetry-card-grid,
-  .telemetry-toolbar {
+  .telemetry-toolbar,
+  .telemetry-chart-grid {
     grid-template-columns: 1fr;
+  }
+
+  .telemetry-chart {
+    height: 240px;
   }
 }

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -1,0 +1,192 @@
+import { FormEventHandler, ReactNode } from "react";
+
+export type ThemeName = "light" | "dark";
+
+type BrandProps = {
+  title: string;
+  icon: ReactNode;
+};
+
+export type PortalNavItem = {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+};
+
+type AuthShellProps = BrandProps & {
+  theme: ThemeName;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  actions?: ReactNode;
+  children: ReactNode;
+};
+
+type PortalShellProps = BrandProps & {
+  theme: ThemeName;
+  topbarActions: ReactNode;
+  navLabel: string;
+  navItems: PortalNavItem[];
+  sidebarTitle: ReactNode;
+  sidebarMeta?: ReactNode;
+  sidebarSubtitle?: ReactNode;
+  sidebarBody?: ReactNode;
+  detailLabel: string;
+  error?: string;
+  children: ReactNode;
+};
+
+type SectionHeadingProps = {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  meta?: ReactNode;
+  actions?: ReactNode;
+};
+
+type SummaryCardProps = {
+  label: ReactNode;
+  value: ReactNode;
+  detail?: ReactNode;
+  tone?: "neutral" | "warning" | "danger";
+};
+
+type FieldRowProps = {
+  label: ReactNode;
+  htmlFor?: string;
+  children: ReactNode;
+};
+
+export function Brand({ title, icon }: BrandProps) {
+  return (
+    <div className="brand-row">
+      <span className="brand-mark">{icon}</span>
+      <h1>{title}</h1>
+    </div>
+  );
+}
+
+export function AuthShell({ theme, title, icon, actions, children, onSubmit }: AuthShellProps) {
+  return (
+    <main className="auth-shell" data-theme={theme}>
+      <form className="auth-panel" onSubmit={onSubmit}>
+        <div className="brand-row">
+          <span className="brand-mark">{icon}</span>
+          <h1>{title}</h1>
+          {actions}
+        </div>
+        {children}
+      </form>
+    </main>
+  );
+}
+
+export function PortalShell({
+  theme,
+  title,
+  icon,
+  topbarActions,
+  navLabel,
+  navItems,
+  sidebarTitle,
+  sidebarMeta,
+  sidebarSubtitle,
+  sidebarBody,
+  detailLabel,
+  error,
+  children,
+}: PortalShellProps) {
+  return (
+    <main className="app-shell" data-theme={theme}>
+      <header className="topbar">
+        <Brand title={title} icon={icon} />
+        <div className="topbar-actions">{topbarActions}</div>
+      </header>
+
+      {error && <div className="banner error" role="alert">{error}</div>}
+
+      <section className="workspace">
+        <aside className="control-sidebar" aria-label={navLabel}>
+          <nav className="portal-tabs" aria-label={navLabel.replace("navigation", "sections")}>
+            {navItems.map((item) => (
+              <TabButton
+                key={item.id}
+                active={item.active}
+                disabled={item.disabled}
+                icon={item.icon}
+                label={item.label}
+                onClick={item.onClick}
+              />
+            ))}
+          </nav>
+          <div className="sidebar-panel">
+            <SectionHeading title={sidebarTitle} subtitle={sidebarSubtitle} meta={sidebarMeta} />
+            {sidebarBody}
+          </div>
+        </aside>
+
+        <section className="detail-pane" aria-label={detailLabel}>
+          {children}
+        </section>
+      </section>
+    </main>
+  );
+}
+
+export function TabButton({
+  active,
+  disabled,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={active ? "tab-button active" : "tab-button"}
+      type="button"
+      aria-current={active ? "page" : undefined}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function SectionHeading({ title, subtitle, meta, actions }: SectionHeadingProps) {
+  return (
+    <div className="section-heading">
+      <div className="section-title-stack">
+        <h2>{title}</h2>
+        {subtitle && <p className="section-subtitle">{subtitle}</p>}
+      </div>
+      {actions ?? (meta !== undefined && meta !== null ? <span>{meta}</span> : null)}
+    </div>
+  );
+}
+
+export function SummaryCard({ label, value, detail, tone = "neutral" }: SummaryCardProps) {
+  return (
+    <div className={`summary-item ${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {detail && <small>{detail}</small>}
+    </div>
+  );
+}
+
+export function FieldRow({ label, htmlFor, children }: FieldRowProps) {
+  return (
+    <>
+      <label htmlFor={htmlFor}>{label}</label>
+      <div className="field-control">{children}</div>
+    </>
+  );
+}

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
   BarChart3,
   Check,
@@ -29,6 +29,7 @@ import {
   UserSession,
 } from "./api";
 import { TeamManagementPanel } from "./TeamManagementPanel";
+import { AuthShell, PortalShell, SectionHeading } from "../ui/components";
 
 const TOKEN_STORAGE_KEY = "denseMem.userApiKey";
 const THEME_STORAGE_KEY = "denseMem.userTheme";
@@ -75,35 +76,36 @@ export function UserPortalApp() {
 
   if (!token) {
     return (
-      <main className="auth-shell" data-theme={theme}>
-        <form className="auth-panel" onSubmit={submitToken}>
-          <div className="brand-row">
-            <span className="brand-mark"><ShieldCheck size={20} aria-hidden="true" /></span>
-            <h1>Dense-Mem Knowledge</h1>
-            <button
-              className="icon-button theme-toggle"
-              type="button"
-              aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-              onClick={toggleTheme}
-            >
-              {theme === "dark" ? <Sun size={17} aria-hidden="true" /> : <Moon size={17} aria-hidden="true" />}
-            </button>
-          </div>
-          <label htmlFor="user-api-key">API key</label>
-          <input
-            id="user-api-key"
-            type="password"
-            value={draftToken}
-            onChange={(event) => setDraftToken(event.target.value)}
-            autoComplete="current-password"
-          />
-          {authError && <p className="field-error" role="alert">{authError}</p>}
-          <button className="primary-button" type="submit">
-            <KeyRound size={17} aria-hidden="true" />
-            Sign in
+      <AuthShell
+        theme={theme}
+        title="Dense-Mem Knowledge"
+        icon={<ShieldCheck size={20} aria-hidden="true" />}
+        onSubmit={submitToken}
+        actions={(
+          <button
+            className="icon-button theme-toggle"
+            type="button"
+            aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            onClick={toggleTheme}
+          >
+            {theme === "dark" ? <Sun size={17} aria-hidden="true" /> : <Moon size={17} aria-hidden="true" />}
           </button>
-        </form>
-      </main>
+        )}
+      >
+        <label htmlFor="user-api-key">API key</label>
+        <input
+          id="user-api-key"
+          type="password"
+          value={draftToken}
+          onChange={(event) => setDraftToken(event.target.value)}
+          autoComplete="current-password"
+        />
+        {authError && <p className="field-error" role="alert">{authError}</p>}
+        <button className="primary-button" type="submit">
+          <KeyRound size={17} aria-hidden="true" />
+          Sign in
+        </button>
+      </AuthShell>
     );
   }
 
@@ -159,14 +161,26 @@ function UserPortal({
     }
   }, [activeTab, session]);
 
+  const navItems = [
+    { id: "search", label: "Recall", icon: <Search size={17} aria-hidden="true" />, active: activeTab === "search", onClick: () => setActiveTab("search") },
+    { id: "usage", label: "Usage", icon: <BarChart3 size={17} aria-hidden="true" />, active: activeTab === "usage", onClick: () => setActiveTab("usage") },
+    { id: "facts", label: "Facts", icon: <ShieldCheck size={17} aria-hidden="true" />, active: activeTab === "facts", onClick: () => setActiveTab("facts") },
+    { id: "claims", label: "Claims", icon: <GitBranch size={17} aria-hidden="true" />, active: activeTab === "claims", onClick: () => setActiveTab("claims") },
+    { id: "fragments", label: "Fragments", icon: <FileText size={17} aria-hidden="true" />, active: activeTab === "fragments", onClick: () => setActiveTab("fragments") },
+    { id: "communities", label: "Communities", icon: <Layers3 size={17} aria-hidden="true" />, active: activeTab === "communities", onClick: () => setActiveTab("communities") },
+    ...(session?.can_manage_team ? [
+      { id: "team", label: "Team", icon: <Users size={17} aria-hidden="true" />, active: activeTab === "team", onClick: () => setActiveTab("team") },
+    ] : []),
+    { id: "key", label: "My key", icon: <KeyRound size={17} aria-hidden="true" />, active: activeTab === "key", onClick: () => setActiveTab("key") },
+  ];
+
   return (
-    <main className="app-shell" data-theme={theme}>
-      <header className="topbar">
-        <div className="brand-row">
-          <span className="brand-mark"><ShieldCheck size={20} aria-hidden="true" /></span>
-          <h1>Dense-Mem Knowledge</h1>
-        </div>
-        <div className="topbar-actions">
+    <PortalShell
+      theme={theme}
+      title="Dense-Mem Knowledge"
+      icon={<ShieldCheck size={20} aria-hidden="true" />}
+      topbarActions={(
+        <>
           <button
             className="icon-button"
             type="button"
@@ -183,94 +197,51 @@ function UserPortal({
             <LogOut size={17} aria-hidden="true" />
             Sign out
           </button>
+        </>
+      )}
+      navLabel="Knowledge navigation"
+      navItems={navItems}
+      sidebarTitle={session?.team.name ?? (loading ? "Loading" : "Team")}
+      sidebarSubtitle={session ? shortId(session.team.id) : undefined}
+      sidebarBody={session && (
+        <div className="key-summary">
+          <span>{session.key.name}</span>
+          <code>{displayKeySuffix(session.key.key_suffix)}</code>
         </div>
-      </header>
-
-      {error && <div className="banner error" role="alert">{error}</div>}
-
-      <section className="workspace">
-        <aside className="control-sidebar" aria-label="Knowledge navigation">
-          <nav className="portal-tabs" aria-label="Knowledge sections">
-            <TabButton active={activeTab === "search"} icon={<Search size={17} aria-hidden="true" />} label="Recall" onClick={() => setActiveTab("search")} />
-            <TabButton active={activeTab === "usage"} icon={<BarChart3 size={17} aria-hidden="true" />} label="Usage" onClick={() => setActiveTab("usage")} />
-            <TabButton active={activeTab === "facts"} icon={<ShieldCheck size={17} aria-hidden="true" />} label="Facts" onClick={() => setActiveTab("facts")} />
-            <TabButton active={activeTab === "claims"} icon={<GitBranch size={17} aria-hidden="true" />} label="Claims" onClick={() => setActiveTab("claims")} />
-            <TabButton active={activeTab === "fragments"} icon={<FileText size={17} aria-hidden="true" />} label="Fragments" onClick={() => setActiveTab("fragments")} />
-            <TabButton active={activeTab === "communities"} icon={<Layers3 size={17} aria-hidden="true" />} label="Communities" onClick={() => setActiveTab("communities")} />
-            {session?.can_manage_team && <TabButton active={activeTab === "team"} icon={<Users size={17} aria-hidden="true" />} label="Team" onClick={() => setActiveTab("team")} />}
-            <TabButton active={activeTab === "key"} icon={<KeyRound size={17} aria-hidden="true" />} label="My key" onClick={() => setActiveTab("key")} />
-          </nav>
-          <div className="section-heading">
-            <div>
-              <h2>{session?.team.name ?? (loading ? "Loading" : "Team")}</h2>
-              {session && <p className="section-subtitle">{shortId(session.team.id)}</p>}
-            </div>
-          </div>
-          {session && (
-            <div className="key-summary">
-              <span>{session.key.name}</span>
-              <code>{displayKeySuffix(session.key.key_suffix)}</code>
-            </div>
-          )}
-        </aside>
-
-        <section className="detail-pane" aria-label="Knowledge details">
-          {activeTab === "search" && <SearchPanel api={api} />}
-          {activeTab === "usage" && <UserTelemetryPanel api={api} />}
-          {activeTab === "facts" && <FactsPanel api={api} />}
-          {activeTab === "claims" && <ClaimsPanel api={api} />}
-          {activeTab === "fragments" && <FragmentsPanel api={api} />}
-          {activeTab === "communities" && <CommunitiesPanel api={api} />}
-          {activeTab === "team" && session?.can_manage_team && (
-            <TeamManagementPanel
-              api={api}
-              session={session}
-              onTeamUpdated={(team) => setSession((current) => current ? { ...current, team } : current)}
-            />
-          )}
-          {activeTab === "key" && session && (
-            <KeyPanel
-              api={api}
-              session={session}
-              onRotated={(rotated) => {
-                sessionStorage.setItem(TOKEN_STORAGE_KEY, rotated.api_key);
-                onTokenChange(rotated.api_key);
-                setSession((current) => current ? {
-                  ...current,
-                  key: rotated.key,
-                  can_rotate: rotated.key.scopes.includes("write"),
-                  can_manage_team: rotated.key.role === "manager",
-                } : current);
-              }}
-            />
-          )}
-        </section>
-      </section>
-    </main>
-  );
-}
-
-function TabButton({
-  active,
-  icon,
-  label,
-  onClick,
-}: {
-  active: boolean;
-  icon: ReactNode;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      className={active ? "tab-button active" : "tab-button"}
-      type="button"
-      aria-current={active ? "page" : undefined}
-      onClick={onClick}
+      )}
+      detailLabel="Knowledge details"
+      error={error}
     >
-      {icon}
-      {label}
-    </button>
+      {activeTab === "search" && <SearchPanel api={api} />}
+      {activeTab === "usage" && <UserTelemetryPanel api={api} />}
+      {activeTab === "facts" && <FactsPanel api={api} />}
+      {activeTab === "claims" && <ClaimsPanel api={api} />}
+      {activeTab === "fragments" && <FragmentsPanel api={api} />}
+      {activeTab === "communities" && <CommunitiesPanel api={api} />}
+      {activeTab === "team" && session?.can_manage_team && (
+        <TeamManagementPanel
+          api={api}
+          session={session}
+          onTeamUpdated={(team) => setSession((current) => current ? { ...current, team } : current)}
+        />
+      )}
+      {activeTab === "key" && session && (
+        <KeyPanel
+          api={api}
+          session={session}
+          onRotated={(rotated) => {
+            sessionStorage.setItem(TOKEN_STORAGE_KEY, rotated.api_key);
+            onTokenChange(rotated.api_key);
+            setSession((current) => current ? {
+              ...current,
+              key: rotated.key,
+              can_rotate: rotated.key.scopes.includes("write"),
+              can_manage_team: rotated.key.role === "manager",
+            } : current);
+          }}
+        />
+      )}
+    </PortalShell>
   );
 }
 
@@ -345,10 +316,7 @@ function SearchPanel({ api }: { api: UserApi }) {
 
   return (
     <section className="surface">
-      <div className="section-heading">
-        <h2>Recall</h2>
-        <span>{hits.length}</span>
-      </div>
+      <SectionHeading title="Recall" meta={hits.length} />
       <form className="search-form" onSubmit={submit}>
         <label htmlFor="recall-query">Keyword</label>
         <input id="recall-query" value={query} onChange={(event) => setQuery(event.target.value)} />
@@ -472,10 +440,7 @@ function KeyPanel({
 
   return (
     <section className="surface">
-      <div className="section-heading">
-        <h2>My key</h2>
-        <span>{session.can_rotate ? "write" : "read"}</span>
-      </div>
+      <SectionHeading title="My key" meta={session.can_rotate ? "write" : "read"} />
       {createdKey && <CreatedKeyNotice apiKey={createdKey} onDismiss={() => setCreatedKey("")} />}
       {error && <div className="banner error" role="alert">{error}</div>}
       <dl className="key-detail-grid">
@@ -500,15 +465,17 @@ function KeyPanel({
 
 function PanelHeading({ title, count, onRefresh }: { title: string; count: number; onRefresh: () => void }) {
   return (
-    <div className="section-heading">
-      <h2>{title}</h2>
-      <div className="button-row">
-        <span>{count}</span>
-        <button className="icon-button" type="button" aria-label={`Refresh ${title}`} onClick={onRefresh}>
-          <RefreshCw size={16} aria-hidden="true" />
-        </button>
-      </div>
-    </div>
+    <SectionHeading
+      title={title}
+      actions={(
+        <div className="button-row">
+          <span>{count}</span>
+          <button className="icon-button" type="button" aria-label={`Refresh ${title}`} onClick={onRefresh}>
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    />
   );
 }
 

--- a/web/src/user/TeamManagementPanel.tsx
+++ b/web/src/user/TeamManagementPanel.tsx
@@ -134,54 +134,58 @@ export function TeamManagementPanel({
   }
 
   return (
-    <section className="surface">
-      <SectionHeading title="Team" meta={profileRoleLabel(session.key.role)} />
-      {createdKey && <CreatedKeyNotice apiKey={createdKey.api_key} onDismiss={() => setCreatedKey(null)} />}
-      {error && <div className="banner error" role="alert">{error}</div>}
-      <form className="edit-grid" onSubmit={saveTeam}>
-        <label htmlFor="user-team-name">Name</label>
-        <input id="user-team-name" value={teamName} onChange={(event) => setTeamName(event.target.value)} />
-        <label htmlFor="user-team-description">Description</label>
-        <textarea id="user-team-description" value={teamDescription} onChange={(event) => setTeamDescription(event.target.value)} />
-        <div className="button-row span">
-          <button className="primary-button" type="submit" disabled={teamBusy}>
-            <Pencil size={16} aria-hidden="true" />
-            Save team
-          </button>
-        </div>
-      </form>
-
-      <SectionHeading
-        title="Profiles"
-        actions={(
-          <div className="button-row">
-            <span>{profiles.length}</span>
-            <button className="icon-button" type="button" aria-label="Refresh profiles" onClick={() => void loadProfiles()}>
-              <RefreshCw size={16} aria-hidden="true" />
+    <section className="surface team-management-surface">
+      <div className="surface-section">
+        <SectionHeading title="Team" meta={profileRoleLabel(session.key.role)} />
+        {createdKey && <CreatedKeyNotice apiKey={createdKey.api_key} onDismiss={() => setCreatedKey(null)} />}
+        {error && <div className="banner error" role="alert">{error}</div>}
+        <form className="edit-grid" onSubmit={saveTeam}>
+          <label htmlFor="user-team-name">Name</label>
+          <input id="user-team-name" value={teamName} onChange={(event) => setTeamName(event.target.value)} />
+          <label htmlFor="user-team-description">Description</label>
+          <textarea id="user-team-description" value={teamDescription} onChange={(event) => setTeamDescription(event.target.value)} />
+          <div className="button-row span">
+            <button className="primary-button" type="submit" disabled={teamBusy}>
+              <Pencil size={16} aria-hidden="true" />
+              Save team
             </button>
           </div>
-        )}
-      />
-      <ManagedProfileCreateForm
-        disabled={loading}
-        onCreate={async (input) => {
-          const created = await api.createTeamProfile(session.team.id, input);
-          setCreatedKey(created);
-          await loadProfiles();
-        }}
-      />
-      {loading && <div className="table-placeholder">Loading</div>}
-      {!loading && (
-        <ManagedProfileTable
-          profiles={profiles}
-          savingProfileId={savingProfileId}
-          rotatingProfileId={rotatingProfileId}
-          deletingProfileId={deletingProfileId}
-          onRename={(profileId, name) => void updateProfileName(profileId, name)}
-          onRotate={(profileId) => void rotateProfile(profileId)}
-          onDelete={(profileId) => void deleteProfile(profileId)}
+        </form>
+      </div>
+
+      <div className="surface-section">
+        <SectionHeading
+          title="Profiles"
+          actions={(
+            <div className="button-row">
+              <span>{profiles.length}</span>
+              <button className="icon-button" type="button" aria-label="Refresh profiles" onClick={() => void loadProfiles()}>
+                <RefreshCw size={16} aria-hidden="true" />
+              </button>
+            </div>
+          )}
         />
-      )}
+        <ManagedProfileCreateForm
+          disabled={loading}
+          onCreate={async (input) => {
+            const created = await api.createTeamProfile(session.team.id, input);
+            setCreatedKey(created);
+            await loadProfiles();
+          }}
+        />
+        {loading && <div className="table-placeholder">Loading</div>}
+        {!loading && (
+          <ManagedProfileTable
+            profiles={profiles}
+            savingProfileId={savingProfileId}
+            rotatingProfileId={rotatingProfileId}
+            deletingProfileId={deletingProfileId}
+            onRename={(profileId, name) => void updateProfileName(profileId, name)}
+            onRotate={(profileId) => void rotateProfile(profileId)}
+            onDelete={(profileId) => void deleteProfile(profileId)}
+          />
+        )}
+      </div>
     </section>
   );
 }

--- a/web/src/user/TeamManagementPanel.tsx
+++ b/web/src/user/TeamManagementPanel.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import { Check, Copy, Pencil, Plus, RefreshCw, Trash2, X } from "lucide-react";
 import { CreatedTeamProfile, UserApi, UserKey, UserSession, UserTeam } from "./api";
+import { SectionHeading } from "../ui/components";
 
 type ProfilePermission = "read" | "read_write";
 
@@ -134,10 +135,7 @@ export function TeamManagementPanel({
 
   return (
     <section className="surface">
-      <div className="section-heading">
-        <h2>Team</h2>
-        <span>{profileRoleLabel(session.key.role)}</span>
-      </div>
+      <SectionHeading title="Team" meta={profileRoleLabel(session.key.role)} />
       {createdKey && <CreatedKeyNotice apiKey={createdKey.api_key} onDismiss={() => setCreatedKey(null)} />}
       {error && <div className="banner error" role="alert">{error}</div>}
       <form className="edit-grid" onSubmit={saveTeam}>
@@ -153,15 +151,17 @@ export function TeamManagementPanel({
         </div>
       </form>
 
-      <div className="section-heading">
-        <h2>Profiles</h2>
-        <div className="button-row">
-          <span>{profiles.length}</span>
-          <button className="icon-button" type="button" aria-label="Refresh profiles" onClick={() => void loadProfiles()}>
-            <RefreshCw size={16} aria-hidden="true" />
-          </button>
-        </div>
-      </div>
+      <SectionHeading
+        title="Profiles"
+        actions={(
+          <div className="button-row">
+            <span>{profiles.length}</span>
+            <button className="icon-button" type="button" aria-label="Refresh profiles" onClick={() => void loadProfiles()}>
+              <RefreshCw size={16} aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      />
       <ManagedProfileCreateForm
         disabled={loading}
         onCreate={async (input) => {

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { UserPortalApp } from "./App";
 import "../styles.css";
+import "../responsive.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -70,6 +70,19 @@ test("control panel shows operational metrics against compose", async ({ page })
   await page.getByLabel("Window").selectOption("360");
   await page.getByLabel("Team", { exact: true }).selectOption(seedTeamId);
   await expect(page.getByRole("heading", { name: "Usage Rollup" })).toBeVisible();
+  await expectNoShellOverlap(page);
+});
+
+test("control panel keeps security settings display-only against compose", async ({ page }) => {
+  await openControlPanel(page);
+
+  await page.getByRole("button", { name: /IP Bans/ }).click();
+
+  await expect(page.getByRole("heading", { name: "IP Bans" })).toBeVisible();
+  await expect(page.getByLabel("IP ban rules")).toContainText("Protection");
+  await expect(page.getByLabel("IP ban rules")).toContainText("Threshold");
+  await expect(page.getByRole("button", { name: /Save settings/ })).toHaveCount(0);
+  await expectNoShellOverlap(page);
 });
 
 test("prometheus telemetry is scraped and rendered in control panel and user portal", async ({ page, request }) => {
@@ -90,6 +103,10 @@ test("prometheus telemetry is scraped and rendered in control panel and user por
   expect(telemetryBody.data?.available).toBe(true);
   expect(Array.isArray(telemetryBody.data?.cards)).toBe(true);
   assertTelemetrySeries(telemetryBody);
+  const cardLabels = telemetryLabels(telemetryBody.data?.cards);
+  const seriesLabels = telemetryLabels(telemetryBody.data?.series);
+  expect(cardLabels.length).toBeGreaterThan(0);
+  expect(seriesLabels.length).toBeGreaterThan(0);
 
   await openControlPanel(page);
   await page.getByRole("button", { name: /^Metrics$/ }).click();
@@ -99,8 +116,13 @@ test("prometheus telemetry is scraped and rendered in control panel and user por
 
   await openUserPortal(page, seedApiKey);
   await page.getByRole("button", { name: "Usage" }).click();
-  await expect(page.getByLabel("Usage totals")).toContainText("HTTP requests");
-  await expect(page.getByLabel("Usage charts")).toContainText("HTTP requests");
+  for (const label of cardLabels) {
+    await expect(page.getByLabel("Usage totals")).toContainText(label);
+  }
+  for (const label of seriesLabels) {
+    await expect(page.getByLabel("Usage charts")).toContainText(label);
+  }
+  await expectNoShellOverlap(page);
 });
 
 test("user portal logs in with a real API key and shows only that profile", async ({ page, request }, testInfo) => {
@@ -240,8 +262,50 @@ function assertTelemetrySeries(body: TelemetryResponse) {
   }
 }
 
+function telemetryLabels(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => (isRecord(item) && typeof item.label === "string" ? item.label : ""))
+    .filter(Boolean);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+async function expectNoShellOverlap(page: Page) {
+  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        className: element.className,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+  ));
+  for (const box of boxes) {
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+  }
+  for (let i = 0; i < boxes.length; i += 1) {
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      expect(rectanglesOverlap(boxes[i], boxes[j]), `${boxes[i].className} overlaps ${boxes[j].className}`).toBe(false);
+    }
+  }
+}
+
+function rectanglesOverlap(
+  first: { left: number; top: number; right: number; bottom: number },
+  second: { left: number; top: number; right: number; bottom: number },
+) {
+  return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
 }
 
 function bearer(token: string) {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -14,6 +14,7 @@ type TestKey = {
   name: string;
   key_suffix: string;
   scopes: string[];
+  role: "manager" | "member";
   rate_limit: number;
   last_used_at: string | null;
   expires_at: string | null;
@@ -26,6 +27,7 @@ const readKey: TestKey = {
   name: "Mine",
   key_suffix: "abc123",
   scopes: ["read"],
+  role: "member",
   rate_limit: 120,
   last_used_at: null,
   expires_at: null,
@@ -35,6 +37,22 @@ const readKey: TestKey = {
 const writeKey: TestKey = {
   ...readKey,
   scopes: ["read", "write"],
+};
+
+const managerKey: TestKey = {
+  ...writeKey,
+  id: "33333333-3333-4333-8333-333333333333",
+  name: "Manager",
+  key_suffix: "mgr123",
+  role: "manager",
+};
+
+const memberProfile: TestKey = {
+  ...writeKey,
+  id: "44444444-4444-4444-8444-444444444444",
+  name: "Member profile",
+  key_suffix: "p6ZAc",
+  role: "member",
 };
 
 const facts = [
@@ -244,6 +262,40 @@ test("responsive user portal layout", async ({ page }) => {
   }
 });
 
+test("manager team page separates team editing from profile management", async ({ page }) => {
+  await mockUserApi(page, {
+    key: managerKey,
+    canManageTeam: true,
+    canRotate: true,
+    profiles: [managerKey, memberProfile],
+  });
+  await openUserPortal(page, "dm_manager");
+
+  await page.getByRole("button", { name: /^Team$/ }).click();
+  const surface = page.locator(".team-management-surface");
+  await expect(surface.getByRole("heading", { name: "Team" })).toBeVisible();
+  await expect(surface.getByRole("heading", { name: "Profiles" })).toBeVisible();
+
+  const spacing = await surface.evaluate((element) => {
+    const sections = Array.from(element.querySelectorAll(".surface-section"));
+    if (sections.length < 2) {
+      throw new Error("team management sections are missing");
+    }
+    const first = sections[0].getBoundingClientRect();
+    const second = sections[1].getBoundingClientRect();
+    const secondStyle = getComputedStyle(sections[1]);
+    return {
+      borderTopWidth: Number.parseFloat(secondStyle.borderTopWidth),
+      marginGap: second.top - first.bottom,
+      paddingTop: Number.parseFloat(secondStyle.paddingTop),
+    };
+  });
+  expect(spacing.marginGap).toBeGreaterThanOrEqual(18);
+  expect(spacing.paddingTop).toBeGreaterThanOrEqual(18);
+  expect(spacing.borderTopWidth).toBeGreaterThanOrEqual(1);
+  await expectNoShellOverlap(page);
+});
+
 async function openUserPortal(page: Page, apiKey: string) {
   await page.goto("/ui/");
   await page.getByLabel("API key").fill(apiKey);
@@ -284,24 +336,74 @@ function rectanglesOverlap(
   return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
 }
 
-async function mockUserApi(page: Page, state: { key: TestKey; canRotate: boolean }) {
+async function mockUserApi(
+  page: Page,
+  state: { key: TestKey; canRotate: boolean; canManageTeam?: boolean; profiles?: TestKey[] },
+) {
   const calls = {
     rotateBodies: [] as string[],
     disallowedProfileCalls: [] as string[],
   };
+  let currentTeam = { ...team };
   let currentKey = { ...state.key };
   let currentCanRotate = state.canRotate;
+  let currentProfiles = (state.profiles ?? []).map((profile) => ({ ...profile }));
 
   await page.route("**/api/v1/teams/**/profiles**", async (route) => {
+    if (state.canManageTeam) {
+      const request = route.request();
+      const url = new URL(request.url());
+      if (url.pathname === `/api/v1/teams/${currentTeam.id}/profiles` && request.method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: currentProfiles,
+            pagination: { limit: 50, offset: 0, total: currentProfiles.length },
+          }),
+        });
+        return;
+      }
+    }
     calls.disallowedProfileCalls.push(route.request().url());
     await route.fulfill({ status: 500, contentType: "application/json", body: JSON.stringify({ message: "profile list must not be called" }) });
+  });
+
+  await page.route("**/api/v1/teams/*", async (route) => {
+    if (!state.canManageTeam) {
+      calls.disallowedProfileCalls.push(route.request().url());
+      await route.fulfill({ status: 500, contentType: "application/json", body: JSON.stringify({ message: "team management must not be called" }) });
+      return;
+    }
+
+    const request = route.request();
+    const url = new URL(request.url());
+    if (url.pathname === `/api/v1/teams/${currentTeam.id}` && request.method() === "PATCH") {
+      const body = JSON.parse(request.postData() ?? "{}") as Partial<typeof team>;
+      currentTeam = {
+        ...currentTeam,
+        name: body.name ?? currentTeam.name,
+        description: body.description ?? currentTeam.description,
+      };
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ data: currentTeam }) });
+      return;
+    }
+
+    await route.fallback();
   });
 
   await page.route("**/ui/api/session", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ data: { team, key: currentKey, can_rotate: currentCanRotate } }),
+      body: JSON.stringify({
+        data: {
+          team: currentTeam,
+          key: currentKey,
+          can_rotate: currentCanRotate,
+          can_manage_team: state.canManageTeam ?? false,
+        },
+      }),
     });
   });
 

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -91,6 +91,50 @@ const communities = [
   },
 ];
 
+const telemetryCards = [
+  { id: "http_requests", label: "HTTP requests", unit: "requests", value: 9 },
+  { id: "http_errors", label: "HTTP errors", unit: "requests", value: 1 },
+  { id: "verifier_tokens", label: "Verifier tokens", unit: "tokens", value: 120 },
+  { id: "embedding_tokens", label: "Embedding tokens", unit: "tokens", value: 320 },
+  { id: "recalls", label: "Recall requests", unit: "requests", value: 3 },
+  { id: "avg_recall_results", label: "Avg recall results", unit: "results", value: 2.5 },
+  { id: "promotions", label: "Promotions", unit: "promotions", value: 1 },
+  { id: "promotion_rate", label: "Promotion rate", unit: "percent", value: 50 },
+  { id: "avg_http_latency", label: "Avg HTTP latency", unit: "ms", value: 16.4 },
+  { id: "avg_embedding_latency", label: "Avg embedding latency", unit: "ms", value: 39.1 },
+  { id: "avg_verifier_latency", label: "Avg verifier latency", unit: "ms", value: 101.5 },
+  { id: "avg_claim_verify_latency", label: "Avg claim-to-verify", unit: "ms", value: 200 },
+  { id: "avg_claim_promotion_latency", label: "Avg claim-to-promote", unit: "ms", value: 300 },
+  { id: "avg_verify_promotion_latency", label: "Avg verify-to-promote", unit: "ms", value: 90 },
+  { id: "pending_claims", label: "Pending claims", unit: "claims", value: 4 },
+  { id: "validated_claims", label: "Validated claims", unit: "claims", value: 8 },
+  { id: "disputed_claims", label: "Disputed claims", unit: "claims", value: 0 },
+  { id: "revalidation_backlog", label: "Revalidation backlog", unit: "facts", value: 2 },
+];
+
+const telemetrySeries = [
+  { id: "http_rps", label: "HTTP requests", unit: "rps" },
+  { id: "http_errors_rps", label: "HTTP errors", unit: "rps" },
+  { id: "embedding_tokens", label: "Embedding tokens", unit: "tokens/s" },
+  { id: "verifier_tokens", label: "Verifier tokens", unit: "tokens/s" },
+  { id: "recalls", label: "Recall requests", unit: "requests/s" },
+  { id: "promotions", label: "Promotions", unit: "promotions/s" },
+  { id: "recall_results", label: "Recall results", unit: "results" },
+  { id: "claim_verify_latency", label: "Claim-to-verify", unit: "ms" },
+  { id: "claim_promotion_latency", label: "Claim-to-promote", unit: "ms" },
+  { id: "verify_promotion_latency", label: "Verify-to-promote", unit: "ms" },
+  { id: "pending_claims", label: "Pending claims", unit: "claims" },
+  { id: "validated_claims", label: "Validated claims", unit: "claims" },
+  { id: "disputed_claims", label: "Disputed claims", unit: "claims" },
+  { id: "revalidation_backlog", label: "Revalidation backlog", unit: "facts" },
+].map((series, index) => ({
+  ...series,
+  points: [
+    { timestamp: "2026-05-02T12:00:00Z", value: index / 20 },
+    { timestamp: "2026-05-02T13:00:00Z", value: index / 20 + 0.2 },
+  ],
+}));
+
 const telemetry = {
   available: true,
   window: {
@@ -101,21 +145,8 @@ const telemetry = {
     retention_days: 30,
   },
   scope: { type: "self", team_id: team.id, profile_id: readKey.id },
-  cards: [
-    { id: "http_requests", label: "HTTP requests", unit: "requests", value: 9 },
-    { id: "embedding_tokens", label: "Embedding tokens", unit: "tokens", value: 320 },
-  ],
-  series: [
-    {
-      id: "http_rps",
-      label: "HTTP requests",
-      unit: "rps",
-      points: [
-        { timestamp: "2026-05-02T12:00:00Z", value: 0.1 },
-        { timestamp: "2026-05-02T13:00:00Z", value: 0.2 },
-      ],
-    },
-  ],
+  cards: telemetryCards,
+  series: telemetrySeries,
 };
 
 test("API key login, recall, and read-only knowledge tabs", async ({ page }) => {
@@ -133,8 +164,14 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await expect(page.getByText("Dense-Mem").first()).toBeVisible();
 
   await page.getByRole("button", { name: "Usage" }).click();
-  await expect(page.getByLabel("Usage totals")).toContainText("HTTP requests");
-  await expect(page.getByLabel("Usage charts")).toContainText("HTTP requests");
+  const usageTotals = page.getByLabel("Usage totals");
+  for (const card of telemetryCards) {
+    await expect(usageTotals).toContainText(card.label);
+  }
+  const usageCharts = page.getByLabel("Usage charts");
+  for (const series of telemetrySeries) {
+    await expect(usageCharts).toContainText(series.label);
+  }
 
   await page.getByRole("button", { name: "Facts" }).click();
   await expect(page.getByText("works_on: project-x")).toBeVisible();
@@ -200,6 +237,7 @@ test("responsive user portal layout", async ({ page }) => {
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
   await expect(page.locator(".control-sidebar")).toHaveCSS("border-radius", "8px");
   await expect(page.locator(".surface").first()).toHaveCSS("border-radius", "8px");
+  await expectNoShellOverlap(page);
 
   if ((page.viewportSize()?.width ?? 1000) < 700) {
     await expect(page.locator(".workspace")).toHaveCSS("grid-template-columns", /[0-9.]+px/);
@@ -211,6 +249,39 @@ async function openUserPortal(page: Page, apiKey: string) {
   await page.getByLabel("API key").fill(apiKey);
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByText("Research Team")).toBeVisible();
+}
+
+async function expectNoShellOverlap(page: Page) {
+  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        className: element.className,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+  ));
+  for (const box of boxes) {
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+  }
+  for (let i = 0; i < boxes.length; i += 1) {
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      expect(rectanglesOverlap(boxes[i], boxes[j]), `${boxes[i].className} overlaps ${boxes[j].className}`).toBe(false);
+    }
+  }
+}
+
+function rectanglesOverlap(
+  first: { left: number; top: number; right: number; bottom: number },
+  second: { left: number; top: number; right: number; bottom: number },
+) {
+  return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
 }
 
 async function mockUserApi(page: Page, state: { key: TestKey; canRotate: boolean }) {

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -86,6 +86,50 @@ const metrics = {
   ],
 };
 
+const telemetryCards = [
+  { id: "http_requests", label: "HTTP requests", unit: "requests", value: 42 },
+  { id: "http_errors", label: "HTTP errors", unit: "requests", value: 2 },
+  { id: "verifier_tokens", label: "Verifier tokens", unit: "tokens", value: 1200 },
+  { id: "embedding_tokens", label: "Embedding tokens", unit: "tokens", value: 3200 },
+  { id: "recalls", label: "Recall requests", unit: "requests", value: 9 },
+  { id: "avg_recall_results", label: "Avg recall results", unit: "results", value: 3.2 },
+  { id: "promotions", label: "Promotions", unit: "promotions", value: 4 },
+  { id: "promotion_rate", label: "Promotion rate", unit: "percent", value: 66.6 },
+  { id: "avg_http_latency", label: "Avg HTTP latency", unit: "ms", value: 18.5 },
+  { id: "avg_embedding_latency", label: "Avg embedding latency", unit: "ms", value: 44.2 },
+  { id: "avg_verifier_latency", label: "Avg verifier latency", unit: "ms", value: 112.8 },
+  { id: "avg_claim_verify_latency", label: "Avg claim-to-verify", unit: "ms", value: 210.4 },
+  { id: "avg_claim_promotion_latency", label: "Avg claim-to-promote", unit: "ms", value: 420.9 },
+  { id: "avg_verify_promotion_latency", label: "Avg verify-to-promote", unit: "ms", value: 190.1 },
+  { id: "pending_claims", label: "Pending claims", unit: "claims", value: 5 },
+  { id: "validated_claims", label: "Validated claims", unit: "claims", value: 12 },
+  { id: "disputed_claims", label: "Disputed claims", unit: "claims", value: 1 },
+  { id: "revalidation_backlog", label: "Revalidation backlog", unit: "facts", value: 7 },
+];
+
+const telemetrySeries = [
+  { id: "http_rps", label: "HTTP requests", unit: "rps" },
+  { id: "http_errors_rps", label: "HTTP errors", unit: "rps" },
+  { id: "embedding_tokens", label: "Embedding tokens", unit: "tokens/s" },
+  { id: "verifier_tokens", label: "Verifier tokens", unit: "tokens/s" },
+  { id: "recalls", label: "Recall requests", unit: "requests/s" },
+  { id: "promotions", label: "Promotions", unit: "promotions/s" },
+  { id: "recall_results", label: "Recall results", unit: "results" },
+  { id: "claim_verify_latency", label: "Claim-to-verify", unit: "ms" },
+  { id: "claim_promotion_latency", label: "Claim-to-promote", unit: "ms" },
+  { id: "verify_promotion_latency", label: "Verify-to-promote", unit: "ms" },
+  { id: "pending_claims", label: "Pending claims", unit: "claims" },
+  { id: "validated_claims", label: "Validated claims", unit: "claims" },
+  { id: "disputed_claims", label: "Disputed claims", unit: "claims" },
+  { id: "revalidation_backlog", label: "Revalidation backlog", unit: "facts" },
+].map((series, index) => ({
+  ...series,
+  points: [
+    { timestamp: "2026-05-02T12:00:00Z", value: index / 10 },
+    { timestamp: "2026-05-02T13:00:00Z", value: index / 10 + 0.4 },
+  ],
+}));
+
 const telemetry = {
   available: true,
   window: {
@@ -96,21 +140,8 @@ const telemetry = {
     retention_days: 30,
   },
   scope: { type: "system" },
-  cards: [
-    { id: "http_requests", label: "HTTP requests", unit: "requests", value: 42 },
-    { id: "verifier_tokens", label: "Verifier tokens", unit: "tokens", value: 1200 },
-  ],
-  series: [
-    {
-      id: "http_rps",
-      label: "HTTP requests",
-      unit: "rps",
-      points: [
-        { timestamp: "2026-05-02T12:00:00Z", value: 0.4 },
-        { timestamp: "2026-05-02T13:00:00Z", value: 0.9 },
-      ],
-    },
-  ],
+  cards: telemetryCards,
+  series: telemetrySeries,
 };
 
 type TestProfile = typeof team;
@@ -193,6 +224,15 @@ test("metrics tab renders operational totals and filter queries", async ({ page 
 
   await page.getByRole("button", { name: /^Metrics$/ }).click();
 
+  const telemetryTotals = page.getByLabel("Telemetry totals");
+  for (const card of telemetryCards) {
+    await expect(telemetryTotals).toContainText(card.label);
+  }
+  const telemetryCharts = page.getByLabel("Telemetry charts");
+  for (const series of telemetrySeries) {
+    await expect(telemetryCharts).toContainText(series.label);
+  }
+
   const summary = page.getByLabel("Request metrics");
   await expect(summary).toContainText("42");
   await expect(summary).toContainText("2");
@@ -211,6 +251,7 @@ test("metrics tab renders operational totals and filter queries", async ({ page 
   await expect.poll(() => calls.metricsUrls.some((url) => (
     url.includes("window_minutes=360") && url.includes(`team_id=${team.id}`)
   ))).toBe(true);
+  await expectNoShellOverlap(page);
 });
 
 test("team delete flow", async ({ page }) => {
@@ -247,6 +288,7 @@ test("responsive portal layout", async ({ page }) => {
   await expect(page.locator(".surface").first()).toHaveCSS("border-radius", "8px");
   await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
   await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
+  await expectNoShellOverlap(page);
 
   if ((page.viewportSize()?.width ?? 1000) < 700) {
     await expect(page.locator(".workspace")).toHaveCSS("grid-template-columns", /[0-9.]+px/);
@@ -259,6 +301,39 @@ async function openPortal(page: Page) {
   await page.getByRole("button", { name: "Unlock" }).click();
   await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
   await expect(page.getByRole("button", { name: /Default/ })).toBeVisible();
+}
+
+async function expectNoShellOverlap(page: Page) {
+  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        className: element.className,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    })
+  ));
+  for (const box of boxes) {
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+  }
+  for (let i = 0; i < boxes.length; i += 1) {
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      expect(rectanglesOverlap(boxes[i], boxes[j]), `${boxes[i].className} overlaps ${boxes[j].className}`).toBe(false);
+    }
+  }
+}
+
+function rectanglesOverlap(
+  first: { left: number; top: number; right: number; bottom: number },
+  second: { left: number; top: number; right: number; bottom: number },
+) {
+  return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
 }
 
 async function mockApi(page: Page, state: { teams: TestProfile[]; keys: TestKey[]; bans?: TestBan[] }) {


### PR DESCRIPTION
## Summary
- Redesign the control portal and `/ui` around a shared Clean Ops shell, nav, heading, card, form, and status component set.
- Render telemetry cards and series from API-provided arrays so the full metric catalog appears without hard-coded omissions.
- Keep security settings display-only while improving the manual IP ban, team, profile, key, and knowledge workflows.
- Add/extend mock Playwright, compose e2e, and live portal layout coverage.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run playwright:mock:control`
- `npm run playwright:mock:user`
- `npm run playwright:compose` attempted; blocked locally because `DENSE_MEM_CONTROL_URL` was not set.
- `cd tests/uat && npm run test:portal-live` ran and skipped because `CONTROL_PORTAL_TOKEN` was not set.
- Push hook passed line lint, Go tests, and coverage gate during `git push`.

## Notes
- No backend API changes.
- No security settings edit form was added; the existing settings remain summary-only by design.