### PR TITLE
[codex] add recall eval telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Dense-Mem at `http://prometheus:9090` for telemetry queries. It also sets
 `TELEMETRY_PROMETHEUS_JOB=dense-mem` so dashboards query only the `dense-mem`
 scrape job when Prometheus is shared.
 
+Recall quality cards such as `Eval Recall@50`, `Eval Hit@5`, `Eval MRR@5`, and
+`Eval tier correctness` use the `densemem_recall_eval_score` gauge. They stay at
+zero until an offline eval runner emits bounded scores with `suite`, `pipeline`,
+`metric`, and `k` labels; normal production recall traffic only contributes
+request volume, result count, and latency.
+
 For the disposable demo image, keep the control portal disabled and use the
 demo telemetry overlay instead:
 

--- a/internal/observability/metrics_discoverability.go
+++ b/internal/observability/metrics_discoverability.go
@@ -17,6 +17,9 @@ type DiscoverabilityMetrics interface {
 	ObserveRecallLatency(durationMs float64)
 	// ObserveRecall records one recall-service call with its result count.
 	ObserveRecall(durationMs float64, resultCount int, outcome string)
+	// ObserveRecallEvaluation records one offline recall-evaluation score.
+	// suite, pipeline, metric, and k must be bounded label sets; k=0 means all.
+	ObserveRecallEvaluation(suite string, pipeline string, metric string, k int, value float64)
 	// ObserveMemoryFunnelLatency records latency between memory pipeline stages.
 	ObserveMemoryFunnelLatency(stage string, seconds float64, outcome string)
 	// IncFragmentCreate bumps the fragment-create outcome counter.
@@ -61,6 +64,8 @@ func (noopMetrics) ObserveEmbeddingLatency(float64, string) {}
 func (noopMetrics) IncEmbeddingError(string)                {}
 func (noopMetrics) ObserveRecallLatency(float64)            {}
 func (noopMetrics) ObserveRecall(float64, int, string)      {}
+func (noopMetrics) ObserveRecallEvaluation(string, string, string, int, float64) {
+}
 func (noopMetrics) ObserveMemoryFunnelLatency(string, float64, string) {
 }
 func (noopMetrics) IncFragmentCreate(string)            {}
@@ -82,6 +87,7 @@ type InMemoryDiscoverabilityMetrics struct {
 	embeddingErrors        map[string]int
 	recallLatencies        []float64
 	recallSamples          []RecallSample
+	recallEvalSamples      []RecallEvaluationSample
 	memoryFunnelSamples    []MemoryFunnelSample
 	fragmentOutcomes       map[string]int
 	claimCreateSamples     []ClaimCreateSample
@@ -117,6 +123,15 @@ type RecallSample struct {
 	DurationMs  float64
 	ResultCount int
 	Outcome     string
+}
+
+// RecallEvaluationSample is one offline recall-evaluation score.
+type RecallEvaluationSample struct {
+	Suite    string
+	Pipeline string
+	Metric   string
+	K        int
+	Value    float64
 }
 
 // MemoryFunnelSample is one observed pipeline-stage latency.
@@ -168,6 +183,19 @@ func (m *InMemoryDiscoverabilityMetrics) ObserveRecall(durationMs float64, resul
 	m.recallSamples = append(m.recallSamples, RecallSample{DurationMs: durationMs, ResultCount: resultCount, Outcome: outcome})
 }
 
+// ObserveRecallEvaluation records one offline recall-evaluation score.
+func (m *InMemoryDiscoverabilityMetrics) ObserveRecallEvaluation(suite string, pipeline string, metric string, k int, value float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recallEvalSamples = append(m.recallEvalSamples, RecallEvaluationSample{
+		Suite:    suite,
+		Pipeline: pipeline,
+		Metric:   metric,
+		K:        k,
+		Value:    value,
+	})
+}
+
 // ObserveMemoryFunnelLatency records one memory-pipeline stage latency.
 func (m *InMemoryDiscoverabilityMetrics) ObserveMemoryFunnelLatency(stage string, seconds float64, outcome string) {
 	m.mu.Lock()
@@ -213,6 +241,15 @@ func (m *InMemoryDiscoverabilityMetrics) RecallSamples() []RecallSample {
 	defer m.mu.Unlock()
 	out := make([]RecallSample, len(m.recallSamples))
 	copy(out, m.recallSamples)
+	return out
+}
+
+// RecallEvaluationSamples returns a copy of the recorded recall eval scores.
+func (m *InMemoryDiscoverabilityMetrics) RecallEvaluationSamples() []RecallEvaluationSample {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]RecallEvaluationSample, len(m.recallEvalSamples))
+	copy(out, m.recallEvalSamples)
 	return out
 }
 

--- a/internal/observability/metrics_discoverability_test.go
+++ b/internal/observability/metrics_discoverability_test.go
@@ -10,6 +10,7 @@ func TestNoopDiscoverabilityMetrics_NeverPanics(t *testing.T) {
 	m.IncEmbeddingError("timeout")
 	m.ObserveRecallLatency(5)
 	m.ObserveRecall(5, 2, "ok")
+	m.ObserveRecallEvaluation("golden", "rrf", "candidate_recall", 50, 0.9)
 	m.ObserveMemoryFunnelLatency("claim_to_verify", 1, "verified")
 	m.IncFragmentCreate("created")
 	m.IncClaimCreate("created", "")
@@ -78,6 +79,19 @@ func TestInMemoryDiscoverabilityMetrics_RecordsRecallResults(t *testing.T) {
 	}
 }
 
+func TestInMemoryDiscoverabilityMetrics_RecordsRecallEvaluation(t *testing.T) {
+	m := NewInMemoryDiscoverabilityMetrics()
+	m.ObserveRecallEvaluation("golden", "rrf", "candidate_recall", 50, 0.875)
+
+	samples := m.RecallEvaluationSamples()
+	if len(samples) != 1 {
+		t.Fatalf("recall eval samples = %d; want 1", len(samples))
+	}
+	if samples[0].Suite != "golden" || samples[0].Pipeline != "rrf" || samples[0].Metric != "candidate_recall" || samples[0].K != 50 || samples[0].Value != 0.875 {
+		t.Errorf("recall eval sample = %+v", samples[0])
+	}
+}
+
 func TestInMemoryDiscoverabilityMetrics_RecordsMemoryFunnelLatency(t *testing.T) {
 	m := NewInMemoryDiscoverabilityMetrics()
 	m.ObserveMemoryFunnelLatency("claim_to_verify", 2.5, "verified")
@@ -114,6 +128,7 @@ func TestInMemoryDiscoverabilityMetrics_ConcurrentSafe(t *testing.T) {
 			m.IncEmbeddingError("timeout")
 			m.ObserveRecallLatency(1)
 			m.ObserveRecall(1, 1, "ok")
+			m.ObserveRecallEvaluation("golden", "rrf", "hit_rate", 5, 1)
 			m.ObserveMemoryFunnelLatency("claim_to_verify", 1, "verified")
 			m.IncFragmentCreate("created")
 		}()
@@ -126,6 +141,9 @@ func TestInMemoryDiscoverabilityMetrics_ConcurrentSafe(t *testing.T) {
 	}
 	if got := m.FragmentCreateCount("created"); got != 50 {
 		t.Errorf("fragment_create created = %d; want 50", got)
+	}
+	if got := len(m.RecallEvaluationSamples()); got != 50 {
+		t.Errorf("recall eval samples = %d; want 50", got)
 	}
 }
 

--- a/internal/observability/metrics_noop_test.go
+++ b/internal/observability/metrics_noop_test.go
@@ -12,6 +12,7 @@ func TestNoopDiscoverabilityMetricsImplementsAllMethods(t *testing.T) {
 	metrics.IncEmbeddingError("timeout")
 	metrics.ObserveRecallLatency(3.5)
 	metrics.ObserveRecall(3.5, 2, "ok")
+	metrics.ObserveRecallEvaluation("golden", "rrf", "mrr", 5, 0.75)
 	metrics.ObserveMemoryFunnelLatency("claim_to_verify", 1.25, "verified")
 	metrics.IncFragmentCreate("created")
 	metrics.IncClaimCreate("duplicate", "content_hash")

--- a/internal/observability/prometheus_metrics.go
+++ b/internal/observability/prometheus_metrics.go
@@ -32,6 +32,7 @@ type ScopedDiscoverabilityMetrics interface {
 	IncVerifyVerdictFor(ctx context.Context, model string, outcome string)
 	ObserveRecallLatencyFor(ctx context.Context, durationMs float64)
 	ObserveRecallFor(ctx context.Context, durationMs float64, resultCount int, outcome string)
+	ObserveRecallEvaluationFor(ctx context.Context, suite string, pipeline string, metric string, k int, value float64)
 	ObserveMemoryFunnelLatencyFor(ctx context.Context, stage string, seconds float64, outcome string)
 	IncFragmentCreateFor(ctx context.Context, outcome string)
 	IncClaimCreateFor(ctx context.Context, outcome string, dedupeReason string)
@@ -60,6 +61,7 @@ type PrometheusMetrics struct {
 	recallCalls     *prometheus.CounterVec
 	recallDur       *prometheus.HistogramVec
 	recallResults   *prometheus.HistogramVec
+	recallEval      *prometheus.GaugeVec
 	memoryFunnel    *prometheus.HistogramVec
 	fragmentCreates *prometheus.CounterVec
 	claimCreates    *prometheus.CounterVec
@@ -135,6 +137,10 @@ func NewPrometheusMetrics() *PrometheusMetrics {
 			Help:    "Recall result count per request.",
 			Buckets: []float64{0, 1, 2, 5, 10, 20, 50, 100},
 		}, append(identityLabels(), "outcome")),
+		recallEval: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "densemem_recall_eval_score",
+			Help: "Offline recall evaluation score from a bounded labeled suite.",
+		}, append(identityLabels(), "suite", "pipeline", "metric", "k")),
 		memoryFunnel: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "densemem_memory_funnel_latency_seconds",
 			Help:    "Latency between memory pipeline stages.",
@@ -188,7 +194,7 @@ func NewPrometheusMetrics() *PrometheusMetrics {
 		m.httpRequests, m.httpDuration,
 		m.embeddingCalls, m.embeddingErrors, m.embeddingDur, m.embeddingTokens,
 		m.verifierCalls, m.verifierDur, m.verifierTokens,
-		m.recallCalls, m.recallDur, m.recallResults, m.memoryFunnel,
+		m.recallCalls, m.recallDur, m.recallResults, m.recallEval, m.memoryFunnel,
 		m.fragmentCreates, m.claimCreates, m.verifyVerdicts, m.promotions,
 		m.promoteWait, m.retractions, m.revalidation,
 		m.communityRuns, m.communityDur, m.communityNodes,
@@ -262,6 +268,15 @@ func (m *PrometheusMetrics) ObserveRecallFor(ctx context.Context, durationMs flo
 		resultCount = 0
 	}
 	m.recallResults.WithLabelValues(append(labels, outcome)...).Observe(float64(resultCount))
+}
+
+func (m *PrometheusMetrics) ObserveRecallEvaluation(suite string, pipeline string, metric string, k int, value float64) {
+	m.ObserveRecallEvaluationFor(context.Background(), suite, pipeline, metric, k, value)
+}
+
+func (m *PrometheusMetrics) ObserveRecallEvaluationFor(ctx context.Context, suite string, pipeline string, metric string, k int, value float64) {
+	labels := append(identityValues(ctx), normalizeLabel(suite), normalizeLabel(pipeline), normalizeLabel(metric), normalizeRecallEvalK(k))
+	m.recallEval.WithLabelValues(labels...).Set(normalizeRecallEvalScore(value))
 }
 
 func (m *PrometheusMetrics) ObserveMemoryFunnelLatency(stage string, seconds float64, outcome string) {
@@ -398,6 +413,23 @@ func statusClass(status int) string {
 	return strconv.Itoa(status/100) + "xx"
 }
 
+func normalizeRecallEvalK(k int) string {
+	if k <= 0 {
+		return "all"
+	}
+	return strconv.Itoa(k)
+}
+
+func normalizeRecallEvalScore(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
 // RecordEmbeddingLatency preserves the narrow DiscoverabilityMetrics contract
 // while allowing scoped recorders to attach request identity and model labels.
 func RecordEmbeddingLatency(ctx context.Context, metrics DiscoverabilityMetrics, model string, durationMs float64, outcome string) {
@@ -490,6 +522,17 @@ func RecordRecall(ctx context.Context, metrics DiscoverabilityMetrics, durationM
 		return
 	}
 	metrics.ObserveRecall(durationMs, resultCount, outcome)
+}
+
+func RecordRecallEvaluation(ctx context.Context, metrics DiscoverabilityMetrics, suite string, pipeline string, metric string, k int, value float64) {
+	if metrics == nil {
+		return
+	}
+	if scoped, ok := metrics.(ScopedDiscoverabilityMetrics); ok {
+		scoped.ObserveRecallEvaluationFor(ctx, suite, pipeline, metric, k, value)
+		return
+	}
+	metrics.ObserveRecallEvaluation(suite, pipeline, metric, k, value)
 }
 
 func RecordMemoryFunnelLatency(ctx context.Context, metrics DiscoverabilityMetrics, stage string, seconds float64, outcome string) {

--- a/internal/observability/prometheus_metrics_test.go
+++ b/internal/observability/prometheus_metrics_test.go
@@ -36,6 +36,7 @@ func TestPrometheusMetrics_RecordsScopedMetrics(t *testing.T) {
 	metrics.IncVerifyVerdictFor(ctx, "verify-model", "verified")
 	metrics.ObserveRecallLatencyFor(ctx, 42)
 	metrics.ObserveRecallFor(ctx, 42, 3, "ok")
+	metrics.ObserveRecallEvaluationFor(ctx, "golden", "rrf", "candidate_recall", 50, 0.92)
 	metrics.ObserveMemoryFunnelLatencyFor(ctx, "claim_to_verify", 2.5, "verified")
 	metrics.IncFragmentCreateFor(ctx, "created")
 	metrics.IncClaimCreateFor(ctx, "duplicate", "content_hash")
@@ -64,6 +65,11 @@ func TestPrometheusMetrics_RecordsScopedMetrics(t *testing.T) {
 		`densemem_verify_verdict_total{`,
 		`outcome="verified"`,
 		`densemem_recall_results_bucket{`,
+		`densemem_recall_eval_score{`,
+		`suite="golden"`,
+		`pipeline="rrf"`,
+		`metric="candidate_recall"`,
+		`k="50"`,
 		`densemem_memory_funnel_latency_seconds_bucket{`,
 		`stage="claim_to_verify"`,
 		`densemem_claim_create_total{`,
@@ -97,6 +103,7 @@ func TestPrometheusMetrics_RecordsUnknownLabelsAndFallbackHelpers(t *testing.T) 
 	metrics.IncEmbeddingError("")
 	metrics.ObserveRecallLatency(2)
 	metrics.ObserveRecall(2, 0, "")
+	metrics.ObserveRecallEvaluation("", "", "", -1, 1.5)
 	metrics.ObserveMemoryFunnelLatency("", 1, "")
 	metrics.IncFragmentCreate("")
 	metrics.IncClaimCreate("", "")
@@ -116,6 +123,7 @@ func TestPrometheusMetrics_RecordsUnknownLabelsAndFallbackHelpers(t *testing.T) 
 	RecordVerifyVerdict(ctx, metrics, "verify-model", "verified")
 	RecordRecallLatency(ctx, metrics, 1)
 	RecordRecall(ctx, metrics, 1, 2, "ok")
+	RecordRecallEvaluation(ctx, metrics, "golden", "candidate-rerank", "hit_rate", 5, 0.8)
 	RecordMemoryFunnelLatency(ctx, metrics, "claim_to_promotion", 5, "promoted")
 	RecordFragmentCreate(ctx, metrics, "created")
 	RecordClaimCreate(ctx, metrics, "created", "")
@@ -133,6 +141,7 @@ func TestPrometheusMetrics_RecordsUnknownLabelsAndFallbackHelpers(t *testing.T) 
 	RecordVerifyVerdict(ctx, fallback, "ignored", "verified")
 	RecordRecallLatency(ctx, fallback, 30)
 	RecordRecall(ctx, fallback, 30, 4, "ok")
+	RecordRecallEvaluation(ctx, fallback, "golden", "rrf", "mrr", 5, 0.7)
 	RecordMemoryFunnelLatency(ctx, fallback, "claim_to_verify", 3, "verified")
 	RecordFragmentCreate(ctx, fallback, "created")
 	RecordClaimCreate(ctx, fallback, "duplicate", "exact")
@@ -154,6 +163,10 @@ func TestPrometheusMetrics_RecordsUnknownLabelsAndFallbackHelpers(t *testing.T) 
 		`model="unknown"`,
 		`outcome="unknown"`,
 		`dedupe_reason="unknown"`,
+		`suite="unknown"`,
+		`pipeline="unknown"`,
+		`metric="unknown"`,
+		`k="all"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("scraped metrics missing %q\n%s", want, body)
@@ -403,6 +416,7 @@ func TestNoopDiscoverabilityMetrics_ConsumesCalls(t *testing.T) {
 	metrics.IncEmbeddingError("timeout")
 	metrics.ObserveRecallLatency(1)
 	metrics.ObserveRecall(1, 2, "ok")
+	metrics.ObserveRecallEvaluation("golden", "rrf", "tier_correctness", 0, 1)
 	metrics.ObserveMemoryFunnelLatency("claim_to_verify", 1, "verified")
 	metrics.IncFragmentCreate("created")
 	metrics.IncClaimCreate("duplicate", "exact")
@@ -481,6 +495,10 @@ func assertFallbackRecorded(t *testing.T, metrics *InMemoryDiscoverabilityMetric
 	if len(recalls) != 1 || recalls[0].ResultCount != 4 || recalls[0].Outcome != "ok" {
 		t.Fatalf("fallback recall samples = %+v", recalls)
 	}
+	recallEval := metrics.RecallEvaluationSamples()
+	if len(recallEval) != 1 || recallEval[0].Metric != "mrr" || recallEval[0].Value != 0.7 {
+		t.Fatalf("fallback recall eval samples = %+v", recallEval)
+	}
 	funnel := metrics.MemoryFunnelSamples()
 	if len(funnel) != 1 || funnel[0].Stage != "claim_to_verify" || funnel[0].Outcome != "verified" {
 		t.Fatalf("fallback funnel samples = %+v", funnel)
@@ -514,6 +532,7 @@ func exerciseNilMetricHelpers(ctx context.Context) {
 	RecordVerifyVerdict(ctx, nil, "model", "verified")
 	RecordRecallLatency(ctx, nil, 1)
 	RecordRecall(ctx, nil, 1, 1, "ok")
+	RecordRecallEvaluation(ctx, nil, "suite", "pipeline", "metric", 5, 1)
 	RecordMemoryFunnelLatency(ctx, nil, "stage", 1, "ok")
 	RecordFragmentCreate(ctx, nil, "created")
 	RecordClaimCreate(ctx, nil, "created", "")

--- a/internal/service/telemetry_service.go
+++ b/internal/service/telemetry_service.go
@@ -237,6 +237,11 @@ func telemetryCardSpecs(scope TelemetryScope, baseLabels map[string]string, wind
 		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens", Query: telemetryIncrease("densemem_embedding_tokens_total", scope, baseLabels, map[string]string{"kind": "total"}, window)},
 		{ID: "recalls", Label: "Recall requests", Unit: "requests", Query: telemetryIncrease("densemem_recall_requests_total", scope, baseLabels, nil, window)},
 		{ID: "avg_recall_results", Label: "Avg recall results", Unit: "results", Query: telemetryHistogramAverage("densemem_recall_results", scope, baseLabels, nil, window, 1)},
+		{ID: "p95_recall_latency", Label: "P95 recall latency", Unit: "ms", Query: telemetryHistogramQuantile("densemem_recall_duration_seconds", scope, baseLabels, nil, window, 0.95, 1000)},
+		{ID: "eval_candidate_recall_50", Label: "Eval Recall@50", Unit: "percent", Query: telemetryRecallEvalScore(scope, baseLabels, "candidate_recall", "50", window)},
+		{ID: "eval_hit_rate_5", Label: "Eval Hit@5", Unit: "percent", Query: telemetryRecallEvalScore(scope, baseLabels, "hit_rate", "5", window)},
+		{ID: "eval_mrr_5", Label: "Eval MRR@5", Unit: "percent", Query: telemetryRecallEvalScore(scope, baseLabels, "mrr", "5", window)},
+		{ID: "eval_tier_correctness", Label: "Eval tier correctness", Unit: "percent", Query: telemetryRecallEvalScore(scope, baseLabels, "tier_correctness", "all", window)},
 		{ID: "promotions", Label: "Promotions", Unit: "promotions", Query: telemetryIncrease("densemem_promotion_outcome_total", scope, baseLabels, map[string]string{"outcome": "promoted"}, window)},
 		{ID: "promotion_rate", Label: "Promotion rate", Unit: "percent", Query: telemetryPromotionRate(scope, baseLabels, window)},
 		{ID: "avg_http_latency", Label: "Avg HTTP latency", Unit: "ms", Query: telemetryAverageLatency("densemem_http_request_duration_seconds", scope, baseLabels, window)},
@@ -261,6 +266,11 @@ func telemetrySeriesSpecs(selector string, rateWindow string) []telemetryQuerySp
 		{ID: "recalls", Label: "Recall requests", Unit: "requests/s", Query: fmt.Sprintf("sum(rate(densemem_recall_requests_total%s[%s]))", selector, rateWindow)},
 		{ID: "promotions", Label: "Promotions", Unit: "promotions/s", Query: fmt.Sprintf("sum(rate(densemem_promotion_outcome_total%s[%s]))", telemetrySelectorWithRaw(selector, `outcome="promoted"`), rateWindow)},
 		{ID: "recall_results", Label: "Recall results", Unit: "results", Query: telemetryRangeHistogramAverage("densemem_recall_results", selector, "", rateWindow, 1)},
+		{ID: "recall_p95_latency", Label: "Recall p95 latency", Unit: "ms", Query: telemetryRangeHistogramQuantile("densemem_recall_duration_seconds", selector, "", rateWindow, 0.95, 1000)},
+		{ID: "eval_candidate_recall_50", Label: "Eval Recall@50", Unit: "percent", Query: telemetryRangeRecallEvalScore(selector, "candidate_recall", "50", 100)},
+		{ID: "eval_hit_rate_5", Label: "Eval Hit@5", Unit: "percent", Query: telemetryRangeRecallEvalScore(selector, "hit_rate", "5", 100)},
+		{ID: "eval_mrr_5", Label: "Eval MRR@5", Unit: "percent", Query: telemetryRangeRecallEvalScore(selector, "mrr", "5", 100)},
+		{ID: "eval_tier_correctness", Label: "Eval tier correctness", Unit: "percent", Query: telemetryRangeRecallEvalScore(selector, "tier_correctness", "all", 100)},
 		{ID: "claim_verify_latency", Label: "Claim-to-verify", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="claim_to_verify"`, rateWindow, 1000)},
 		{ID: "claim_promotion_latency", Label: "Claim-to-promote", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="claim_to_promotion"`, rateWindow, 1000)},
 		{ID: "verify_promotion_latency", Label: "Verify-to-promote", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="verify_to_promotion"`, rateWindow, 1000)},
@@ -284,6 +294,17 @@ func telemetryHistogramAverage(metric string, scope TelemetryScope, baseLabels m
 	return fmt.Sprintf("%g * sum(increase(%s_sum%s[%s])) / sum(increase(%s_count%s[%s]))", multiplier, metric, selector, window, metric, selector, window)
 }
 
+func telemetryHistogramQuantile(metric string, scope TelemetryScope, baseLabels map[string]string, extra map[string]string, window string, quantile float64, multiplier float64) string {
+	selector := telemetrySelector(scope, mergeTelemetryLabels(baseLabels, extra))
+	return fmt.Sprintf("%g * histogram_quantile(%g, sum(rate(%s_bucket%s[%s])) by (le))", multiplier, quantile, metric, selector, window)
+}
+
+func telemetryRecallEvalScore(scope TelemetryScope, baseLabels map[string]string, metric string, k string, window string) string {
+	extra := map[string]string{"metric": metric, "k": k}
+	selector := telemetrySelector(scope, mergeTelemetryLabels(baseLabels, extra))
+	return fmt.Sprintf("100 * avg(avg_over_time(densemem_recall_eval_score%s[%s]))", selector, window)
+}
+
 func telemetryGaugeSum(metric string, scope TelemetryScope, baseLabels map[string]string, extra map[string]string) string {
 	return fmt.Sprintf("sum(%s%s)", metric, telemetrySelector(scope, mergeTelemetryLabels(baseLabels, extra)))
 }
@@ -293,6 +314,18 @@ func telemetryRangeHistogramAverage(metric string, selector string, raw string, 
 		selector = telemetrySelectorWithRaw(selector, raw)
 	}
 	return fmt.Sprintf("%g * sum(rate(%s_sum%s[%s])) / sum(rate(%s_count%s[%s]))", multiplier, metric, selector, rateWindow, metric, selector, rateWindow)
+}
+
+func telemetryRangeHistogramQuantile(metric string, selector string, raw string, rateWindow string, quantile float64, multiplier float64) string {
+	if raw != "" {
+		selector = telemetrySelectorWithRaw(selector, raw)
+	}
+	return fmt.Sprintf("%g * histogram_quantile(%g, sum(rate(%s_bucket%s[%s])) by (le))", multiplier, quantile, metric, selector, rateWindow)
+}
+
+func telemetryRangeRecallEvalScore(selector string, metric string, k string, multiplier float64) string {
+	selector = telemetrySelectorWithRaw(selector, fmt.Sprintf(`metric=%q,k=%q`, metric, k))
+	return fmt.Sprintf("%g * avg(densemem_recall_eval_score%s)", multiplier, selector)
 }
 
 func telemetryRangeGauge(metric string, selector string, raw string) string {
@@ -518,6 +551,11 @@ func telemetryEmptyCards() []TelemetryCard {
 		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens"},
 		{ID: "recalls", Label: "Recall requests", Unit: "requests"},
 		{ID: "avg_recall_results", Label: "Avg recall results", Unit: "results"},
+		{ID: "p95_recall_latency", Label: "P95 recall latency", Unit: "ms"},
+		{ID: "eval_candidate_recall_50", Label: "Eval Recall@50", Unit: "percent"},
+		{ID: "eval_hit_rate_5", Label: "Eval Hit@5", Unit: "percent"},
+		{ID: "eval_mrr_5", Label: "Eval MRR@5", Unit: "percent"},
+		{ID: "eval_tier_correctness", Label: "Eval tier correctness", Unit: "percent"},
 		{ID: "promotions", Label: "Promotions", Unit: "promotions"},
 		{ID: "promotion_rate", Label: "Promotion rate", Unit: "percent"},
 		{ID: "avg_http_latency", Label: "Avg HTTP latency", Unit: "ms"},
@@ -543,6 +581,11 @@ func telemetryEmptySeries() []TelemetrySeries {
 		{ID: "recalls", Label: "Recall requests", Unit: "requests/s", Points: emptyPoints},
 		{ID: "promotions", Label: "Promotions", Unit: "promotions/s", Points: emptyPoints},
 		{ID: "recall_results", Label: "Recall results", Unit: "results", Points: emptyPoints},
+		{ID: "recall_p95_latency", Label: "Recall p95 latency", Unit: "ms", Points: emptyPoints},
+		{ID: "eval_candidate_recall_50", Label: "Eval Recall@50", Unit: "percent", Points: emptyPoints},
+		{ID: "eval_hit_rate_5", Label: "Eval Hit@5", Unit: "percent", Points: emptyPoints},
+		{ID: "eval_mrr_5", Label: "Eval MRR@5", Unit: "percent", Points: emptyPoints},
+		{ID: "eval_tier_correctness", Label: "Eval tier correctness", Unit: "percent", Points: emptyPoints},
 		{ID: "claim_verify_latency", Label: "Claim-to-verify", Unit: "ms", Points: emptyPoints},
 		{ID: "claim_promotion_latency", Label: "Claim-to-promote", Unit: "ms", Points: emptyPoints},
 		{ID: "verify_promotion_latency", Label: "Verify-to-promote", Unit: "ms", Points: emptyPoints},

--- a/internal/service/telemetry_service_test.go
+++ b/internal/service/telemetry_service_test.go
@@ -94,6 +94,25 @@ func TestPrometheusTelemetryService_QueriesTypedScope(t *testing.T) {
 	require.NotEmpty(t, httpErrorCardQuery)
 	require.Contains(t, httpErrorCardQuery, `status_class=~"4xx|5xx"`)
 	require.NotContains(t, httpErrorCardQuery, `status_class="4xx|5xx"`)
+	require.Condition(t, func() bool {
+		for _, query := range queries {
+			if strings.Contains(query, `densemem_recall_eval_score`) &&
+				strings.Contains(query, `metric="candidate_recall"`) &&
+				strings.Contains(query, `k="50"`) {
+				return true
+			}
+		}
+		return false
+	})
+	require.Condition(t, func() bool {
+		for _, query := range queries {
+			if strings.Contains(query, `histogram_quantile(0.95`) &&
+				strings.Contains(query, `densemem_recall_duration_seconds_bucket`) {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 func TestPrometheusTelemetryService_RejectsInvalidWindow(t *testing.T) {
@@ -155,6 +174,8 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 	require.Equal(t, `{kind="total"}`, telemetrySelectorWithRaw("", `kind="total"`))
 	require.Equal(t, `{status_class=~"4xx|5xx"}`, telemetrySelector(TelemetryScope{}, map[string]string{"status_class": `~"4xx|5xx"`}))
 	require.Equal(t, `{job="dense-mem-demo",status_class=~"4xx|5xx"}`, telemetrySelector(TelemetryScope{}, mergeTelemetryLabels(map[string]string{"job": "dense-mem-demo"}, map[string]string{"status_class": `~"4xx|5xx"`})))
+	require.Equal(t, `100 * avg(avg_over_time(densemem_recall_eval_score{k="5",metric="hit_rate"}[1h]))`, telemetryRecallEvalScore(TelemetryScope{}, nil, "hit_rate", "5", "1h"))
+	require.Equal(t, `1000 * histogram_quantile(0.95, sum(rate(densemem_recall_duration_seconds_bucket[1m])) by (le))`, telemetryRangeHistogramQuantile("densemem_recall_duration_seconds", "", "", "1m", 0.95, 1000))
 
 	scope, err = normalizeTelemetryScope(TelemetryFilter{Scope: "self", TeamID: &teamID, ProfileID: &profileID})
 	require.NoError(t, err)

--- a/web/src/telemetry/TelemetryDashboard.test.tsx
+++ b/web/src/telemetry/TelemetryDashboard.test.tsx
@@ -9,6 +9,11 @@ describe("TelemetryDashboard helpers", () => {
     expect(formatTelemetryAxisTick(1.5, "requests/s")).toBe("1.5");
   });
 
+  it("formats percent axis labels with units", () => {
+    expect(formatTelemetryAxisTick(91.2, "percent")).toBe("91%");
+    expect(formatTelemetryAxisTick(8.5, "percent")).toBe("8.5%");
+  });
+
   it("uses the selected telemetry window as empty chart axis data", () => {
     const points = telemetryChartPoints([], "2026-05-02T12:00:00Z", "2026-05-02T13:00:00Z");
 

--- a/web/src/telemetry/TelemetryDashboard.tsx
+++ b/web/src/telemetry/TelemetryDashboard.tsx
@@ -150,6 +150,9 @@ export function formatTelemetryAxisTick(value: number, unit: string) {
   if (!Number.isFinite(value)) {
     return "";
   }
+  if (unit === "percent") {
+    return `${trimFixed(value, value >= 10 ? 0 : 1)}%`;
+  }
   if (unit.includes("/s") || unit === "rps") {
     return formatRateTick(value);
   }


### PR DESCRIPTION
## What changed

- Added a bounded `densemem_recall_eval_score` Prometheus gauge for offline recall evaluation summaries.
- Added telemetry cards and series for Eval Recall@50, Eval Hit@5, Eval MRR@5, Eval tier correctness, and live recall p95 latency.
- Updated telemetry UI percent axis formatting and tests.
- Documented that eval quality cards require an offline eval runner while production recall telemetry remains volume/result/latency focused.

## Why

Recall quality needs to be tracked separately from live request telemetry because production traffic does not include gold labels. This gives an offline eval runner a low-cardinality telemetry contract while keeping normal recall request metrics operational.

## Validation

- `go test ./internal/observability ./internal/service ./internal/service/recallservice`
- `go test ./...`
- `npm test -- --run src/telemetry/TelemetryDashboard.test.tsx`
- `npm run typecheck`
- `git diff --check`
- Pre-push hook: textlint, Go tests, coverage threshold passed at 90.0%, npm audit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry overlay now includes offline evaluation quality cards (Eval Recall@50, Eval Hit@5, Eval MRR@5, Eval tier correctness)
  * Added p95 recall latency metric to telemetry dashboard
* **UI/Formatting**
  * Improved percentage axis tick formatting for cleaner display (e.g., 91%, 8.5%)
* **Documentation**
  * README updated with guidance on the new telemetry cards and their sourcing
* **Tests**
  * Added/updated tests to cover telemetry helpers and offline recall-evaluation metrics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->