### PR TITLE
[codex] Harden full-text search input

### DIFF
--- a/internal/fulltextquery/query.go
+++ b/internal/fulltextquery/query.go
@@ -1,0 +1,26 @@
+package fulltextquery
+
+import (
+	"strings"
+	"unicode"
+)
+
+// PlainText converts user-facing search text into a Lucene-safe query string.
+func PlainText(input string) string {
+	var b strings.Builder
+	lastSpace := true
+
+	for _, r := range input {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			b.WriteRune(r)
+			lastSpace = false
+			continue
+		}
+		if !lastSpace {
+			b.WriteByte(' ')
+			lastSpace = true
+		}
+	}
+
+	return strings.TrimSpace(b.String())
+}

--- a/internal/fulltextquery/query_test.go
+++ b/internal/fulltextquery/query_test.go
@@ -1,0 +1,57 @@
+package fulltextquery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlainText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "slash paths and URLs",
+			input: "git-vibe GitVibe /git-vibe github.com/markhuangai/git-vibe",
+			want:  "git vibe GitVibe git vibe github com markhuangai git vibe",
+		},
+		{
+			name:  "bare slash",
+			input: "GitVibe workflows / git-vibe command",
+			want:  "GitVibe workflows git vibe command",
+		},
+		{
+			name:  "lucene operators and grouping",
+			input: `context: "project decisions" +(memory) -draft`,
+			want:  "context project decisions memory draft",
+		},
+		{
+			name:  "punctuation only",
+			input: `/ \ + - && || ! ( ) { } [ ] ^ " ~ * ? :`,
+			want:  "",
+		},
+		{
+			name:  "unicode text",
+			input: "记忆/检索 dense-mem",
+			want:  "记忆 检索 dense mem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, PlainText(tt.input))
+		})
+	}
+}
+
+func TestPlainTextRemovesLuceneControlCharacters(t *testing.T) {
+	got := PlainText(`a/b +c -d (e) [f] {g} h:i "j" k~ l* m? n^ && ||`)
+
+	for _, token := range []string{"/", "+", "-", "(", ")", "[", "]", "{", "}", ":", `"`, "~", "*", "?", "^", "&", "|"} {
+		require.NotContains(t, got, token)
+	}
+	require.Equal(t, strings.Join(strings.Fields(got), " "), got)
+}

--- a/internal/openapi/routes.go
+++ b/internal/openapi/routes.go
@@ -101,7 +101,7 @@ func DefaultRoutes() []RouteDescriptor {
 
 		// --- Advanced tool routes (full variant only) ---
 		{Method: "POST", Path: "/api/v1/tools/graph_query", OperationID: "graphQueryTool", ToolName: "graph_query", Description: "Advanced: read-only Cypher query."},
-		{Method: "POST", Path: "/api/v1/tools/keyword_search", OperationID: "keywordSearchTool", ToolName: "keyword_search", Description: "Advanced: BM25 keyword search."},
+		{Method: "POST", Path: "/api/v1/tools/keyword_search", OperationID: "keywordSearchTool", ToolName: "keyword_search", Description: "Advanced: plain-text BM25 keyword search."},
 		{Method: "POST", Path: "/api/v1/tools/semantic_search", OperationID: "semanticSearchTool", ToolName: "semantic_search", Description: "Advanced: kNN vector search."},
 
 		// --- MCP Streamable HTTP (full runtime variant) ---

--- a/internal/service/dreamservice/service.go
+++ b/internal/service/dreamservice/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/fulltextquery"
 	"github.com/markhuangai/dense-mem/internal/http/dto"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	neo4jstorage "github.com/markhuangai/dense-mem/internal/storage/neo4j"
@@ -274,6 +275,10 @@ func (s *service) Recall(ctx context.Context, profileID, query string, limit int
 	if s.deps.Graph == nil || strings.TrimSpace(query) == "" {
 		return nil, nil
 	}
+	searchQuery := fulltextquery.PlainText(query)
+	if searchQuery == "" {
+		return nil, nil
+	}
 	if limit <= 0 {
 		limit = 5
 	}
@@ -287,7 +292,7 @@ WHERE d.team_id = $profileId
 RETURN d, score
 ORDER BY score DESC
 LIMIT $limit`, map[string]any{
-		"searchQuery": query,
+		"searchQuery": searchQuery,
 		"limit":       int64(limit),
 	})
 	if err != nil {

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -271,6 +271,11 @@ func TestDreamServiceReadPaths(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, recalled, 1)
 
+	recalled, err = svc.Recall(context.Background(), "profile-1", "GitVibe workflows / git-vibe command", 100)
+	require.NoError(t, err)
+	require.Len(t, recalled, 1)
+	require.Equal(t, "GitVibe workflows git vibe command", graph.lastReadParams["searchQuery"])
+
 	emptyRecall, err := svc.Recall(context.Background(), "profile-1", "", 5)
 	require.NoError(t, err)
 	require.Nil(t, emptyRecall)
@@ -574,19 +579,21 @@ func (s dreamProfileStub) List(context.Context, int, int) ([]*domain.Profile, er
 }
 
 type cycleRunGraphStub struct {
-	existingRun   bool
-	writes        int
-	readErr       error
-	writeErr      error
-	executeWrites bool
-	writeQueries  []string
-	dreamRows     []map[string]any
-	runRows       []map[string]any
-	inputRows     []map[string]any
-	recordsFor    func(query string, params map[string]any) []*neo4j.Record
+	existingRun    bool
+	writes         int
+	readErr        error
+	writeErr       error
+	executeWrites  bool
+	writeQueries   []string
+	dreamRows      []map[string]any
+	runRows        []map[string]any
+	inputRows      []map[string]any
+	lastReadParams map[string]any
+	recordsFor     func(query string, params map[string]any) []*neo4j.Record
 }
 
-func (s *cycleRunGraphStub) ScopedRead(_ context.Context, _ string, query string, _ map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
+func (s *cycleRunGraphStub) ScopedRead(_ context.Context, _ string, query string, params map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
+	s.lastReadParams = params
 	if s.readErr != nil {
 		return nil, nil, s.readErr
 	}

--- a/internal/service/recallservice/recall_tier_test.go
+++ b/internal/service/recallservice/recall_tier_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/tools/keywordsearch"
 	"github.com/markhuangai/dense-mem/internal/tools/semanticsearch"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,36 @@ func TestRecallService_ReturnsClassifiedBranchErrors(t *testing.T) {
 		require.ErrorIs(t, err, ErrKeywordUnavailable)
 		require.Equal(t, int32(1), atomic.LoadInt32(&logger.errors))
 	})
+}
+
+func TestRecallService_UsesPlainTextKeywordBranchQuery(t *testing.T) {
+	reader := &recallKeywordReader{}
+	svc := NewRecallService(
+		&stubEmbedding{DimensionsResult: 4},
+		&fakeSemanticSearcher{},
+		keywordsearch.NewFragmentSearcher(reader),
+		&fakeHydrator{},
+		nil,
+		nil,
+	)
+
+	out, err := svc.Recall(context.Background(), "pA", RecallRequest{
+		Query: "GitVibe workflows / git-vibe command",
+		Limit: 3,
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Equal(t, "GitVibe workflows git vibe command", reader.lastParams["searchQuery"])
+}
+
+type recallKeywordReader struct {
+	lastParams map[string]any
+}
+
+func (r *recallKeywordReader) ScopedRead(_ context.Context, _ string, _ string, params map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
+	r.lastParams = params
+	return nil, nil, nil
 }
 
 func TestRecallService_HydrationFallbacksAndMisses(t *testing.T) {

--- a/internal/service/recallservice/searcher.go
+++ b/internal/service/recallservice/searcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/markhuangai/dense-mem/internal/fulltextquery"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
@@ -35,6 +36,11 @@ func NewClaimSearcher(reader RecallScopedReader) ClaimSearcher {
 }
 
 func (s *neo4jFactSearcher) SearchActive(ctx context.Context, profileID string, query string, limit int) ([]FactRecallResult, error) {
+	searchQuery := fulltextquery.PlainText(query)
+	if searchQuery == "" {
+		return []FactRecallResult{}, nil
+	}
+
 	cypher := `
 CALL db.index.fulltext.queryNodes('fact_recall_idx', $searchQuery) YIELD node AS f, score
 WHERE f.team_id = $profileId AND f.status = 'active'
@@ -58,7 +64,7 @@ RETURN
 LIMIT $limit`
 
 	_, rows, err := s.reader.ScopedRead(ctx, profileID, cypher, map[string]any{
-		"searchQuery": query,
+		"searchQuery": searchQuery,
 		"limit":       limit,
 	})
 	if err != nil {
@@ -83,6 +89,11 @@ LIMIT $limit`
 }
 
 func (s *neo4jClaimSearcher) SearchValidated(ctx context.Context, profileID string, query string, limit int) ([]ClaimRecallResult, error) {
+	searchQuery := fulltextquery.PlainText(query)
+	if searchQuery == "" {
+		return []ClaimRecallResult{}, nil
+	}
+
 	cypher := `
 CALL db.index.fulltext.queryNodes('claim_recall_idx', $searchQuery) YIELD node AS c, score
 WHERE c.team_id = $profileId AND c.status = 'validated'
@@ -97,7 +108,7 @@ RETURN
 LIMIT $limit`
 
 	_, rows, err := s.reader.ScopedRead(ctx, profileID, cypher, map[string]any{
-		"searchQuery": query,
+		"searchQuery": searchQuery,
 		"limit":       limit,
 	})
 	if err != nil {

--- a/internal/service/recallservice/searcher_test.go
+++ b/internal/service/recallservice/searcher_test.go
@@ -16,9 +16,11 @@ type unitRecallScopedReader struct {
 	lastProfile string
 	lastQuery   string
 	lastParams  map[string]any
+	calls       int
 }
 
 func (r *unitRecallScopedReader) ScopedRead(_ context.Context, profileID string, query string, params map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
+	r.calls++
 	r.lastProfile = profileID
 	r.lastQuery = query
 	r.lastParams = params
@@ -82,4 +84,36 @@ func TestRecallSearcherHelpersReturnZeroValuesForWrongTypes(t *testing.T) {
 	require.Equal(t, 0.0, recallFloat64(row, "float"))
 	require.Nil(t, recallTimePtr(row, "time"))
 	require.True(t, recallTime(row, "time").IsZero())
+}
+
+func TestRecallSearchersNormalizeLuceneQueryText(t *testing.T) {
+	t.Run("fact recall uses plain-text query", func(t *testing.T) {
+		reader := &unitRecallScopedReader{}
+
+		got, err := NewFactSearcher(reader).SearchActive(context.Background(), "profile-1", "GitVibe workflows / git-vibe command", 5)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, "GitVibe workflows git vibe command", reader.lastParams["searchQuery"])
+	})
+
+	t.Run("claim recall uses plain-text query", func(t *testing.T) {
+		reader := &unitRecallScopedReader{}
+
+		got, err := NewClaimSearcher(reader).SearchValidated(context.Background(), "profile-1", "github.com/markhuangai/git-vibe", 5)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, "github com markhuangai git vibe", reader.lastParams["searchQuery"])
+	})
+
+	t.Run("punctuation-only query returns empty result without calling neo4j", func(t *testing.T) {
+		reader := &unitRecallScopedReader{}
+
+		got, err := NewFactSearcher(reader).SearchActive(context.Background(), "profile-1", "/", 5)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, 0, reader.calls)
+	})
 }

--- a/internal/tools/keywordsearch/searcher.go
+++ b/internal/tools/keywordsearch/searcher.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 
+	"github.com/markhuangai/dense-mem/internal/fulltextquery"
 	neo4jstore "github.com/markhuangai/dense-mem/internal/storage/neo4j"
 )
 
@@ -33,6 +34,11 @@ func NewFragmentSearcher(reader ScopedReaderInterface) FragmentSearcherInterface
 // SearchContent performs full-text search on SourceFragment content.
 // Results are filtered by team_id and retract status in the Cypher query.
 func (s *neo4jFragmentSearcher) SearchContent(ctx context.Context, profileID string, query string, labels []string, limit int) ([]FragmentSearchResult, error) {
+	searchQuery := fulltextquery.PlainText(query)
+	if searchQuery == "" {
+		return []FragmentSearchResult{}, nil
+	}
+
 	// Adapt FragmentActiveFilter (which uses the sf. node alias) to the f. alias used here.
 	// This excludes retracted SourceFragment nodes; legacy nodes without a status property
 	// are treated as active per the coalesce default (AC-44).
@@ -57,7 +63,7 @@ LIMIT $limit`
 
 	// Build params
 	params := map[string]any{
-		"searchQuery": query,
+		"searchQuery": searchQuery,
 		"limit":       limit,
 	}
 
@@ -104,6 +110,11 @@ func NewFactSearcher(reader ScopedReaderInterface) FactSearcherInterface {
 // SearchPredicate performs full-text search on Fact predicates.
 // Results are filtered by team_id in the Cypher query.
 func (s *neo4jFactSearcher) SearchPredicate(ctx context.Context, profileID string, query string, labels []string, limit int) ([]FactSearchResult, error) {
+	searchQuery := fulltextquery.PlainText(query)
+	if searchQuery == "" {
+		return []FactSearchResult{}, nil
+	}
+
 	// Build the Cypher query with full-text index search
 	// Uses db.index.fulltext.queryNodes for predicate search — fact_predicate_idx is a node index on Fact.predicate
 	cypherQuery := `
@@ -116,7 +127,7 @@ func (s *neo4jFactSearcher) SearchPredicate(ctx context.Context, profileID strin
 
 	// Build params
 	params := map[string]any{
-		"searchQuery": query,
+		"searchQuery": searchQuery,
 		"limit":       limit,
 	}
 

--- a/internal/tools/keywordsearch/service_test.go
+++ b/internal/tools/keywordsearch/service_test.go
@@ -435,12 +435,49 @@ type capturingReader struct {
 	capturedQuery  string
 	capturedParams map[string]any
 	rows           []map[string]any
+	calls          int
 }
 
 func (c *capturingReader) ScopedRead(_ context.Context, _ string, query string, params map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
+	c.calls++
 	c.capturedQuery = query
 	c.capturedParams = params
 	return nil, c.rows, nil
+}
+
+func TestSearchersNormalizeLuceneQueryText(t *testing.T) {
+	t.Run("fragment search uses plain-text query", func(t *testing.T) {
+		reader := &capturingReader{}
+		s := NewFragmentSearcher(reader)
+
+		got, err := s.SearchContent(context.Background(), "p1", "git-vibe GitVibe /git-vibe github.com/markhuangai/git-vibe", nil, 10)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, "git vibe GitVibe git vibe github com markhuangai git vibe", reader.capturedParams["searchQuery"])
+	})
+
+	t.Run("fact search uses plain-text query", func(t *testing.T) {
+		reader := &capturingReader{}
+		s := NewFactSearcher(reader)
+
+		got, err := s.SearchPredicate(context.Background(), "p1", `context: "project decisions" +(memory) -draft`, nil, 10)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, "context project decisions memory draft", reader.capturedParams["searchQuery"])
+	})
+
+	t.Run("punctuation-only query returns empty result without calling neo4j", func(t *testing.T) {
+		reader := &capturingReader{}
+		s := NewFragmentSearcher(reader)
+
+		got, err := s.SearchContent(context.Background(), "p1", `/ \ + - && || ! ( ) { } [ ] ^ " ~ * ? :`, nil, 10)
+
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Equal(t, 0, reader.calls)
+	})
 }
 
 // TestLabelFiltering verifies that label filter values are passed as Cypher parameters

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -503,7 +503,7 @@ func recallHitToMap(hit recallservice.RecallHit) (map[string]any, error) {
 func keywordSearchTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "keyword_search",
-		Description: "Advanced: BM25 full-text search across fragments and fact predicates.",
+		Description: "Advanced: plain-text BM25 search across fragments and fact predicates.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"keywords"},


### PR DESCRIPTION
## Summary

- Add a shared plain-text normalizer before Neo4j full-text queries reach Lucene.
- Apply it to keyword search, recall fact/claim enrichment, fragment keyword recall, and dream recall.
- Return empty full-text hits for punctuation-only input instead of invoking `db.index.fulltext.queryNodes` with invalid Lucene syntax.

## Root Cause

Dense-Mem passed user search text as a Cypher parameter to Neo4j full-text indexes. That is safe for Cypher injection, but Neo4j still sends the parameter value through Lucene's query parser, so slash/path-style input like `/git-vibe` can raise parser errors and surface as `keyword search unavailable` through recall.

## Validation

- `go test ./internal/fulltextquery ./internal/tools/keywordsearch ./internal/service/recallservice ./internal/service/dreamservice ./internal/tools/registry ./internal/mcp`
- `go test ./internal/openapi`
- `go test ./...`
- Live read-only Neo4j check confirmed the normalized original failing query is accepted by `fragment_content_idx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries are now automatically normalized, removing special characters and consolidating whitespace to improve the reliability and consistency of full-text search operations.

* **Documentation**
  * Updated search tool descriptions to specify plain-text query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->