### PR TITLE
[codex] dreaming observability and operation logs

### DIFF
--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -100,6 +100,7 @@ func main() {
 		level = slog.LevelDebug
 	}
 	logger := observability.New(level)
+	slog.SetDefault(logger.Slog())
 
 	// Wire embedding dimension into request validator so the embedding_dim tag
 	// on dto.SemanticSearchRequest enforces the configured length at bind time.
@@ -182,6 +183,7 @@ func main() {
 	appConfigRepo := repository.NewAppConfigRepository(pgDB.GetDB(), rlsHelper)
 	securityRepo := repository.NewSecurityRepository(pgDB.GetDB(), rlsHelper)
 	usageMetricsRepo := repository.NewUsageMetricsRepository(pgDB.GetDB(), rlsHelper)
+	operationLogRepo := repository.NewOperationLogRepository(pgDB.GetDB(), rlsHelper)
 	skillPackImportRepo := repository.NewSkillPackImportRepository(pgDB.GetDB(), rlsHelper)
 
 	// ========================================
@@ -195,6 +197,10 @@ func main() {
 	// ========================================
 	auditService := service.NewAuditService(pgDB.GetDB())
 	appConfigService := service.NewAppConfigService(appConfigRepo, auditService)
+	operationLogService := service.NewOperationLogService(operationLogRepo, appConfigService)
+	logger = observability.NewWithSinks(level, operationLogService)
+	slog.SetDefault(logger.Slog())
+	operationLogService.Start(context.Background())
 	securityService := service.NewSecurityService(securityRepo, auditService)
 	usageMetricsService := service.NewUsageMetricsService(usageMetricsRepo, logger)
 	usageMetricsService.Start(context.Background())
@@ -640,6 +646,7 @@ func main() {
 		AuditSvc:        auditService,
 		SecuritySvc:     securityService,
 		SSOService:      ssoService,
+		AppConfig:       appConfigService,
 		Config:          &cfg,
 		ExtraMiddleware: runtimeServices.UserPortalMiddleware,
 	})
@@ -666,6 +673,7 @@ func main() {
 				ScrapeToken:   cfg.GetTelemetryScrapeToken(),
 				SSO:           ssoService,
 				Config:        appConfigService,
+				Logs:          operationLogService,
 			},
 			healthConfig,
 			logger,
@@ -734,5 +742,8 @@ func main() {
 	defer metricsShutdownCancel()
 	if err := usageMetricsService.Shutdown(metricsShutdownCtx); err != nil {
 		logger.Error("usage metrics shutdown error", err)
+	}
+	if err := operationLogService.Shutdown(metricsShutdownCtx); err != nil {
+		log.Printf("operation log shutdown error: %v", err)
 	}
 }

--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/claimservice"
 	"github.com/markhuangai/dense-mem/internal/service/communityservice"
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/factservice"
 	"github.com/markhuangai/dense-mem/internal/service/fragmentdedupe"
 	"github.com/markhuangai/dense-mem/internal/service/fragmentservice"
@@ -443,6 +444,16 @@ func main() {
 		FactConfirm:    factConfirmSvc,
 		FactList:       factListSvc,
 	})
+	dreamSvc := dreamservice.New(dreamservice.Dependencies{
+		Graph:          profileScopeEnforcer,
+		Memory:         memorySvc,
+		FragmentCreate: fragmentCreateRegistrySvc,
+		AppConfig:      appConfigService,
+		Profiles:       profileService,
+		Locker:         dreamservice.NewPostgresCycleLocker(),
+		Postgres:       pgDB.GetDB(),
+		Generator:      dreamservice.NewHeuristicGenerator(cfg.GetAIVerifierModel()),
+	})
 	contextSvc := contextservice.New(contextservice.Dependencies{
 		Reader:      profileScopeEnforcer,
 		FactGet:     factGetSvc,
@@ -450,6 +461,7 @@ func main() {
 		FragmentGet: fragmentGetSvc,
 		Recall:      recallRegistrySvc,
 		Memory:      memorySvc,
+		Dreams:      dreamSvc,
 	})
 	skillPackSvc := skillpackservice.New(skillpackservice.Dependencies{
 		FragmentCreate:  fragmentCreateRegistrySvc,
@@ -492,6 +504,7 @@ func main() {
 		Context:                     contextSvc,
 		Memory:                      memorySvc,
 		SkillPack:                   skillPackSvc,
+		Dreams:                      dreamSvc,
 	})
 	if err != nil {
 		log.Fatalf("failed to build tool registry: %v", err)
@@ -545,6 +558,7 @@ func main() {
 	openAPIFullHandler := handler.NewOpenAPIHandler(openAPIGen, openapi.SpecVariantFull)
 
 	recallHandler := handler.NewRecallHandler(recallHTTPSvc)
+	dreamHandler := handler.NewDreamHandler(dreamSvc)
 
 	// ========================================
 	// Health checks
@@ -632,6 +646,10 @@ func main() {
 		OpenAPIAISafe:   openAPIAISafeHandler.Handle,
 		OpenAPIFull:     openAPIFullHandler.Handle,
 		Recall:          recallHandler.Handle,
+		DreamingStatus:  dreamHandler.Status,
+		DreamingRuns:    dreamHandler.Runs,
+		DreamList:       dreamHandler.List,
+		DreamGet:        dreamHandler.Get,
 	}
 	protectedHandlers.FragmentCreate = fragmentCreateHandler.Handle
 
@@ -674,6 +692,7 @@ func main() {
 				SSO:           ssoService,
 				Config:        appConfigService,
 				Logs:          operationLogService,
+				Dreams:        dreamSvc,
 			},
 			healthConfig,
 			logger,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -94,6 +94,7 @@ func main() {
 		level = slog.LevelDebug
 	}
 	logger := observability.New(level)
+	slog.SetDefault(logger.Slog())
 
 	// Wire embedding dimension into request validator so the embedding_dim tag
 	// on dto.SemanticSearchRequest enforces the configured length at bind time.
@@ -173,6 +174,7 @@ func main() {
 	appConfigRepo := repository.NewAppConfigRepository(pgDB.GetDB(), rlsHelper)
 	securityRepo := repository.NewSecurityRepository(pgDB.GetDB(), rlsHelper)
 	usageMetricsRepo := repository.NewUsageMetricsRepository(pgDB.GetDB(), rlsHelper)
+	operationLogRepo := repository.NewOperationLogRepository(pgDB.GetDB(), rlsHelper)
 	skillPackImportRepo := repository.NewSkillPackImportRepository(pgDB.GetDB(), rlsHelper)
 
 	// ========================================
@@ -186,6 +188,10 @@ func main() {
 	// ========================================
 	auditService := service.NewAuditService(pgDB.GetDB())
 	appConfigService := service.NewAppConfigService(appConfigRepo, auditService)
+	operationLogService := service.NewOperationLogService(operationLogRepo, appConfigService)
+	logger = observability.NewWithSinks(level, operationLogService)
+	slog.SetDefault(logger.Slog())
+	operationLogService.Start(context.Background())
 	securityService := service.NewSecurityService(securityRepo, auditService)
 	usageMetricsService := service.NewUsageMetricsService(usageMetricsRepo, logger)
 	usageMetricsService.Start(context.Background())
@@ -500,6 +506,7 @@ func main() {
 	openAPIFullHandler := handler.NewOpenAPIHandler(openAPIGen, openapi.SpecVariantFull)
 
 	recallHandler := handler.NewRecallHandler(recallHTTPSvc)
+	dreamHandler := handler.NewDreamHandler(dreamSvc)
 
 	// ========================================
 	// Health checks
@@ -583,6 +590,10 @@ func main() {
 		OpenAPIAISafe:   openAPIAISafeHandler.Handle,
 		OpenAPIFull:     openAPIFullHandler.Handle,
 		Recall:          recallHandler.Handle,
+		DreamingStatus:  dreamHandler.Status,
+		DreamingRuns:    dreamHandler.Runs,
+		DreamList:       dreamHandler.List,
+		DreamGet:        dreamHandler.Get,
 	}
 	protectedHandlers.FragmentCreate = fragmentCreateHandler.Handle
 
@@ -597,6 +608,7 @@ func main() {
 		AuditSvc:     auditService,
 		SecuritySvc:  securityService,
 		SSOService:   ssoService,
+		AppConfig:    appConfigService,
 		Config:       &cfg,
 	}
 	if telemetryHTTPMetrics != nil {
@@ -615,6 +627,8 @@ func main() {
 			ScrapeToken:   cfg.GetTelemetryScrapeToken(),
 			SSO:           ssoService,
 			Config:        appConfigService,
+			Logs:          operationLogService,
+			Dreams:        dreamSvc,
 		},
 		healthConfig,
 		logger,
@@ -666,5 +680,8 @@ func main() {
 	defer metricsShutdownCancel()
 	if err := usageMetricsService.Shutdown(metricsShutdownCtx); err != nil {
 		logger.Error("usage metrics shutdown error", err)
+	}
+	if err := operationLogService.Shutdown(metricsShutdownCtx); err != nil {
+		log.Printf("operation log shutdown error: %v", err)
 	}
 }

--- a/internal/domain/app_config.go
+++ b/internal/domain/app_config.go
@@ -20,6 +20,8 @@ const (
 	AppConfigDreamingReevaluateEnabled = "DREAMING_REEVALUATE_ENABLED"
 	AppConfigDreamingDreamEnabled      = "DREAMING_DREAM_ENABLED"
 	AppConfigDreamingMaxOutputs        = "DREAMING_MAX_OUTPUTS"
+
+	AppConfigOperationLogRetentionDays = "OPERATION_LOG_RETENTION_DAYS"
 )
 
 type AppConfigEntry struct {
@@ -38,4 +40,25 @@ type SSOConfigItem struct {
 type SSOConfigSettings struct {
 	UpdateTime string
 	Items      []SSOConfigItem
+}
+
+// OperationLogConfigSettings is the editable runtime configuration for
+// database-backed application log retention.
+type OperationLogConfigSettings struct {
+	UpdateTime string                    `json:"update_time"`
+	Items      []OperationLogConfigItem  `json:"items"`
+	Effective  OperationLogRuntimeConfig `json:"effective"`
+}
+
+// OperationLogConfigItem is one control-panel editable operation log config entry.
+type OperationLogConfigItem struct {
+	Key            string    `json:"key"`
+	Value          string    `json:"value"`
+	EffectiveValue string    `json:"effective_value"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// OperationLogRuntimeConfig is the effective operation log runtime config.
+type OperationLogRuntimeConfig struct {
+	RetentionDays int `json:"retention_days"`
 }

--- a/internal/domain/operation_log.go
+++ b/internal/domain/operation_log.go
@@ -33,6 +33,6 @@ type OperationLogFilter struct {
 
 // OperationLogPage is a paginated operation log response.
 type OperationLogPage struct {
-	Items []OperationLog
-	Total int64
+	Items []OperationLog `json:"items"`
+	Total int64          `json:"total"`
 }

--- a/internal/domain/operation_log.go
+++ b/internal/domain/operation_log.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OperationLog is one structured application log record persisted for control
+// portal inspection.
+type OperationLog struct {
+	ID            uuid.UUID      `json:"id"`
+	Timestamp     time.Time      `json:"timestamp"`
+	Severity      string         `json:"severity"`
+	SeverityRank  int            `json:"severity_rank"`
+	Message       string         `json:"message"`
+	Source        string         `json:"source,omitempty"`
+	TeamID        *uuid.UUID     `json:"team_id,omitempty"`
+	ProfileID     *uuid.UUID     `json:"profile_id,omitempty"`
+	CorrelationID string         `json:"correlation_id,omitempty"`
+	Error         string         `json:"error,omitempty"`
+	Attrs         map[string]any `json:"attrs,omitempty"`
+}
+
+// OperationLogFilter controls control-portal log listing.
+type OperationLogFilter struct {
+	Limit     int
+	Offset    int
+	Severity  string
+	Sort      string
+	Direction string
+}
+
+// OperationLogPage is a paginated operation log response.
+type OperationLogPage struct {
+	Items []OperationLog
+	Total int64
+}

--- a/internal/http/control_portal.go
+++ b/internal/http/control_portal.go
@@ -25,6 +25,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 )
 
 // NewControlPortalServer creates the token-protected management portal server.
@@ -65,6 +66,8 @@ type ControlPortalTelemetry struct {
 	ScrapeToken   string
 	SSO           *service.SSOService
 	Config        service.AppConfigService
+	Logs          service.OperationLogReader
+	Dreams        dreamservice.Service
 }
 
 func NewControlPortalServerWithMetricsAndTelemetry(
@@ -128,16 +131,25 @@ func NewControlPortalServerWithMetricsAndTelemetry(
 		e.GET("/metrics", echo.WrapHandler(telemetry.ScrapeHandler), telemetryScrapeTokenMiddleware(telemetry.ScrapeToken))
 	}
 
-	control := &controlPortalHandler{profiles: profileSvc, keys: apiKeySvc, security: securitySvc, metrics: metricsSvc, telemetry: telemetry.Reader, health: health, sso: telemetry.SSO, appConfig: telemetry.Config}
+	control := &controlPortalHandler{profiles: profileSvc, keys: apiKeySvc, security: securitySvc, metrics: metricsSvc, telemetry: telemetry.Reader, operationLogs: telemetry.Logs, dreams: telemetry.Dreams, health: health, sso: telemetry.SSO, appConfig: telemetry.Config}
 	api := e.Group("/control/api")
 	api.Use(controlPortalMiddleware(cfg.GetControlPortalToken(), securitySvc))
 	api.GET("/session", control.session)
 	api.GET("/metrics", control.getMetrics)
 	api.GET("/telemetry", control.getTelemetry)
+	if telemetry.Logs != nil {
+		api.GET("/logs", control.listOperationLogs)
+	}
 	api.GET("/teams", control.listProfiles)
 	api.POST("/teams", control.createProfile)
 	api.PATCH("/teams/:teamId", control.updateProfile)
 	api.DELETE("/teams/:teamId", control.deleteProfile)
+	if telemetry.Dreams != nil {
+		api.GET("/teams/:teamId/dreaming/status", control.getTeamDreamingStatus)
+		api.GET("/teams/:teamId/dreaming/runs", control.listTeamDreamingRuns)
+		api.GET("/teams/:teamId/dreams", control.listTeamDreams)
+		api.GET("/teams/:teamId/dreams/:dreamId", control.getTeamDream)
+	}
 	api.GET("/teams/:teamId/profiles", control.listAPIKeys)
 	api.POST("/teams/:teamId/profiles", control.createAPIKey)
 	api.PATCH("/teams/:teamId/profiles/:profileId", control.updateAPIKey)
@@ -163,6 +175,8 @@ func NewControlPortalServerWithMetricsAndTelemetry(
 		api.PATCH("/config/sso", control.updateSSOConfig)
 		api.GET("/config/dreaming", control.getDreamingConfig)
 		api.PATCH("/config/dreaming", control.updateDreamingConfig)
+		api.GET("/config/operation-logs", control.getOperationLogConfig)
+		api.PATCH("/config/operation-logs", control.updateOperationLogConfig)
 	}
 	if telemetry.SSO != nil {
 		api.GET("/sso/providers", control.listSSOProviders)
@@ -183,14 +197,16 @@ func NewControlPortalServerWithMetricsAndTelemetry(
 }
 
 type controlPortalHandler struct {
-	profiles  handler.ProfileServiceInterface
-	keys      handler.APIKeyServiceInterface
-	security  service.SecurityService
-	metrics   service.UsageMetricsReader
-	telemetry service.TelemetryReader
-	health    HealthConfig
-	sso       *service.SSOService
-	appConfig service.AppConfigService
+	profiles      handler.ProfileServiceInterface
+	keys          handler.APIKeyServiceInterface
+	security      service.SecurityService
+	metrics       service.UsageMetricsReader
+	telemetry     service.TelemetryReader
+	operationLogs service.OperationLogReader
+	dreams        dreamservice.Service
+	health        HealthConfig
+	sso           *service.SSOService
+	appConfig     service.AppConfigService
 }
 
 func (h *controlPortalHandler) session(c echo.Context) error {
@@ -246,7 +262,7 @@ func (h *controlPortalHandler) listProfiles(c echo.Context) error {
 	}
 	items := make([]controlProfileResponse, 0, len(profiles))
 	for _, profile := range profiles {
-		items = append(items, toControlProfile(profile))
+		items = append(items, h.toControlProfile(c.Request().Context(), profile))
 	}
 	return c.JSON(nethttp.StatusOK, handler.PaginationEnvelope{
 		Data:       items,
@@ -271,7 +287,7 @@ func (h *controlPortalHandler) createProfile(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(nethttp.StatusCreated, map[string]any{"data": toControlProfile(profile)})
+	return c.JSON(nethttp.StatusCreated, map[string]any{"data": h.toControlProfile(c.Request().Context(), profile)})
 }
 
 func (h *controlPortalHandler) updateProfile(c echo.Context) error {
@@ -302,7 +318,7 @@ func (h *controlPortalHandler) updateProfile(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(nethttp.StatusOK, map[string]any{"data": toControlProfile(profile)})
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": h.toControlProfile(c.Request().Context(), profile)})
 }
 
 func (h *controlPortalHandler) deleteProfile(c echo.Context) error {
@@ -695,46 +711,6 @@ func controlTelemetryFilter(c echo.Context) (service.TelemetryFilter, error) {
 	}, nil
 }
 
-func controlDependencySnapshot(ctx context.Context, health HealthConfig) []controlDependencyResponse {
-	responses := make([]controlDependencyResponse, 0, len(health.Checks)+1)
-	for _, check := range health.Checks {
-		if check.Check == nil {
-			continue
-		}
-		checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-		start := time.Now()
-		err := check.Check(checkCtx)
-		latency := time.Since(start).Milliseconds()
-		cancel()
-
-		status := "ok"
-		var message *string
-		if err != nil {
-			status = "error"
-			text := err.Error()
-			message = &text
-		}
-		responses = append(responses, controlDependencyResponse{
-			Name:      check.Name,
-			Status:    status,
-			LatencyMS: &latency,
-			Message:   message,
-		})
-	}
-	if health.Degraded {
-		message := health.Reason
-		if message == "" {
-			message = "degraded mode"
-		}
-		responses = append(responses, controlDependencyResponse{
-			Name:    "redis",
-			Status:  "degraded",
-			Message: &message,
-		})
-	}
-	return responses
-}
-
 func telemetryScrapeTokenMiddleware(token string) echo.MiddlewareFunc {
 	expected := strings.TrimSpace(token)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -927,24 +903,26 @@ func toControlSecurityBan(ban domain.SecurityIPBan) controlSecurityBanResponse {
 }
 
 type controlProfileResponse struct {
-	ID          uuid.UUID      `json:"id"`
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Metadata    map[string]any `json:"metadata"`
-	Config      map[string]any `json:"config"`
-	CreatedAt   string         `json:"created_at"`
-	UpdatedAt   string         `json:"updated_at"`
+	ID                uuid.UUID                     `json:"id"`
+	Name              string                        `json:"name"`
+	Description       string                        `json:"description"`
+	Metadata          map[string]any                `json:"metadata"`
+	Config            map[string]any                `json:"config"`
+	DreamingEffective *dreamservice.EffectiveConfig `json:"dreaming_effective,omitempty"`
+	CreatedAt         string                        `json:"created_at"`
+	UpdatedAt         string                        `json:"updated_at"`
 }
 
-func toControlProfile(profile *domain.Profile) controlProfileResponse {
+func (h *controlPortalHandler) toControlProfile(ctx context.Context, profile *domain.Profile) controlProfileResponse {
 	return controlProfileResponse{
-		ID:          profile.ID,
-		Name:        profile.Name,
-		Description: profile.Description,
-		Metadata:    profile.Metadata,
-		Config:      profile.Config,
-		CreatedAt:   profile.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   profile.UpdatedAt.Format(time.RFC3339),
+		ID:                profile.ID,
+		Name:              profile.Name,
+		Description:       profile.Description,
+		Metadata:          profile.Metadata,
+		Config:            profile.Config,
+		DreamingEffective: effectiveDreamingConfig(ctx, h.appConfig, profile.Config),
+		CreatedAt:         profile.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:         profile.UpdatedAt.Format(time.RFC3339),
 	}
 }
 

--- a/internal/http/control_portal_config.go
+++ b/internal/http/control_portal_config.go
@@ -78,11 +78,48 @@ func (h *controlPortalHandler) updateDreamingConfig(c echo.Context) error {
 	return c.JSON(nethttp.StatusOK, map[string]any{"data": toControlDreamingConfig(settings)})
 }
 
+func (h *controlPortalHandler) getOperationLogConfig(c echo.Context) error {
+	if h.appConfig == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "app config service unavailable")
+	}
+	settings, err := h.appConfig.GetOperationLogSettings(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": toControlOperationLogConfig(settings)})
+}
+
+func (h *controlPortalHandler) updateOperationLogConfig(c echo.Context) error {
+	if h.appConfig == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "app config service unavailable")
+	}
+	var body controlOperationLogConfigRequest
+	if err := c.Bind(&body); err != nil {
+		return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
+	}
+	values := make(map[string]string, len(body.Items))
+	for _, item := range body.Items {
+		values[item.Key] = item.Value
+	}
+	settings, err := h.appConfig.UpdateOperationLogSettings(c.Request().Context(), values, "control", c.RealIP(), "")
+	if err != nil {
+		if errors.Is(err, service.ErrInvalidAppConfig) {
+			return httperr.New(httperr.VALIDATION_ERROR, err.Error())
+		}
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": toControlOperationLogConfig(settings)})
+}
+
 type controlSSOConfigRequest struct {
 	Items []controlSSOConfigItemRequest `json:"items"`
 }
 
 type controlDreamingConfigRequest struct {
+	Items []controlSSOConfigItemRequest `json:"items"`
+}
+
+type controlOperationLogConfigRequest struct {
 	Items []controlSSOConfigItemRequest `json:"items"`
 }
 
@@ -100,6 +137,12 @@ type controlDreamingConfigResponse struct {
 	UpdateTime string                         `json:"update_time"`
 	Items      []controlSSOConfigItemResponse `json:"items"`
 	Effective  domain.DreamingRuntimeConfig   `json:"effective"`
+}
+
+type controlOperationLogConfigResponse struct {
+	UpdateTime string                           `json:"update_time"`
+	Items      []controlSSOConfigItemResponse   `json:"items"`
+	Effective  domain.OperationLogRuntimeConfig `json:"effective"`
 }
 
 type controlSSOConfigItemResponse struct {
@@ -142,6 +185,26 @@ func toControlDreamingConfig(settings *domain.DreamingConfigSettings) controlDre
 		})
 	}
 	return controlDreamingConfigResponse{
+		UpdateTime: settings.UpdateTime,
+		Items:      items,
+		Effective:  settings.Effective,
+	}
+}
+
+func toControlOperationLogConfig(settings *domain.OperationLogConfigSettings) controlOperationLogConfigResponse {
+	if settings == nil {
+		return controlOperationLogConfigResponse{Items: []controlSSOConfigItemResponse{}}
+	}
+	items := make([]controlSSOConfigItemResponse, 0, len(settings.Items))
+	for _, item := range settings.Items {
+		items = append(items, controlSSOConfigItemResponse{
+			Key:            item.Key,
+			Value:          item.Value,
+			EffectiveValue: item.EffectiveValue,
+			UpdatedAt:      item.UpdatedAt.Format(time.RFC3339),
+		})
+	}
+	return controlOperationLogConfigResponse{
 		UpdateTime: settings.UpdateTime,
 		Items:      items,
 		Effective:  settings.Effective,

--- a/internal/http/control_portal_config_test.go
+++ b/internal/http/control_portal_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/markhuangai/dense-mem/internal/config"
@@ -17,12 +18,16 @@ import (
 )
 
 type controlAppConfigSvc struct {
-	settings         *domain.SSOConfigSettings
-	dreamingSettings *domain.DreamingConfigSettings
-	values           map[string]string
-	dreamingValues   map[string]string
-	getErr           error
-	updateErr        error
+	settings             *domain.SSOConfigSettings
+	dreamingSettings     *domain.DreamingConfigSettings
+	operationLogSettings *domain.OperationLogConfigSettings
+	values               map[string]string
+	dreamingValues       map[string]string
+	operationLogValues   map[string]string
+	getErr               error
+	updateErr            error
+	dreamingRuntime      domain.DreamingRuntimeConfig
+	dreamingRuntimeErr   error
 }
 
 func (s *controlAppConfigSvc) GetSSOSettings(context.Context) (*domain.SSOConfigSettings, error) {
@@ -70,7 +75,31 @@ func (s *controlAppConfigSvc) UpdateDreamingSettings(_ context.Context, values m
 }
 
 func (s *controlAppConfigSvc) DreamingRuntimeConfig(context.Context) (domain.DreamingRuntimeConfig, error) {
-	return domain.DreamingRuntimeConfig{}, nil
+	return s.dreamingRuntime, s.dreamingRuntimeErr
+}
+
+func (s *controlAppConfigSvc) GetOperationLogSettings(context.Context) (*domain.OperationLogConfigSettings, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.operationLogSettings, nil
+}
+
+func (s *controlAppConfigSvc) UpdateOperationLogSettings(_ context.Context, values map[string]string, _, _, _ string) (*domain.OperationLogConfigSettings, error) {
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	if s.operationLogValues == nil {
+		s.operationLogValues = make(map[string]string)
+	}
+	for key, value := range values {
+		s.operationLogValues[key] = value
+	}
+	return s.operationLogSettings, nil
+}
+
+func (s *controlAppConfigSvc) OperationLogRuntimeConfig(context.Context) (domain.OperationLogRuntimeConfig, error) {
+	return domain.OperationLogRuntimeConfig{}, nil
 }
 
 func TestControlPortalSSOConfigFlows(t *testing.T) {
@@ -184,4 +213,69 @@ func TestControlPortalDreamingConfigFlows(t *testing.T) {
 	appConfig.updateErr = service.ErrInvalidAppConfig
 	rec = do(http.MethodPatch, "/control/api/config/dreaming", `{"items":[{"key":"DREAMING_MAX_OUTPUTS","value":"0"}]}`)
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestControlPortalOperationLogConfigFlows(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	appConfig := &controlAppConfigSvc{
+		operationLogSettings: &domain.OperationLogConfigSettings{
+			UpdateTime: now.Format(time.RFC3339Nano),
+			Items: []domain.OperationLogConfigItem{{
+				Key:            domain.AppConfigOperationLogRetentionDays,
+				Value:          "30",
+				EffectiveValue: "30",
+				UpdatedAt:      now,
+			}},
+			Effective: domain.OperationLogRuntimeConfig{RetentionDays: 30},
+		},
+	}
+	e, err := NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
+		ControlHTTPAddr:    "127.0.0.1:8090",
+		ControlPortalToken: "secret",
+	}, &controlProfileSvc{}, &controlKeySvc{}, nil, ControlPortalTelemetry{
+		Config: appConfig,
+	}, HealthConfig{}, nil)
+	require.NoError(t, err)
+
+	do := func(method, path, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer secret")
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	rec := do(http.MethodGet, "/control/api/config/operation-logs", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"update_time":"2026-06-14T12:00:00Z"`)
+	require.Contains(t, rec.Body.String(), `"retention_days":30`)
+
+	rec = do(http.MethodPatch, "/control/api/config/operation-logs", `{"items":[{"key":"OPERATION_LOG_RETENTION_DAYS","value":"45"}]}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "45", appConfig.operationLogValues[domain.AppConfigOperationLogRetentionDays])
+
+	rec = do(http.MethodPatch, "/control/api/config/operation-logs", "{")
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+	appConfig.updateErr = service.ErrInvalidAppConfig
+	rec = do(http.MethodPatch, "/control/api/config/operation-logs", `{"items":[{"key":"OPERATION_LOG_RETENTION_DAYS","value":"0"}]}`)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestControlConfigNilResponses(t *testing.T) {
+	require.Empty(t, toControlSSOConfig(nil).Items)
+	require.Empty(t, toControlDreamingConfig(nil).Items)
+	require.Empty(t, toControlOperationLogConfig(nil).Items)
+}
+
+func TestControlPortalOperationLogConfigUnavailable(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	h := &controlPortalHandler{}
+
+	require.ErrorContains(t, h.getOperationLogConfig(c), "app config service unavailable")
+	require.ErrorContains(t, h.updateOperationLogConfig(c), "app config service unavailable")
 }

--- a/internal/http/control_portal_observability.go
+++ b/internal/http/control_portal_observability.go
@@ -1,0 +1,218 @@
+package http
+
+import (
+	"context"
+	"errors"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/http/handler"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+)
+
+func (h *controlPortalHandler) listOperationLogs(c echo.Context) error {
+	if h.operationLogs == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "operation logs unavailable")
+	}
+	filter, err := controlOperationLogsFilter(c)
+	if err != nil {
+		return err
+	}
+	page, err := h.operationLogs.ListOperationLogs(c.Request().Context(), filter)
+	if err != nil {
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, handler.PaginationEnvelope{
+		Data: page.Items,
+		Pagination: handler.Pagination{
+			Limit:  filter.Limit,
+			Offset: filter.Offset,
+			Total:  page.Total,
+		},
+	})
+}
+
+func (h *controlPortalHandler) getTeamDreamingStatus(c echo.Context) error {
+	if h.dreams == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "dream service unavailable")
+	}
+	profileID, err := parseControlUUID(controlTeamIDParam(c), "team ID")
+	if err != nil {
+		return err
+	}
+	status, err := h.dreams.Status(c.Request().Context(), profileID.String())
+	if err != nil {
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": status})
+}
+
+func (h *controlPortalHandler) listTeamDreamingRuns(c echo.Context) error {
+	if h.dreams == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "dream service unavailable")
+	}
+	profileID, err := parseControlUUID(controlTeamIDParam(c), "team ID")
+	if err != nil {
+		return err
+	}
+	limit, err := controlDreamLimit(c.QueryParam("limit"))
+	if err != nil {
+		return err
+	}
+	runs, err := h.dreams.ListRuns(c.Request().Context(), profileID.String(), limit)
+	if err != nil {
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": runs})
+}
+
+func (h *controlPortalHandler) listTeamDreams(c echo.Context) error {
+	if h.dreams == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "dream service unavailable")
+	}
+	profileID, err := parseControlUUID(controlTeamIDParam(c), "team ID")
+	if err != nil {
+		return err
+	}
+	opts, err := controlDreamListOptions(c)
+	if err != nil {
+		return err
+	}
+	dreams, _, err := h.dreams.List(c.Request().Context(), profileID.String(), opts)
+	if err != nil {
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": dreams})
+}
+
+func (h *controlPortalHandler) getTeamDream(c echo.Context) error {
+	if h.dreams == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "dream service unavailable")
+	}
+	profileID, err := parseControlUUID(controlTeamIDParam(c), "team ID")
+	if err != nil {
+		return err
+	}
+	dreamID := strings.TrimSpace(c.Param("dreamId"))
+	if dreamID == "" {
+		return httperr.New(httperr.VALIDATION_ERROR, "dream ID is required")
+	}
+	dream, err := h.dreams.Get(c.Request().Context(), profileID.String(), dreamID)
+	if err != nil {
+		if errors.Is(err, dreamservice.ErrDreamNotFound) {
+			return httperr.New(httperr.NOT_FOUND, "dream not found")
+		}
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": dream})
+}
+
+func controlOperationLogsFilter(c echo.Context) (domain.OperationLogFilter, error) {
+	limit, offset := controlPagination(c)
+	if raw := strings.TrimSpace(c.QueryParam("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 500 {
+			return domain.OperationLogFilter{}, httperr.New(httperr.VALIDATION_ERROR, "limit must be between 1 and 500")
+		}
+		limit = parsed
+	}
+	severity := strings.ToUpper(strings.TrimSpace(c.QueryParam("severity")))
+	switch severity {
+	case "", "DEBUG", "INFO", "WARN", "ERROR":
+	default:
+		return domain.OperationLogFilter{}, httperr.New(httperr.VALIDATION_ERROR, "severity must be one of DEBUG, INFO, WARN, ERROR")
+	}
+	sort := strings.ToLower(strings.TrimSpace(c.QueryParam("sort")))
+	switch sort {
+	case "", "timestamp", "severity":
+	default:
+		return domain.OperationLogFilter{}, httperr.New(httperr.VALIDATION_ERROR, "sort must be timestamp or severity")
+	}
+	direction := strings.ToLower(strings.TrimSpace(c.QueryParam("direction")))
+	switch direction {
+	case "", "asc", "desc":
+	default:
+		return domain.OperationLogFilter{}, httperr.New(httperr.VALIDATION_ERROR, "direction must be asc or desc")
+	}
+	return domain.OperationLogFilter{
+		Limit:     limit,
+		Offset:    offset,
+		Severity:  severity,
+		Sort:      sort,
+		Direction: direction,
+	}, nil
+}
+
+func controlDreamListOptions(c echo.Context) (dreamservice.ListOptions, error) {
+	limit, err := controlDreamLimit(c.QueryParam("limit"))
+	if err != nil {
+		return dreamservice.ListOptions{}, err
+	}
+	status := strings.TrimSpace(c.QueryParam("status"))
+	if status != "" && !domain.DreamStatus(status).IsValid() {
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "status must be one of proposed, reinforced, stale, rejected, promoted")
+	}
+	return dreamservice.ListOptions{
+		Limit:  limit,
+		Status: status,
+		Cursor: strings.TrimSpace(c.QueryParam("cursor")),
+	}, nil
+}
+
+func controlDreamLimit(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 20, nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 1 || parsed > 100 {
+		return 0, httperr.New(httperr.VALIDATION_ERROR, "limit must be between 1 and 100")
+	}
+	return parsed, nil
+}
+
+func controlDependencySnapshot(ctx context.Context, health HealthConfig) []controlDependencyResponse {
+	responses := make([]controlDependencyResponse, 0, len(health.Checks)+1)
+	for _, check := range health.Checks {
+		if check.Check == nil {
+			continue
+		}
+		checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		start := time.Now()
+		err := check.Check(checkCtx)
+		latency := time.Since(start).Milliseconds()
+		cancel()
+
+		status := "ok"
+		var message *string
+		if err != nil {
+			status = "error"
+			text := err.Error()
+			message = &text
+		}
+		responses = append(responses, controlDependencyResponse{
+			Name:      check.Name,
+			Status:    status,
+			LatencyMS: &latency,
+			Message:   message,
+		})
+	}
+	if health.Degraded {
+		message := health.Reason
+		if message == "" {
+			message = "degraded mode"
+		}
+		responses = append(responses, controlDependencyResponse{
+			Name:    "redis",
+			Status:  "degraded",
+			Message: &message,
+		})
+	}
+	return responses
+}

--- a/internal/http/control_portal_observability.go
+++ b/internal/http/control_portal_observability.go
@@ -16,6 +16,11 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 )
 
+type controlDreamListResponse struct {
+	Items      []*domain.Dream `json:"items"`
+	NextCursor string          `json:"next_cursor,omitempty"`
+}
+
 func (h *controlPortalHandler) listOperationLogs(c echo.Context) error {
 	if h.operationLogs == nil {
 		return httperr.New(httperr.SERVICE_UNAVAILABLE, "operation logs unavailable")
@@ -84,11 +89,11 @@ func (h *controlPortalHandler) listTeamDreams(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	dreams, _, err := h.dreams.List(c.Request().Context(), profileID.String(), opts)
+	dreams, nextCursor, err := h.dreams.List(c.Request().Context(), profileID.String(), opts)
 	if err != nil {
 		return err
 	}
-	return c.JSON(nethttp.StatusOK, map[string]any{"data": dreams})
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": controlDreamListResponse{Items: dreams, NextCursor: nextCursor}})
 }
 
 func (h *controlPortalHandler) getTeamDream(c echo.Context) error {

--- a/internal/http/control_portal_observability_test.go
+++ b/internal/http/control_portal_observability_test.go
@@ -37,14 +37,15 @@ func (s *controlOperationLogReaderStub) ListOperationLogs(_ context.Context, fil
 }
 
 type controlDreamServiceStub struct {
-	status    *dreamservice.StatusResult
-	runs      []*dreamservice.RunCycleResult
-	dreams    []*domain.Dream
-	dream     *domain.Dream
-	listOpts  dreamservice.ListOptions
-	runsLimit int
-	profileID string
-	getErr    error
+	status     *dreamservice.StatusResult
+	runs       []*dreamservice.RunCycleResult
+	dreams     []*domain.Dream
+	dream      *domain.Dream
+	nextCursor string
+	listOpts   dreamservice.ListOptions
+	runsLimit  int
+	profileID  string
+	getErr     error
 }
 
 func (s *controlDreamServiceStub) RunCycle(context.Context, string, dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -54,7 +55,7 @@ func (s *controlDreamServiceStub) RunCycle(context.Context, string, dreamservice
 func (s *controlDreamServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
 	s.profileID = profileID
 	s.listOpts = opts
-	return s.dreams, "", nil
+	return s.dreams, s.nextCursor, nil
 }
 
 func (s *controlDreamServiceStub) Get(_ context.Context, profileID, dreamID string) (*domain.Dream, error) {
@@ -120,6 +121,7 @@ func TestControlPortalObservabilityRoutes(t *testing.T) {
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}},
+		nextCursor: "after-control-dream-1",
 		dream: &domain.Dream{
 			ProfileID:  teamID.String(),
 			Hypothesis: "A control dream appears",
@@ -169,6 +171,7 @@ func TestControlPortalObservabilityRoutes(t *testing.T) {
 	rec = do("/control/api/teams/" + teamID.String() + "/dreams?limit=4&status=proposed&cursor=next")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), "A control dream appears")
+	assert.Contains(t, rec.Body.String(), `"next_cursor":"after-control-dream-1"`)
 	assert.Equal(t, teamID.String(), dreams.profileID)
 	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next"}, dreams.listOpts)
 

--- a/internal/http/control_portal_observability_test.go
+++ b/internal/http/control_portal_observability_test.go
@@ -1,0 +1,258 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+	"github.com/markhuangai/dense-mem/internal/service/fragmentservice"
+)
+
+type controlOperationLogReaderStub struct {
+	page    *domain.OperationLogPage
+	filter  domain.OperationLogFilter
+	listErr error
+}
+
+func (s *controlOperationLogReaderStub) ListOperationLogs(_ context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error) {
+	s.filter = filter
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	if s.page != nil {
+		return s.page, nil
+	}
+	return &domain.OperationLogPage{}, nil
+}
+
+type controlDreamServiceStub struct {
+	status    *dreamservice.StatusResult
+	runs      []*dreamservice.RunCycleResult
+	dreams    []*domain.Dream
+	dream     *domain.Dream
+	listOpts  dreamservice.ListOptions
+	runsLimit int
+	profileID string
+	getErr    error
+}
+
+func (s *controlDreamServiceStub) RunCycle(context.Context, string, dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
+	return nil, nil
+}
+
+func (s *controlDreamServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
+	s.profileID = profileID
+	s.listOpts = opts
+	return s.dreams, "", nil
+}
+
+func (s *controlDreamServiceStub) Get(_ context.Context, profileID, dreamID string) (*domain.Dream, error) {
+	s.profileID = profileID
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.dream != nil {
+		s.dream.DreamID = dreamID
+		return s.dream, nil
+	}
+	return &domain.Dream{DreamID: dreamID, ProfileID: profileID, Status: domain.DreamStatusProposed}, nil
+}
+
+func (s *controlDreamServiceStub) ListRuns(_ context.Context, profileID string, limit int) ([]*dreamservice.RunCycleResult, error) {
+	s.profileID = profileID
+	s.runsLimit = limit
+	return s.runs, nil
+}
+
+func (s *controlDreamServiceStub) Recall(context.Context, string, string, int) ([]*domain.Dream, error) {
+	return nil, nil
+}
+
+func (s *controlDreamServiceStub) ResolveFeedback(context.Context, string, dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
+	return &dreamservice.ResolveFeedbackResult{Fragment: &fragmentservice.CreateResult{}}, nil
+}
+
+func (s *controlDreamServiceStub) Status(_ context.Context, profileID string) (*dreamservice.StatusResult, error) {
+	s.profileID = profileID
+	return s.status, nil
+}
+
+func (s *controlDreamServiceStub) EffectiveConfig(context.Context, string) (dreamservice.EffectiveConfig, error) {
+	return dreamservice.EffectiveConfig{}, nil
+}
+
+func TestControlPortalObservabilityRoutes(t *testing.T) {
+	teamID := uuid.New()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	logs := &controlOperationLogReaderStub{page: &domain.OperationLogPage{
+		Items: []domain.OperationLog{{
+			ID:        uuid.New(),
+			Timestamp: now,
+			Severity:  "WARN",
+			Message:   "dream cycle completed",
+		}},
+		Total: 1,
+	}}
+	dreams := &controlDreamServiceStub{
+		status: &dreamservice.StatusResult{PendingCount: 1},
+		runs: []*dreamservice.RunCycleResult{{
+			RunID:     "run-1",
+			ProfileID: teamID.String(),
+			RunDate:   "2026-06-14",
+			Status:    "completed",
+		}},
+		dreams: []*domain.Dream{{
+			DreamID:    "dream-1",
+			ProfileID:  teamID.String(),
+			Hypothesis: "A control dream appears",
+			Status:     domain.DreamStatusProposed,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}},
+		dream: &domain.Dream{
+			ProfileID:  teamID.String(),
+			Hypothesis: "A control dream appears",
+			Status:     domain.DreamStatusProposed,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+	profiles := &controlProfileSvc{profiles: []*domain.Profile{{ID: teamID, Name: "Default"}}}
+	server, err := NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
+		ControlHTTPAddr:    "127.0.0.1:8090",
+		ControlPortalToken: "secret",
+	}, profiles, &controlKeySvc{}, nil, ControlPortalTelemetry{
+		Logs:   logs,
+		Dreams: dreams,
+	}, HealthConfig{}, nil)
+	require.NoError(t, err)
+
+	do := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, req)
+		return rec
+	}
+
+	rec := do("/control/api/logs?limit=5&offset=2&severity=warn&sort=severity&direction=asc")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "dream cycle completed")
+	assert.Equal(t, domain.OperationLogFilter{
+		Limit:     5,
+		Offset:    2,
+		Severity:  "WARN",
+		Sort:      "severity",
+		Direction: "asc",
+	}, logs.filter)
+
+	rec = do("/control/api/teams/" + teamID.String() + "/dreaming/status")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"pending_count":1`)
+
+	rec = do("/control/api/teams/" + teamID.String() + "/dreaming/runs?limit=3")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"run_id":"run-1"`)
+	assert.Equal(t, 3, dreams.runsLimit)
+
+	rec = do("/control/api/teams/" + teamID.String() + "/dreams?limit=4&status=proposed&cursor=next")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "A control dream appears")
+	assert.Equal(t, teamID.String(), dreams.profileID)
+	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next"}, dreams.listOpts)
+
+	rec = do("/control/api/teams/" + teamID.String() + "/dreams/dream-1")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"dream_id":"dream-1"`)
+}
+
+func TestControlPortalObservabilityValidation(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/control/api/logs?limit=501", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_, err := controlOperationLogsFilter(c)
+	require.ErrorContains(t, err, "limit must be between 1 and 500")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/logs?severity=trace", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlOperationLogsFilter(c)
+	require.ErrorContains(t, err, "severity must be one of")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/logs?sort=message", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlOperationLogsFilter(c)
+	require.ErrorContains(t, err, "sort must be timestamp or severity")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/logs?direction=sideways", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlOperationLogsFilter(c)
+	require.ErrorContains(t, err, "direction must be asc or desc")
+
+	limit, err := controlDreamLimit("")
+	require.NoError(t, err)
+	assert.Equal(t, 20, limit)
+	_, err = controlDreamLimit("101")
+	require.ErrorContains(t, err, "limit must be between 1 and 100")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/dreams?status=unknown", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlDreamListOptions(c)
+	require.ErrorContains(t, err, "status must be one of")
+}
+
+func TestControlPortalObservabilityUnavailableAndNotFound(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	h := &controlPortalHandler{}
+
+	require.ErrorContains(t, h.listOperationLogs(c), "operation logs unavailable")
+	require.ErrorContains(t, h.getTeamDreamingStatus(c), "dream service unavailable")
+	require.ErrorContains(t, h.listTeamDreamingRuns(c), "dream service unavailable")
+	require.ErrorContains(t, h.listTeamDreams(c), "dream service unavailable")
+	require.ErrorContains(t, h.getTeamDream(c), "dream service unavailable")
+
+	teamID := uuid.New()
+	h.dreams = &controlDreamServiceStub{getErr: dreamservice.ErrDreamNotFound}
+	req = httptest.NewRequest(http.MethodGet, "/control/api/teams/"+teamID.String()+"/dreams/dream-missing", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	c.SetParamNames("teamId", "dreamId")
+	c.SetParamValues(teamID.String(), "dream-missing")
+	err := h.getTeamDream(c)
+	require.ErrorContains(t, err, "dream not found")
+}
+
+func TestControlDependencySnapshotErrorAndDegraded(t *testing.T) {
+	snapshot := controlDependencySnapshot(context.Background(), HealthConfig{
+		Checks: []HealthCheck{
+			{Name: "postgres", Check: func(context.Context) error { return assert.AnError }},
+			{Name: "missing"},
+		},
+		Degraded: true,
+	})
+
+	require.Len(t, snapshot, 2)
+	assert.Equal(t, "postgres", snapshot[0].Name)
+	assert.Equal(t, "error", snapshot[0].Status)
+	require.NotNil(t, snapshot[0].Message)
+	assert.Contains(t, *snapshot[0].Message, assert.AnError.Error())
+	assert.Equal(t, "redis", snapshot[1].Name)
+	assert.Equal(t, "degraded", snapshot[1].Status)
+}
+
+var _ service.OperationLogReader = (*controlOperationLogReaderStub)(nil)
+var _ dreamservice.Service = (*controlDreamServiceStub)(nil)

--- a/internal/http/dreaming_effective.go
+++ b/internal/http/dreaming_effective.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"context"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+)
+
+func effectiveDreamingConfig(ctx context.Context, appConfig service.AppConfigService, teamConfig map[string]any) *dreamservice.EffectiveConfig {
+	var global domain.DreamingRuntimeConfig
+	if appConfig != nil {
+		runtime, err := appConfig.DreamingRuntimeConfig(ctx)
+		if err != nil {
+			return nil
+		}
+		global = runtime
+	}
+	effective, err := dreamservice.EffectiveDreamingConfig(global, teamConfig)
+	if err != nil {
+		return nil
+	}
+	return &effective
+}

--- a/internal/http/dreaming_effective_test.go
+++ b/internal/http/dreaming_effective_test.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestEffectiveDreamingConfigHelper(t *testing.T) {
+	ctx := context.Background()
+
+	effective := effectiveDreamingConfig(ctx, &controlAppConfigSvc{
+		dreamingRuntime: domain.DreamingRuntimeConfig{
+			Enabled:           true,
+			ForceEnabled:      true,
+			StartTimeLocal:    "03:00",
+			Timezone:          "UTC",
+			ReflectEnabled:    true,
+			ReevaluateEnabled: true,
+			DreamEnabled:      true,
+			MaxOutputs:        5,
+		},
+	}, map[string]any{"dreaming": map[string]any{"enabled": false}})
+	require.NotNil(t, effective)
+	require.True(t, effective.Enabled)
+	require.True(t, effective.TeamEnabled)
+	require.Equal(t, "global_force", effective.Source)
+
+	effective = effectiveDreamingConfig(ctx, nil, map[string]any{"dreaming": map[string]any{"enabled": true}})
+	require.NotNil(t, effective)
+	require.True(t, effective.Enabled)
+	require.Equal(t, "team", effective.Source)
+
+	require.Nil(t, effectiveDreamingConfig(ctx, &controlAppConfigSvc{
+		dreamingRuntimeErr: errors.New("config failed"),
+	}, nil))
+	require.Nil(t, effectiveDreamingConfig(ctx, &controlAppConfigSvc{
+		dreamingRuntime: domain.DreamingRuntimeConfig{
+			StartTimeLocal: "99:99",
+			Timezone:       "UTC",
+			MaxOutputs:     5,
+		},
+	}, nil))
+}

--- a/internal/http/handler/dream_handler.go
+++ b/internal/http/handler/dream_handler.go
@@ -24,6 +24,11 @@ type DreamHandler struct {
 	svc dreamservice.Service
 }
 
+type dreamListResponse struct {
+	Items      []*domain.Dream `json:"items"`
+	NextCursor string          `json:"next_cursor,omitempty"`
+}
+
 func NewDreamHandler(svc dreamservice.Service) *DreamHandler {
 	return &DreamHandler{svc: svc}
 }
@@ -65,11 +70,11 @@ func (h *DreamHandler) List(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	dreams, _, err := h.svc.List(c.Request().Context(), profileID.String(), opts)
+	dreams, nextCursor, err := h.svc.List(c.Request().Context(), profileID.String(), opts)
 	if err != nil {
 		return err
 	}
-	return response.SuccessOK(c, dreams)
+	return response.SuccessOK(c, dreamListResponse{Items: dreams, NextCursor: nextCursor})
 }
 
 func (h *DreamHandler) Get(c echo.Context) error {

--- a/internal/http/handler/dream_handler.go
+++ b/internal/http/handler/dream_handler.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/http/response"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+)
+
+const (
+	defaultDreamListLimit = 20
+	maxDreamListLimit     = 100
+)
+
+type DreamHandler struct {
+	svc dreamservice.Service
+}
+
+func NewDreamHandler(svc dreamservice.Service) *DreamHandler {
+	return &DreamHandler{svc: svc}
+}
+
+func (h *DreamHandler) Status(c echo.Context) error {
+	profileID, ok := middleware.GetResolvedProfileID(c.Request().Context())
+	if !ok {
+		return httperr.New(httperr.PROFILE_ID_REQUIRED, "profile ID is required")
+	}
+	status, err := h.svc.Status(c.Request().Context(), profileID.String())
+	if err != nil {
+		return err
+	}
+	return response.SuccessOK(c, status)
+}
+
+func (h *DreamHandler) Runs(c echo.Context) error {
+	profileID, ok := middleware.GetResolvedProfileID(c.Request().Context())
+	if !ok {
+		return httperr.New(httperr.PROFILE_ID_REQUIRED, "profile ID is required")
+	}
+	limit, err := dreamLimit(c.QueryParam("limit"))
+	if err != nil {
+		return err
+	}
+	runs, err := h.svc.ListRuns(c.Request().Context(), profileID.String(), limit)
+	if err != nil {
+		return err
+	}
+	return response.SuccessOK(c, runs)
+}
+
+func (h *DreamHandler) List(c echo.Context) error {
+	profileID, ok := middleware.GetResolvedProfileID(c.Request().Context())
+	if !ok {
+		return httperr.New(httperr.PROFILE_ID_REQUIRED, "profile ID is required")
+	}
+	opts, err := dreamListOptions(c)
+	if err != nil {
+		return err
+	}
+	dreams, _, err := h.svc.List(c.Request().Context(), profileID.String(), opts)
+	if err != nil {
+		return err
+	}
+	return response.SuccessOK(c, dreams)
+}
+
+func (h *DreamHandler) Get(c echo.Context) error {
+	profileID, ok := middleware.GetResolvedProfileID(c.Request().Context())
+	if !ok {
+		return httperr.New(httperr.PROFILE_ID_REQUIRED, "profile ID is required")
+	}
+	dreamID := strings.TrimSpace(c.Param("dreamId"))
+	if dreamID == "" {
+		return httperr.New(httperr.VALIDATION_ERROR, "dream ID is required")
+	}
+	dream, err := h.svc.Get(c.Request().Context(), profileID.String(), dreamID)
+	if err != nil {
+		if errors.Is(err, dreamservice.ErrDreamNotFound) {
+			return httperr.New(httperr.NOT_FOUND, "dream not found")
+		}
+		return err
+	}
+	return c.JSON(http.StatusOK, map[string]any{"data": dream})
+}
+
+func dreamListOptions(c echo.Context) (dreamservice.ListOptions, error) {
+	limit, err := dreamLimit(c.QueryParam("limit"))
+	if err != nil {
+		return dreamservice.ListOptions{}, err
+	}
+	status := strings.TrimSpace(c.QueryParam("status"))
+	if status != "" && !domain.DreamStatus(status).IsValid() {
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "status must be one of proposed, reinforced, stale, rejected, promoted")
+	}
+	return dreamservice.ListOptions{
+		Limit:  limit,
+		Status: status,
+		Cursor: strings.TrimSpace(c.QueryParam("cursor")),
+	}, nil
+}
+
+func dreamLimit(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultDreamListLimit, nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 1 || parsed > maxDreamListLimit {
+		return 0, httperr.New(httperr.VALIDATION_ERROR, "limit must be between 1 and 100")
+	}
+	return parsed, nil
+}

--- a/internal/http/handler/dream_handler_test.go
+++ b/internal/http/handler/dream_handler_test.go
@@ -24,6 +24,7 @@ type dreamHandlerServiceStub struct {
 	runs       []*dreamservice.RunCycleResult
 	dreams     []*domain.Dream
 	dream      *domain.Dream
+	nextCursor string
 	listOpts   dreamservice.ListOptions
 	runsLimit  int
 	profileIDs []string
@@ -37,7 +38,7 @@ func (s *dreamHandlerServiceStub) RunCycle(context.Context, string, dreamservice
 func (s *dreamHandlerServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
 	s.profileIDs = append(s.profileIDs, profileID)
 	s.listOpts = opts
-	return s.dreams, "", nil
+	return s.dreams, s.nextCursor, nil
 }
 
 func (s *dreamHandlerServiceStub) Get(_ context.Context, profileID, dreamID string) (*domain.Dream, error) {
@@ -98,6 +99,7 @@ func TestDreamHandlerRoutes(t *testing.T) {
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}},
+		nextCursor: "after-dream-1",
 		dream: &domain.Dream{
 			ProfileID:  profileID.String(),
 			Hypothesis: "A dream appears",
@@ -119,7 +121,7 @@ func TestDreamHandlerRoutes(t *testing.T) {
 	}{
 		{path: "/api/v1/dreaming/status", want: `"pending_count":2`},
 		{path: "/api/v1/dreaming/runs?limit=3", want: `"run_id":"run-1"`},
-		{path: "/api/v1/dreams?limit=4&status=proposed&cursor=next", want: `"hypothesis":"A dream appears"`},
+		{path: "/api/v1/dreams?limit=4&status=proposed&cursor=next", want: `"next_cursor":"after-dream-1"`},
 		{path: "/api/v1/dreams/dream-1", want: `"dream_id":"dream-1"`},
 	}
 	for _, tt := range tests {

--- a/internal/http/handler/dream_handler_test.go
+++ b/internal/http/handler/dream_handler_test.go
@@ -1,0 +1,184 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+	"github.com/markhuangai/dense-mem/internal/service/fragmentservice"
+)
+
+type dreamHandlerServiceStub struct {
+	status     *dreamservice.StatusResult
+	runs       []*dreamservice.RunCycleResult
+	dreams     []*domain.Dream
+	dream      *domain.Dream
+	listOpts   dreamservice.ListOptions
+	runsLimit  int
+	profileIDs []string
+	getErr     error
+}
+
+func (s *dreamHandlerServiceStub) RunCycle(context.Context, string, dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
+	return nil, nil
+}
+
+func (s *dreamHandlerServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
+	s.profileIDs = append(s.profileIDs, profileID)
+	s.listOpts = opts
+	return s.dreams, "", nil
+}
+
+func (s *dreamHandlerServiceStub) Get(_ context.Context, profileID, dreamID string) (*domain.Dream, error) {
+	s.profileIDs = append(s.profileIDs, profileID)
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.dream != nil {
+		s.dream.DreamID = dreamID
+		return s.dream, nil
+	}
+	return &domain.Dream{DreamID: dreamID, ProfileID: profileID, Status: domain.DreamStatusProposed}, nil
+}
+
+func (s *dreamHandlerServiceStub) ListRuns(_ context.Context, profileID string, limit int) ([]*dreamservice.RunCycleResult, error) {
+	s.profileIDs = append(s.profileIDs, profileID)
+	s.runsLimit = limit
+	return s.runs, nil
+}
+
+func (s *dreamHandlerServiceStub) Recall(context.Context, string, string, int) ([]*domain.Dream, error) {
+	return nil, nil
+}
+
+func (s *dreamHandlerServiceStub) ResolveFeedback(context.Context, string, dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
+	return &dreamservice.ResolveFeedbackResult{Fragment: &fragmentservice.CreateResult{}}, nil
+}
+
+func (s *dreamHandlerServiceStub) Status(_ context.Context, profileID string) (*dreamservice.StatusResult, error) {
+	s.profileIDs = append(s.profileIDs, profileID)
+	return s.status, nil
+}
+
+func (s *dreamHandlerServiceStub) EffectiveConfig(context.Context, string) (dreamservice.EffectiveConfig, error) {
+	return dreamservice.EffectiveConfig{}, nil
+}
+
+func TestDreamHandlerRoutes(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	profileID := uuid.New()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	svc := &dreamHandlerServiceStub{
+		status: &dreamservice.StatusResult{PendingCount: 2},
+		runs: []*dreamservice.RunCycleResult{{
+			RunID:       "run-1",
+			ProfileID:   profileID.String(),
+			RunDate:     "2026-06-14",
+			StartedAt:   now,
+			CompletedAt: now,
+			Status:      "completed",
+		}},
+		dreams: []*domain.Dream{{
+			DreamID:    "dream-1",
+			ProfileID:  profileID.String(),
+			Hypothesis: "A dream appears",
+			Status:     domain.DreamStatusProposed,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}},
+		dream: &domain.Dream{
+			ProfileID:  profileID.String(),
+			Hypothesis: "A dream appears",
+			Status:     domain.DreamStatusProposed,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+	h := NewDreamHandler(svc)
+	e.Use(injectProfileMiddleware(profileID))
+	e.GET("/api/v1/dreaming/status", h.Status)
+	e.GET("/api/v1/dreaming/runs", h.Runs)
+	e.GET("/api/v1/dreams", h.List)
+	e.GET("/api/v1/dreams/:dreamId", h.Get)
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/api/v1/dreaming/status", want: `"pending_count":2`},
+		{path: "/api/v1/dreaming/runs?limit=3", want: `"run_id":"run-1"`},
+		{path: "/api/v1/dreams?limit=4&status=proposed&cursor=next", want: `"hypothesis":"A dream appears"`},
+		{path: "/api/v1/dreams/dream-1", want: `"dream_id":"dream-1"`},
+	}
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		assert.Contains(t, rec.Body.String(), tt.want)
+	}
+	assert.Equal(t, 3, svc.runsLimit)
+	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next"}, svc.listOpts)
+	assert.Contains(t, svc.profileIDs, profileID.String())
+}
+
+func TestDreamHandlerValidationAndNotFound(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	profileID := uuid.New()
+	svc := &dreamHandlerServiceStub{getErr: dreamservice.ErrDreamNotFound}
+	h := NewDreamHandler(svc)
+
+	e.GET("/api/v1/dreaming/status", h.Status)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dreaming/status", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	e = echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := middleware.SetResolvedProfileIDForTest(c.Request().Context(), profileID)
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+	e.GET("/api/v1/dreaming/runs", h.Runs)
+	e.GET("/api/v1/dreams", h.List)
+	e.GET("/api/v1/dreams/:dreamId", h.Get)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreaming/runs?limit=101", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "limit must be between 1 and 100")
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams?status=unknown", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "status must be one of")
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams/dream-missing", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "dream not found")
+
+	limit, err := dreamLimit("")
+	require.NoError(t, err)
+	assert.Equal(t, defaultDreamListLimit, limit)
+}

--- a/internal/http/middleware/profile_resolution.go
+++ b/internal/http/middleware/profile_resolution.go
@@ -52,6 +52,8 @@ func isHeaderScopedProfileRoute(path string) bool {
 		"/api/v1/facts",
 		"/api/v1/communities",
 		"/api/v1/recall",
+		"/api/v1/dreaming",
+		"/api/v1/dreams",
 	}
 
 	for _, prefix := range headerScopedPrefixes {

--- a/internal/http/middleware/profile_resolution.go
+++ b/internal/http/middleware/profile_resolution.go
@@ -57,7 +57,7 @@ func isHeaderScopedProfileRoute(path string) bool {
 	}
 
 	for _, prefix := range headerScopedPrefixes {
-		if strings.HasPrefix(path, prefix) {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
 			return true
 		}
 	}

--- a/internal/http/middleware/profile_resolution_test.go
+++ b/internal/http/middleware/profile_resolution_test.go
@@ -182,6 +182,24 @@ func TestProfileResolution_HeaderScopedCanonicalRoutes(t *testing.T) {
 	}
 }
 
+func TestHeaderScopedProfileRouteRequiresPathBoundary(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/api/v1/dreams", want: true},
+		{path: "/api/v1/dreams/dream-1", want: true},
+		{path: "/api/v1/dreams-extra", want: false},
+		{path: "/api/v1/recallXYZ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isHeaderScopedProfileRoute(tt.path))
+		})
+	}
+}
+
 func TestProfileResolution_HeaderScoped_UsesPrincipalProfile(t *testing.T) {
 	e := echo.New()
 	e.HTTPErrorHandler = httperr.ErrorHandler

--- a/internal/http/router_protected.go
+++ b/internal/http/router_protected.go
@@ -343,6 +343,36 @@ func RegisterProtectedRoutesWithHandlers(e *echo.Echo, deps ProtectedDeps, handl
 	if handlers.Recall != nil {
 		recallGroup.GET("", handlers.Recall, middleware.RequireScopes("read"))
 	}
+
+	dreamingGroup := e.Group("/api/v1/dreaming")
+	dreamingGroup.Use(authMW)
+	dreamingGroup.Use(middleware.ProfileResolutionMiddleware(deps.ProfileService))
+	dreamingGroup.Use(middleware.AuthorizeProfile(profileAuthzSvc))
+	dreamingGroup.Use(deps.PostAuthMiddleware...)
+	dreamingGroup.Use(usageMW)
+	dreamingGroup.Use(rateLimitMW)
+	dreamingGroup.Use(lastUsedMW)
+	if handlers.DreamingStatus != nil {
+		dreamingGroup.GET("/status", handlers.DreamingStatus, middleware.RequireScopes("read"))
+	}
+	if handlers.DreamingRuns != nil {
+		dreamingGroup.GET("/runs", handlers.DreamingRuns, middleware.RequireScopes("read"))
+	}
+
+	dreamGroup := e.Group("/api/v1/dreams")
+	dreamGroup.Use(authMW)
+	dreamGroup.Use(middleware.ProfileResolutionMiddleware(deps.ProfileService))
+	dreamGroup.Use(middleware.AuthorizeProfile(profileAuthzSvc))
+	dreamGroup.Use(deps.PostAuthMiddleware...)
+	dreamGroup.Use(usageMW)
+	dreamGroup.Use(rateLimitMW)
+	dreamGroup.Use(lastUsedMW)
+	if handlers.DreamList != nil {
+		dreamGroup.GET("", handlers.DreamList, middleware.RequireScopes("read"))
+	}
+	if handlers.DreamGet != nil {
+		dreamGroup.GET("/:dreamId", handlers.DreamGet, middleware.RequireScopes("read"))
+	}
 }
 
 // ProtectedHandlers holds handler functions for protected routes.
@@ -391,5 +421,9 @@ type ProtectedHandlers struct {
 	// CommunityList handles GET /api/v1/communities.
 	CommunityList echo.HandlerFunc
 	// Recall handles GET /api/v1/recall?q=...&limit=... (Phase 9 hybrid recall)
-	Recall echo.HandlerFunc
+	Recall         echo.HandlerFunc
+	DreamingStatus echo.HandlerFunc
+	DreamingRuns   echo.HandlerFunc
+	DreamList      echo.HandlerFunc
+	DreamGet       echo.HandlerFunc
 }

--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 )
 
 // UserPortalDeps holds the dependencies for the API-key user portal.
@@ -36,6 +37,7 @@ type UserPortalDeps struct {
 	AuditSvc        service.AuditService
 	SecuritySvc     httpmw.SecurityBanService
 	SSOService      *service.SSOService
+	AppConfig       service.AppConfigService
 	Config          config.ConfigProvider
 	UserStaticDir   string
 	ExtraMiddleware []echo.MiddlewareFunc
@@ -48,6 +50,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 		keys:      deps.APIKeySvc,
 		telemetry: deps.Telemetry,
 		sso:       deps.SSOService,
+		appConfig: deps.AppConfig,
 	}
 
 	if deps.SSOService != nil {
@@ -91,6 +94,7 @@ type userPortalHandler struct {
 	keys      handler.APIKeyServiceInterface
 	telemetry service.TelemetryReader
 	sso       *service.SSOService
+	appConfig service.AppConfigService
 }
 
 type userPortalSessionResponse struct {
@@ -114,12 +118,13 @@ type userPortalTeamOptionResponse struct {
 }
 
 type userPortalTeamResponse struct {
-	ID          uuid.UUID      `json:"id"`
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Config      map[string]any `json:"config"`
-	CreatedAt   string         `json:"created_at"`
-	UpdatedAt   string         `json:"updated_at"`
+	ID                uuid.UUID                     `json:"id"`
+	Name              string                        `json:"name"`
+	Description       string                        `json:"description"`
+	Config            map[string]any                `json:"config"`
+	DreamingEffective *dreamservice.EffectiveConfig `json:"dreaming_effective,omitempty"`
+	CreatedAt         string                        `json:"created_at"`
+	UpdatedAt         string                        `json:"updated_at"`
 }
 
 type userPortalKeyResponse struct {
@@ -267,7 +272,7 @@ func (h *userPortalHandler) currentSession(c echo.Context) (userPortalSessionRes
 	}
 
 	return userPortalSessionResponse{
-		Team:          toUserPortalTeam(team),
+		Team:          h.toUserPortalTeam(ctx, team),
 		Key:           toUserPortalKey(key),
 		AuthMethod:    "api_key",
 		CanRotate:     userPortalHasScope(principal.Scopes, service.APIKeyScopeWrite),
@@ -290,9 +295,9 @@ func (h *userPortalHandler) currentSSOSession(c echo.Context) (userPortalSession
 	}
 	teams := make([]userPortalTeamOptionResponse, 0, len(info.Teams))
 	for _, team := range info.Teams {
-		teams = append(teams, toUserPortalTeamOption(team))
+		teams = append(teams, h.toUserPortalTeamOption(ctx, team))
 	}
-	selected := toUserPortalTeamOption(info.Selected)
+	selected := h.toUserPortalTeamOption(ctx, info.Selected)
 	response := userPortalSessionResponse{
 		Team:          selected.Team,
 		Key:           selected.Key,
@@ -635,14 +640,15 @@ func rejectEditableRotateBody(c echo.Context) error {
 	return nil
 }
 
-func toUserPortalTeam(team *domain.Profile) userPortalTeamResponse {
+func (h *userPortalHandler) toUserPortalTeam(ctx context.Context, team *domain.Profile) userPortalTeamResponse {
 	return userPortalTeamResponse{
-		ID:          team.ID,
-		Name:        team.Name,
-		Description: team.Description,
-		Config:      team.Config,
-		CreatedAt:   team.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   team.UpdatedAt.Format(time.RFC3339),
+		ID:                team.ID,
+		Name:              team.Name,
+		Description:       team.Description,
+		Config:            team.Config,
+		DreamingEffective: effectiveDreamingConfig(ctx, h.appConfig, team.Config),
+		CreatedAt:         team.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:         team.UpdatedAt.Format(time.RFC3339),
 	}
 }
 
@@ -661,9 +667,9 @@ func toUserPortalKey(key *domain.APIKey) userPortalKeyResponse {
 	}
 }
 
-func toUserPortalTeamOption(item domain.SSOTeamProfile) userPortalTeamOptionResponse {
+func (h *userPortalHandler) toUserPortalTeamOption(ctx context.Context, item domain.SSOTeamProfile) userPortalTeamOptionResponse {
 	return userPortalTeamOptionResponse{
-		Team:          toUserPortalTeam(&item.Team),
+		Team:          h.toUserPortalTeam(ctx, &item.Team),
 		Key:           toUserPortalKey(&item.Profile),
 		CanRotate:     false,
 		CanManageTeam: item.Profile.GetRole() == service.APIKeyRoleManager,

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -298,8 +298,7 @@ func (h operationLogHandler) Handle(ctx context.Context, record slog.Record) err
 	if logRecord.Timestamp.IsZero() {
 		logRecord.Timestamp = time.Now().UTC()
 	}
-	_ = h.sink.WriteLog(ctx, logRecord)
-	return nil
+	return h.sink.WriteLog(ctx, logRecord)
 }
 
 func (h operationLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -1,8 +1,13 @@
 package observability
 
 import (
+	"context"
 	"log/slog"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // Logger is a structured logger wrapper that includes correlation and request context.
@@ -27,6 +32,27 @@ var _ LogProvider = (*Logger)(nil)
 type LogAttr struct {
 	Key   string
 	Value interface{}
+}
+
+// LogRecord is the sanitized application log representation sent to secondary
+// sinks such as Postgres.
+type LogRecord struct {
+	Timestamp     time.Time
+	Severity      string
+	SeverityRank  int
+	Message       string
+	Source        string
+	TeamID        string
+	ProfileID     string
+	CorrelationID string
+	Error         string
+	Attrs         map[string]any
+}
+
+// LogSink receives structured application log records. Implementations must not
+// call back into the application logger from WriteLog.
+type LogSink interface {
+	WriteLog(ctx context.Context, record LogRecord) error
 }
 
 // String returns a string LogAttr.
@@ -71,9 +97,21 @@ func KeyPrefix(value string) LogAttr {
 
 // New creates a new Logger with the given log level.
 func New(level slog.Level) *Logger {
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: level,
-	})
+	return NewWithSinks(level)
+}
+
+// NewWithSinks creates a logger that writes JSON to stdout and sanitized records
+// to any additional sinks.
+func NewWithSinks(level slog.Level, sinks ...LogSink) *Logger {
+	handlers := []slog.Handler{
+		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}),
+	}
+	for _, sink := range sinks {
+		if sink != nil {
+			handlers = append(handlers, newOperationLogHandler(level, sink))
+		}
+	}
+	handler := newTeeHandler(handlers...)
 	return &Logger{
 		logger: slog.New(handler),
 	}
@@ -84,6 +122,14 @@ func NewWithHandler(handler slog.Handler) *Logger {
 	return &Logger{
 		logger: slog.New(handler),
 	}
+}
+
+// Slog returns the underlying slog logger for packages that require *slog.Logger.
+func (l *Logger) Slog() *slog.Logger {
+	if l == nil {
+		return slog.Default()
+	}
+	return l.logger
 }
 
 // toSlogAttrs converts LogAttr slice to slog.Attr slice.
@@ -102,11 +148,20 @@ func toSlogAttrs(attrs []LogAttr) []any {
 
 // isSensitiveField returns true if the field should never be logged.
 func isSensitiveField(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	compact := strings.ReplaceAll(normalized, "_", "")
 	sensitive := map[string]bool{
+		"access_token":     true,
+		"accesstoken":      true,
+		"authorization":    true,
 		"key_hash":         true,
 		"encrypted_secret": true,
 		"api_key":          true,
+		"apikey":           true,
 		"raw_key":          true,
+		"refresh_token":    true,
+		"refreshtoken":     true,
 		"secret":           true,
 		"password":         true,
 		"token":            true,
@@ -114,7 +169,16 @@ func isSensitiveField(key string) bool {
 		"embedding":        true,
 		"embeddings":       true,
 	}
-	return sensitive[key]
+	return sensitive[normalized] ||
+		sensitive[compact] ||
+		strings.HasSuffix(normalized, "_api_key") ||
+		strings.HasSuffix(normalized, "_password") ||
+		strings.HasSuffix(normalized, "_secret") ||
+		strings.HasSuffix(normalized, "_token") ||
+		strings.HasSuffix(compact, "apikey") ||
+		strings.HasSuffix(compact, "password") ||
+		strings.HasSuffix(compact, "secret") ||
+		strings.HasSuffix(compact, "token")
 }
 
 // Info logs an info message.
@@ -143,4 +207,265 @@ func (l *Logger) With(attrs ...LogAttr) LogProvider {
 	return &Logger{
 		logger: l.logger.With(toSlogAttrs(attrs)...),
 	}
+}
+
+type teeHandler struct {
+	handlers []slog.Handler
+}
+
+func newTeeHandler(handlers ...slog.Handler) slog.Handler {
+	return teeHandler{handlers: handlers}
+}
+
+func (h teeHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h teeHandler) Handle(ctx context.Context, record slog.Record) error {
+	var firstErr error
+	for _, handler := range h.handlers {
+		if !handler.Enabled(ctx, record.Level) {
+			continue
+		}
+		if err := handler.Handle(ctx, record.Clone()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (h teeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		next = append(next, handler.WithAttrs(attrs))
+	}
+	return teeHandler{handlers: next}
+}
+
+func (h teeHandler) WithGroup(name string) slog.Handler {
+	next := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		next = append(next, handler.WithGroup(name))
+	}
+	return teeHandler{handlers: next}
+}
+
+type operationLogHandler struct {
+	level  slog.Level
+	sink   LogSink
+	attrs  []slog.Attr
+	groups []string
+}
+
+func newOperationLogHandler(level slog.Level, sink LogSink) slog.Handler {
+	return operationLogHandler{level: level, sink: sink}
+}
+
+func (h operationLogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h operationLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if h.sink == nil {
+		return nil
+	}
+	attrs := map[string]any{}
+	for _, attr := range h.attrs {
+		h.appendAttr(attrs, attr)
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		h.appendAttr(attrs, attr)
+		return true
+	})
+
+	logRecord := LogRecord{
+		Timestamp:     record.Time.UTC(),
+		Severity:      severityName(record.Level),
+		SeverityRank:  severityRank(record.Level),
+		Message:       record.Message,
+		Source:        sourceFromPC(record.PC),
+		TeamID:        stringAttr(attrs, "team_id"),
+		ProfileID:     stringAttr(attrs, "profile_id"),
+		CorrelationID: firstStringAttr(attrs, "correlation_id", "request_id"),
+		Error:         stringAttr(attrs, "error"),
+		Attrs:         attrs,
+	}
+	if logRecord.Timestamp.IsZero() {
+		logRecord.Timestamp = time.Now().UTC()
+	}
+	_ = h.sink.WriteLog(ctx, logRecord)
+	return nil
+}
+
+func (h operationLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := operationLogHandler{
+		level:  h.level,
+		sink:   h.sink,
+		attrs:  append([]slog.Attr{}, h.attrs...),
+		groups: append([]string{}, h.groups...),
+	}
+	next.attrs = append(next.attrs, attrs...)
+	return next
+}
+
+func (h operationLogHandler) WithGroup(name string) slog.Handler {
+	next := operationLogHandler{
+		level:  h.level,
+		sink:   h.sink,
+		attrs:  append([]slog.Attr{}, h.attrs...),
+		groups: append([]string{}, h.groups...),
+	}
+	if strings.TrimSpace(name) != "" {
+		next.groups = append(next.groups, name)
+	}
+	return next
+}
+
+func (h operationLogHandler) appendAttr(attrs map[string]any, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Key == "" {
+		return
+	}
+	if isSensitiveField(attr.Key) {
+		return
+	}
+	key := attr.Key
+	if len(h.groups) > 0 {
+		key = strings.Join(append(append([]string{}, h.groups...), attr.Key), ".")
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		group := map[string]any{}
+		for _, child := range attr.Value.Group() {
+			if child.Key == "" || isSensitiveField(child.Key) {
+				continue
+			}
+			group[child.Key] = sanitizeLogValue(child.Key, slogValueAny(child.Value.Resolve()))
+		}
+		attrs[key] = group
+		return
+	}
+	attrs[key] = sanitizeLogValue(key, slogValueAny(attr.Value))
+}
+
+func slogValueAny(value slog.Value) any {
+	switch value.Kind() {
+	case slog.KindString:
+		return value.String()
+	case slog.KindInt64:
+		return value.Int64()
+	case slog.KindUint64:
+		return value.Uint64()
+	case slog.KindFloat64:
+		return value.Float64()
+	case slog.KindBool:
+		return value.Bool()
+	case slog.KindDuration:
+		return value.Duration().String()
+	case slog.KindTime:
+		return value.Time().UTC().Format(time.RFC3339Nano)
+	case slog.KindLogValuer:
+		return slogValueAny(value.Resolve())
+	case slog.KindAny:
+		if err, ok := value.Any().(error); ok {
+			return err.Error()
+		}
+		return value.Any()
+	default:
+		return value.String()
+	}
+}
+
+func sanitizeLogValue(key string, value any) any {
+	if isSensitiveField(key) {
+		return nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for childKey, childValue := range typed {
+			if isSensitiveField(childKey) {
+				continue
+			}
+			out[childKey] = sanitizeLogValue(childKey, childValue)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(typed))
+		for childKey, childValue := range typed {
+			if isSensitiveField(childKey) {
+				continue
+			}
+			out[childKey] = childValue
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, child := range typed {
+			out = append(out, sanitizeLogValue("", child))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func severityName(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return "ERROR"
+	case level >= slog.LevelWarn:
+		return "WARN"
+	case level <= slog.LevelDebug:
+		return "DEBUG"
+	default:
+		return "INFO"
+	}
+}
+
+func severityRank(level slog.Level) int {
+	switch {
+	case level >= slog.LevelError:
+		return 40
+	case level >= slog.LevelWarn:
+		return 30
+	case level <= slog.LevelDebug:
+		return 10
+	default:
+		return 20
+	}
+}
+
+func sourceFromPC(pc uintptr) string {
+	if pc == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames([]uintptr{pc})
+	frame, _ := frames.Next()
+	if frame.File == "" {
+		return ""
+	}
+	return frame.File + ":" + strconv.Itoa(frame.Line)
+}
+
+func stringAttr(attrs map[string]any, key string) string {
+	if value, ok := attrs[key]; ok {
+		if text, ok := value.(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func firstStringAttr(attrs map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := stringAttr(attrs, key); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -24,6 +24,14 @@ func (s *recordingLogSink) WriteLog(_ context.Context, record LogRecord) error {
 	return nil
 }
 
+type failingLogSink struct {
+	err error
+}
+
+func (s failingLogSink) WriteLog(context.Context, LogRecord) error {
+	return s.err
+}
+
 type testLogValuer struct{}
 
 func (testLogValuer) LogValue() slog.Value {
@@ -321,6 +329,15 @@ func TestOperationLogHandlerBuildsSanitizedRecords(t *testing.T) {
 	items, ok := got.Attrs["items"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, map[string]any{"name": "visible"}, items[0])
+}
+
+func TestOperationLogHandlerReturnsSinkErrors(t *testing.T) {
+	writeErr := errors.New("write failed")
+	handler := newOperationLogHandler(slog.LevelDebug, failingLogSink{err: writeErr})
+
+	err := handler.Handle(context.Background(), slog.NewRecord(time.Now(), slog.LevelInfo, "persist me", 0))
+
+	require.ErrorIs(t, err, writeErr)
 }
 
 func TestNewWithSinksAndTeeHandler(t *testing.T) {

--- a/internal/observability/logger_test.go
+++ b/internal/observability/logger_test.go
@@ -2,13 +2,33 @@ package observability
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingLogSink struct {
+	records []LogRecord
+}
+
+func (s *recordingLogSink) WriteLog(_ context.Context, record LogRecord) error {
+	s.records = append(s.records, record)
+	return nil
+}
+
+type testLogValuer struct{}
+
+func (testLogValuer) LogValue() slog.Value {
+	return slog.StringValue("resolved")
+}
 
 func TestLoggerNeverEmitsSecrets(t *testing.T) {
 	var buf bytes.Buffer
@@ -258,6 +278,112 @@ func TestLoggerWith(t *testing.T) {
 		assert.Contains(t, output, "safe")
 		assert.Contains(t, output, "value")
 	})
+}
+
+func TestOperationLogHandlerBuildsSanitizedRecords(t *testing.T) {
+	sink := &recordingLogSink{}
+	handler := newOperationLogHandler(slog.LevelDebug, sink).WithAttrs([]slog.Attr{
+		slog.String("team_id", "team-1"),
+		slog.String("api_key", "secret-key"),
+	})
+	pc, _, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	record := slog.NewRecord(time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC), slog.LevelError, "request failed", pc)
+	record.AddAttrs(
+		slog.String("profile_id", "profile-1"),
+		slog.String("request_id", "request-1"),
+		slog.Any("error", errors.New("boom")),
+		slog.Group("http",
+			slog.String("path", "/control/api/logs"),
+			slog.String("authorization", "Bearer secret"),
+		),
+		slog.Any("metadata", map[string]string{
+			"safe":  "visible",
+			"token": "hidden",
+		}),
+		slog.Any("items", []any{map[string]any{"password": "hidden", "name": "visible"}}),
+	)
+
+	require.NoError(t, handler.Handle(context.Background(), record))
+	require.Len(t, sink.records, 1)
+	got := sink.records[0]
+	assert.Equal(t, "ERROR", got.Severity)
+	assert.Equal(t, 40, got.SeverityRank)
+	assert.Equal(t, "request failed", got.Message)
+	assert.Equal(t, "team-1", got.TeamID)
+	assert.Equal(t, "profile-1", got.ProfileID)
+	assert.Equal(t, "request-1", got.CorrelationID)
+	assert.Equal(t, "boom", got.Error)
+	assert.NotEmpty(t, got.Source)
+	assert.NotContains(t, got.Attrs, "api_key")
+	assert.Equal(t, map[string]any{"path": "/control/api/logs"}, got.Attrs["http"])
+	assert.Equal(t, map[string]any{"safe": "visible"}, got.Attrs["metadata"])
+	items, ok := got.Attrs["items"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"name": "visible"}, items[0])
+}
+
+func TestNewWithSinksAndTeeHandler(t *testing.T) {
+	sink := &recordingLogSink{}
+	handler := newTeeHandler(
+		slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn}),
+		newOperationLogHandler(slog.LevelDebug, sink),
+	)
+	logger := slog.New(handler)
+
+	assert.True(t, handler.Enabled(context.Background(), slog.LevelError))
+	assert.NoError(t, handler.WithGroup("control").Handle(context.Background(), slog.NewRecord(time.Now(), slog.LevelInfo, "grouped", 0)))
+	assert.False(t, newTeeHandler(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})).Enabled(context.Background(), slog.LevelDebug))
+	withAttrs := handler.WithAttrs([]slog.Attr{slog.String("team_id", "team-3")})
+	assert.NoError(t, withAttrs.Handle(context.Background(), slog.NewRecord(time.Now(), slog.LevelInfo, "with attrs", 0)))
+	logger.Debug("debug message", slog.String("correlation_id", "corr-1"))
+
+	require.Len(t, sink.records, 3)
+	assert.Equal(t, "INFO", sink.records[0].Severity)
+	assert.Equal(t, "team-3", sink.records[1].TeamID)
+	assert.Equal(t, "DEBUG", sink.records[2].Severity)
+	assert.Equal(t, "corr-1", sink.records[2].CorrelationID)
+
+	withSink := NewWithSinks(slog.LevelInfo, sink)
+	assert.NotNil(t, withSink.Slog())
+	withSink.Warn("warning", String("team_id", "team-2"))
+	require.Len(t, sink.records, 4)
+	assert.Equal(t, "WARN", sink.records[3].Severity)
+	assert.Equal(t, "team-2", sink.records[3].TeamID)
+
+	var nilLogger *Logger
+	assert.NotNil(t, nilLogger.Slog())
+}
+
+func TestLogSeverityHelpers(t *testing.T) {
+	tests := []struct {
+		level slog.Level
+		name  string
+		rank  int
+	}{
+		{level: slog.LevelDebug, name: "DEBUG", rank: 10},
+		{level: slog.LevelInfo, name: "INFO", rank: 20},
+		{level: slog.LevelWarn, name: "WARN", rank: 30},
+		{level: slog.LevelError, name: "ERROR", rank: 40},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.name, severityName(tt.level))
+		assert.Equal(t, tt.rank, severityRank(tt.level))
+	}
+	assert.Empty(t, sourceFromPC(0))
+	assert.Empty(t, stringAttr(map[string]any{"team_id": 12}, "team_id"))
+	assert.Empty(t, firstStringAttr(map[string]any{"a": 1}, "a", "b"))
+
+	now := time.Date(2026, 6, 14, 12, 0, 0, 123, time.UTC)
+	assert.Equal(t, int64(12), slogValueAny(slog.Int64Value(12)))
+	assert.Equal(t, uint64(12), slogValueAny(slog.Uint64Value(12)))
+	assert.Equal(t, 1.5, slogValueAny(slog.Float64Value(1.5)))
+	assert.Equal(t, true, slogValueAny(slog.BoolValue(true)))
+	assert.Equal(t, "2s", slogValueAny(slog.DurationValue(2*time.Second)))
+	assert.Equal(t, now.Format(time.RFC3339Nano), slogValueAny(slog.TimeValue(now)))
+	assert.Equal(t, "resolved", slogValueAny(slog.AnyValue(testLogValuer{})))
+	assert.Equal(t, "boom", slogValueAny(slog.AnyValue(errors.New("boom"))))
+	assert.Equal(t, []string{"a"}, slogValueAny(slog.AnyValue([]string{"a"})))
 }
 
 func TestLogProviderInterface(t *testing.T) {

--- a/internal/repository/operation_log_repository.go
+++ b/internal/repository/operation_log_repository.go
@@ -1,0 +1,242 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+type OperationLogRepository interface {
+	AppendBatch(ctx context.Context, logs []domain.OperationLog) error
+	List(ctx context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error)
+	PruneBefore(ctx context.Context, cutoff time.Time) error
+}
+
+type OperationLogRepositoryImpl struct {
+	db  *gorm.DB
+	rls postgres.RLSHelper
+}
+
+var _ OperationLogRepository = (*OperationLogRepositoryImpl)(nil)
+
+func NewOperationLogRepository(db *gorm.DB, rls postgres.RLSHelper) *OperationLogRepositoryImpl {
+	return &OperationLogRepositoryImpl{db: db, rls: rls}
+}
+
+func (r *OperationLogRepositoryImpl) AppendBatch(ctx context.Context, logs []domain.OperationLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		for _, entry := range logs {
+			attrs, err := json.Marshal(nonNilMap(entry.Attrs))
+			if err != nil {
+				return err
+			}
+			if err := tx.Exec(`
+				INSERT INTO operation_logs (
+					timestamp, severity, severity_rank, message, source,
+					team_id, profile_id, correlation_id, error, attrs
+				) VALUES (
+					$1, $2, $3, $4, $5,
+					$6, $7, $8, $9, $10::jsonb
+				)
+			`,
+				entry.Timestamp.UTC(),
+				normalizeOperationLogSeverity(entry.Severity),
+				entry.SeverityRank,
+				entry.Message,
+				entry.Source,
+				uuidPtrValue(entry.TeamID),
+				uuidPtrValue(entry.ProfileID),
+				entry.CorrelationID,
+				entry.Error,
+				string(attrs),
+			).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to append operation logs: %w", err)
+	}
+	return nil
+}
+
+func (r *OperationLogRepositoryImpl) List(ctx context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error) {
+	normalized := normalizeOperationLogFilter(filter)
+	var page domain.OperationLogPage
+	severity := strings.ToUpper(strings.TrimSpace(normalized.Severity))
+
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		var total int64
+		if err := tx.Raw(`
+			SELECT count(*)
+			FROM operation_logs
+			WHERE ($1 = '' OR severity = $1)
+		`, severity).Scan(&total).Error; err != nil {
+			return err
+		}
+		page.Total = total
+
+		rows, err := tx.Raw(`
+			SELECT
+				id::text, timestamp, severity, severity_rank, message, source,
+				team_id::text, profile_id::text, correlation_id, error, attrs
+			FROM operation_logs
+			WHERE ($1 = '' OR severity = $1)
+			`+operationLogOrderClause(normalized)+`
+			LIMIT $2 OFFSET $3
+		`, severity, normalized.Limit, normalized.Offset).Rows()
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		items := make([]domain.OperationLog, 0, normalized.Limit)
+		for rows.Next() {
+			entry, err := scanOperationLog(rows)
+			if err != nil {
+				return err
+			}
+			items = append(items, entry)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		page.Items = items
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list operation logs: %w", err)
+	}
+	return &page, nil
+}
+
+func (r *OperationLogRepositoryImpl) PruneBefore(ctx context.Context, cutoff time.Time) error {
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		return tx.Exec("DELETE FROM operation_logs WHERE timestamp < $1", cutoff.UTC()).Error
+	})
+	if err != nil {
+		return fmt.Errorf("failed to prune operation logs: %w", err)
+	}
+	return nil
+}
+
+func (r *OperationLogRepositoryImpl) withSystemTx(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.rls != nil {
+		return r.rls.WithSystemTx(ctx, r.db, fn)
+	}
+	return r.db.WithContext(ctx).Transaction(fn)
+}
+
+func normalizeOperationLogFilter(filter domain.OperationLogFilter) domain.OperationLogFilter {
+	if filter.Limit <= 0 {
+		filter.Limit = 100
+	}
+	if filter.Limit > 500 {
+		filter.Limit = 500
+	}
+	if filter.Offset < 0 {
+		filter.Offset = 0
+	}
+	filter.Sort = strings.ToLower(strings.TrimSpace(filter.Sort))
+	if filter.Sort != "severity" {
+		filter.Sort = "timestamp"
+	}
+	filter.Direction = strings.ToLower(strings.TrimSpace(filter.Direction))
+	if filter.Direction != "asc" {
+		filter.Direction = "desc"
+	}
+	filter.Severity = strings.ToUpper(strings.TrimSpace(filter.Severity))
+	return filter
+}
+
+func operationLogOrderClause(filter domain.OperationLogFilter) string {
+	direction := "DESC"
+	if filter.Direction == "asc" {
+		direction = "ASC"
+	}
+	if filter.Sort == "severity" {
+		return "ORDER BY severity_rank " + direction + ", timestamp DESC, id DESC"
+	}
+	return "ORDER BY timestamp " + direction + ", id " + direction
+}
+
+func scanOperationLog(rows *sql.Rows) (domain.OperationLog, error) {
+	var (
+		entry        domain.OperationLog
+		idRaw        string
+		teamIDRaw    sql.NullString
+		profileIDRaw sql.NullString
+		attrsRaw     []byte
+	)
+	if err := rows.Scan(
+		&idRaw,
+		&entry.Timestamp,
+		&entry.Severity,
+		&entry.SeverityRank,
+		&entry.Message,
+		&entry.Source,
+		&teamIDRaw,
+		&profileIDRaw,
+		&entry.CorrelationID,
+		&entry.Error,
+		&attrsRaw,
+	); err != nil {
+		return domain.OperationLog{}, err
+	}
+	if parsed, err := uuid.Parse(idRaw); err == nil {
+		entry.ID = parsed
+	}
+	entry.TeamID = parseNullableUUID(teamIDRaw)
+	entry.ProfileID = parseNullableUUID(profileIDRaw)
+	entry.Attrs = map[string]any{}
+	if len(attrsRaw) > 0 {
+		_ = json.Unmarshal(attrsRaw, &entry.Attrs)
+	}
+	return entry, nil
+}
+
+func parseNullableUUID(raw sql.NullString) *uuid.UUID {
+	if !raw.Valid || strings.TrimSpace(raw.String) == "" {
+		return nil
+	}
+	parsed, err := uuid.Parse(raw.String)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func uuidPtrValue(id *uuid.UUID) any {
+	if id == nil || *id == uuid.Nil {
+		return nil
+	}
+	return id.String()
+}
+
+func nonNilMap(value map[string]any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	return value
+}
+
+func normalizeOperationLogSeverity(severity string) string {
+	severity = strings.ToUpper(strings.TrimSpace(severity))
+	if severity == "" {
+		return "INFO"
+	}
+	return severity
+}

--- a/internal/repository/operation_log_repository.go
+++ b/internal/repository/operation_log_repository.go
@@ -203,7 +203,9 @@ func scanOperationLog(rows *sql.Rows) (domain.OperationLog, error) {
 	entry.ProfileID = parseNullableUUID(profileIDRaw)
 	entry.Attrs = map[string]any{}
 	if len(attrsRaw) > 0 {
-		_ = json.Unmarshal(attrsRaw, &entry.Attrs)
+		if err := json.Unmarshal(attrsRaw, &entry.Attrs); err != nil {
+			return domain.OperationLog{}, fmt.Errorf("invalid operation_logs.attrs JSON: %w", err)
+		}
 	}
 	return entry, nil
 }

--- a/internal/repository/operation_log_repository_test.go
+++ b/internal/repository/operation_log_repository_test.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanOperationLogRejectsMalformedAttrsJSON(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{
+		"id",
+		"timestamp",
+		"severity",
+		"severity_rank",
+		"message",
+		"source",
+		"team_id",
+		"profile_id",
+		"correlation_id",
+		"error",
+		"attrs",
+	}).AddRow(
+		uuid.New().String(),
+		time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC),
+		"INFO",
+		20,
+		"message",
+		"source",
+		nil,
+		nil,
+		"corr-1",
+		"",
+		[]byte("{bad-json"),
+	)
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	sqlRows, err := db.Query("SELECT")
+	require.NoError(t, err)
+	defer sqlRows.Close()
+	require.True(t, sqlRows.Next())
+
+	_, err = scanOperationLog(sqlRows)
+	require.ErrorContains(t, err, "invalid operation_logs.attrs JSON")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/service/app_config_service.go
+++ b/internal/service/app_config_service.go
@@ -16,6 +16,7 @@ import (
 )
 
 const DefaultAppConfigCacheCheckInterval = 5 * time.Second
+const DefaultOperationLogRetentionDays = 30
 
 var ErrInvalidAppConfig = errors.New("invalid app config")
 
@@ -26,6 +27,9 @@ type AppConfigService interface {
 	GetDreamingSettings(ctx context.Context) (*domain.DreamingConfigSettings, error)
 	UpdateDreamingSettings(ctx context.Context, values map[string]string, actorRole, clientIP, correlationID string) (*domain.DreamingConfigSettings, error)
 	DreamingRuntimeConfig(ctx context.Context) (domain.DreamingRuntimeConfig, error)
+	GetOperationLogSettings(ctx context.Context) (*domain.OperationLogConfigSettings, error)
+	UpdateOperationLogSettings(ctx context.Context, values map[string]string, actorRole, clientIP, correlationID string) (*domain.OperationLogConfigSettings, error)
+	OperationLogRuntimeConfig(ctx context.Context) (domain.OperationLogRuntimeConfig, error)
 }
 
 type AppConfigServiceImpl struct {
@@ -44,6 +48,7 @@ type appConfigCache struct {
 	sso        SSORuntimeConfig
 	settings   domain.SSOConfigSettings
 	dreaming   domain.DreamingConfigSettings
+	opLogs     domain.OperationLogConfigSettings
 	checkedAt  time.Time
 }
 
@@ -138,6 +143,46 @@ func (s *AppConfigServiceImpl) DreamingRuntimeConfig(ctx context.Context) (domai
 	return cache.dreaming.Effective, nil
 }
 
+func (s *AppConfigServiceImpl) GetOperationLogSettings(ctx context.Context) (*domain.OperationLogConfigSettings, error) {
+	cache, err := s.currentCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	settings := cache.opLogs
+	settings.Items = append([]domain.OperationLogConfigItem(nil), cache.opLogs.Items...)
+	return &settings, nil
+}
+
+func (s *AppConfigServiceImpl) UpdateOperationLogSettings(ctx context.Context, values map[string]string, actorRole, clientIP, correlationID string) (*domain.OperationLogConfigSettings, error) {
+	normalized, err := normalizeOperationLogConfigValues(values)
+	if err != nil {
+		return nil, err
+	}
+	before, _ := s.GetOperationLogSettings(ctx)
+	now := s.now().UTC()
+	changed, err := s.repo.UpdateValues(ctx, normalized, now.Format(time.RFC3339Nano), now)
+	if err != nil {
+		return nil, err
+	}
+	s.invalidate()
+	updated, err := s.GetOperationLogSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		s.appendAudit("APP_CONFIG_UPDATE", "app_config", "operation_logs", actorRole, clientIP, correlationID, operationLogSettingsPayload(before), operationLogSettingsPayload(updated), map[string]any{"section": "operation_logs"})
+	}
+	return updated, nil
+}
+
+func (s *AppConfigServiceImpl) OperationLogRuntimeConfig(ctx context.Context) (domain.OperationLogRuntimeConfig, error) {
+	cache, err := s.currentCache(ctx)
+	if err != nil {
+		return domain.OperationLogRuntimeConfig{}, err
+	}
+	return cache.opLogs.Effective, nil
+}
+
 func (s *AppConfigServiceImpl) currentCache(ctx context.Context) (*appConfigCache, error) {
 	if s == nil || s.repo == nil {
 		return nil, fmt.Errorf("app config service is unavailable")
@@ -216,12 +261,17 @@ func buildAppConfigCache(entries map[string]domain.AppConfigEntry, checkedAt tim
 	if err != nil {
 		return nil, err
 	}
+	opLogs, err := operationLogRuntimeConfigFromEntries(entries)
+	if err != nil {
+		return nil, err
+	}
 	return &appConfigCache{
 		updateTime: updateEntry.Value,
 		entries:    cloneAppConfigEntries(entries),
 		sso:        runtime,
 		settings:   settings,
 		dreaming:   dreaming,
+		opLogs:     opLogs,
 		checkedAt:  checkedAt,
 	}, nil
 }
@@ -363,6 +413,54 @@ func normalizeDreamingConfigValues(values map[string]string) (map[string]string,
 	return normalized, nil
 }
 
+func operationLogRuntimeConfigFromEntries(entries map[string]domain.AppConfigEntry) (domain.OperationLogConfigSettings, error) {
+	values := make(map[string]string, len(editableOperationLogConfigKeys()))
+	for _, key := range editableOperationLogConfigKeys() {
+		values[key] = strings.TrimSpace(entries[key].Value)
+	}
+	normalized, err := normalizeOperationLogConfigValues(values)
+	if err != nil {
+		return domain.OperationLogConfigSettings{}, err
+	}
+	retentionDays, retentionEffective := operationLogConfigInt(normalized[domain.AppConfigOperationLogRetentionDays], DefaultOperationLogRetentionDays)
+	runtime := domain.OperationLogRuntimeConfig{RetentionDays: retentionDays}
+	updateTime := entries[domain.AppConfigUpdateTimeKey].Value
+	items := []domain.OperationLogConfigItem{
+		operationLogConfigItem(entries, domain.AppConfigOperationLogRetentionDays, retentionEffective),
+	}
+	return domain.OperationLogConfigSettings{UpdateTime: updateTime, Items: items, Effective: runtime}, nil
+}
+
+func normalizeOperationLogConfigValues(values map[string]string) (map[string]string, error) {
+	allowed := make(map[string]struct{}, len(editableOperationLogConfigKeys()))
+	for _, key := range editableOperationLogConfigKeys() {
+		allowed[key] = struct{}{}
+	}
+	normalized := make(map[string]string, len(values))
+	for key, value := range values {
+		if key == domain.AppConfigUpdateTimeKey {
+			return nil, fmt.Errorf("%w: update_time is read-only", ErrInvalidAppConfig)
+		}
+		if _, ok := allowed[key]; !ok {
+			return nil, fmt.Errorf("%w: unknown key %s", ErrInvalidAppConfig, key)
+		}
+		trimmed := strings.TrimSpace(value)
+		switch key {
+		case domain.AppConfigOperationLogRetentionDays:
+			if trimmed == "" {
+				trimmed = strconv.Itoa(DefaultOperationLogRetentionDays)
+			}
+			parsed, err := strconv.Atoi(trimmed)
+			if err != nil || parsed < 1 || parsed > 365 {
+				return nil, fmt.Errorf("%w: OPERATION_LOG_RETENTION_DAYS must be between 1 and 365", ErrInvalidAppConfig)
+			}
+			trimmed = strconv.Itoa(parsed)
+		}
+		normalized[key] = trimmed
+	}
+	return normalized, nil
+}
+
 func normalizeSSOConfigValues(values map[string]string) (map[string]string, error) {
 	allowed := make(map[string]struct{}, len(editableSSOConfigKeys()))
 	for _, key := range editableSSOConfigKeys() {
@@ -436,6 +534,12 @@ func editableDreamingConfigKeys() []string {
 	}
 }
 
+func editableOperationLogConfigKeys() []string {
+	return []string{
+		domain.AppConfigOperationLogRetentionDays,
+	}
+}
+
 func ssoConfigSeconds(value string, fallback time.Duration) (time.Duration, string) {
 	if strings.TrimSpace(value) == "" {
 		return fallback, strconv.Itoa(int(fallback / time.Second))
@@ -468,6 +572,14 @@ func dreamingConfigInt(value string, fallback int) (int, string) {
 	return parsed, strconv.Itoa(parsed)
 }
 
+func operationLogConfigInt(value string, fallback int) (int, string) {
+	if strings.TrimSpace(value) == "" {
+		return fallback, strconv.Itoa(fallback)
+	}
+	parsed, _ := strconv.Atoi(value)
+	return parsed, strconv.Itoa(parsed)
+}
+
 func dreamingConfigString(value, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback
@@ -493,6 +605,16 @@ func dreamingConfigItem(entries map[string]domain.AppConfigEntry, key, effective
 	}
 }
 
+func operationLogConfigItem(entries map[string]domain.AppConfigEntry, key, effective string) domain.OperationLogConfigItem {
+	entry := entries[key]
+	return domain.OperationLogConfigItem{
+		Key:            key,
+		Value:          strings.TrimSpace(entry.Value),
+		EffectiveValue: effective,
+		UpdatedAt:      entry.UpdatedAt,
+	}
+}
+
 func ssoConfigItem(entries map[string]domain.AppConfigEntry, key, effective string) domain.SSOConfigItem {
 	entry := entries[key]
 	return domain.SSOConfigItem{
@@ -511,6 +633,7 @@ func cloneAppConfigCache(cache *appConfigCache) *appConfigCache {
 	copy.entries = cloneAppConfigEntries(cache.entries)
 	copy.settings.Items = append([]domain.SSOConfigItem(nil), cache.settings.Items...)
 	copy.dreaming.Items = append([]domain.DreamingConfigItem(nil), cache.dreaming.Items...)
+	copy.opLogs.Items = append([]domain.OperationLogConfigItem(nil), cache.opLogs.Items...)
 	return &copy
 }
 
@@ -541,6 +664,24 @@ func ssoSettingsPayload(settings *domain.SSOConfigSettings) map[string]any {
 }
 
 func dreamingSettingsPayload(settings *domain.DreamingConfigSettings) map[string]any {
+	if settings == nil {
+		return nil
+	}
+	items := make([]map[string]string, 0, len(settings.Items))
+	for _, item := range settings.Items {
+		items = append(items, map[string]string{
+			"key":   item.Key,
+			"value": item.Value,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i]["key"] < items[j]["key"] })
+	return map[string]any{
+		"update_time": settings.UpdateTime,
+		"items":       items,
+	}
+}
+
+func operationLogSettingsPayload(settings *domain.OperationLogConfigSettings) map[string]any {
 	if settings == nil {
 		return nil
 	}

--- a/internal/service/app_config_service_test.go
+++ b/internal/service/app_config_service_test.go
@@ -114,6 +114,35 @@ func TestAppConfigServiceDreamingSettingsDefaultsAndUpdate(t *testing.T) {
 	assert.Equal(t, 9, runtime.MaxOutputs)
 }
 
+func TestAppConfigServiceOperationLogSettingsDefaultsAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	repo := newAppConfigRepoStub(now, map[string]string{
+		domain.AppConfigUpdateTimeKey: now.Format(time.RFC3339Nano),
+	})
+	svc := NewAppConfigService(repo, nil)
+	svc.now = func() time.Time { return now }
+
+	settings, err := svc.GetOperationLogSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "30", operationLogConfigItemForTest(settings, domain.AppConfigOperationLogRetentionDays).EffectiveValue)
+
+	runtime, err := svc.OperationLogRuntimeConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultOperationLogRetentionDays, runtime.RetentionDays)
+
+	now = now.Add(time.Minute)
+	updated, err := svc.UpdateOperationLogSettings(ctx, map[string]string{
+		domain.AppConfigOperationLogRetentionDays: "45",
+	}, "control", "127.0.0.1", "corr")
+	require.NoError(t, err)
+	assert.Equal(t, "45", operationLogConfigItemForTest(updated, domain.AppConfigOperationLogRetentionDays).EffectiveValue)
+
+	runtime, err = svc.OperationLogRuntimeConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 45, runtime.RetentionDays)
+}
+
 func TestAppConfigServiceSSOCookieSecureEffectiveDefault(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
@@ -276,6 +305,12 @@ func TestAppConfigServiceValidation(t *testing.T) {
 
 	_, err = svc.UpdateDreamingSettings(ctx, map[string]string{domain.AppConfigDreamingMaxOutputs: "0"}, "control", "", "")
 	require.ErrorIs(t, err, ErrInvalidAppConfig)
+
+	_, err = svc.UpdateOperationLogSettings(ctx, map[string]string{"unknown": "value"}, "control", "", "")
+	require.ErrorIs(t, err, ErrInvalidAppConfig)
+
+	_, err = svc.UpdateOperationLogSettings(ctx, map[string]string{domain.AppConfigOperationLogRetentionDays: "0"}, "control", "", "")
+	require.ErrorIs(t, err, ErrInvalidAppConfig)
 }
 
 func TestAppConfigServiceAuditNoopAndUnavailableBranches(t *testing.T) {
@@ -316,6 +351,7 @@ func TestAppConfigServiceAuditNoopAndUnavailableBranches(t *testing.T) {
 	assert.Nil(t, cloneAppConfigCache(nil))
 	assert.Nil(t, ssoSettingsPayload(nil))
 	assert.Nil(t, dreamingSettingsPayload(nil))
+	assert.Nil(t, operationLogSettingsPayload(nil))
 }
 
 func TestAppConfigServiceInitialLoadAndRefreshErrors(t *testing.T) {
@@ -383,6 +419,9 @@ func newAppConfigRepoStub(now time.Time, values map[string]string) *appConfigRep
 		entries[key] = domain.AppConfigEntry{Key: key, Value: "", UpdatedAt: now}
 	}
 	for _, key := range editableDreamingConfigKeys() {
+		entries[key] = domain.AppConfigEntry{Key: key, Value: "", UpdatedAt: now}
+	}
+	for _, key := range editableOperationLogConfigKeys() {
 		entries[key] = domain.AppConfigEntry{Key: key, Value: "", UpdatedAt: now}
 	}
 	entries[domain.AppConfigUpdateTimeKey] = domain.AppConfigEntry{Key: domain.AppConfigUpdateTimeKey, Value: now.Format(time.RFC3339Nano), UpdatedAt: now}
@@ -453,6 +492,15 @@ func dreamingConfigItemForTest(settings *domain.DreamingConfigSettings, key stri
 		}
 	}
 	return domain.DreamingConfigItem{}
+}
+
+func operationLogConfigItemForTest(settings *domain.OperationLogConfigSettings, key string) domain.OperationLogConfigItem {
+	for _, item := range settings.Items {
+		if item.Key == key {
+			return item
+		}
+	}
+	return domain.OperationLogConfigItem{}
 }
 
 type appConfigAuditStub struct {

--- a/internal/service/contextservice/context_test.go
+++ b/internal/service/contextservice/context_test.go
@@ -632,6 +632,10 @@ func (f *fakeDreams) Get(context.Context, string, string) (*domain.Dream, error)
 	return nil, errors.New("not implemented")
 }
 
+func (f *fakeDreams) ListRuns(context.Context, string, int) ([]*dreamservice.RunCycleResult, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (f *fakeDreams) Recall(_ context.Context, _ string, query string, _ int) ([]*domain.Dream, error) {
 	f.recallQuery = query
 	if f.recallErr != nil {

--- a/internal/service/dreamservice/config.go
+++ b/internal/service/dreamservice/config.go
@@ -23,28 +23,26 @@ func EffectiveDreamingConfig(global domain.DreamingRuntimeConfig, teamConfig map
 	}
 	dreaming, ok := nestedMap(teamConfig, "dreaming")
 	if ok {
-		cfg.Source = "team"
+		hasTeamOverride := false
 		if v, ok := boolFromAny(dreaming["enabled"]); ok {
 			cfg.Enabled = v
 			cfg.TeamEnabled = v
+			hasTeamOverride = true
 		}
 		if v, ok := boolFromAny(dreaming["reflect_enabled"]); ok {
 			cfg.ReflectEnabled = v
+			hasTeamOverride = true
 		}
 		if v, ok := boolFromAny(dreaming["reevaluate_enabled"]); ok {
 			cfg.ReevaluateEnabled = v
+			hasTeamOverride = true
 		}
 		if v, ok := boolFromAny(dreaming["dream_enabled"]); ok {
 			cfg.DreamEnabled = v
+			hasTeamOverride = true
 		}
-		if v, ok := stringFromAny(dreaming["start_time_local"]); ok && strings.TrimSpace(v) != "" {
-			cfg.StartTimeLocal = strings.TrimSpace(v)
-		}
-		if v, ok := stringFromAny(dreaming["timezone"]); ok && strings.TrimSpace(v) != "" {
-			cfg.Timezone = strings.TrimSpace(v)
-		}
-		if v, ok := intFromAny(dreaming["max_outputs"]); ok {
-			cfg.MaxOutputs = v
+		if hasTeamOverride {
+			cfg.Source = "team"
 		}
 	}
 	if cfg.ForceEnabled {

--- a/internal/service/dreamservice/config_test.go
+++ b/internal/service/dreamservice/config_test.go
@@ -37,9 +37,9 @@ func TestEffectiveDreamingConfigTeamOverridesAndForceEnable(t *testing.T) {
 	require.True(t, cfg.ReflectEnabled)
 	require.False(t, cfg.ReevaluateEnabled)
 	require.True(t, cfg.DreamEnabled)
-	require.Equal(t, "02:30", cfg.StartTimeLocal)
-	require.Equal(t, "America/New_York", cfg.Timezone)
-	require.Equal(t, 9, cfg.MaxOutputs)
+	require.Equal(t, "03:00", cfg.StartTimeLocal)
+	require.Equal(t, "UTC", cfg.Timezone)
+	require.Equal(t, 5, cfg.MaxOutputs)
 	require.Equal(t, "team", cfg.Source)
 
 	cfg, err = EffectiveDreamingConfig(global, map[string]any{
@@ -51,9 +51,9 @@ func TestEffectiveDreamingConfigTeamOverridesAndForceEnable(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, cfg.Enabled)
 	require.True(t, cfg.TeamEnabled)
-	require.Equal(t, "America/Los_Angeles", cfg.Timezone)
-	require.Equal(t, 7, cfg.MaxOutputs)
-	require.Equal(t, "team", cfg.Source)
+	require.Equal(t, "UTC", cfg.Timezone)
+	require.Equal(t, 5, cfg.MaxOutputs)
+	require.Equal(t, "global", cfg.Source)
 
 	global.ForceEnabled = true
 	cfg, err = EffectiveDreamingConfig(global, map[string]any{
@@ -70,8 +70,8 @@ func TestEffectiveDreamingConfigRawMessageAndValidation(t *testing.T) {
 	cfg, err := EffectiveDreamingConfig(domain.DreamingRuntimeConfig{}, map[string]any{"dreaming": raw})
 	require.NoError(t, err)
 	require.True(t, cfg.Enabled)
-	require.Equal(t, "04:15", cfg.StartTimeLocal)
-	require.Equal(t, 3, cfg.MaxOutputs)
+	require.Equal(t, "03:00", cfg.StartTimeLocal)
+	require.Equal(t, 5, cfg.MaxOutputs)
 
 	_, err = EffectiveDreamingConfig(domain.DreamingRuntimeConfig{StartTimeLocal: "25:99", Timezone: "UTC", MaxOutputs: 5}, nil)
 	require.ErrorContains(t, err, "start_time_local")

--- a/internal/service/dreamservice/scheduler_test.go
+++ b/internal/service/dreamservice/scheduler_test.go
@@ -221,6 +221,10 @@ func (s *schedulerDreamStub) Get(context.Context, string, string) (*domain.Dream
 	return nil, nil
 }
 
+func (s *schedulerDreamStub) ListRuns(context.Context, string, int) ([]*RunCycleResult, error) {
+	return nil, nil
+}
+
 func (s *schedulerDreamStub) Recall(context.Context, string, string, int) ([]*domain.Dream, error) {
 	return nil, nil
 }

--- a/internal/service/dreamservice/service.go
+++ b/internal/service/dreamservice/service.go
@@ -270,6 +270,34 @@ LIMIT 1`, map[string]any{"dreamId": dreamID})
 	return dreamFromRow(rows[0])
 }
 
+func (s *service) ListRuns(ctx context.Context, profileID string, limit int) ([]*RunCycleResult, error) {
+	if s.deps.Graph == nil {
+		return nil, fmt.Errorf("dream runs: graph is required")
+	}
+	if limit <= 0 {
+		limit = defaultListLimit
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	_, rows, err := s.deps.Graph.ScopedRead(ctx, profileID, `
+MATCH (r:DreamCycleRun {team_id: $profileId})
+RETURN r
+ORDER BY r.started_at DESC
+LIMIT $limit`, map[string]any{"limit": int64(limit)})
+	if err != nil {
+		return nil, fmt.Errorf("dream runs: %w", err)
+	}
+	runs := make([]*RunCycleResult, 0, len(rows))
+	for _, row := range rows {
+		run := runCycleResultFromRow(row, profileID)
+		if run != nil {
+			runs = append(runs, run)
+		}
+	}
+	return runs, nil
+}
+
 func (s *service) Recall(ctx context.Context, profileID, query string, limit int) ([]*domain.Dream, error) {
 	if s.deps.Graph == nil || strings.TrimSpace(query) == "" {
 		return nil, nil
@@ -693,9 +721,13 @@ LIMIT 1`, nil)
 	if err != nil || len(rows) == 0 {
 		return nil, err
 	}
-	node, ok := rows[0]["r"].(neo4j.Node)
+	return runCycleResultFromRow(rows[0], profileID), nil
+}
+
+func runCycleResultFromRow(row map[string]any, profileID string) *RunCycleResult {
+	node, ok := row["r"].(neo4j.Node)
 	if !ok {
-		return nil, nil
+		return nil
 	}
 	props := node.Props
 	return &RunCycleResult{
@@ -715,7 +747,7 @@ LIMIT 1`, nil)
 		CreatedDreams:     intFromRow(props, "created_dreams"),
 		Status:            stringFromMap(props, "status"),
 		Error:             stringFromMap(props, "error"),
-	}, nil
+	}
 }
 
 func dreamFromRow(row map[string]any) (*domain.Dream, error) {

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -559,7 +559,7 @@ func TestDreamServiceListRuns(t *testing.T) {
 			"started_at":         now,
 			"completed_at":       now.Add(time.Minute),
 			"reflect_ran":        true,
-			"re_evaluate_ran":    true,
+			"reevaluate_ran":     true,
 			"dream_ran":          true,
 			"stale_facts":        int64(1),
 			"candidate_claims":   int64(2),
@@ -578,6 +578,7 @@ func TestDreamServiceListRuns(t *testing.T) {
 	require.Len(t, runs, 1)
 	require.Equal(t, "run-1", runs[0].RunID)
 	require.Equal(t, "profile-1", runs[0].ProfileID)
+	require.True(t, runs[0].ReevaluateRan)
 	require.Equal(t, 6, runs[0].CreatedDreams)
 
 	_, err = New(Dependencies{}).ListRuns(context.Background(), "profile-1", 1)

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -385,9 +385,9 @@ func TestDreamServiceEffectiveConfigUsesProfileOverrides(t *testing.T) {
 	require.True(t, cfg.Enabled)
 	require.True(t, cfg.TeamEnabled)
 	require.Equal(t, "team", cfg.Source)
-	require.Equal(t, "04:30", cfg.StartTimeLocal)
-	require.Equal(t, "America/New_York", cfg.Timezone)
-	require.Equal(t, 3, cfg.MaxOutputs)
+	require.Equal(t, "03:00", cfg.StartTimeLocal)
+	require.Equal(t, "UTC", cfg.Timezone)
+	require.Equal(t, 5, cfg.MaxOutputs)
 }
 
 func TestDreamServiceNotFoundAndInternalBranches(t *testing.T) {
@@ -543,6 +543,44 @@ func TestDreamServiceReadErrors(t *testing.T) {
 
 	_, _, err = New(Dependencies{}).List(context.Background(), "profile-1", ListOptions{})
 	require.ErrorContains(t, err, "graph is required")
+}
+
+func TestDreamServiceListRuns(t *testing.T) {
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	graph := &cycleRunGraphStub{runRows: []map[string]any{{
+		"r": neo4j.Node{Props: map[string]any{
+			"run_id":             "run-1",
+			"run_date":           "2026-06-14",
+			"started_at":         now,
+			"completed_at":       now.Add(time.Minute),
+			"reflect_ran":        true,
+			"re_evaluate_ran":    true,
+			"dream_ran":          true,
+			"stale_facts":        int64(1),
+			"candidate_claims":   int64(2),
+			"disputed_claims":    int64(3),
+			"clarifications":     int64(4),
+			"reevaluated_dreams": int64(5),
+			"created_dreams":     int64(6),
+			"status":             "completed",
+			"error":              "",
+		}},
+	}}}
+	svc := New(Dependencies{Graph: graph})
+
+	runs, err := svc.ListRuns(context.Background(), "profile-1", 500)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	require.Equal(t, "run-1", runs[0].RunID)
+	require.Equal(t, "profile-1", runs[0].ProfileID)
+	require.Equal(t, 6, runs[0].CreatedDreams)
+
+	_, err = New(Dependencies{}).ListRuns(context.Background(), "profile-1", 1)
+	require.ErrorContains(t, err, "graph is required")
+
+	graph.readErr = errors.New("read failed")
+	_, err = svc.ListRuns(context.Background(), "profile-1", 1)
+	require.ErrorContains(t, err, "read failed")
 }
 
 type cycleAppConfigStub struct {

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -69,6 +69,7 @@ type Service interface {
 	RunCycle(ctx context.Context, profileID string, req RunCycleRequest) (*RunCycleResult, error)
 	List(ctx context.Context, profileID string, opts ListOptions) ([]*domain.Dream, string, error)
 	Get(ctx context.Context, profileID, dreamID string) (*domain.Dream, error)
+	ListRuns(ctx context.Context, profileID string, limit int) ([]*RunCycleResult, error)
 	Recall(ctx context.Context, profileID, query string, limit int) ([]*domain.Dream, error)
 	ResolveFeedback(ctx context.Context, profileID string, req ResolveFeedbackRequest) (*ResolveFeedbackResult, error)
 	Status(ctx context.Context, profileID string) (*StatusResult, error)

--- a/internal/service/operation_log_service.go
+++ b/internal/service/operation_log_service.go
@@ -1,0 +1,232 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/repository"
+)
+
+const (
+	operationLogQueueSize     = 4096
+	operationLogBatchSize     = 100
+	operationLogFlushInterval = 2 * time.Second
+	operationLogPruneInterval = time.Hour
+)
+
+type OperationLogReader interface {
+	ListOperationLogs(ctx context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error)
+}
+
+type OperationLogService interface {
+	OperationLogReader
+	WriteLog(ctx context.Context, record observability.LogRecord) error
+	Flush(ctx context.Context) error
+	Prune(ctx context.Context) error
+	Start(ctx context.Context)
+	Shutdown(ctx context.Context) error
+}
+
+type OperationLogRetentionProvider interface {
+	OperationLogRuntimeConfig(ctx context.Context) (domain.OperationLogRuntimeConfig, error)
+}
+
+type OperationLogServiceImpl struct {
+	repo      repository.OperationLogRepository
+	retention OperationLogRetentionProvider
+
+	queue chan domain.OperationLog
+
+	lifecycleMu sync.Mutex
+	cancel      context.CancelFunc
+	done        chan struct{}
+}
+
+var _ OperationLogService = (*OperationLogServiceImpl)(nil)
+var _ observability.LogSink = (*OperationLogServiceImpl)(nil)
+
+func NewOperationLogService(repo repository.OperationLogRepository, retention OperationLogRetentionProvider) *OperationLogServiceImpl {
+	return &OperationLogServiceImpl{
+		repo:      repo,
+		retention: retention,
+		queue:     make(chan domain.OperationLog, operationLogQueueSize),
+	}
+}
+
+func (s *OperationLogServiceImpl) WriteLog(_ context.Context, record observability.LogRecord) error {
+	if s == nil || s.repo == nil {
+		return nil
+	}
+	entry := domain.OperationLog{
+		Timestamp:     record.Timestamp,
+		Severity:      strings.ToUpper(strings.TrimSpace(record.Severity)),
+		SeverityRank:  record.SeverityRank,
+		Message:       record.Message,
+		Source:        record.Source,
+		CorrelationID: record.CorrelationID,
+		Error:         record.Error,
+		Attrs:         record.Attrs,
+	}
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+	if entry.Severity == "" {
+		entry.Severity = "INFO"
+	}
+	if entry.SeverityRank == 0 {
+		entry.SeverityRank = operationLogSeverityRank(entry.Severity)
+	}
+	entry.TeamID = parseLogUUID(record.TeamID)
+	entry.ProfileID = parseLogUUID(record.ProfileID)
+
+	select {
+	case s.queue <- entry:
+	default:
+		return nil
+	}
+	return nil
+}
+
+func operationLogSeverityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "ERROR":
+		return 40
+	case "WARN":
+		return 30
+	case "DEBUG":
+		return 10
+	default:
+		return 20
+	}
+}
+
+func (s *OperationLogServiceImpl) ListOperationLogs(ctx context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error) {
+	if s == nil || s.repo == nil {
+		return nil, fmt.Errorf("operation log service unavailable")
+	}
+	if err := s.Flush(ctx); err != nil {
+		return nil, err
+	}
+	return s.repo.List(ctx, filter)
+}
+
+func (s *OperationLogServiceImpl) Flush(ctx context.Context) error {
+	if s == nil || s.repo == nil {
+		return nil
+	}
+	for {
+		batch := make([]domain.OperationLog, 0, operationLogBatchSize)
+		for len(batch) < operationLogBatchSize {
+			select {
+			case entry := <-s.queue:
+				batch = append(batch, entry)
+			default:
+				if len(batch) == 0 {
+					return nil
+				}
+				if err := s.repo.AppendBatch(ctx, batch); err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+		if err := s.repo.AppendBatch(ctx, batch); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *OperationLogServiceImpl) Prune(ctx context.Context) error {
+	if s == nil || s.repo == nil {
+		return nil
+	}
+	days := DefaultOperationLogRetentionDays
+	if s.retention != nil {
+		cfg, err := s.retention.OperationLogRuntimeConfig(ctx)
+		if err == nil && cfg.RetentionDays > 0 {
+			days = cfg.RetentionDays
+		}
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -days)
+	return s.repo.PruneBefore(ctx, cutoff)
+}
+
+func (s *OperationLogServiceImpl) Start(ctx context.Context) {
+	if s == nil || s.repo == nil {
+		return
+	}
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if s.cancel != nil {
+		return
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	s.cancel = cancel
+	s.done = done
+	go s.run(runCtx, done)
+}
+
+func (s *OperationLogServiceImpl) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.lifecycleMu.Lock()
+	cancel := s.cancel
+	done := s.done
+	s.cancel = nil
+	s.done = nil
+	s.lifecycleMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.Flush(ctx)
+}
+
+func (s *OperationLogServiceImpl) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	_ = s.Prune(ctx)
+	flushTicker := time.NewTicker(operationLogFlushInterval)
+	pruneTicker := time.NewTicker(operationLogPruneInterval)
+	defer flushTicker.Stop()
+	defer pruneTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = s.Flush(context.Background())
+			return
+		case <-flushTicker.C:
+			_ = s.Flush(ctx)
+		case <-pruneTicker.C:
+			_ = s.Prune(ctx)
+		}
+	}
+}
+
+func parseLogUUID(value string) *uuid.UUID {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}

--- a/internal/service/operation_log_service.go
+++ b/internal/service/operation_log_service.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	operationLogQueueSize     = 4096
-	operationLogBatchSize     = 100
-	operationLogFlushInterval = 2 * time.Second
-	operationLogPruneInterval = time.Hour
+	operationLogQueueSize            = 4096
+	operationLogBatchSize            = 100
+	operationLogFlushInterval        = 2 * time.Second
+	operationLogPruneInterval        = time.Hour
+	operationLogShutdownFlushTimeout = 5 * time.Second
 )
 
 type OperationLogReader interface {
@@ -209,7 +210,9 @@ func (s *OperationLogServiceImpl) run(ctx context.Context, done chan struct{}) {
 	for {
 		select {
 		case <-ctx.Done():
-			_ = s.Flush(context.Background())
+			flushCtx, cancel := context.WithTimeout(context.Background(), operationLogShutdownFlushTimeout)
+			_ = s.Flush(flushCtx)
+			cancel()
 			return
 		case <-flushTicker.C:
 			_ = s.Flush(ctx)

--- a/internal/service/operation_log_service_test.go
+++ b/internal/service/operation_log_service_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/observability"
+)
+
+type operationLogRepoStub struct {
+	appended    []domain.OperationLog
+	filters     []domain.OperationLogFilter
+	prunedAt    *time.Time
+	appendErr   error
+	listErr     error
+	pruneErr    error
+	appendCalls int
+}
+
+func (s *operationLogRepoStub) AppendBatch(_ context.Context, logs []domain.OperationLog) error {
+	s.appendCalls++
+	if s.appendErr != nil {
+		return s.appendErr
+	}
+	s.appended = append(s.appended, logs...)
+	return nil
+}
+
+func (s *operationLogRepoStub) List(_ context.Context, filter domain.OperationLogFilter) (*domain.OperationLogPage, error) {
+	s.filters = append(s.filters, filter)
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return &domain.OperationLogPage{
+		Items: s.appended,
+		Total: int64(len(s.appended)),
+	}, nil
+}
+
+func (s *operationLogRepoStub) PruneBefore(_ context.Context, cutoff time.Time) error {
+	s.prunedAt = &cutoff
+	return s.pruneErr
+}
+
+type operationLogRetentionStub struct {
+	cfg domain.OperationLogRuntimeConfig
+	err error
+}
+
+func (s operationLogRetentionStub) OperationLogRuntimeConfig(context.Context) (domain.OperationLogRuntimeConfig, error) {
+	return s.cfg, s.err
+}
+
+func TestOperationLogServiceWriteFlushListAndPrune(t *testing.T) {
+	ctx := context.Background()
+	repo := &operationLogRepoStub{}
+	retention := operationLogRetentionStub{cfg: domain.OperationLogRuntimeConfig{RetentionDays: 7}}
+	svc := NewOperationLogService(repo, retention)
+	teamID := uuid.New()
+	profileID := uuid.New()
+
+	require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{
+		Severity:      " warn ",
+		Message:       "dream cycle completed",
+		Source:        "scheduler",
+		TeamID:        teamID.String(),
+		ProfileID:     profileID.String(),
+		CorrelationID: "corr-1",
+		Error:         "boom",
+		Attrs:         map[string]any{"phase": "dream"},
+	}))
+
+	require.NoError(t, svc.Flush(ctx))
+	require.Len(t, repo.appended, 1)
+	got := repo.appended[0]
+	assert.False(t, got.Timestamp.IsZero())
+	assert.Equal(t, "WARN", got.Severity)
+	assert.Equal(t, 30, got.SeverityRank)
+	assert.Equal(t, "dream cycle completed", got.Message)
+	assert.Equal(t, "scheduler", got.Source)
+	require.NotNil(t, got.TeamID)
+	require.NotNil(t, got.ProfileID)
+	assert.Equal(t, teamID, *got.TeamID)
+	assert.Equal(t, profileID, *got.ProfileID)
+	assert.Equal(t, "corr-1", got.CorrelationID)
+	assert.Equal(t, "boom", got.Error)
+	assert.Equal(t, "dream", got.Attrs["phase"])
+
+	page, err := svc.ListOperationLogs(ctx, domain.OperationLogFilter{Limit: 5, Severity: "WARN"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.Total)
+	require.Len(t, repo.filters, 1)
+	assert.Equal(t, 5, repo.filters[0].Limit)
+	assert.Equal(t, "WARN", repo.filters[0].Severity)
+
+	before := time.Now().UTC().AddDate(0, 0, -7).Add(-time.Second)
+	require.NoError(t, svc.Prune(ctx))
+	require.NotNil(t, repo.prunedAt)
+	after := time.Now().UTC().AddDate(0, 0, -7).Add(time.Second)
+	assert.True(t, repo.prunedAt.After(before), "cutoff %s should be after %s", repo.prunedAt, before)
+	assert.True(t, repo.prunedAt.Before(after), "cutoff %s should be before %s", repo.prunedAt, after)
+}
+
+func TestOperationLogServiceBatchesAndPropagatesErrors(t *testing.T) {
+	ctx := context.Background()
+	repo := &operationLogRepoStub{}
+	svc := NewOperationLogService(repo, nil)
+	for i := 0; i < operationLogBatchSize+1; i++ {
+		require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{
+			Severity: "debug",
+			Message:  "queued",
+		}))
+	}
+	require.NoError(t, svc.Flush(ctx))
+	assert.Equal(t, 2, repo.appendCalls)
+	assert.Len(t, repo.appended, operationLogBatchSize+1)
+	assert.Equal(t, "DEBUG", repo.appended[0].Severity)
+	assert.Equal(t, 10, repo.appended[0].SeverityRank)
+
+	repo = &operationLogRepoStub{appendErr: errors.New("append failed")}
+	svc = NewOperationLogService(repo, nil)
+	require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{Severity: "error", Message: "queued"}))
+	require.ErrorContains(t, svc.Flush(ctx), "append failed")
+
+	repo = &operationLogRepoStub{listErr: errors.New("list failed")}
+	svc = NewOperationLogService(repo, nil)
+	_, err := svc.ListOperationLogs(ctx, domain.OperationLogFilter{})
+	require.ErrorContains(t, err, "list failed")
+
+	repo = &operationLogRepoStub{pruneErr: errors.New("prune failed")}
+	svc = NewOperationLogService(repo, operationLogRetentionStub{err: errors.New("config unavailable")})
+	require.ErrorContains(t, svc.Prune(ctx), "prune failed")
+	require.NotNil(t, repo.prunedAt)
+}
+
+func TestOperationLogServiceLifecycleAndUnavailableBranches(t *testing.T) {
+	ctx := context.Background()
+	var nilSvc *OperationLogServiceImpl
+	require.NoError(t, nilSvc.WriteLog(ctx, observability.LogRecord{}))
+	require.NoError(t, nilSvc.Flush(ctx))
+	require.NoError(t, nilSvc.Prune(ctx))
+	require.NoError(t, nilSvc.Shutdown(ctx))
+	_, err := nilSvc.ListOperationLogs(ctx, domain.OperationLogFilter{})
+	require.ErrorContains(t, err, "unavailable")
+
+	svc := NewOperationLogService(nil, nil)
+	require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{TeamID: "not-a-uuid", ProfileID: " "}))
+	require.NoError(t, svc.Flush(ctx))
+	require.NoError(t, svc.Prune(ctx))
+	svc.Start(ctx)
+	require.NoError(t, svc.Shutdown(ctx))
+
+	repo := &operationLogRepoStub{}
+	svc = NewOperationLogService(repo, operationLogRetentionStub{cfg: domain.OperationLogRuntimeConfig{RetentionDays: 1}})
+	svc.Start(ctx)
+	svc.Start(ctx)
+	require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{Message: "started"}))
+	require.NoError(t, svc.Shutdown(ctx))
+	require.Len(t, repo.appended, 1)
+}

--- a/internal/service/operation_log_service_test.go
+++ b/internal/service/operation_log_service_test.go
@@ -15,19 +15,23 @@ import (
 )
 
 type operationLogRepoStub struct {
-	appended    []domain.OperationLog
-	filters     []domain.OperationLogFilter
-	prunedAt    *time.Time
-	appendErr   error
-	listErr     error
-	pruneErr    error
-	appendCalls int
+	appended        []domain.OperationLog
+	filters         []domain.OperationLogFilter
+	prunedAt        *time.Time
+	appendErr       error
+	listErr         error
+	pruneErr        error
+	appendCalls     int
+	appendDeadlines []time.Time
 }
 
-func (s *operationLogRepoStub) AppendBatch(_ context.Context, logs []domain.OperationLog) error {
+func (s *operationLogRepoStub) AppendBatch(ctx context.Context, logs []domain.OperationLog) error {
 	s.appendCalls++
 	if s.appendErr != nil {
 		return s.appendErr
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		s.appendDeadlines = append(s.appendDeadlines, deadline)
 	}
 	s.appended = append(s.appended, logs...)
 	return nil
@@ -164,4 +168,6 @@ func TestOperationLogServiceLifecycleAndUnavailableBranches(t *testing.T) {
 	require.NoError(t, svc.WriteLog(ctx, observability.LogRecord{Message: "started"}))
 	require.NoError(t, svc.Shutdown(ctx))
 	require.Len(t, repo.appended, 1)
+	require.NotEmpty(t, repo.appendDeadlines)
+	assert.WithinDuration(t, time.Now().UTC().Add(operationLogShutdownFlushTimeout), repo.appendDeadlines[0], time.Second)
 }

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -105,6 +105,10 @@ func (s *stubDreamService) Get(ctx context.Context, profileID, dreamID string) (
 	return dream, nil
 }
 
+func (s *stubDreamService) ListRuns(context.Context, string, int) ([]*dreamservice.RunCycleResult, error) {
+	return []*dreamservice.RunCycleResult{{RunID: "run-1", Status: "completed"}}, nil
+}
+
 func (s *stubDreamService) Recall(ctx context.Context, profileID, query string, limit int) ([]*domain.Dream, error) {
 	s.recallQuery = query
 	if s.recallErr != nil {

--- a/migrations/postgres/2026061420_operation_logs.sql
+++ b/migrations/postgres/2026061420_operation_logs.sql
@@ -26,6 +26,9 @@ CREATE INDEX IF NOT EXISTS idx_operation_logs_timestamp
 CREATE INDEX IF NOT EXISTS idx_operation_logs_severity_timestamp
     ON operation_logs(severity_rank DESC, timestamp DESC, id DESC);
 
+CREATE INDEX IF NOT EXISTS idx_operation_logs_severity_value_timestamp
+    ON operation_logs(severity, timestamp DESC, id DESC);
+
 CREATE INDEX IF NOT EXISTS idx_operation_logs_team_timestamp
     ON operation_logs(team_id, timestamp DESC)
     WHERE team_id IS NOT NULL;

--- a/migrations/postgres/2026061420_operation_logs.sql
+++ b/migrations/postgres/2026061420_operation_logs.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+CREATE TABLE IF NOT EXISTS operation_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    severity VARCHAR(16) NOT NULL,
+    severity_rank SMALLINT NOT NULL,
+    message TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT '',
+    team_id UUID NULL,
+    profile_id UUID NULL,
+    correlation_id TEXT NOT NULL DEFAULT '',
+    error TEXT NOT NULL DEFAULT '',
+    attrs JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_operation_logs_timestamp
+    ON operation_logs(timestamp DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_operation_logs_severity_timestamp
+    ON operation_logs(severity_rank DESC, timestamp DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_operation_logs_team_timestamp
+    ON operation_logs(team_id, timestamp DESC)
+    WHERE team_id IS NOT NULL;
+
+ALTER TABLE operation_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE operation_logs FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS operation_logs_system_access ON operation_logs;
+CREATE POLICY operation_logs_system_access ON operation_logs
+    FOR ALL
+    USING (current_setting('app.tx_mode', true) = 'system')
+    WITH CHECK (current_setting('app.tx_mode', true) = 'system');
+
+INSERT INTO app_config (key, value)
+VALUES ('OPERATION_LOG_RETENTION_DAYS', '30')
+ON CONFLICT (key) DO NOTHING;
+
+UPDATE app_config
+SET value = regexp_replace(
+        to_char(clock_timestamp() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+        '\.?0+Z$',
+        'Z'
+    ),
+    updated_at = clock_timestamp()
+WHERE key = 'update_time';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+DELETE FROM app_config
+WHERE key = 'OPERATION_LOG_RETENTION_DAYS';
+
+UPDATE app_config
+SET value = regexp_replace(
+        to_char(clock_timestamp() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+        '\.?0+Z$',
+        'Z'
+    ),
+    updated_at = clock_timestamp()
+WHERE key = 'update_time';
+
+DROP TABLE IF EXISTS operation_logs;
+
+-- +goose StatementEnd

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -290,8 +290,6 @@ describe("App", () => {
     const scheduledToggle = screen.getByLabelText("Scheduled cycle", { selector: "input" });
     expect(scheduledToggle).not.toBeChecked();
     await userEvent.click(scheduledToggle);
-    await userEvent.selectOptions(screen.getByLabelText("Timezone", { selector: "select" }), "America/New_York");
-    await userEvent.click(screen.getByRole("button", { name: /clear max dream outputs override/i }));
     await userEvent.click(screen.getByRole("button", { name: /save dreaming/i }));
 
     const patchCall = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith(`/teams/${configuredTeam.id}`) && init?.method === "PATCH");
@@ -300,9 +298,9 @@ describe("App", () => {
     expect(body.config.retention).toBe("standard");
     expect(body.config.dreaming).toMatchObject({
       enabled: true,
-      timezone: "America/New_York",
       provider: "manual",
     });
+    expect(body.config.dreaming.timezone).toBeUndefined();
     expect(body.config.dreaming.max_outputs).toBeUndefined();
     expect(await screen.findByText("Saved")).toBeInTheDocument();
   });
@@ -416,7 +414,6 @@ describe("App", () => {
     expect(enabledToggle).toHaveAttribute("type", "checkbox");
     expect(enabledToggle).not.toBeChecked();
     await userEvent.click(enabledToggle);
-    await userEvent.click(screen.getByRole("button", { name: /clear force all teams override/i }));
     await userEvent.selectOptions(screen.getByLabelText("Timezone", { selector: "select" }), "America/New_York");
     await userEvent.click(screen.getByRole("button", { name: /clear timezone override/i }));
     await userEvent.clear(screen.getByLabelText("Cycle start time"));
@@ -437,7 +434,7 @@ describe("App", () => {
     const body = JSON.parse(String(patchCall?.[1]?.body));
     expect(body.items).toEqual(expect.arrayContaining([
       { key: "DREAMING_ENABLED", value: "true" },
-      { key: "DREAMING_FORCE_ENABLED", value: "" },
+      { key: "DREAMING_FORCE_ENABLED", value: "false" },
       { key: "DREAMING_TIMEZONE", value: "" },
       { key: "DREAMING_START_TIME_LOCAL", value: "02:30" },
     ]));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Copy,
   KeyRound,
+  ListFilter,
   LogOut,
   Moon,
   Pencil,
@@ -28,6 +29,8 @@ import { MetricsPanel } from "./control/MetricsPanel";
 import { SecurityPanel } from "./control/SecurityPanel";
 import { SSOPanel } from "./control/SSOPanel";
 import { ConfigPanel } from "./control/ConfigPanel";
+import { ControlDreamsPanel } from "./control/DreamsPanel";
+import { LogsPanel } from "./control/LogsPanel";
 import { TeamDreamingConfigForm } from "./teamDreamingConfig";
 import { displayKeySuffix, formatDate, profilePermissionLabel, profileRoleLabel, readError, shortId } from "./control/utils";
 import { AuthShell, PortalShell, SectionHeading } from "./ui/components";
@@ -37,7 +40,7 @@ const THEME_STORAGE_KEY = "denseMem.controlTheme";
 
 type LoadState = "idle" | "loading" | "error";
 type Theme = "light" | "dark";
-type PortalTab = "teams" | "metrics" | "profiles" | "security" | "sso" | "config";
+type PortalTab = "teams" | "dreams" | "metrics" | "logs" | "profiles" | "security" | "sso" | "config";
 type ProfilePermission = "read" | "read_write";
 
 export function App() {
@@ -202,6 +205,21 @@ function Portal({
           onClick: () => setActiveTab("metrics"),
         },
         {
+          id: "dreams",
+          label: "Dreams",
+          icon: <Moon size={17} aria-hidden="true" />,
+          active: activeTab === "dreams",
+          disabled: !selectedTeam,
+          onClick: () => setActiveTab("dreams"),
+        },
+        {
+          id: "logs",
+          label: "Logs",
+          icon: <ListFilter size={17} aria-hidden="true" />,
+          active: activeTab === "logs",
+          onClick: () => setActiveTab("logs"),
+        },
+        {
           id: "profiles",
           label: "Profiles & API Keys",
           icon: <KeyRound size={17} aria-hidden="true" />,
@@ -267,7 +285,11 @@ function Portal({
       {activeTab === "profiles" && (
         selectedTeam ? <TeamProfilesPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
       )}
+      {activeTab === "dreams" && (
+        selectedTeam ? <ControlDreamsPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
+      )}
       {activeTab === "metrics" && <MetricsPanel api={api} teams={teams} />}
+      {activeTab === "logs" && <LogsPanel api={api} teams={teams} />}
       {activeTab === "security" && <SecurityPanel api={api} />}
       {activeTab === "sso" && <SSOPanel api={api} teams={teams} />}
       {activeTab === "config" && <ConfigPanel api={api} />}
@@ -435,6 +457,7 @@ function TeamEditor({
         <TeamDreamingConfigForm
           key={team.id}
           config={team.config}
+          effective={team.dreaming_effective}
           disabled={busy}
           onSave={async (config) => {
             onUpdated(await api.updateTeam(team.id, { name: team.name, description: team.description ?? "", config }));

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -112,4 +112,20 @@ describe("ControlApi", () => {
       body: JSON.stringify({ items: [{ key: "DREAMING_START_TIME_LOCAL", value: "02:30" }] }),
     }));
   });
+
+  it("requests team dreams with cursor pagination", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        items: [],
+        next_cursor: "next-dream",
+      },
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new ControlApi("secret", "/control/api");
+    const result = await api.listTeamDreams("team-1", { limit: 50, status: "proposed", cursor: "current-dream" });
+
+    expect(result.next_cursor).toBe("next-dream");
+    expect(fetchMock).toHaveBeenCalledWith("/control/api/teams/team-1/dreams?limit=50&status=proposed&cursor=current-dream", expect.any(Object));
+  });
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -6,6 +6,7 @@ export type Team = {
   description: string;
   metadata: Record<string, unknown> | null;
   config: Record<string, unknown> | null;
+  dreaming_effective?: DreamingEffectiveConfig | null;
   created_at: string;
   updated_at: string;
 };
@@ -222,6 +223,11 @@ export type DreamingRuntimeConfig = {
   max_outputs: number;
 };
 
+export type DreamingEffectiveConfig = DreamingRuntimeConfig & {
+  team_enabled: boolean;
+  source: "global" | "team" | "global_force" | string;
+};
+
 export type DreamingConfigItem = SSOConfigItem;
 
 export type DreamingConfig = {
@@ -235,6 +241,96 @@ export type DreamingConfigInput = {
     key: string;
     value: string;
   }>;
+};
+
+export type OperationLogRuntimeConfig = {
+  retention_days: number;
+};
+
+export type OperationLogConfigItem = SSOConfigItem;
+
+export type OperationLogConfig = {
+  update_time: string;
+  items: OperationLogConfigItem[];
+  effective: OperationLogRuntimeConfig;
+};
+
+export type OperationLogConfigInput = {
+  items: Array<{
+    key: string;
+    value: string;
+  }>;
+};
+
+export type OperationLog = {
+  id: string;
+  timestamp: string;
+  severity: "DEBUG" | "INFO" | "WARN" | "ERROR" | string;
+  severity_rank: number;
+  message: string;
+  source: string;
+  team_id: string | null;
+  profile_id: string | null;
+  correlation_id: string;
+  error: string;
+  attrs: Record<string, unknown> | null;
+};
+
+export type OperationLogQuery = {
+  limit?: number;
+  offset?: number;
+  severity?: OperationLog["severity"] | "";
+  sort?: "timestamp" | "severity";
+  direction?: "asc" | "desc";
+};
+
+export type Dream = {
+  dream_id: string;
+  team_id: string;
+  hypothesis: string;
+  what_if: string;
+  possible_outcome: string;
+  rationale: string;
+  likelihood: number;
+  confidence: number;
+  status: "proposed" | "reinforced" | "stale" | "rejected" | "promoted" | string;
+  cycle: string;
+  cycle_run_id?: string;
+  generator_model?: string;
+  source_refs?: Array<{ type: string; id: string }>;
+  invalidated_reason?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DreamRun = {
+  run_id: string;
+  team_id: string;
+  run_date: string;
+  started_at: string;
+  completed_at: string;
+  reflect_ran: boolean;
+  reevaluate_ran: boolean;
+  dream_ran: boolean;
+  stale_facts: number;
+  candidate_claims: number;
+  disputed_claims: number;
+  clarifications: number;
+  reevaluated_dreams: number;
+  created_dreams: number;
+  status: string;
+  error?: string;
+};
+
+export type DreamStatus = {
+  effective_config: DreamingEffectiveConfig;
+  latest_run?: DreamRun | null;
+  pending_count: number;
+};
+
+export type DreamQuery = {
+  limit?: number;
+  status?: Dream["status"] | "";
 };
 
 export class ApiError extends Error {
@@ -398,6 +494,55 @@ export class ControlApi {
 
   updateDreamingConfig(input: DreamingConfigInput): Promise<DreamingConfig> {
     return this.requestEnvelope<DreamingConfig>("/config/dreaming", { method: "PATCH", body: input });
+  }
+
+  getOperationLogConfig(): Promise<OperationLogConfig> {
+    return this.requestEnvelope<OperationLogConfig>("/config/operation-logs");
+  }
+
+  updateOperationLogConfig(input: OperationLogConfigInput): Promise<OperationLogConfig> {
+    return this.requestEnvelope<OperationLogConfig>("/config/operation-logs", { method: "PATCH", body: input });
+  }
+
+  listOperationLogs(query: OperationLogQuery = {}): Promise<Page<OperationLog>> {
+    const params = new URLSearchParams();
+    if (query.limit !== undefined) {
+      params.set("limit", String(query.limit));
+    }
+    if (query.offset !== undefined) {
+      params.set("offset", String(query.offset));
+    }
+    if (query.severity) {
+      params.set("severity", query.severity);
+    }
+    if (query.sort) {
+      params.set("sort", query.sort);
+    }
+    if (query.direction) {
+      params.set("direction", query.direction);
+    }
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    return this.request<Page<OperationLog>>(`/logs${suffix}`);
+  }
+
+  getTeamDreamingStatus(teamId: string): Promise<DreamStatus> {
+    return this.requestEnvelope<DreamStatus>(`/teams/${teamId}/dreaming/status`);
+  }
+
+  listTeamDreamingRuns(teamId: string, limit = 20): Promise<DreamRun[]> {
+    return this.requestEnvelope<DreamRun[]>(`/teams/${teamId}/dreaming/runs?limit=${limit}`);
+  }
+
+  listTeamDreams(teamId: string, query: DreamQuery = {}): Promise<Dream[]> {
+    const params = new URLSearchParams();
+    if (query.limit !== undefined) {
+      params.set("limit", String(query.limit));
+    }
+    if (query.status) {
+      params.set("status", query.status);
+    }
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    return this.requestEnvelope<Dream[]>(`/teams/${teamId}/dreams${suffix}`);
   }
 
   private async requestEnvelope<T>(path: string, options: RequestOptions = {}): Promise<T> {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -331,6 +331,12 @@ export type DreamStatus = {
 export type DreamQuery = {
   limit?: number;
   status?: Dream["status"] | "";
+  cursor?: string;
+};
+
+export type DreamListResponse = {
+  items: Dream[];
+  next_cursor?: string;
 };
 
 export class ApiError extends Error {
@@ -533,7 +539,7 @@ export class ControlApi {
     return this.requestEnvelope<DreamRun[]>(`/teams/${teamId}/dreaming/runs?limit=${limit}`);
   }
 
-  listTeamDreams(teamId: string, query: DreamQuery = {}): Promise<Dream[]> {
+  listTeamDreams(teamId: string, query: DreamQuery = {}): Promise<DreamListResponse> {
     const params = new URLSearchParams();
     if (query.limit !== undefined) {
       params.set("limit", String(query.limit));
@@ -541,8 +547,11 @@ export class ControlApi {
     if (query.status) {
       params.set("status", query.status);
     }
+    if (query.cursor) {
+      params.set("cursor", query.cursor);
+    }
     const suffix = params.toString() ? `?${params.toString()}` : "";
-    return this.requestEnvelope<Dream[]>(`/teams/${teamId}/dreams${suffix}`);
+    return this.requestEnvelope<DreamListResponse>(`/teams/${teamId}/dreams${suffix}`);
   }
 
   private async requestEnvelope<T>(path: string, options: RequestOptions = {}): Promise<T> {

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -1,10 +1,10 @@
 import { FormEvent, useEffect, useState } from "react";
-import { Check, Moon, RefreshCw, Settings, X } from "lucide-react";
-import { ControlApi, DreamingConfig, DreamingConfigItem, SSOConfig, SSOConfigItem } from "../api";
+import { Check, ListFilter, Moon, RefreshCw, Settings, X } from "lucide-react";
+import { ControlApi, DreamingConfig, DreamingConfigItem, OperationLogConfig, OperationLogConfigItem, SSOConfig, SSOConfigItem } from "../api";
 import { SectionHeading } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
-type ConfigTab = "sso" | "dreaming";
+type ConfigTab = "sso" | "dreaming" | "operation-logs";
 
 const CONFIG_LABELS: Record<string, string> = {
   SSO_PUBLIC_BASE_URL: "Public base URL",
@@ -21,6 +21,7 @@ const CONFIG_LABELS: Record<string, string> = {
   DREAMING_REEVALUATE_ENABLED: "Re-evaluate phase",
   DREAMING_DREAM_ENABLED: "Dream phase",
   DREAMING_MAX_OUTPUTS: "Max dream outputs",
+  OPERATION_LOG_RETENTION_DAYS: "Retention days",
 };
 
 const CONFIG_PLACEHOLDERS: Record<string, string> = {
@@ -31,6 +32,7 @@ const CONFIG_PLACEHOLDERS: Record<string, string> = {
   DREAMING_START_TIME_LOCAL: "03:00",
   DREAMING_TIMEZONE: "UTC",
   DREAMING_MAX_OUTPUTS: "5",
+  OPERATION_LOG_RETENTION_DAYS: "30",
 };
 
 const FALLBACK_TIMEZONES = [
@@ -83,10 +85,21 @@ export function ConfigPanel({ api }: { api: ControlApi }) {
             <Moon size={16} aria-hidden="true" />
             <span>Dreaming</span>
           </button>
+          <button
+            className={activeTab === "operation-logs" ? "tab-button active" : "tab-button"}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "operation-logs"}
+            onClick={() => setActiveTab("operation-logs")}
+          >
+            <ListFilter size={16} aria-hidden="true" />
+            <span>Logs</span>
+          </button>
         </div>
       </section>
       {activeTab === "sso" && <SSOConfigPanel api={api} />}
       {activeTab === "dreaming" && <DreamingConfigPanel api={api} />}
+      {activeTab === "operation-logs" && <OperationLogConfigPanel api={api} />}
     </>
   );
 }
@@ -259,12 +272,96 @@ function DreamingConfigPanel({ api }: { api: ControlApi }) {
   );
 }
 
+function OperationLogConfigPanel({ api }: { api: ControlApi }) {
+  const [config, setConfig] = useState<OperationLogConfig | null>(null);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function loadConfig() {
+    setLoading(true);
+    setError("");
+    setMessage("");
+    try {
+      const next = await api.getOperationLogConfig();
+      setConfig(next);
+      setDraft(Object.fromEntries(next.items.map((item) => [item.key, item.value])));
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadConfig();
+  }, []);
+
+  async function saveConfig(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError("");
+    setMessage("");
+    try {
+      const next = await api.updateOperationLogConfig({
+        items: Object.entries(draft).map(([key, value]) => ({ key, value })),
+      });
+      setConfig(next);
+      setDraft(Object.fromEntries(next.items.map((item) => [item.key, item.value])));
+      setMessage("Saved");
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="surface">
+      <SectionHeading
+        title="Operation Logs"
+        actions={(
+          <div className="button-row">
+            {config?.update_time && <span className="form-meta">{formatDate(config.update_time)}</span>}
+            <button className="icon-button" type="button" aria-label="Refresh operation log config" onClick={() => void loadConfig()}>
+              <RefreshCw size={16} aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      />
+      {error && <div className="banner error" role="alert">{error}</div>}
+      {message && <div className="banner neutral">{message}</div>}
+      {loading && !config ? (
+        <div className="table-placeholder compact">Loading</div>
+      ) : (
+        <form className="edit-grid" onSubmit={saveConfig}>
+          {(config?.items ?? []).map((item) => (
+            <ConfigField
+              key={item.key}
+              item={item}
+              value={draft[item.key] ?? ""}
+              onChange={(value) => setDraft((current) => ({ ...current, [item.key]: value }))}
+            />
+          ))}
+          <div className="button-row span">
+            <button className="primary-button" type="submit" disabled={loading || !config}>
+              <Check size={16} aria-hidden="true" />
+              Save config
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
 function ConfigField({
   item,
   value,
   onChange,
 }: {
-  item: SSOConfigItem | DreamingConfigItem;
+  item: SSOConfigItem | DreamingConfigItem | OperationLogConfigItem;
   value: string;
   onChange: (value: string) => void;
 }) {
@@ -298,11 +395,6 @@ function ConfigField({
               onChange={(event) => onChange(event.target.checked ? "true" : "false")}
             />
           </label>
-          {value !== "" && (
-            <button className="icon-button" type="button" aria-label={`Clear ${label} override`} title={`Clear ${label} override`} onClick={() => onChange("")}>
-              <X size={16} aria-hidden="true" />
-            </button>
-          )}
         </div>
       </>
     );
@@ -329,7 +421,7 @@ function ConfigField({
     );
   }
 
-  const numeric = item.key.endsWith("_SECONDS") || item.key === "DREAMING_MAX_OUTPUTS";
+  const numeric = item.key.endsWith("_SECONDS") || item.key === "DREAMING_MAX_OUTPUTS" || item.key === "OPERATION_LOG_RETENTION_DAYS";
   const time = item.key === "DREAMING_START_TIME_LOCAL";
   return (
     <>
@@ -338,7 +430,7 @@ function ConfigField({
         id={item.key}
         type={time ? "time" : numeric ? "number" : "text"}
         min={numeric ? 1 : undefined}
-        max={item.key === "DREAMING_MAX_OUTPUTS" ? 50 : undefined}
+        max={item.key === "DREAMING_MAX_OUTPUTS" ? 50 : item.key === "OPERATION_LOG_RETENTION_DAYS" ? 365 : undefined}
         placeholder={CONFIG_PLACEHOLDERS[item.key] ?? ""}
         value={value}
         onChange={(event) => onChange(event.target.value)}

--- a/web/src/control/DreamsPanel.tsx
+++ b/web/src/control/DreamsPanel.tsx
@@ -25,7 +25,7 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
       ]);
       setStatus(nextStatusResult);
       setRuns(nextRuns);
-      setDreams(nextDreams);
+      setDreams(nextDreams.items);
     } catch (err) {
       setError(readError(err));
     } finally {

--- a/web/src/control/DreamsPanel.tsx
+++ b/web/src/control/DreamsPanel.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { ControlApi, Dream, DreamRun, DreamStatus, Team } from "../api";
+import { SectionHeading } from "../ui/components";
+import { formatDate, readError } from "./utils";
+
+const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
+
+export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team }) {
+  const [status, setStatus] = useState<DreamStatus | null>(null);
+  const [runs, setRuns] = useState<DreamRun[]>([]);
+  const [dreams, setDreams] = useState<Dream[]>([]);
+  const [dreamStatus, setDreamStatus] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function loadData(nextStatus = dreamStatus) {
+    setLoading(true);
+    setError("");
+    try {
+      const [nextStatusResult, nextRuns, nextDreams] = await Promise.all([
+        api.getTeamDreamingStatus(team.id),
+        api.listTeamDreamingRuns(team.id, 10),
+        api.listTeamDreams(team.id, { status: nextStatus, limit: 50 }),
+      ]);
+      setStatus(nextStatusResult);
+      setRuns(nextRuns);
+      setDreams(nextDreams);
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadData();
+  }, [team.id]);
+
+  return (
+    <>
+      <section className="surface">
+        <SectionHeading
+          title="Dreaming"
+          meta={team.name}
+          actions={(
+            <button className="icon-button" type="button" aria-label="Refresh dreams" onClick={() => void loadData()}>
+              <RefreshCw size={16} aria-hidden="true" />
+            </button>
+          )}
+        />
+        {error && <div className="banner error" role="alert">{error}</div>}
+        {status && (
+          <div className="metrics-summary">
+            <SummaryMetric label="Source" value={sourceLabel(status.effective_config.source)} />
+            <SummaryMetric label="Scheduled" value={status.effective_config.enabled ? "Enabled" : "Disabled"} />
+            <SummaryMetric label="Pending" value={status.pending_count} />
+            <SummaryMetric label="Latest run" value={status.latest_run ? runLabel(status.latest_run) : "None"} />
+          </div>
+        )}
+      </section>
+
+      <section className="surface">
+        <SectionHeading title="Dream Outputs" meta={dreams.length} />
+        <div className="metrics-toolbar">
+          <label>
+            Status
+            <select
+              value={dreamStatus}
+              onChange={(event) => {
+                setDreamStatus(event.target.value);
+                void loadData(event.target.value);
+              }}
+            >
+              {DREAM_STATUSES.map((statusOption) => (
+                <option value={statusOption} key={statusOption}>{statusOption || "All"}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        {loading && dreams.length === 0 ? (
+          <div className="table-placeholder">Loading</div>
+        ) : dreams.length === 0 ? (
+          <div className="table-placeholder">No dreams</div>
+        ) : (
+          <DreamTable dreams={dreams} />
+        )}
+      </section>
+
+      <section className="surface">
+        <SectionHeading title="Cycle Runs" meta={runs.length} />
+        {runs.length === 0 ? <div className="table-placeholder">No runs</div> : <RunTable runs={runs} />}
+      </section>
+    </>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function DreamTable({ dreams }: { dreams: Dream[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table dreams-table">
+        <thead>
+          <tr>
+            <th>Updated</th>
+            <th>Status</th>
+            <th>Hypothesis</th>
+            <th>Confidence</th>
+            <th>Run</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dreams.map((dream) => (
+            <tr key={dream.dream_id}>
+              <td>{formatDate(dream.updated_at)}</td>
+              <td><span className={dreamStatusClass(dream.status)}>{dream.status}</span></td>
+              <td>
+                <strong>{dream.hypothesis}</strong>
+                <small>{dream.rationale}</small>
+              </td>
+              <td>{Math.round(dream.confidence * 100)}%</td>
+              <td><code>{dream.cycle_run_id?.slice(0, 8) || "-"}</code></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RunTable({ runs }: { runs: DreamRun[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table dream-runs-table">
+        <thead>
+          <tr>
+            <th>Started</th>
+            <th>Status</th>
+            <th>Phases</th>
+            <th>Created</th>
+            <th>Re-evaluated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.run_id}>
+              <td>{formatDate(run.started_at)}</td>
+              <td><span className={runStatusClass(run.status)}>{run.status}</span></td>
+              <td>{[run.reflect_ran && "reflect", run.reevaluate_ran && "re-evaluate", run.dream_ran && "dream"].filter(Boolean).join(", ") || "-"}</td>
+              <td>{run.created_dreams}</td>
+              <td>{run.reevaluated_dreams}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function runLabel(run: DreamRun): string {
+  return `${run.status} ${formatDate(run.started_at)}`;
+}
+
+function sourceLabel(source: string): string {
+  if (source === "global_force") {
+    return "Global force";
+  }
+  if (source === "team") {
+    return "Team";
+  }
+  return "Global";
+}
+
+function dreamStatusClass(status: string): string {
+  switch (status) {
+    case "rejected":
+    case "stale":
+      return "status-pill warning";
+    case "promoted":
+    case "reinforced":
+      return "status-pill";
+    default:
+      return "status-pill neutral";
+  }
+}
+
+function runStatusClass(status: string): string {
+  if (status === "error") {
+    return "status-pill error";
+  }
+  if (status === "skipped") {
+    return "status-pill warning";
+  }
+  return "status-pill";
+}

--- a/web/src/control/LogsPanel.tsx
+++ b/web/src/control/LogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { ControlApi, OperationLog, OperationLogQuery, Team } from "../api";
 import { SectionHeading } from "../ui/components";
@@ -12,19 +12,30 @@ export function LogsPanel({ api, teams }: { api: ControlApi; teams: Team[] }) {
   const [query, setQuery] = useState<OperationLogQuery>({ limit: 100, offset: 0, sort: "timestamp", direction: "desc" });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const requestSeqRef = useRef(0);
 
   async function loadLogs(nextQuery = query) {
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
     setLoading(true);
     setError("");
     try {
       const page = await api.listOperationLogs(nextQuery);
+      if (requestSeq !== requestSeqRef.current) {
+        return;
+      }
       setLogs(page.data);
       setTotal(page.pagination.total);
       setQuery({ ...nextQuery, limit: page.pagination.limit, offset: page.pagination.offset });
     } catch (err) {
+      if (requestSeq !== requestSeqRef.current) {
+        return;
+      }
       setError(readError(err));
     } finally {
-      setLoading(false);
+      if (requestSeq === requestSeqRef.current) {
+        setLoading(false);
+      }
     }
   }
 

--- a/web/src/control/LogsPanel.tsx
+++ b/web/src/control/LogsPanel.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { ControlApi, OperationLog, OperationLogQuery, Team } from "../api";
+import { SectionHeading } from "../ui/components";
+import { formatDate, readError, shortId } from "./utils";
+
+const SEVERITIES = ["", "DEBUG", "INFO", "WARN", "ERROR"];
+
+export function LogsPanel({ api, teams }: { api: ControlApi; teams: Team[] }) {
+  const [logs, setLogs] = useState<OperationLog[]>([]);
+  const [total, setTotal] = useState(0);
+  const [query, setQuery] = useState<OperationLogQuery>({ limit: 100, offset: 0, sort: "timestamp", direction: "desc" });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function loadLogs(nextQuery = query) {
+    setLoading(true);
+    setError("");
+    try {
+      const page = await api.listOperationLogs(nextQuery);
+      setLogs(page.data);
+      setTotal(page.pagination.total);
+      setQuery({ ...nextQuery, limit: page.pagination.limit, offset: page.pagination.offset });
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadLogs();
+  }, []);
+
+  const teamNames = new Map(teams.map((team) => [team.id, team.name]));
+  const offset = query.offset ?? 0;
+  const limit = query.limit ?? 100;
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = Math.min(offset + logs.length, total);
+
+  return (
+    <section className="surface">
+      <SectionHeading
+        title="Operation Logs"
+        meta={total}
+        actions={(
+          <button className="icon-button" type="button" aria-label="Refresh logs" onClick={() => void loadLogs()}>
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+        )}
+      />
+      {error && <div className="banner error" role="alert">{error}</div>}
+      <div className="metrics-toolbar">
+        <label>
+          Severity
+          <select
+            value={query.severity ?? ""}
+            onChange={(event) => {
+              const next = { ...query, severity: event.target.value, offset: 0 };
+              setQuery(next);
+              void loadLogs(next);
+            }}
+          >
+            {SEVERITIES.map((severity) => (
+              <option value={severity} key={severity}>{severity || "All"}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Sort
+          <select
+            value={query.sort ?? "timestamp"}
+            onChange={(event) => {
+              const next = { ...query, sort: event.target.value as OperationLogQuery["sort"], offset: 0 };
+              setQuery(next);
+              void loadLogs(next);
+            }}
+          >
+            <option value="timestamp">Time</option>
+            <option value="severity">Severity</option>
+          </select>
+        </label>
+        <label>
+          Direction
+          <select
+            value={query.direction ?? "desc"}
+            onChange={(event) => {
+              const next = { ...query, direction: event.target.value as OperationLogQuery["direction"], offset: 0 };
+              setQuery(next);
+              void loadLogs(next);
+            }}
+          >
+            <option value="desc">Desc</option>
+            <option value="asc">Asc</option>
+          </select>
+        </label>
+      </div>
+      {loading && logs.length === 0 ? (
+        <div className="table-placeholder">Loading</div>
+      ) : logs.length === 0 ? (
+        <div className="table-placeholder">No logs</div>
+      ) : (
+        <div className="table-wrap">
+          <table className="data-table logs-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Severity</th>
+                <th>Message</th>
+                <th>Source</th>
+                <th>Team</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id}>
+                  <td>{formatDate(log.timestamp)}</td>
+                  <td><span className={severityClass(log.severity)}>{log.severity}</span></td>
+                  <td>
+                    <strong>{log.message}</strong>
+                    {log.error && <small>{log.error}</small>}
+                  </td>
+                  <td><code>{compactSource(log.source)}</code></td>
+                  <td>{log.team_id ? (teamNames.get(log.team_id) ?? shortId(log.team_id)) : "System"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <div className="table-actions">
+        <span className="form-meta">{rangeStart}-{rangeEnd} of {total}</span>
+        <button
+          className="ghost-button"
+          type="button"
+          disabled={loading || offset === 0}
+          onClick={() => {
+            const next = { ...query, offset: Math.max(0, offset - limit) };
+            setQuery(next);
+            void loadLogs(next);
+          }}
+        >
+          Previous
+        </button>
+        <button
+          className="ghost-button"
+          type="button"
+          disabled={loading || offset + limit >= total}
+          onClick={() => {
+            const next = { ...query, offset: offset + limit };
+            setQuery(next);
+            void loadLogs(next);
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function severityClass(severity: string): string {
+  switch (severity) {
+    case "ERROR":
+      return "status-pill error";
+    case "WARN":
+      return "status-pill warning";
+    case "DEBUG":
+      return "status-pill neutral";
+    default:
+      return "status-pill";
+  }
+}
+
+function compactSource(source: string): string {
+  return source.replace(/^.*\/dense-mem\//, "");
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
+import "./observability.css";
 import "./responsive.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/web/src/observability.css
+++ b/web/src/observability.css
@@ -1,0 +1,72 @@
+.dreaming-effective-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-strong);
+}
+
+.dreaming-effective-grid span {
+  color: var(--subtle);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.dreaming-effective-grid strong {
+  min-width: 0;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.logs-table {
+  min-width: 980px;
+}
+
+.logs-table th:nth-child(1),
+.logs-table td:nth-child(1),
+.dreams-table th:nth-child(1),
+.dreams-table td:nth-child(1),
+.dream-runs-table th:nth-child(1),
+.dream-runs-table td:nth-child(1) {
+  width: 150px;
+}
+
+.logs-table th:nth-child(2),
+.logs-table td:nth-child(2),
+.dreams-table th:nth-child(2),
+.dreams-table td:nth-child(2),
+.dream-runs-table th:nth-child(2),
+.dream-runs-table td:nth-child(2) {
+  width: 108px;
+}
+
+.logs-table th:nth-child(4),
+.logs-table td:nth-child(4) {
+  width: 260px;
+}
+
+.logs-table th:nth-child(5),
+.logs-table td:nth-child(5) {
+  width: 160px;
+}
+
+.dreams-table {
+  min-width: 900px;
+}
+
+.dreams-table th:nth-child(4),
+.dreams-table td:nth-child(4),
+.dreams-table th:nth-child(5),
+.dreams-table td:nth-child(5),
+.dream-runs-table th:nth-child(4),
+.dream-runs-table td:nth-child(4),
+.dream-runs-table th:nth-child(5),
+.dream-runs-table td:nth-child(5) {
+  width: 112px;
+}
+
+.dream-runs-table {
+  min-width: 760px;
+}

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -49,6 +49,7 @@
 
   .security-summary,
   .metrics-summary,
+  .dreaming-effective-grid,
   .dependency-grid,
   .telemetry-card-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -89,6 +90,7 @@
   .portal-tabs,
   .security-summary,
   .metrics-summary,
+  .dreaming-effective-grid,
   .dependency-grid,
   .metrics-toolbar,
   .telemetry-card-grid {

--- a/web/src/teamDreamingConfig.tsx
+++ b/web/src/teamDreamingConfig.tsx
@@ -1,23 +1,21 @@
-import { useEffect, useMemo, useState } from "react";
-import type { FormEvent, ReactNode } from "react";
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
 import { X } from "lucide-react";
+import type { DreamingEffectiveConfig } from "./api";
 import { SectionHeading } from "./ui/components";
 
 type DreamingBooleanKey = "enabled" | "reflect_enabled" | "reevaluate_enabled" | "dream_enabled";
-type DreamingStringKey = "start_time_local" | "timezone";
 
 type TeamDreamingDraft = {
   enabled?: boolean;
   reflect_enabled?: boolean;
   reevaluate_enabled?: boolean;
   dream_enabled?: boolean;
-  start_time_local?: string;
-  timezone?: string;
-  max_outputs?: string;
 };
 
 type TeamDreamingConfigFormProps = {
   config: Record<string, unknown> | null | undefined;
+  effective?: DreamingEffectiveConfig | null;
   disabled?: boolean;
   onSave: (config: Record<string, unknown>) => Promise<void>;
 };
@@ -29,16 +27,11 @@ const BOOLEAN_FIELDS: Array<{ key: DreamingBooleanKey; label: string }> = [
   { key: "dream_enabled", label: "Dream phase" },
 ];
 
-const FALLBACK_TIMEZONES = ["UTC", "America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Singapore", "Australia/Sydney"];
-const SUPPORTED_TIMEZONES = getSupportedTimezones();
-
-export function TeamDreamingConfigForm({ config, disabled = false, onSave }: TeamDreamingConfigFormProps) {
+export function TeamDreamingConfigForm({ config, effective, disabled = false, onSave }: TeamDreamingConfigFormProps) {
   const [draft, setDraft] = useState<TeamDreamingDraft>(() => draftFromConfig(config));
   const [error, setError] = useState("");
   const [status, setStatus] = useState("");
   const [busy, setBusy] = useState(false);
-  const timezone = draft.timezone ?? "";
-  const timezoneValues = useMemo(() => timezoneOptions(timezone), [timezone]);
 
   useEffect(() => {
     setDraft(draftFromConfig(config));
@@ -70,14 +63,6 @@ export function TeamDreamingConfigForm({ config, disabled = false, onSave }: Tea
     setDraft((current) => ({ ...current, [key]: value }));
   }
 
-  function setString(key: DreamingStringKey, value: string | undefined) {
-    setDraft((current) => ({ ...current, [key]: value }));
-  }
-
-  function setMaxOutputs(value: string | undefined) {
-    setDraft((current) => ({ ...current, max_outputs: value }));
-  }
-
   return (
     <div className="team-dreaming-panel">
       <SectionHeading title="Dreaming" />
@@ -89,44 +74,24 @@ export function TeamDreamingConfigForm({ config, disabled = false, onSave }: Tea
             key={field.key}
             label={field.label}
             value={draft[field.key]}
+            effectiveValue={effective?.[field.key] ?? false}
+            forced={field.key === "enabled" && effective?.force_enabled === true}
             disabled={disabled || busy}
             onChange={(value) => setBoolean(field.key, value)}
           />
         ))}
-        <FieldOverride label="Cycle start time" htmlFor="team-dreaming-start-time" hasOverride={draft.start_time_local !== undefined} disabled={disabled || busy} onClear={() => setString("start_time_local", undefined)}>
-          <input
-            id="team-dreaming-start-time"
-            type="time"
-            value={draft.start_time_local ?? ""}
-            disabled={disabled || busy}
-            onChange={(event) => setString("start_time_local", event.target.value || undefined)}
-          />
-        </FieldOverride>
-        <FieldOverride label="Timezone" htmlFor="team-dreaming-timezone" hasOverride={draft.timezone !== undefined} disabled={disabled || busy} onClear={() => setString("timezone", undefined)}>
-          <select
-            id="team-dreaming-timezone"
-            value={timezone}
-            disabled={disabled || busy}
-            onChange={(event) => setString("timezone", event.target.value || undefined)}
-          >
-            <option value="">Inherited</option>
-            {timezoneValues.map((option) => (
-              <option value={option} key={option}>{option}</option>
-            ))}
-          </select>
-        </FieldOverride>
-        <FieldOverride label="Max dream outputs" htmlFor="team-dreaming-max-outputs" hasOverride={draft.max_outputs !== undefined} disabled={disabled || busy} onClear={() => setMaxOutputs(undefined)}>
-          <input
-            id="team-dreaming-max-outputs"
-            type="number"
-            min={1}
-            max={50}
-            inputMode="numeric"
-            value={draft.max_outputs ?? ""}
-            disabled={disabled || busy}
-            onChange={(event) => setMaxOutputs(event.target.value || undefined)}
-          />
-        </FieldOverride>
+        {effective && (
+          <div className="dreaming-effective-grid span">
+            <span>Cycle start</span>
+            <strong>{effective.start_time_local}</strong>
+            <span>Timezone</span>
+            <strong>{effective.timezone}</strong>
+            <span>Max outputs</span>
+            <strong>{effective.max_outputs}</strong>
+            <span>Source</span>
+            <strong>{effective.source === "global_force" ? "Global force" : effective.source === "team" ? "Team" : "Global"}</strong>
+          </div>
+        )}
         <div className="button-row span">
           <button className="primary-button" type="submit" disabled={disabled || busy}>
             Save dreaming
@@ -140,17 +105,21 @@ export function TeamDreamingConfigForm({ config, disabled = false, onSave }: Tea
 function BooleanOverride({
   label,
   value,
+  effectiveValue,
+  forced,
   disabled,
   onChange,
 }: {
   label: string;
   value: boolean | undefined;
+  effectiveValue: boolean;
+  forced: boolean;
   disabled: boolean;
   onChange: (value: boolean | undefined) => void;
 }) {
   const id = `team-dreaming-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
   const hasOverride = value !== undefined;
-  const checked = value ?? false;
+  const checked = forced ? true : value ?? effectiveValue;
   return (
     <div className="team-dreaming-row">
       <label htmlFor={id}>{label}</label>
@@ -160,45 +129,15 @@ function BooleanOverride({
             id={id}
             type="checkbox"
             checked={checked}
-            disabled={disabled}
+            disabled={disabled || forced}
             onChange={(event) => onChange(event.target.checked)}
           />
           <span aria-hidden="true">{checked ? "Enabled" : "Disabled"}</span>
         </div>
-        {hasOverride ? (
+        {forced ? (
+          <span className="form-meta">Forced</span>
+        ) : hasOverride ? (
           <button className="icon-button" type="button" aria-label={`Clear ${label} override`} title={`Clear ${label} override`} disabled={disabled} onClick={() => onChange(undefined)}>
-            <X size={16} aria-hidden="true" />
-          </button>
-        ) : (
-          <span className="form-meta">Inherited</span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function FieldOverride({
-  label,
-  htmlFor,
-  hasOverride,
-  disabled,
-  children,
-  onClear,
-}: {
-  label: string;
-  htmlFor: string;
-  hasOverride: boolean;
-  disabled: boolean;
-  children: ReactNode;
-  onClear: () => void;
-}) {
-  return (
-    <div className="team-dreaming-row">
-      <label htmlFor={htmlFor}>{label}</label>
-      <div className="button-row">
-        {children}
-        {hasOverride ? (
-          <button className="icon-button" type="button" aria-label={`Clear ${label} override`} title={`Clear ${label} override`} disabled={disabled} onClick={onClear}>
             <X size={16} aria-hidden="true" />
           </button>
         ) : (
@@ -219,9 +158,6 @@ function draftFromConfig(config: Record<string, unknown> | null | undefined): Te
     reflect_enabled: boolFromUnknown(dreaming.reflect_enabled),
     reevaluate_enabled: boolFromUnknown(dreaming.reevaluate_enabled),
     dream_enabled: boolFromUnknown(dreaming.dream_enabled),
-    start_time_local: stringFromUnknown(dreaming.start_time_local),
-    timezone: stringFromUnknown(dreaming.timezone),
-    max_outputs: numberStringFromUnknown(dreaming.max_outputs),
   };
 }
 
@@ -229,14 +165,14 @@ function buildTeamConfigWithDreaming(config: Record<string, unknown> | null | un
   const next = { ...(asRecord(config) ?? {}) };
   const existingDreaming = asRecord(next.dreaming);
   const dreaming = { ...(existingDreaming ?? {}) };
+  delete dreaming.start_time_local;
+  delete dreaming.timezone;
+  delete dreaming.max_outputs;
 
   setOptional(dreaming, "enabled", draft.enabled);
   setOptional(dreaming, "reflect_enabled", draft.reflect_enabled);
   setOptional(dreaming, "reevaluate_enabled", draft.reevaluate_enabled);
   setOptional(dreaming, "dream_enabled", draft.dream_enabled);
-  setOptional(dreaming, "start_time_local", nonEmpty(draft.start_time_local));
-  setOptional(dreaming, "timezone", nonEmpty(draft.timezone));
-  setOptional(dreaming, "max_outputs", draft.max_outputs === undefined ? undefined : Number.parseInt(draft.max_outputs, 10));
 
   if (Object.keys(dreaming).length > 0) {
     next.dreaming = dreaming;
@@ -254,16 +190,7 @@ function setOptional(target: Record<string, unknown>, key: string, value: unknow
   target[key] = value;
 }
 
-function validateDraft(draft: TeamDreamingDraft): string {
-  if (draft.start_time_local !== undefined && !/^\d{2}:\d{2}$/.test(draft.start_time_local)) {
-    return "Cycle start time must use HH:MM.";
-  }
-  if (draft.max_outputs !== undefined) {
-    const value = Number.parseInt(draft.max_outputs, 10);
-    if (!Number.isFinite(value) || value < 1 || value > 50) {
-      return "Max dream outputs must be between 1 and 50.";
-    }
-  }
+function validateDraft(_draft: TeamDreamingDraft): string {
   return "";
 }
 
@@ -288,49 +215,4 @@ function boolFromUnknown(value: unknown): boolean | undefined {
     }
   }
   return undefined;
-}
-
-function stringFromUnknown(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function numberStringFromUnknown(value: unknown): string | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-  if (typeof value === "string" && value.trim()) {
-    return value.trim();
-  }
-  return undefined;
-}
-
-function nonEmpty(value: string | undefined): string | undefined {
-  return value?.trim() || undefined;
-}
-
-function getSupportedTimezones(): string[] {
-  const intl = Intl as typeof Intl & {
-    supportedValuesOf?: (key: "timeZone") => string[];
-  };
-  try {
-    return intl.supportedValuesOf?.("timeZone") ?? FALLBACK_TIMEZONES;
-  } catch {
-    return FALLBACK_TIMEZONES;
-  }
-}
-
-function timezoneOptions(current: string): string[] {
-  const values = new Set<string>(["UTC", ...SUPPORTED_TIMEZONES, ...FALLBACK_TIMEZONES]);
-  if (current.trim()) {
-    values.add(current.trim());
-  }
-  return [...values].sort((left, right) => {
-    if (left === "UTC") {
-      return -1;
-    }
-    if (right === "UTC") {
-      return 1;
-    }
-    return left.localeCompare(right);
-  });
 }

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -207,8 +207,6 @@ describe("UserPortalApp", () => {
     const scheduledToggle = await screen.findByLabelText("Scheduled cycle", { selector: "input" });
     expect(scheduledToggle).not.toBeChecked();
     await userEvent.click(scheduledToggle);
-    await userEvent.selectOptions(screen.getByLabelText("Timezone", { selector: "select" }), "America/New_York");
-    await userEvent.click(screen.getByRole("button", { name: /clear max dream outputs override/i }));
     await userEvent.click(screen.getByRole("button", { name: /save dreaming/i }));
 
     await waitFor(() => {
@@ -222,8 +220,8 @@ describe("UserPortalApp", () => {
     expect(body.config.retention).toBe("long");
     expect(body.config.dreaming).toMatchObject({
       enabled: true,
-      timezone: "America/New_York",
     });
+    expect(body.config.dreaming.timezone).toBeUndefined();
     expect(body.config.dreaming.max_outputs).toBeUndefined();
     expect(await screen.findByText("Saved")).toBeInTheDocument();
   });

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -30,6 +30,7 @@ import {
   UserSession,
 } from "./api";
 import { TeamManagementPanel } from "./TeamManagementPanel";
+import { UserDreamsPanel } from "./DreamsPanel";
 import { AuthShell, PortalShell, SectionHeading } from "../ui/components";
 
 const TOKEN_STORAGE_KEY = "denseMem.userApiKey";
@@ -37,7 +38,7 @@ const THEME_STORAGE_KEY = "denseMem.userTheme";
 
 type Theme = "light" | "dark";
 type AuthMode = "none" | "api_key" | "sso";
-type UserTab = "search" | "usage" | "facts" | "claims" | "fragments" | "communities" | "team" | "key";
+type UserTab = "search" | "dreams" | "usage" | "facts" | "claims" | "fragments" | "communities" | "team" | "key";
 type ProfilePermission = "read" | "read_write";
 
 function sessionAuthMode(session: UserSession): AuthMode {
@@ -281,6 +282,7 @@ function UserPortal({
 
   const navItems = [
     { id: "search", label: "Recall", icon: <Search size={17} aria-hidden="true" />, active: activeTab === "search", onClick: () => setActiveTab("search") },
+    { id: "dreams", label: "Dreams", icon: <Moon size={17} aria-hidden="true" />, active: activeTab === "dreams", onClick: () => setActiveTab("dreams") },
     { id: "usage", label: "Usage", icon: <BarChart3 size={17} aria-hidden="true" />, active: activeTab === "usage", onClick: () => setActiveTab("usage") },
     { id: "facts", label: "Facts", icon: <ShieldCheck size={17} aria-hidden="true" />, active: activeTab === "facts", onClick: () => setActiveTab("facts") },
     { id: "claims", label: "Claims", icon: <GitBranch size={17} aria-hidden="true" />, active: activeTab === "claims", onClick: () => setActiveTab("claims") },
@@ -351,6 +353,7 @@ function UserPortal({
       error={error}
     >
       {activeTab === "search" && <SearchPanel api={api} />}
+      {activeTab === "dreams" && <UserDreamsPanel api={api} />}
       {activeTab === "usage" && <UserTelemetryPanel api={api} />}
       {activeTab === "facts" && <FactsPanel api={api} />}
       {activeTab === "claims" && <ClaimsPanel api={api} />}

--- a/web/src/user/DreamsPanel.tsx
+++ b/web/src/user/DreamsPanel.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { SectionHeading } from "../ui/components";
+import { Dream, DreamRun, DreamStatus, UserApi } from "./api";
+
+const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
+
+export function UserDreamsPanel({ api }: { api: UserApi }) {
+  const [status, setStatus] = useState<DreamStatus | null>(null);
+  const [runs, setRuns] = useState<DreamRun[]>([]);
+  const [dreams, setDreams] = useState<Dream[]>([]);
+  const [dreamStatus, setDreamStatus] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function loadData(nextStatus = dreamStatus) {
+    setLoading(true);
+    setError("");
+    try {
+      const [nextStatusResult, nextRuns, nextDreams] = await Promise.all([
+        api.dreamingStatus(),
+        api.listDreamingRuns(10),
+        api.listDreams(nextStatus, 50),
+      ]);
+      setStatus(nextStatusResult);
+      setRuns(nextRuns);
+      setDreams(nextDreams);
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadData();
+  }, [api]);
+
+  return (
+    <>
+      <section className="surface">
+        <SectionHeading
+          title="Dreaming"
+          actions={(
+            <button className="icon-button" type="button" aria-label="Refresh dreams" onClick={() => void loadData()}>
+              <RefreshCw size={16} aria-hidden="true" />
+            </button>
+          )}
+        />
+        {error && <div className="banner error" role="alert">{error}</div>}
+        {status && (
+          <div className="metrics-summary">
+            <SummaryMetric label="Source" value={sourceLabel(status.effective_config.source)} />
+            <SummaryMetric label="Scheduled" value={status.effective_config.enabled ? "Enabled" : "Disabled"} />
+            <SummaryMetric label="Pending" value={status.pending_count} />
+            <SummaryMetric label="Latest run" value={status.latest_run ? `${status.latest_run.status} ${formatDate(status.latest_run.started_at)}` : "None"} />
+          </div>
+        )}
+      </section>
+
+      <section className="surface">
+        <SectionHeading title="Dream Outputs" meta={dreams.length} />
+        <div className="metrics-toolbar">
+          <label>
+            Status
+            <select
+              value={dreamStatus}
+              onChange={(event) => {
+                setDreamStatus(event.target.value);
+                void loadData(event.target.value);
+              }}
+            >
+              {DREAM_STATUSES.map((statusOption) => (
+                <option value={statusOption} key={statusOption}>{statusOption || "All"}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        {loading && dreams.length === 0 ? (
+          <div className="table-placeholder">Loading</div>
+        ) : dreams.length === 0 ? (
+          <div className="table-placeholder">No dreams</div>
+        ) : (
+          <DreamTable dreams={dreams} />
+        )}
+      </section>
+
+      <section className="surface">
+        <SectionHeading title="Cycle Runs" meta={runs.length} />
+        {runs.length === 0 ? <div className="table-placeholder">No runs</div> : <RunTable runs={runs} />}
+      </section>
+    </>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function DreamTable({ dreams }: { dreams: Dream[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table dreams-table">
+        <thead>
+          <tr>
+            <th>Updated</th>
+            <th>Status</th>
+            <th>Hypothesis</th>
+            <th>Confidence</th>
+            <th>Run</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dreams.map((dream) => (
+            <tr key={dream.dream_id}>
+              <td>{formatDate(dream.updated_at)}</td>
+              <td><span className={dreamStatusClass(dream.status)}>{dream.status}</span></td>
+              <td>
+                <strong>{dream.hypothesis}</strong>
+                <small>{dream.rationale}</small>
+              </td>
+              <td>{Math.round(dream.confidence * 100)}%</td>
+              <td><code>{dream.cycle_run_id?.slice(0, 8) || "-"}</code></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RunTable({ runs }: { runs: DreamRun[] }) {
+  return (
+    <div className="table-wrap">
+      <table className="data-table dream-runs-table">
+        <thead>
+          <tr>
+            <th>Started</th>
+            <th>Status</th>
+            <th>Phases</th>
+            <th>Created</th>
+            <th>Re-evaluated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.run_id}>
+              <td>{formatDate(run.started_at)}</td>
+              <td><span className={runStatusClass(run.status)}>{run.status}</span></td>
+              <td>{[run.reflect_ran && "reflect", run.reevaluate_ran && "re-evaluate", run.dream_ran && "dream"].filter(Boolean).join(", ") || "-"}</td>
+              <td>{run.created_dreams}</td>
+              <td>{run.reevaluated_dreams}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function sourceLabel(source: string): string {
+  if (source === "global_force") {
+    return "Global force";
+  }
+  if (source === "team") {
+    return "Team";
+  }
+  return "Global";
+}
+
+function dreamStatusClass(status: string): string {
+  switch (status) {
+    case "rejected":
+    case "stale":
+      return "status-pill warning";
+    case "promoted":
+    case "reinforced":
+      return "status-pill";
+    default:
+      return "status-pill neutral";
+  }
+}
+
+function runStatusClass(status: string): string {
+  if (status === "error") {
+    return "status-pill error";
+  }
+  if (status === "skipped") {
+    return "status-pill warning";
+  }
+  return "status-pill";
+}
+
+function readError(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/web/src/user/DreamsPanel.tsx
+++ b/web/src/user/DreamsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { SectionHeading } from "../ui/components";
 import { Dream, DreamRun, DreamStatus, UserApi } from "./api";
@@ -12,8 +12,11 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
   const [dreamStatus, setDreamStatus] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const requestSeqRef = useRef(0);
 
   async function loadData(nextStatus = dreamStatus) {
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
     setLoading(true);
     setError("");
     try {
@@ -22,13 +25,21 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
         api.listDreamingRuns(10),
         api.listDreams(nextStatus, 50),
       ]);
+      if (requestSeq !== requestSeqRef.current) {
+        return;
+      }
       setStatus(nextStatusResult);
       setRuns(nextRuns);
-      setDreams(nextDreams);
+      setDreams(nextDreams.items);
     } catch (err) {
+      if (requestSeq !== requestSeqRef.current) {
+        return;
+      }
       setError(readError(err));
     } finally {
-      setLoading(false);
+      if (requestSeq === requestSeqRef.current) {
+        setLoading(false);
+      }
     }
   }
 
@@ -87,7 +98,13 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
 
       <section className="surface">
         <SectionHeading title="Cycle Runs" meta={runs.length} />
-        {runs.length === 0 ? <div className="table-placeholder">No runs</div> : <RunTable runs={runs} />}
+        {loading && runs.length === 0 ? (
+          <div className="table-placeholder">Loading</div>
+        ) : runs.length === 0 ? (
+          <div className="table-placeholder">No runs</div>
+        ) : (
+          <RunTable runs={runs} />
+        )}
       </section>
     </>
   );

--- a/web/src/user/TeamManagementPanel.tsx
+++ b/web/src/user/TeamManagementPanel.tsx
@@ -158,6 +158,7 @@ export function TeamManagementPanel({
         <TeamDreamingConfigForm
           key={session.team.id}
           config={session.team.config}
+          effective={session.team.dreaming_effective}
           disabled={teamBusy}
           onSave={async (config) => {
             onTeamUpdated(await api.updateTeam(session.team.id, { name: session.team.name, description: session.team.description ?? "", config }));

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -60,6 +60,23 @@ describe("UserApi", () => {
     }));
   });
 
+  it("requests dreams with cursor pagination", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        items: [],
+        next_cursor: "next-dream",
+      },
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await new UserApi("dm_key").listDreams("proposed", 50, "current-dream");
+
+    expect(result.next_cursor).toBe("next-dream");
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/dreams?limit=50&status=proposed&cursor=current-dream", expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
+    }));
+  });
+
   it("throws ApiError with server message", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ message: "invalid api key" }), { status: 401 })));
 

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -346,12 +346,15 @@ export class UserApi {
     return payload.data;
   }
 
-  async listDreams(status = "", limit = 20): Promise<Dream[]> {
+  async listDreams(status = "", limit = 20, cursor = ""): Promise<ListResponse<Dream>> {
     const params = new URLSearchParams({ limit: String(limit) });
     if (status) {
       params.set("status", status);
     }
-    const payload = await this.request<Envelope<Dream[]>>(`/api/v1/dreams?${params.toString()}`);
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+    const payload = await this.request<Envelope<ListResponse<Dream>>>(`/api/v1/dreams?${params.toString()}`);
     return payload.data;
   }
 

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -5,6 +5,7 @@ export type UserTeam = {
   name: string;
   description: string;
   config?: Record<string, unknown> | null;
+  dreaming_effective?: DreamingEffectiveConfig | null;
   created_at: string;
   updated_at: string;
 };
@@ -133,6 +134,66 @@ export type ListResponse<T> = {
   next_cursor?: string;
   has_more?: boolean;
   total?: number;
+};
+
+export type DreamingRuntimeConfig = {
+  enabled: boolean;
+  force_enabled: boolean;
+  start_time_local: string;
+  timezone: string;
+  reflect_enabled: boolean;
+  reevaluate_enabled: boolean;
+  dream_enabled: boolean;
+  max_outputs: number;
+};
+
+export type DreamingEffectiveConfig = DreamingRuntimeConfig & {
+  team_enabled: boolean;
+  source: "global" | "team" | "global_force" | string;
+};
+
+export type Dream = {
+  dream_id: string;
+  team_id: string;
+  hypothesis: string;
+  what_if: string;
+  possible_outcome: string;
+  rationale: string;
+  likelihood: number;
+  confidence: number;
+  status: "proposed" | "reinforced" | "stale" | "rejected" | "promoted" | string;
+  cycle: string;
+  cycle_run_id?: string;
+  generator_model?: string;
+  source_refs?: Array<{ type: string; id: string }>;
+  invalidated_reason?: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DreamRun = {
+  run_id: string;
+  team_id: string;
+  run_date: string;
+  started_at: string;
+  completed_at: string;
+  reflect_ran: boolean;
+  reevaluate_ran: boolean;
+  dream_ran: boolean;
+  stale_facts: number;
+  candidate_claims: number;
+  disputed_claims: number;
+  clarifications: number;
+  reevaluated_dreams: number;
+  created_dreams: number;
+  status: string;
+  error?: string;
+};
+
+export type DreamStatus = {
+  effective_config: DreamingEffectiveConfig;
+  latest_run?: DreamRun | null;
+  pending_count: number;
 };
 
 export type RecallHit = {
@@ -273,6 +334,25 @@ export class UserApi {
 
   listCommunities(limit = 20): Promise<ListResponse<Community>> {
     return this.request<ListResponse<Community>>(`/api/v1/communities?limit=${limit}`);
+  }
+
+  async dreamingStatus(): Promise<DreamStatus> {
+    const payload = await this.request<Envelope<DreamStatus>>("/api/v1/dreaming/status");
+    return payload.data;
+  }
+
+  async listDreamingRuns(limit = 20): Promise<DreamRun[]> {
+    const payload = await this.request<Envelope<DreamRun[]>>(`/api/v1/dreaming/runs?limit=${limit}`);
+    return payload.data;
+  }
+
+  async listDreams(status = "", limit = 20): Promise<Dream[]> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (status) {
+      params.set("status", status);
+    }
+    const payload = await this.request<Envelope<Dream[]>>(`/api/v1/dreams?${params.toString()}`);
+    return payload.data;
   }
 
   private async request<T>(path: string, options: RequestOptions = {}): Promise<T> {

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { UserPortalApp } from "./App";
 import "../styles.css";
+import "../observability.css";
 import "../responsive.css";
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary
- Add persisted operation logs in Postgres with configurable retention and control portal log browsing.
- Add dream observability APIs and UI views for control and user portals, including dream runs and dream outputs.
- Align team dreaming config with global-only schedule/timezone/max output settings and make force-all effective config visible.
- Remove redundant clear buttons from boolean global dreaming toggles.

## Validation
- `git diff --check`
- `go test ./...`
- `npm --prefix web run typecheck`
- `npm --prefix web test` (passes; existing Recharts width/height warning appears in output)
- `npm --prefix web run build` (passes; Vite chunk-size warning appears in output)
- `scripts/ci-check.sh` (passes; coverage gate reports `90.0% meets required 90.0%`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **Operation Logs** – Adds a Logs section to the control portal to view, filter, sort, and paginate operation logs, plus a configuration screen to manage retention days.
* **Dreaming Management** – Adds Dreams sections to both control and user portals, including team dreaming status, cycle runs, dreams list (with cursor pagination), and dream detail.
* **Effective Configuration** – The UI now displays “effective” dreaming settings and limits editing to boolean overrides only.

## Improvements
* Hardened profile-route matching to avoid accidental partial-prefix matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->