### PR TITLE
[codex] improve control config UX

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -372,7 +372,12 @@ describe("App", () => {
     await userEvent.click(await screen.findByRole("tab", { name: /dreaming/i }));
 
     expect(await screen.findByRole("heading", { name: "Dreaming" })).toBeInTheDocument();
-    await userEvent.selectOptions(screen.getByLabelText("Enable scheduled cycle"), "true");
+    expect(screen.queryByText(/^effective /i)).not.toBeInTheDocument();
+    const enabledToggle = screen.getByLabelText("Enable scheduled cycle", { selector: "input" });
+    expect(enabledToggle).toHaveAttribute("type", "checkbox");
+    expect(enabledToggle).not.toBeChecked();
+    await userEvent.click(enabledToggle);
+    await userEvent.selectOptions(screen.getByLabelText("Timezone", { selector: "select" }), "America/New_York");
     await userEvent.clear(screen.getByLabelText("Cycle start time"));
     await userEvent.type(screen.getByLabelText("Cycle start time"), "02:30");
     await userEvent.click(screen.getByRole("button", { name: /save config/i }));
@@ -386,6 +391,14 @@ describe("App", () => {
         }),
       );
     });
+    const patchCall = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith("/config/dreaming") && init?.method === "PATCH");
+    expect(patchCall).toBeDefined();
+    const body = JSON.parse(String(patchCall?.[1]?.body));
+    expect(body.items).toEqual(expect.arrayContaining([
+      { key: "DREAMING_ENABLED", value: "true" },
+      { key: "DREAMING_TIMEZONE", value: "America/New_York" },
+      { key: "DREAMING_START_TIME_LOCAL", value: "02:30" },
+    ]));
     expect(await screen.findByText("Saved")).toBeInTheDocument();
   });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -377,6 +377,7 @@ describe("App", () => {
     expect(enabledToggle).toHaveAttribute("type", "checkbox");
     expect(enabledToggle).not.toBeChecked();
     await userEvent.click(enabledToggle);
+    await userEvent.click(screen.getByRole("button", { name: /clear force all teams override/i }));
     await userEvent.selectOptions(screen.getByLabelText("Timezone", { selector: "select" }), "America/New_York");
     await userEvent.clear(screen.getByLabelText("Cycle start time"));
     await userEvent.type(screen.getByLabelText("Cycle start time"), "02:30");
@@ -396,6 +397,7 @@ describe("App", () => {
     const body = JSON.parse(String(patchCall?.[1]?.body));
     expect(body.items).toEqual(expect.arrayContaining([
       { key: "DREAMING_ENABLED", value: "true" },
+      { key: "DREAMING_FORCE_ENABLED", value: "" },
       { key: "DREAMING_TIMEZONE", value: "America/New_York" },
       { key: "DREAMING_START_TIME_LOCAL", value: "02:30" },
     ]));

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from "react";
-import { Check, Moon, RefreshCw, Settings } from "lucide-react";
+import { Check, Moon, RefreshCw, Settings, X } from "lucide-react";
 import { ControlApi, DreamingConfig, DreamingConfigItem, SSOConfig, SSOConfigItem } from "../api";
 import { SectionHeading } from "../ui/components";
 import { formatDate, readError } from "./utils";
@@ -288,15 +288,22 @@ function ConfigField({
     return (
       <>
         <label htmlFor={item.key}>{label}</label>
-        <label className="toggle-row config-toggle" htmlFor={item.key}>
-          <span>{checked ? "Enabled" : "Disabled"}</span>
-          <input
-            id={item.key}
-            type="checkbox"
-            checked={checked}
-            onChange={(event) => onChange(event.target.checked ? "true" : "false")}
-          />
-        </label>
+        <div className="button-row">
+          <label className="toggle-row config-toggle" htmlFor={item.key}>
+            <span>{checked ? "Enabled" : "Disabled"}</span>
+            <input
+              id={item.key}
+              type="checkbox"
+              checked={checked}
+              onChange={(event) => onChange(event.target.checked ? "true" : "false")}
+            />
+          </label>
+          {value !== "" && (
+            <button className="icon-button" type="button" aria-label={`Clear ${label} override`} title={`Clear ${label} override`} onClick={() => onChange("")}>
+              <X size={16} aria-hidden="true" />
+            </button>
+          )}
+        </div>
       </>
     );
   }

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -33,39 +33,57 @@ const CONFIG_PLACEHOLDERS: Record<string, string> = {
   DREAMING_MAX_OUTPUTS: "5",
 };
 
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Phoenix",
+  "America/Anchorage",
+  "America/Honolulu",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Madrid",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+];
+
+const SUPPORTED_TIMEZONES = getSupportedTimezones();
+
 export function ConfigPanel({ api }: { api: ControlApi }) {
   const [activeTab, setActiveTab] = useState<ConfigTab>("sso");
 
   return (
     <>
-      <section className="surface">
-        <SectionHeading
-          title="Config"
-          actions={(
-            <div className="config-tabs" role="tablist" aria-label="Config sections">
-              <button
-                className={activeTab === "sso" ? "tab-button active" : "tab-button"}
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "sso"}
-                onClick={() => setActiveTab("sso")}
-              >
-                <Settings size={16} aria-hidden="true" />
-                <span>SSO</span>
-              </button>
-              <button
-                className={activeTab === "dreaming" ? "tab-button active" : "tab-button"}
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "dreaming"}
-                onClick={() => setActiveTab("dreaming")}
-              >
-                <Moon size={16} aria-hidden="true" />
-                <span>Dreaming</span>
-              </button>
-            </div>
-          )}
-        />
+      <section className="surface config-surface">
+        <SectionHeading title="Config" />
+        <div className="config-tabs" role="tablist" aria-label="Config sections">
+          <button
+            className={activeTab === "sso" ? "tab-button active" : "tab-button"}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "sso"}
+            onClick={() => setActiveTab("sso")}
+          >
+            <Settings size={16} aria-hidden="true" />
+            <span>SSO</span>
+          </button>
+          <button
+            className={activeTab === "dreaming" ? "tab-button active" : "tab-button"}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "dreaming"}
+            onClick={() => setActiveTab("dreaming")}
+          >
+            <Moon size={16} aria-hidden="true" />
+            <span>Dreaming</span>
+          </button>
+        </div>
       </section>
       {activeTab === "sso" && <SSOConfigPanel api={api} />}
       {activeTab === "dreaming" && <DreamingConfigPanel api={api} />}
@@ -251,7 +269,6 @@ function ConfigField({
   onChange: (value: string) => void;
 }) {
   const label = CONFIG_LABELS[item.key] ?? item.key;
-  const effective = item.effective_value ? `effective ${item.effective_value}` : "";
 
   if (item.key === "SSO_COOKIE_SECURE") {
     return (
@@ -259,24 +276,41 @@ function ConfigField({
         <label htmlFor={item.key}>{label}</label>
         <select id={item.key} value={value} onChange={(event) => onChange(event.target.value)}>
           <option value="">Auto from public URL</option>
-          <option value="true">true</option>
-          <option value="false">false</option>
+          <option value="true">Enabled</option>
+          <option value="false">Disabled</option>
         </select>
-        <span className="form-meta span">{effective}</span>
       </>
     );
   }
 
   if (item.key.startsWith("DREAMING_") && item.key.endsWith("_ENABLED")) {
+    const checked = (value || item.effective_value) === "true";
     return (
       <>
         <label htmlFor={item.key}>{label}</label>
-        <select id={item.key} value={value} onChange={(event) => onChange(event.target.value)}>
-          <option value="">Default</option>
-          <option value="true">true</option>
-          <option value="false">false</option>
+        <label className="toggle-row config-toggle" htmlFor={item.key}>
+          <span>{checked ? "Enabled" : "Disabled"}</span>
+          <input
+            id={item.key}
+            type="checkbox"
+            checked={checked}
+            onChange={(event) => onChange(event.target.checked ? "true" : "false")}
+          />
+        </label>
+      </>
+    );
+  }
+
+  if (item.key === "DREAMING_TIMEZONE") {
+    const timezone = value || item.effective_value || "UTC";
+    return (
+      <>
+        <label htmlFor={item.key}>{label}</label>
+        <select id={item.key} value={timezone} onChange={(event) => onChange(event.target.value)}>
+          {timezoneOptions(timezone).map((option) => (
+            <option value={option} key={option}>{option}</option>
+          ))}
         </select>
-        <span className="form-meta span">{effective}</span>
       </>
     );
   }
@@ -295,7 +329,33 @@ function ConfigField({
         value={value}
         onChange={(event) => onChange(event.target.value)}
       />
-      <span className="form-meta span">{effective}</span>
     </>
   );
+}
+
+function getSupportedTimezones(): string[] {
+  const intl = Intl as typeof Intl & {
+    supportedValuesOf?: (key: "timeZone") => string[];
+  };
+  try {
+    return intl.supportedValuesOf?.("timeZone") ?? FALLBACK_TIMEZONES;
+  } catch {
+    return FALLBACK_TIMEZONES;
+  }
+}
+
+function timezoneOptions(current: string): string[] {
+  const values = new Set<string>(["UTC", ...SUPPORTED_TIMEZONES, ...FALLBACK_TIMEZONES]);
+  if (current.trim()) {
+    values.add(current.trim());
+  }
+  return [...values].sort((left, right) => {
+    if (left === "UTC") {
+      return -1;
+    }
+    if (right === "UTC") {
+      return 1;
+    }
+    return left.localeCompare(right);
+  });
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -260,16 +260,13 @@ button {
   cursor: not-allowed;
 }
 
+.config-surface .section-heading { margin-bottom: 12px; }
 .config-tabs {
-  display: flex;
-  gap: 8px;
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; width: min(420px, 100%);
+  padding: 4px; background: var(--panel-muted); border: 1px solid var(--border); border-radius: 8px;
 }
-
-.config-tabs .tab-button {
-  width: auto;
-  border: 1px solid var(--border);
-}
-
+.config-tabs .tab-button { justify-content: center; min-height: 38px; width: 100%; border: 1px solid transparent; border-radius: 6px; }
+.config-tabs .tab-button.active { color: var(--text); background: var(--panel); border-color: var(--border); box-shadow: var(--shadow-soft); }
 .danger-icon {
   color: var(--danger);
 }
@@ -445,6 +442,9 @@ textarea:focus {
 .toggle-row input:focus-visible {
   box-shadow: 0 0 0 3px var(--focus);
 }
+
+.config-toggle { width: min(280px, 100%); }
+.config-toggle span { color: var(--text); font-size: 14px; font-weight: 740; text-transform: none; }
 
 .span {
   grid-column: 1 / -1;


### PR DESCRIPTION
## What changed

- Removed noisy effective-value labels from the control portal runtime config form.
- Replaced dreaming enable/disable dropdowns with toggle controls.
- Replaced the dreaming timezone text field with a timezone dropdown.
- Moved Config section tabs out of the heading action area and restyled them as a segmented control below the title.
- Added app-level test coverage for the updated dreaming config controls and payload.

## Why

The previous Config UI exposed implementation details such as `effective true`, used dropdowns for boolean enable/disable values, and placed primary section navigation in the right-side heading action slot. The updated UI maps controls to their value types and makes Config navigation easier to scan.

## Validation

- `npm --prefix web test -- App.test.tsx`
- `npm --prefix web run typecheck`
- `docker compose build server && docker compose up -d --no-deps --force-recreate server`
- `curl -fsS http://127.0.0.1:8080/ready`
- `curl -fsS -H "Authorization: Bearer ${CONTROL_PORTAL_TOKEN}" http://127.0.0.1:8090/control/api/session`
- Compose-backed Playwright checks for the Config tab layout and dreaming config controls
- Pre-push hook: textlint line checks, Go tests, and coverage gate

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timezone support to the configuration panel, including automatic detection of supported timezones and a populated timezone selector.

* **Improvements**
  * Updated configuration UI layout and styling for clearer sections and tab controls.
  * Refreshed SSO and Dreaming settings inputs: clearer Enabled/Disabled presentation, Dreaming as checkbox toggles, and improved override controls.

* **Tests**
  * Strengthened the runtime config test to verify UI interactions and the specific request payload values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->