### PR TITLE
[codex] remove redundant memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ memory, applies explicit gates, and returns structured outcomes.
 | `reflect_memories` | Reviews active facts, candidate or disputed claims, contradictions, stale memories, and clarification needs. |
 | `confirm_memory` | Applies the user's answer to a clarification task, either accepting a claim and superseding comparable active facts or keeping/rejecting it. |
 
-Low-level tools remain available for advanced callers: `save_memory`,
-`post_claim`, `verify_claim`, `promote_claim`, search tools, graph query tools,
-community tools, and retraction tools.
+Low-level tools remain available for advanced callers: `post_claim`,
+`verify_claim`, `promote_claim`, search tools, graph query tools, community
+tools, and retraction tools.
 
 Memory moves through this path:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,9 +220,8 @@ Dense-Mem 不是 agent brain、planner，也不是外部真相裁判。它负责
 | `reflect_memories` | 查看 active facts、candidate/disputed claims、contradictions、stale memories 和 clarification needs。 |
 | `confirm_memory` | 应用用户对 clarification task 的回答：接受 claim 并 supersede 可比较的 active facts，或保留/拒绝它。 |
 
-高级调用方仍然可以使用低层工具：`save_memory`、`post_claim`、`verify_claim`、
-`promote_claim`、搜索工具、graph query tools、community tools 和 retraction
-tools。
+高级调用方仍然可以使用低层工具：`post_claim`、`verify_claim`、`promote_claim`、
+搜索工具、graph query tools、community tools 和 retraction tools。
 
 记忆在系统里的主路径如下：
 

--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -485,8 +485,6 @@ func main() {
 
 	// Tool registry is the single source of truth for MCP / HTTP catalog / OpenAPI.
 	toolRegistry, err := registry.BuildDefault(registry.Dependencies{
-		FragmentCreate:              fragmentCreateRegistrySvc,
-		FragmentGet:                 fragmentGetSvc,
 		FragmentList:                fragmentListSvc,
 		Recall:                      recallRegistrySvc,
 		Metrics:                     discoverabilityMetrics,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -433,8 +433,6 @@ func main() {
 
 	// Tool registry is the single source of truth for MCP / HTTP catalog / OpenAPI.
 	toolRegistry, err := registry.BuildDefault(registry.Dependencies{
-		FragmentCreate:              fragmentCreateRegistrySvc,
-		FragmentGet:                 fragmentGetSvc,
 		FragmentList:                fragmentListSvc,
 		Recall:                      recallRegistrySvc,
 		Metrics:                     discoverabilityMetrics,

--- a/internal/http/handler/tool_catalog_handler_test.go
+++ b/internal/http/handler/tool_catalog_handler_test.go
@@ -27,8 +27,8 @@ func (s catalogRecallFeedbackConfigStub) RecallFeedbackRuntimeConfig(context.Con
 func TestToolCatalogHandler_ReturnsRegisteredTools(t *testing.T) {
 	reg := registry.New()
 	if err := reg.Register(registry.Tool{
-		Name:           "save_memory",
-		Description:    "store a fragment",
+		Name:           "remember",
+		Description:    "store memory evidence and typed claims",
 		InputSchema:    map[string]any{"type": "object"},
 		OutputSchema:   map[string]any{"type": "object"},
 		RequiredScopes: []string{"write"},
@@ -54,8 +54,8 @@ func TestToolCatalogHandler_ReturnsRegisteredTools(t *testing.T) {
 	if len(resp.Tools) != 1 {
 		t.Fatalf("Tools length = %d; want 1", len(resp.Tools))
 	}
-	if resp.Tools[0].Name != "save_memory" {
-		t.Errorf("Tools[0].Name = %q; want save_memory", resp.Tools[0].Name)
+	if resp.Tools[0].Name != "remember" {
+		t.Errorf("Tools[0].Name = %q; want remember", resp.Tools[0].Name)
 	}
 	if len(resp.Tools[0].RequiredScopes) == 0 {
 		t.Error("Tools[0].RequiredScopes empty")
@@ -132,8 +132,9 @@ func TestToolCatalogHandler_FullV1Surface(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	expected := []string{
-		"save_memory", "get_memory", "list_recent_memories", "recall_memory",
-		"dreaming_status", "run_dreaming_cycle", "list_dreams", "get_dream", "resolve_dream_feedback",
+		"list_recent_memories", "recall_memory",
+		"remember", "import_memories", "reflect_memories", "confirm_memory",
+		"list_dreams", "get_dream", "resolve_dream_feedback",
 		"keyword_search", "semantic_search", "graph_query",
 	}
 	seen := make(map[string]bool, len(resp.Tools))

--- a/internal/http/handler/tool_execute_handler_test.go
+++ b/internal/http/handler/tool_execute_handler_test.go
@@ -38,7 +38,7 @@ func (s handlerRecallFeedbackConfigStub) RecallFeedbackRuntimeConfig(context.Con
 func TestToolExecuteHandler_RejectsMissingRequiredField(t *testing.T) {
 	reg := registry.New()
 	err := reg.Register(registry.Tool{
-		Name:           "save_memory",
+		Name:           "remember",
 		InputSchema:    map[string]any{"type": "object", "required": []string{"content"}, "properties": map[string]any{"content": map[string]any{"type": "string"}}, "additionalProperties": false},
 		RequiredScopes: []string{"write"},
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
@@ -66,7 +66,7 @@ func TestToolExecuteHandler_RejectsMissingRequiredField(t *testing.T) {
 
 	e.POST("/api/v1/tools/:name", h.Handle)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/save_memory", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/remember", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Profile-ID", profileID.String())
 	rec := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestToolExecuteHandler_RejectsUnknownNonTenantFieldWhenAdditionalProperties
 	reg := registry.New()
 	called := false
 	err := reg.Register(registry.Tool{
-		Name:           "get_memory",
+		Name:           "example_tool",
 		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"id": map[string]any{"type": "string"}}, "additionalProperties": false},
 		RequiredScopes: []string{"read"},
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
@@ -113,7 +113,7 @@ func TestToolExecuteHandler_RejectsUnknownNonTenantFieldWhenAdditionalProperties
 
 	e.POST("/api/v1/tools/:name", h.Handle)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/get_memory", strings.NewReader(`{"id":"frag-1","unexpected":"forged"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/example_tool", strings.NewReader(`{"id":"frag-1","unexpected":"forged"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Profile-ID", profileID.String())
 	rec := httptest.NewRecorder()
@@ -132,7 +132,7 @@ func TestToolExecuteHandler_StripsTenantFieldsBeforeStrictValidation(t *testing.
 	reg := registry.New()
 	var gotInput map[string]any
 	err := reg.Register(registry.Tool{
-		Name:           "get_memory",
+		Name:           "example_tool",
 		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"id": map[string]any{"type": "string"}}, "additionalProperties": false},
 		RequiredScopes: []string{"read"},
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
@@ -161,7 +161,7 @@ func TestToolExecuteHandler_StripsTenantFieldsBeforeStrictValidation(t *testing.
 
 	e.POST("/api/v1/tools/:name", h.Handle)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/get_memory", strings.NewReader(`{"id":"frag-1","team_id":"forged","profile_id":"forged-profile"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/example_tool", strings.NewReader(`{"id":"frag-1","team_id":"forged","profile_id":"forged-profile"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Profile-ID", profileID.String())
 	rec := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestToolExecuteHandler_StripsTenantFieldsBeforeStrictValidation(t *testing.
 func TestToolExecuteHandler_MapsEmbeddingFailureToServiceUnavailable(t *testing.T) {
 	reg := registry.New()
 	err := reg.Register(registry.Tool{
-		Name:           "save_memory",
+		Name:           "remember",
 		InputSchema:    map[string]any{"type": "object", "required": []string{"content"}, "properties": map[string]any{"content": map[string]any{"type": "string"}}, "additionalProperties": false},
 		RequiredScopes: []string{"write"},
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
@@ -203,7 +203,7 @@ func TestToolExecuteHandler_MapsEmbeddingFailureToServiceUnavailable(t *testing.
 
 	e.POST("/api/v1/tools/:name", h.Handle)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/save_memory", strings.NewReader(`{"content":"hello"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/remember", strings.NewReader(`{"content":"hello"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Profile-ID", profileID.String())
 	rec := httptest.NewRecorder()

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -198,7 +198,7 @@ func TestMCP_ToolsListMirrorsRegistry(t *testing.T) {
 	logger, _ := testLogger(t)
 	reg := registry.New()
 	_ = reg.Register(registry.Tool{
-		Name:        "save_memory",
+		Name:        "remember",
 		Description: "store",
 		InputSchema: map[string]any{"type": "object"},
 	})
@@ -210,8 +210,8 @@ func TestMCP_ToolsListMirrorsRegistry(t *testing.T) {
 	s := NewServer(reg, "pA", logger)
 
 	out := runRPC(t, s, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
-	if !strings.Contains(out, `"save_memory"`) {
-		t.Errorf("tools/list missing save_memory; got %s", out)
+	if !strings.Contains(out, `"remember"`) {
+		t.Errorf("tools/list missing remember; got %s", out)
 	}
 	if !strings.Contains(out, `"recall_memory"`) {
 		t.Errorf("tools/list missing recall_memory; got %s", out)
@@ -230,8 +230,8 @@ func TestMCP_ToolsListMirrorsRegistry(t *testing.T) {
 	if len(payload.Tools) != 2 {
 		t.Fatalf("tools count = %d; want 2", len(payload.Tools))
 	}
-	// Registry.List is sorted, so save_memory comes after recall_memory.
-	if payload.Tools[0]["name"] != "recall_memory" || payload.Tools[1]["name"] != "save_memory" {
+	// Registry.List is sorted, so remember comes after recall_memory.
+	if payload.Tools[0]["name"] != "recall_memory" || payload.Tools[1]["name"] != "remember" {
 		t.Errorf("unsorted: %v", payload.Tools)
 	}
 	if _, ok := payload.Tools[0]["inputSchema"]; !ok {
@@ -362,7 +362,7 @@ func TestMCP_ToolsCallInvokesRegistry(t *testing.T) {
 	var gotProfile string
 	var gotArgs map[string]any
 	_ = reg.Register(registry.Tool{
-		Name:        "save_memory",
+		Name:        "remember",
 		Description: "store",
 		InputSchema: map[string]any{"type": "object"},
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
@@ -373,7 +373,7 @@ func TestMCP_ToolsCallInvokesRegistry(t *testing.T) {
 	})
 	s := NewServer(reg, "pA", logger)
 
-	out := runRPC(t, s, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"save_memory","arguments":{"text":"hello"}}}`)
+	out := runRPC(t, s, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"remember","arguments":{"text":"hello"}}}`)
 	if gotProfile != "pA" {
 		t.Errorf("profileID = %q; want pA", gotProfile)
 	}

--- a/internal/openapi/generator_test.go
+++ b/internal/openapi/generator_test.go
@@ -60,6 +60,61 @@ func TestGenerator_FullIncludesRuntimeOnlyRoutes(t *testing.T) {
 	}
 }
 
+func TestGenerator_FullFragmentRoutesUseExplicitSchemas(t *testing.T) {
+	g := New(testRegistry(t), DefaultRoutes())
+	spec, err := g.Generate(SpecVariantFull)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	paths := spec["paths"].(map[string]any)
+	fragmentsPath := paths["/api/v1/fragments"].(map[string]any)
+	createOp := fragmentsPath["post"].(map[string]any)
+
+	reqBody, ok := createOp["requestBody"].(map[string]any)
+	if !ok {
+		t.Fatal("POST /api/v1/fragments requestBody missing")
+	}
+	reqContent := reqBody["content"].(map[string]any)
+	reqJSON := reqContent["application/json"].(map[string]any)
+	reqSchema := reqJSON["schema"].(map[string]any)
+	if got := reqSchema["$ref"]; got != "#/components/schemas/CreateFragmentRequest" {
+		t.Fatalf("POST /api/v1/fragments requestBody $ref = %v; want #/components/schemas/CreateFragmentRequest", got)
+	}
+
+	responses := createOp["responses"].(map[string]any)
+	resp201, ok := responses["201"].(map[string]any)
+	if !ok {
+		t.Fatalf("POST /api/v1/fragments 201 response missing; have: %v", keysOf(responses))
+	}
+	resp201Content := resp201["content"].(map[string]any)
+	resp201JSON := resp201Content["application/json"].(map[string]any)
+	resp201Schema := resp201JSON["schema"].(map[string]any)
+	if got := resp201Schema["$ref"]; got != "#/components/schemas/FragmentResponse" {
+		t.Fatalf("POST /api/v1/fragments 201 response $ref = %v; want #/components/schemas/FragmentResponse", got)
+	}
+
+	fragmentByIDPath := paths["/api/v1/fragments/{id}"].(map[string]any)
+	getOp := fragmentByIDPath["get"].(map[string]any)
+	getResponses := getOp["responses"].(map[string]any)
+	resp200 := getResponses["200"].(map[string]any)
+	resp200Content := resp200["content"].(map[string]any)
+	resp200JSON := resp200Content["application/json"].(map[string]any)
+	resp200Schema := resp200JSON["schema"].(map[string]any)
+	if got := resp200Schema["$ref"]; got != "#/components/schemas/FragmentResponse" {
+		t.Fatalf("GET /api/v1/fragments/{id} 200 response $ref = %v; want #/components/schemas/FragmentResponse", got)
+	}
+
+	components := spec["components"].(map[string]any)
+	schemas := components["schemas"].(map[string]any)
+	if _, has := schemas["CreateFragmentRequest"]; !has {
+		t.Fatalf("CreateFragmentRequest schema missing from components")
+	}
+	if _, has := schemas["FragmentResponse"]; !has {
+		t.Fatalf("FragmentResponse schema missing from components")
+	}
+}
+
 func TestGenerator_ValidOpenAPIVersion(t *testing.T) {
 	g := New(testRegistry(t), DefaultRoutes())
 	spec, err := g.Generate(SpecVariantFull)

--- a/internal/openapi/generator_test.go
+++ b/internal/openapi/generator_test.go
@@ -35,6 +35,10 @@ func TestGenerator_AISafeExcludesRuntimeOnlyRoutes(t *testing.T) {
 	if _, present := paths["/api/v1/fragments"]; !present {
 		t.Errorf("ai-safe spec must include /api/v1/fragments")
 	}
+	fragmentsPath := paths["/api/v1/fragments"].(map[string]any)
+	if _, present := fragmentsPath["post"]; present {
+		t.Errorf("ai-safe spec must not include raw fragment creation")
+	}
 }
 
 func TestGenerator_FullIncludesRuntimeOnlyRoutes(t *testing.T) {
@@ -49,6 +53,10 @@ func TestGenerator_FullIncludesRuntimeOnlyRoutes(t *testing.T) {
 	}
 	if _, present := paths["/api/v1/fragments"]; !present {
 		t.Errorf("full spec must include /api/v1/fragments")
+	}
+	fragmentsPath := paths["/api/v1/fragments"].(map[string]any)
+	if _, present := fragmentsPath["post"]; !present {
+		t.Errorf("full spec must include raw fragment creation")
 	}
 }
 
@@ -132,12 +140,12 @@ func TestGenerator_SchemasDerivedFromRegistry(t *testing.T) {
 	components := spec["components"].(map[string]any)
 	schemas := components["schemas"].(map[string]any)
 
-	// save_memory -> SavememoryInput/Output per schemaNameFor naming
-	if _, has := schemas["SavememoryInput"]; !has {
-		t.Errorf("registry-derived schema SavememoryInput missing; have keys: %v", keysOf(schemas))
+	// remember -> RememberInput/Output per schemaNameFor naming
+	if _, has := schemas["RememberInput"]; !has {
+		t.Errorf("registry-derived schema RememberInput missing; have keys: %v", keysOf(schemas))
 	}
-	if _, has := schemas["SavememoryOutput"]; !has {
-		t.Errorf("registry-derived schema SavememoryOutput missing")
+	if _, has := schemas["RememberOutput"]; !has {
+		t.Errorf("registry-derived schema RememberOutput missing")
 	}
 	if _, has := schemas["ErrorResponse"]; !has {
 		t.Errorf("ErrorResponse schema missing")
@@ -168,7 +176,7 @@ func TestGenerator_JSONRoundTrips(t *testing.T) {
 
 func TestGenerator_PathParamsDeclared(t *testing.T) {
 	g := New(testRegistry(t), DefaultRoutes())
-	spec, err := g.Generate(SpecVariantAISafe)
+	spec, err := g.Generate(SpecVariantFull)
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}

--- a/internal/openapi/knowledge_schemas.go
+++ b/internal/openapi/knowledge_schemas.go
@@ -1,10 +1,9 @@
 package openapi
 
-// knowledgeSchemas returns component-schema definitions for the knowledge
-// pipeline entities (Claim, Fact, Community). These schemas are merged into
-// every generated spec so that routes can reference them via explicit
-// RequestSchema / ResponseSchema fields on RouteDescriptor — decoupled from
-// MCP tool registration, which may complete later.
+// knowledgeSchemas returns component-schema definitions for REST resources that
+// need explicit schema refs. These schemas are merged into every generated spec
+// so routes can reference them via RouteDescriptor fields, decoupled from MCP
+// tool registration.
 //
 // Schema names follow the PascalCase component convention used throughout this
 // package. They are intentionally separate from tool-derived schemas (which
@@ -12,6 +11,149 @@ package openapi
 // evolution of the REST surface vs. the tool surface.
 func knowledgeSchemas() map[string]any {
 	return map[string]any{
+		// CreateFragmentRequest is the raw REST request body for creating a
+		// source fragment. The server generates embeddings before persistence.
+		"CreateFragmentRequest": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"content": map[string]any{
+					"type":        "string",
+					"description": "Fragment text.",
+					"maxLength":   8192,
+				},
+				"source_type": map[string]any{
+					"type": "string",
+					"enum": []string{"conversation", "document", "observation", "manual"},
+				},
+				"source": map[string]any{
+					"type":      "string",
+					"maxLength": 256,
+				},
+				"authority": map[string]any{
+					"type": "string",
+					"enum": []string{"authoritative", "primary", "secondary", "inferred", "unknown"},
+				},
+				"idempotency_key": map[string]any{
+					"type":      "string",
+					"maxLength": 128,
+				},
+				"labels": map[string]any{
+					"type":     "array",
+					"items":    map[string]any{"type": "string", "maxLength": 64},
+					"maxItems": 20,
+				},
+				"metadata": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+				"source_quality": map[string]any{
+					"type":    "number",
+					"format":  "float",
+					"minimum": 0,
+					"maximum": 1,
+				},
+				"classification": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+			},
+			"required": []string{"content"},
+		},
+
+		// FragmentResponse mirrors internal/http/dto.FragmentResponse and
+		// intentionally excludes the embedding vector.
+		"FragmentResponse": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":   "string",
+					"format": "uuid",
+				},
+				"fragment_id": map[string]any{
+					"type":   "string",
+					"format": "uuid",
+				},
+				"team_id": map[string]any{
+					"type":   "string",
+					"format": "uuid",
+				},
+				"owner_profile_id": map[string]any{
+					"type":   "string",
+					"format": "uuid",
+				},
+				"owner_profile_name": map[string]any{
+					"type": "string",
+				},
+				"created_by_profile_id": map[string]any{
+					"type":   "string",
+					"format": "uuid",
+				},
+				"created_by_profile_name": map[string]any{
+					"type": "string",
+				},
+				"content": map[string]any{
+					"type": "string",
+				},
+				"source_type": map[string]any{
+					"type": "string",
+				},
+				"source": map[string]any{
+					"type": "string",
+				},
+				"authority": map[string]any{
+					"type": "string",
+				},
+				"labels": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string"},
+				},
+				"metadata": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+				"content_hash": map[string]any{
+					"type": "string",
+				},
+				"idempotency_key": map[string]any{
+					"type": "string",
+				},
+				"embedding_model": map[string]any{
+					"type": "string",
+				},
+				"embedding_dimensions": map[string]any{
+					"type": "integer",
+				},
+				"source_quality": map[string]any{
+					"type":   "number",
+					"format": "float",
+				},
+				"classification": map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				},
+				"status": map[string]any{
+					"type": "string",
+				},
+				"recorded_to": map[string]any{
+					"type":   "string",
+					"format": "date-time",
+				},
+				"retracted_at": map[string]any{
+					"type":   "string",
+					"format": "date-time",
+				},
+				"created_at": map[string]any{
+					"type":   "string",
+					"format": "date-time",
+				},
+				"updated_at": map[string]any{
+					"type":   "string",
+					"format": "date-time",
+				},
+			},
+			"required": []string{"id", "fragment_id", "content", "source_type", "content_hash", "embedding_model", "embedding_dimensions", "source_quality", "created_at", "updated_at"},
+		},
+
 		// ClaimRequest is the request body for creating a candidate claim from
 		// one or more supporting fragments.
 		"ClaimRequest": map[string]any{

--- a/internal/openapi/routes.go
+++ b/internal/openapi/routes.go
@@ -75,10 +75,10 @@ func DefaultRoutes() []RouteDescriptor {
 		{Method: "GET", Path: "/api/v1/communities", OperationID: "listCommunities", ResponseSchema: "ListCommunitiesResponse", AISafe: true, Tags: []string{"community"}, Description: "List persisted community summaries for the caller's profile."},
 		{Method: "GET", Path: "/api/v1/communities/{id}", OperationID: "getCommunitySummary", ResponseSchema: "CommunityResponse", AISafe: true, Tags: []string{"community"}, Description: "Fetch one persisted community summary by community_id."},
 
-		// --- Fragments (AI-safe) ---
-		{Method: "POST", Path: "/api/v1/fragments", OperationID: "createFragment", ToolName: "save_memory", AISafe: true, Description: "Save a new memory fragment."},
+		// --- Fragments ---
+		{Method: "POST", Path: "/api/v1/fragments", OperationID: "createFragment", Description: "Create a source fragment."},
 		{Method: "GET", Path: "/api/v1/fragments", OperationID: "listFragments", ToolName: "list_recent_memories", AISafe: true, Description: "List recent fragments (keyset pagination)."},
-		{Method: "GET", Path: "/api/v1/fragments/{id}", OperationID: "getFragment", ToolName: "get_memory", AISafe: true, Description: "Fetch a single fragment by id."},
+		{Method: "GET", Path: "/api/v1/fragments/{id}", OperationID: "getFragment", Description: "Fetch a single fragment by id."},
 		{Method: "DELETE", Path: "/api/v1/fragments/{id}", OperationID: "deleteFragment", AISafe: true, Description: "Hard-delete a fragment."},
 		// Phase 6: soft tombstone (AC-48)
 		{Method: "POST", Path: "/api/v1/fragments/{id}/retract", OperationID: "retractFragment", ResponseSchema: "RetractFragmentResponse", AISafe: true, Tags: []string{"knowledge"}, Description: "Soft-tombstone a fragment; preserves graph lineage and triggers fact revalidation."},
@@ -93,8 +93,6 @@ func DefaultRoutes() []RouteDescriptor {
 			"503": "Embedding provider unavailable.",
 		}},
 		{Method: "POST", Path: "/api/v1/tools/recall_memory", OperationID: "recallMemory", ToolName: "recall_memory", AISafe: true, Description: "Hybrid semantic + keyword recall over fragments."},
-		{Method: "POST", Path: "/api/v1/tools/dreaming_status", OperationID: "dreamingStatusTool", ToolName: "dreaming_status", AISafe: true, Description: "Inspect effective dreaming-cycle config and pending dream hypotheses."},
-		{Method: "POST", Path: "/api/v1/tools/run_dreaming_cycle", OperationID: "runDreamingCycleTool", ToolName: "run_dreaming_cycle", AISafe: true, Description: "Run the fixed reflect, re-evaluate, dream cycle for the caller's team."},
 		{Method: "POST", Path: "/api/v1/tools/list_dreams", OperationID: "listDreamsTool", ToolName: "list_dreams", AISafe: true, Description: "List reviewable dream hypotheses."},
 		{Method: "POST", Path: "/api/v1/tools/get_dream", OperationID: "getDreamTool", ToolName: "get_dream", AISafe: true, Description: "Fetch one dream hypothesis and its source references."},
 		{Method: "POST", Path: "/api/v1/tools/resolve_dream_feedback", OperationID: "resolveDreamFeedbackTool", ToolName: "resolve_dream_feedback", AISafe: true, Description: "Apply evidence-driven user feedback to a dream hypothesis without directly promoting facts."},

--- a/internal/openapi/routes.go
+++ b/internal/openapi/routes.go
@@ -76,9 +76,9 @@ func DefaultRoutes() []RouteDescriptor {
 		{Method: "GET", Path: "/api/v1/communities/{id}", OperationID: "getCommunitySummary", ResponseSchema: "CommunityResponse", AISafe: true, Tags: []string{"community"}, Description: "Fetch one persisted community summary by community_id."},
 
 		// --- Fragments ---
-		{Method: "POST", Path: "/api/v1/fragments", OperationID: "createFragment", Description: "Create a source fragment."},
+		{Method: "POST", Path: "/api/v1/fragments", OperationID: "createFragment", RequestSchema: "CreateFragmentRequest", ResponseSchema: "FragmentResponse", SuccessStatus: 201, Description: "Create a source fragment."},
 		{Method: "GET", Path: "/api/v1/fragments", OperationID: "listFragments", ToolName: "list_recent_memories", AISafe: true, Description: "List recent fragments (keyset pagination)."},
-		{Method: "GET", Path: "/api/v1/fragments/{id}", OperationID: "getFragment", Description: "Fetch a single fragment by id."},
+		{Method: "GET", Path: "/api/v1/fragments/{id}", OperationID: "getFragment", ResponseSchema: "FragmentResponse", Description: "Fetch a single fragment by id."},
 		{Method: "DELETE", Path: "/api/v1/fragments/{id}", OperationID: "deleteFragment", AISafe: true, Description: "Hard-delete a fragment."},
 		// Phase 6: soft tombstone (AC-48)
 		{Method: "POST", Path: "/api/v1/fragments/{id}/retract", OperationID: "retractFragment", ResponseSchema: "RetractFragmentResponse", AISafe: true, Tags: []string{"knowledge"}, Description: "Soft-tombstone a fragment; preserves graph lineage and triggers fact revalidation."},

--- a/internal/tools/registry/dream_tools.go
+++ b/internal/tools/registry/dream_tools.go
@@ -8,65 +8,6 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 )
 
-func dreamingStatusTool(deps Dependencies) Tool {
-	return Tool{
-		Name:        "dreaming_status",
-		Description: "Inspect the effective dreaming-cycle config and latest run status for the caller's team. Dreams are hypotheses, not facts.",
-		InputSchema: map[string]any{
-			"type":                 "object",
-			"properties":           map[string]any{},
-			"additionalProperties": false,
-		},
-		OutputSchema:   map[string]any{"type": "object"},
-		RequiredScopes: []string{"read"},
-		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
-			_ = input
-			if deps.Dreams == nil {
-				return nil, ErrToolUnavailable
-			}
-			res, err := deps.Dreams.Status(ctx, profileID)
-			if err != nil {
-				return nil, err
-			}
-			return structToMap(res)
-		},
-	}
-}
-
-func runDreamingCycleTool(deps Dependencies) Tool {
-	return Tool{
-		Name:        "run_dreaming_cycle",
-		Description: "Manually run the fixed reflect -> re-evaluate -> dream cycle chain for the caller's team. Disabled phases are skipped unless explicitly overridden. This never promotes facts directly.",
-		InputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"reflect_enabled":    map[string]any{"type": "boolean"},
-				"reevaluate_enabled": map[string]any{"type": "boolean"},
-				"dream_enabled":      map[string]any{"type": "boolean"},
-				"max_outputs":        map[string]any{"type": "integer", "minimum": 1, "maximum": 50},
-			},
-			"additionalProperties": false,
-		},
-		OutputSchema:   map[string]any{"type": "object"},
-		RequiredScopes: []string{"write"},
-		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
-			if deps.Dreams == nil {
-				return nil, ErrToolUnavailable
-			}
-			var req dreamservice.RunCycleRequest
-			if err := remapInput(input, &req); err != nil {
-				return nil, fmt.Errorf("run_dreaming_cycle: invalid input: %w", err)
-			}
-			req.Manual = true
-			res, err := deps.Dreams.RunCycle(ctx, profileID, req)
-			if err != nil {
-				return nil, err
-			}
-			return structToMap(res)
-		},
-	}
-}
-
 func listDreamsTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "list_dreams",

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -13,35 +13,6 @@ func TestBuildDefault_DreamInvokers(t *testing.T) {
 	dreams := &stubDreamService{}
 	reg, _ := BuildDefault(Dependencies{Dreams: dreams})
 
-	statusTool, _ := reg.Get("dreaming_status")
-	statusOut, err := statusTool.Invoke(context.Background(), "profile-dream", map[string]any{})
-	if err != nil {
-		t.Fatalf("dreaming_status Invoke: %v", err)
-	}
-	if statusOut["pending_count"] != float64(1) {
-		t.Fatalf("dreaming_status pending_count = %v, want 1", statusOut["pending_count"])
-	}
-
-	runTool, _ := reg.Get("run_dreaming_cycle")
-	runOut, err := runTool.Invoke(context.Background(), "profile-dream", map[string]any{
-		"reflect_enabled":    false,
-		"reevaluate_enabled": true,
-		"dream_enabled":      true,
-		"max_outputs":        float64(4),
-	})
-	if err != nil {
-		t.Fatalf("run_dreaming_cycle Invoke: %v", err)
-	}
-	if runOut["status"] != "completed" {
-		t.Fatalf("run_dreaming_cycle status = %v, want completed", runOut["status"])
-	}
-	if !dreams.lastRunReq.Manual || dreams.lastRunReq.ReflectEnabled == nil || *dreams.lastRunReq.ReflectEnabled {
-		t.Fatalf("run_dreaming_cycle request = %+v, want manual with reflect override false", dreams.lastRunReq)
-	}
-	if dreams.lastRunReq.ReevaluateEnabled == nil || !*dreams.lastRunReq.ReevaluateEnabled || dreams.lastRunReq.MaxOutputs != 4 {
-		t.Fatalf("run_dreaming_cycle request = %+v, want reevaluate true and max outputs 4", dreams.lastRunReq)
-	}
-
 	listTool, _ := reg.Get("list_dreams")
 	listOut, err := listTool.Invoke(context.Background(), "profile-dream", map[string]any{
 		"limit":  float64(3),

--- a/internal/tools/registry/registry.go
+++ b/internal/tools/registry/registry.go
@@ -1,8 +1,8 @@
 // Package registry is the single source of truth for the dense-mem tool catalog.
 //
-// Every AI-exposed verb (save_memory, recall_memory, list_recent_memories,
-// get_memory, plus the lower-level keyword_search / semantic_search / graph_query
-// primitives) is registered once here with its name, description, JSON Schemas,
+// Every AI-exposed verb (remember, recall_memory, list_recent_memories,
+// plus the lower-level keyword_search / semantic_search / graph_query primitives)
+// is registered once here with its name, description, JSON Schemas,
 // required scopes, and a bound invoker. HTTP handlers, the
 // catalog endpoint (Unit 21), the OpenAPI generator (Unit 23), and the MCP
 // server (Unit 24) all read from this registry instead of duplicating schemas.

--- a/internal/tools/registry/registry_test.go
+++ b/internal/tools/registry/registry_test.go
@@ -8,24 +8,24 @@ import (
 
 func TestRegistry_RegisterAndList(t *testing.T) {
 	r := New()
-	if err := r.Register(Tool{Name: "save_memory", Description: "store a fragment"}); err != nil {
+	if err := r.Register(Tool{Name: "remember", Description: "store memory"}); err != nil {
 		t.Fatalf("register: %v", err)
 	}
 	list := r.List()
 	if len(list) != 1 {
 		t.Fatalf("List length = %d; want 1", len(list))
 	}
-	if list[0].Name != "save_memory" {
-		t.Errorf("List[0].Name = %q; want save_memory", list[0].Name)
+	if list[0].Name != "remember" {
+		t.Errorf("List[0].Name = %q; want remember", list[0].Name)
 	}
 }
 
 func TestRegistry_RejectDuplicate(t *testing.T) {
 	r := New()
-	if err := r.Register(Tool{Name: "save_memory"}); err != nil {
+	if err := r.Register(Tool{Name: "remember"}); err != nil {
 		t.Fatalf("first register: %v", err)
 	}
-	err := r.Register(Tool{Name: "save_memory"})
+	err := r.Register(Tool{Name: "remember"})
 	if err == nil {
 		t.Fatal("duplicate Register expected to return an error")
 	}
@@ -70,7 +70,7 @@ func TestRegistry_InvokeProxiesToBoundFunc(t *testing.T) {
 	called := false
 	var gotProfile string
 	if err := r.Register(Tool{
-		Name: "save_memory",
+		Name: "remember",
 		Invoke: func(ctx context.Context, profileID string, _ map[string]any) (map[string]any, error) {
 			called = true
 			gotProfile = profileID
@@ -79,7 +79,7 @@ func TestRegistry_InvokeProxiesToBoundFunc(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	tool, ok := r.Get("save_memory")
+	tool, ok := r.Get("remember")
 	if !ok {
 		t.Fatal("Get returned ok=false for just-registered tool")
 	}
@@ -118,12 +118,12 @@ func TestRegistry_List_SortedAlphabetically(t *testing.T) {
 	r := New()
 	_ = r.Register(Tool{Name: "semantic_search"})
 	_ = r.Register(Tool{Name: "graph_query"})
-	_ = r.Register(Tool{Name: "save_memory"})
+	_ = r.Register(Tool{Name: "remember"})
 	got := r.List()
 	if len(got) != 3 {
 		t.Fatalf("List length = %d; want 3", len(got))
 	}
-	want := []string{"graph_query", "save_memory", "semantic_search"}
+	want := []string{"graph_query", "remember", "semantic_search"}
 	for i, n := range want {
 		if got[i].Name != n {
 			t.Errorf("List[%d] = %q; want %q", i, got[i].Name, n)
@@ -137,10 +137,9 @@ func TestRegistry_List_SortedAlphabetically(t *testing.T) {
 func TestToolRegistry_ListReturnsAllRegistered(t *testing.T) {
 	r := New()
 	names := []string{
-		"save_memory",
-		"get_memory",
 		"list_recent_memories",
 		"recall_memory",
+		"remember",
 		"keyword_search",
 		"semantic_search",
 		"graph_query",

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -31,11 +31,9 @@ import (
 // canonical v1 tool catalog.
 type Dependencies struct {
 	// Fragment tools (v1)
-	FragmentCreate fragmentservice.CreateFragmentService
-	FragmentGet    fragmentservice.GetFragmentService
-	FragmentList   fragmentservice.ListFragmentsService
-	Recall         recallservice.RecallService
-	Metrics        observability.DiscoverabilityMetrics
+	FragmentList fragmentservice.ListFragmentsService
+	Recall       recallservice.RecallService
+	Metrics      observability.DiscoverabilityMetrics
 
 	// RecallFeedbackConfig controls whether recall_memory emits deferred
 	// recall events and whether session feedback submission is callable.
@@ -86,9 +84,7 @@ func BuildDefault(deps Dependencies) (Registry, error) {
 
 func defaultTools(deps Dependencies) []Tool {
 	tools := []Tool{
-		// v1 fragment + search tools
-		saveMemoryTool(deps),
-		getMemoryTool(deps),
+		// v1 fragment read + search tools
 		listRecentMemoriesTool(deps),
 		recallMemoryTool(deps),
 		traceMemoryTool(deps),
@@ -97,8 +93,6 @@ func defaultTools(deps Dependencies) []Tool {
 		importMemoriesTool(deps),
 		reflectMemoriesTool(deps),
 		confirmMemoryTool(deps),
-		dreamingStatusTool(deps),
-		runDreamingCycleTool(deps),
 		listDreamsTool(deps),
 		getDreamTool(deps),
 		resolveDreamFeedbackTool(deps),
@@ -126,100 +120,6 @@ func defaultTools(deps Dependencies) []Tool {
 		submitRecallSessionFeedbackTool(deps),
 	}
 	return tools
-}
-
-// --- save_memory -----------------------------------------------------------
-
-func saveMemoryTool(deps Dependencies) Tool {
-	return Tool{
-		Name:        "save_memory",
-		Description: "Persist one granular SourceFragment for the caller's profile. Keep each entry under 1000 characters and split large scenarios into claim-worthy evidence pieces so future claims can attach to precise support. The server produces the embedding; text and metadata are stored with an audit entry. Supports idempotency via idempotency_key or content hash.",
-		InputSchema: map[string]any{
-			"type":     "object",
-			"required": []string{"content"},
-			"properties": map[string]any{
-				"content":         memoryEntryString("Fragment text."),
-				"source_type":     schemaEnum([]string{"conversation", "document", "observation", "manual"}),
-				"source":          schemaString("Free-form provenance.", 256),
-				"authority":       schemaEnum([]string{"authoritative", "primary", "secondary", "inferred", "unknown"}),
-				"idempotency_key": schemaString("Client-supplied dedupe key (scoped to profile).", 128),
-				"labels":          map[string]any{"type": "array", "items": map[string]any{"type": "string", "maxLength": 64}, "maxItems": 20},
-				"metadata":        map[string]any{"type": "object", "additionalProperties": true},
-			},
-			"additionalProperties": false,
-		},
-		OutputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"id":           map[string]any{"type": "string"},
-				"status":       schemaEnum([]string{"created", "duplicate"}),
-				"duplicate_of": map[string]any{"type": "string"},
-				"created_at":   map[string]any{"type": "string", "format": "date-time"},
-			},
-		},
-		RequiredScopes: []string{"write"},
-		Invoke:         saveMemoryInvoker(deps.FragmentCreate),
-	}
-}
-
-func saveMemoryInvoker(svc fragmentservice.CreateFragmentService) ToolInvoker {
-	return func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
-		if svc == nil {
-			return nil, ErrToolUnavailable
-		}
-		var req dto.CreateFragmentRequest
-		if err := remapInput(input, &req); err != nil {
-			return nil, fmt.Errorf("save_memory: invalid input: %w", err)
-		}
-		res, err := svc.Create(ctx, profileID, &req)
-		if err != nil {
-			return nil, err
-		}
-		status := "created"
-		if res.Duplicate {
-			status = "duplicate"
-		}
-		out := map[string]any{
-			"id":         res.Fragment.FragmentID,
-			"status":     status,
-			"created_at": res.Fragment.CreatedAt,
-		}
-		if res.DuplicateOf != "" {
-			out["duplicate_of"] = res.DuplicateOf
-		}
-		return out, nil
-	}
-}
-
-// --- get_memory ------------------------------------------------------------
-
-func getMemoryTool(deps Dependencies) Tool {
-	return Tool{
-		Name:        "get_memory",
-		Description: "Fetch a single SourceFragment by id within the caller's profile scope.",
-		InputSchema: map[string]any{
-			"type":                 "object",
-			"required":             []string{"id"},
-			"properties":           map[string]any{"id": schemaString("Fragment id.", 128)},
-			"additionalProperties": false,
-		},
-		OutputSchema:   fragmentObjectSchema(),
-		RequiredScopes: []string{"read"},
-		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
-			if deps.FragmentGet == nil {
-				return nil, ErrToolUnavailable
-			}
-			id, _ := input["id"].(string)
-			if id == "" {
-				return nil, errors.New("get_memory: id is required")
-			}
-			frag, err := deps.FragmentGet.GetByID(ctx, profileID, id)
-			if err != nil {
-				return nil, err
-			}
-			return structToMap(frag)
-		},
-	}
 }
 
 // --- list_recent_memories --------------------------------------------------

--- a/internal/tools/registry/toolset_test.go
+++ b/internal/tools/registry/toolset_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/http/dto"
 	"github.com/markhuangai/dense-mem/internal/service/claimservice"
 	"github.com/markhuangai/dense-mem/internal/service/communityservice"
 	"github.com/markhuangai/dense-mem/internal/service/factservice"
@@ -20,30 +19,6 @@ import (
 	"github.com/markhuangai/dense-mem/internal/tools/keywordsearch"
 	"github.com/markhuangai/dense-mem/internal/tools/semanticsearch"
 )
-
-type stubCreate struct {
-	called      int
-	lastProfile string
-	lastReq     *dto.CreateFragmentRequest
-}
-
-func (s *stubCreate) Create(ctx context.Context, profileID string, req *dto.CreateFragmentRequest) (*fragmentservice.CreateResult, error) {
-	s.called++
-	s.lastProfile = profileID
-	s.lastReq = req
-	return &fragmentservice.CreateResult{
-		Fragment: &domain.Fragment{FragmentID: "f-1", ProfileID: profileID, Content: req.Content},
-	}, nil
-}
-
-type stubGet struct{}
-
-func (stubGet) GetByID(ctx context.Context, profileID, fragmentID string) (*domain.Fragment, error) {
-	if fragmentID == "miss" {
-		return nil, fragmentservice.ErrFragmentNotFound
-	}
-	return &domain.Fragment{FragmentID: fragmentID, ProfileID: profileID, Content: "hello"}, nil
-}
 
 type stubList struct{}
 
@@ -91,10 +66,10 @@ func TestBuildDefault_RegistersV1ToolSurface(t *testing.T) {
 		t.Fatalf("BuildDefault: %v", err)
 	}
 	required := []string{
-		"save_memory", "get_memory", "list_recent_memories", "recall_memory",
+		"list_recent_memories", "recall_memory",
 		"trace_memory", "assemble_context",
 		"remember", "import_memories", "reflect_memories", "confirm_memory",
-		"dreaming_status", "run_dreaming_cycle", "list_dreams", "get_dream", "resolve_dream_feedback",
+		"list_dreams", "get_dream", "resolve_dream_feedback",
 		"keyword_search", "semantic_search", "graph_query",
 		"find_skill_pack_candidates", "export_skill_pack", "inspect_skill_pack",
 		"import_skill_pack", "rollback_skill_pack_import",
@@ -116,15 +91,15 @@ func TestBuildDefault_RegistersV1ToolSurface(t *testing.T) {
 
 func TestBuildDefault_SchemaFieldsPopulated(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{})
-	tool, _ := reg.Get("save_memory")
+	tool, _ := reg.Get("remember")
 	if tool.Description == "" {
-		t.Error("save_memory description is empty")
+		t.Error("remember description is empty")
 	}
 	if tool.InputSchema == nil || tool.OutputSchema == nil {
-		t.Error("save_memory schemas must not be nil")
+		t.Error("remember schemas must not be nil")
 	}
 	if len(tool.RequiredScopes) == 0 {
-		t.Error("save_memory must declare required scopes")
+		t.Error("remember must declare required scopes")
 	}
 }
 
@@ -179,88 +154,16 @@ func TestValidateInputRejectsNestedMemoryClaimViolations(t *testing.T) {
 	}
 }
 
-func TestValidateInputRejectsNestedSaveMemoryFields(t *testing.T) {
-	reg, err := BuildDefault(Dependencies{})
-	if err != nil {
-		t.Fatalf("BuildDefault: %v", err)
-	}
-	tool, ok := reg.Get("save_memory")
-	if !ok {
-		t.Fatal("save_memory tool not registered")
-	}
-
-	properties := tool.InputSchema["properties"].(map[string]any)
-	contentSchema := properties["content"].(map[string]any)
-	if got, want := contentSchema["maxLength"], memoryEntryMaxLength; got != want {
-		t.Fatalf("save_memory content maxLength = %v; want %d", got, want)
-	}
-	if err := ValidateInput(tool, map[string]any{
-		"content": strings.Repeat("x", memoryEntryMaxLength+1),
-	}); err == nil || !strings.Contains(err.Error(), "Split large scenarios") {
-		t.Fatalf("ValidateInput long content error = %v; want split guidance", err)
-	}
-
-	if err := ValidateInput(tool, map[string]any{
-		"content":     "hello",
-		"source_type": "webhook",
-	}); err == nil || !strings.Contains(err.Error(), "source_type") {
-		t.Fatalf("ValidateInput invalid enum error = %v; want source_type validation", err)
-	}
-
-	if err := ValidateInput(tool, map[string]any{
-		"content": "hello",
-		"labels":  []any{strings.Repeat("x", 65)},
-	}); err == nil || !strings.Contains(err.Error(), "labels[0]") {
-		t.Fatalf("ValidateInput invalid label error = %v; want labels[0] validation", err)
-	}
-}
-
-func TestBuildDefault_SaveInvokerCallsService(t *testing.T) {
-	create := &stubCreate{}
-	reg, _ := BuildDefault(Dependencies{
-		FragmentCreate: create,
-	})
-	tool, _ := reg.Get("save_memory")
-	out, err := tool.Invoke(context.Background(), "pA", map[string]any{"content": "hello"})
-	if err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
-	if create.called != 1 {
-		t.Errorf("service called %d times; want 1", create.called)
-	}
-	if create.lastProfile != "pA" {
-		t.Errorf("service profile = %q; want pA", create.lastProfile)
-	}
-	if out["status"] != "created" {
-		t.Errorf("output status = %v; want created", out["status"])
-	}
-	if out["id"] != "f-1" {
-		t.Errorf("output id = %v; want f-1", out["id"])
-	}
-}
-
-func TestBuildDefault_InvokerReturnsUnavailableWhenDepsMissing(t *testing.T) {
-	reg, _ := BuildDefault(Dependencies{}) // nothing wired
-	tool, _ := reg.Get("save_memory")
-	_, err := tool.Invoke(context.Background(), "pA", map[string]any{"content": "x"})
-	if !errors.Is(err, ErrToolUnavailable) {
-		t.Errorf("err = %v; want ErrToolUnavailable", err)
-	}
-}
-
 func TestBuildDefault_V1InvokersReturnUnavailableWhenDepsMissing(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{})
 	cases := []struct {
 		name  string
 		input map[string]any
 	}{
-		{name: "get_memory", input: map[string]any{"id": "fragment-1"}},
 		{name: "list_recent_memories", input: map[string]any{}},
 		{name: "recall_memory", input: map[string]any{"query": "hello"}},
 		{name: "trace_memory", input: map[string]any{"type": "fact", "id": "fact-1"}},
 		{name: "assemble_context", input: map[string]any{"query": "hello"}},
-		{name: "dreaming_status", input: map[string]any{}},
-		{name: "run_dreaming_cycle", input: map[string]any{}},
 		{name: "list_dreams", input: map[string]any{}},
 		{name: "get_dream", input: map[string]any{"dream_id": "dream-1"}},
 		{name: "resolve_dream_feedback", input: map[string]any{"dream_id": "dream-1", "decision": "reject"}},
@@ -287,12 +190,6 @@ func TestBuildDefault_V1InvokerInvalidInputBranches(t *testing.T) {
 		want string
 	}{
 		{
-			name: "save_memory",
-			deps: Dependencies{FragmentCreate: &stubCreate{}},
-			in:   map[string]any{"content": func() {}},
-			want: "save_memory: invalid input",
-		},
-		{
 			name: "recall_memory",
 			deps: Dependencies{Recall: stubRecall{}},
 			in:   map[string]any{"query": func() {}},
@@ -311,12 +208,6 @@ func TestBuildDefault_V1InvokerInvalidInputBranches(t *testing.T) {
 			want: "semantic_search: invalid input",
 		},
 		{
-			name: "run_dreaming_cycle",
-			deps: Dependencies{Dreams: &stubDreamService{}},
-			in:   map[string]any{"max_outputs": func() {}},
-			want: "run_dreaming_cycle: invalid input",
-		},
-		{
 			name: "resolve_dream_feedback",
 			deps: Dependencies{Dreams: &stubDreamService{}},
 			in:   map[string]any{"dream_id": func() {}, "decision": "reject"},
@@ -333,18 +224,6 @@ func TestBuildDefault_V1InvokerInvalidInputBranches(t *testing.T) {
 				t.Fatalf("err = %v; want %q", err, tc.want)
 			}
 		})
-	}
-}
-
-func TestBuildDefault_GetInvokerWraps(t *testing.T) {
-	reg, _ := BuildDefault(Dependencies{FragmentGet: stubGet{}})
-	tool, _ := reg.Get("get_memory")
-	out, err := tool.Invoke(context.Background(), "pA", map[string]any{"id": "f-42"})
-	if err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
-	if out["id"] != "f-42" {
-		t.Errorf("out[id] = %v; want f-42", out["id"])
 	}
 }
 
@@ -641,31 +520,6 @@ func TestImportSkillPackReturnsRecoverableResultOnPartialError(t *testing.T) {
 }
 
 func TestBuildDefault_FragmentInvokerEdgeBranches(t *testing.T) {
-	t.Run("save duplicate includes duplicate_of", func(t *testing.T) {
-		reg, _ := BuildDefault(Dependencies{FragmentCreate: duplicateCreate{}})
-		tool, _ := reg.Get("save_memory")
-
-		out, err := tool.Invoke(context.Background(), "profileA", map[string]any{"content": "hello"})
-
-		if err != nil {
-			t.Fatalf("save_memory Invoke: %v", err)
-		}
-		if out["status"] != "duplicate" || out["duplicate_of"] != "fragment-original" {
-			t.Fatalf("save_memory duplicate out = %v", out)
-		}
-	})
-
-	t.Run("get memory requires id", func(t *testing.T) {
-		reg, _ := BuildDefault(Dependencies{FragmentGet: stubGet{}})
-		tool, _ := reg.Get("get_memory")
-
-		_, err := tool.Invoke(context.Background(), "profileA", map[string]any{})
-
-		if err == nil || !strings.Contains(err.Error(), "id is required") {
-			t.Fatalf("get_memory err = %v, want id required", err)
-		}
-	})
-
 	t.Run("list memory maps options and cursor", func(t *testing.T) {
 		list := &stubListCapture{}
 		reg, _ := BuildDefault(Dependencies{FragmentList: list})
@@ -730,16 +584,6 @@ func (stubMemoryReflectError) Reflect(ctx context.Context, profileID string, req
 
 func (stubMemoryReflectError) ConfirmMemory(ctx context.Context, profileID string, req memoryservice.ConfirmRequest) (*memoryservice.ConfirmResult, error) {
 	return &memoryservice.ConfirmResult{}, nil
-}
-
-type duplicateCreate struct{}
-
-func (duplicateCreate) Create(ctx context.Context, profileID string, req *dto.CreateFragmentRequest) (*fragmentservice.CreateResult, error) {
-	return &fragmentservice.CreateResult{
-		Fragment:    &domain.Fragment{FragmentID: "fragment-duplicate", ProfileID: profileID, Content: req.Content},
-		Duplicate:   true,
-		DuplicateOf: "fragment-original",
-	}, nil
 }
 
 type stubListCapture struct {

--- a/tests/uat/auth-matrix.spec.ts
+++ b/tests/uat/auth-matrix.spec.ts
@@ -74,7 +74,7 @@ function readOnlyWriteRoutes(profileId: string): RouteCase[] {
     { method: 'DELETE', path: `/api/v1/claims/${ID}` },
     { method: 'POST', path: `/api/v1/claims/${ID}/verify`, data: { verifier_model: 'test-verifier' } },
     { method: 'POST', path: `/api/v1/claims/${ID}/promote`, data: { policy: 'single_supporter' } },
-    { method: 'POST', path: '/api/v1/tools/save_memory', data: { content: 'denied' } },
+    { method: 'POST', path: '/api/v1/tools/remember', data: { content: 'denied' } },
   ];
 }
 

--- a/tests/uat/discoverability/phase1_test.go
+++ b/tests/uat/discoverability/phase1_test.go
@@ -177,7 +177,7 @@ func TestUAT10_ToolCatalogAndOpenAPI(t *testing.T) {
 	toolset := readFile(t, "internal/tools/registry/toolset.go")
 	// AI-facing verbs use underscore_case consistently.
 	for _, name := range []string{
-		"save_memory", "get_memory", "list_recent_memories", "recall_memory",
+		"list_recent_memories", "recall_memory", "remember",
 		"keyword_search", "semantic_search", "graph_query",
 	} {
 		assert.Contains(t, toolset, name,
@@ -196,7 +196,6 @@ func TestUAT10_ToolCatalogAndOpenAPI(t *testing.T) {
 
 	// In-process contract check: BuildDefault advertises every canonical tool
 	// even with zero service wiring, so discovery never silently drops entries.
-	// Phase 8 (knowledge pipeline) added 9 new tools on top of the original 7.
 	reg, err := registry.BuildDefault(registry.Dependencies{})
 	require.NoError(t, err)
 	list := reg.List()
@@ -205,8 +204,8 @@ func TestUAT10_ToolCatalogAndOpenAPI(t *testing.T) {
 		seen[tl.Name] = true
 	}
 	for _, name := range []string{
-		// Original 7 (Phase 1 canonical set)
-		"save_memory", "get_memory", "list_recent_memories", "recall_memory",
+		// Canonical memory/search set
+		"list_recent_memories", "recall_memory", "remember",
 		"keyword_search", "semantic_search", "graph_query",
 		// Phase 8 knowledge pipeline tools
 		"post_claim", "get_claim", "list_claims",
@@ -220,14 +219,14 @@ func TestUAT10_ToolCatalogAndOpenAPI(t *testing.T) {
 	for _, name := range []string{"keyword-search", "semantic-search", "graph-query"} {
 		assert.False(t, seen[name], "registry must not list legacy hyphenated tool %q", name)
 	}
-	assert.GreaterOrEqual(t, len(list), 7, "BuildDefault must register at least the original 7 canonical tools")
+	assert.GreaterOrEqual(t, len(list), 6, "BuildDefault must register at least the canonical memory/search tools")
 
-	// save_memory stays part of the stable catalog even when the write service is
+	// remember stays part of the stable catalog even when the memory service is
 	// not wired in this test harness.
-	save, ok := reg.Get("save_memory")
+	remember, ok := reg.Get("remember")
 	require.True(t, ok)
-	assert.Contains(t, save.RequiredScopes, "write",
-		"save_memory must require the write scope")
+	assert.Contains(t, remember.RequiredScopes, "write",
+		"remember must require the write scope")
 }
 
 // UAT-11: MCP Streamable HTTP derives profile scope from the API key and reuses

--- a/tests/uat/mcp_e2e_test.go
+++ b/tests/uat/mcp_e2e_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/factservice"
 	"github.com/markhuangai/dense-mem/internal/service/fragmentdedupe"
 	"github.com/markhuangai/dense-mem/internal/service/fragmentservice"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 	neo4jstorage "github.com/markhuangai/dense-mem/internal/storage/neo4j"
 	pgclient "github.com/markhuangai/dense-mem/internal/storage/postgres"
@@ -184,6 +185,14 @@ func startWritableMemoryServer(t *testing.T, env *TestEnv) (*httptest.Server, fr
 	)
 	factGetSvc := factservice.NewGetFactService(profileScopeEnforcer)
 	factListSvc := factservice.NewListFactsService(profileScopeEnforcer)
+	memorySvc := memoryservice.New(memoryservice.Dependencies{
+		FragmentCreate: fragmentCreateSvc,
+		ClaimCreate:    claimCreateSvc,
+		ClaimGet:       claimGetSvc,
+		ClaimList:      claimListSvc,
+		FactPromote:    factPromoteSvc,
+		FactList:       factListSvc,
+	})
 	skillPackSvc := skillpackservice.New(skillpackservice.Dependencies{
 		FragmentCreate: fragmentCreateSvc,
 		ClaimCreate:    claimCreateSvc,
@@ -198,16 +207,15 @@ func startWritableMemoryServer(t *testing.T, env *TestEnv) (*httptest.Server, fr
 	})
 
 	reg, err := registry.BuildDefault(registry.Dependencies{
-		FragmentCreate: fragmentCreateSvc,
-		FragmentGet:    fragmentGetSvc,
-		FragmentList:   fragmentListSvc,
-		ClaimCreate:    claimCreateSvc,
-		ClaimGet:       claimGetSvc,
-		ClaimList:      claimListSvc,
-		FactPromote:    factPromoteSvc,
-		FactGet:        factGetSvc,
-		FactList:       factListSvc,
-		SkillPack:      skillPackSvc,
+		FragmentList: fragmentListSvc,
+		ClaimCreate:  claimCreateSvc,
+		ClaimGet:     claimGetSvc,
+		ClaimList:    claimListSvc,
+		FactPromote:  factPromoteSvc,
+		FactGet:      factGetSvc,
+		FactList:     factListSvc,
+		Memory:       memorySvc,
+		SkillPack:    skillPackSvc,
 	})
 	require.NoError(t, err)
 
@@ -255,7 +263,7 @@ func createProfileAndKey(t *testing.T, ctx context.Context, env *TestEnv) (strin
 	return profile.ID.String(), rawKey
 }
 
-func TestUATMCPRuntime_SaveMemoryPersistsAndReadsBack(t *testing.T) {
+func TestUATMCPRuntime_RememberPersistsAndReadsBack(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -276,22 +284,22 @@ func TestUATMCPRuntime_SaveMemoryPersistsAndReadsBack(t *testing.T) {
 	})
 	require.NotNil(t, initResp["result"], "initialize must succeed")
 
-	saveResp := toolResult(t, mcp.call(t, "tools/call", map[string]any{
-		"name": "save_memory",
+	rememberResp := toolResult(t, mcp.call(t, "tools/call", map[string]any{
+		"name": "remember",
 		"arguments": map[string]any{
 			"content":         "MCP persisted memory for runtime verification.",
-			"source_type":     "manual",
-			"authority":       "primary",
-			"idempotency_key": "uat-mcp-runtime-save",
+			"idempotency_key": "uat-mcp-runtime-remember",
 			"labels":          []string{"uat", "mcp"},
 			"metadata": map[string]any{
 				"origin": "uat",
 			},
 		},
 	}))
-	require.Equal(t, "created", saveResp["status"])
+	fragmentResp, ok := rememberResp["fragment"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "created", fragmentResp["status"])
 
-	fragmentID, ok := saveResp["id"].(string)
+	fragmentID, ok := fragmentResp["id"].(string)
 	require.True(t, ok)
 	require.NotEmpty(t, fragmentID)
 
@@ -299,17 +307,6 @@ func TestUATMCPRuntime_SaveMemoryPersistsAndReadsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "MCP persisted memory for runtime verification.", stored.Content)
 	require.Equal(t, "primary", string(stored.Authority))
-
-	getResp := toolResult(t, mcp.call(t, "tools/call", map[string]any{
-		"name": "get_memory",
-		"arguments": map[string]any{
-			"id":         fragmentID,
-			"profile_id": "foreign-profile-should-be-ignored",
-		},
-	}))
-	require.Equal(t, fragmentID, getResp["id"])
-	require.Equal(t, "MCP persisted memory for runtime verification.", getResp["content"])
-	require.Equal(t, "primary", getResp["authority"])
 
 	listResp := toolResult(t, mcp.call(t, "tools/call", map[string]any{
 		"name": "list_recent_memories",
@@ -326,16 +323,16 @@ func TestUATMCPRuntime_SaveMemoryPersistsAndReadsBack(t *testing.T) {
 	require.Equal(t, fragmentID, first["id"])
 
 	dupResp := toolResult(t, mcp.call(t, "tools/call", map[string]any{
-		"name": "save_memory",
+		"name": "remember",
 		"arguments": map[string]any{
 			"content":         "MCP persisted memory for runtime verification.",
-			"source_type":     "manual",
-			"authority":       "primary",
-			"idempotency_key": "uat-mcp-runtime-save",
+			"idempotency_key": "uat-mcp-runtime-remember",
 		},
 	}))
-	require.Equal(t, "duplicate", dupResp["status"])
-	require.Equal(t, fragmentID, dupResp["duplicate_of"])
+	dupFragment, ok := dupResp["fragment"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "duplicate", dupFragment["status"])
+	require.Equal(t, fragmentID, dupFragment["duplicate_of"])
 }
 
 func TestUATMCPRuntime_SkillPackReviewImportAndRollback(t *testing.T) {

--- a/tests/uat/phase8-mcp.spec.ts
+++ b/tests/uat/phase8-mcp.spec.ts
@@ -68,12 +68,14 @@ test('UAT-11b: MCP endpoint exposes required memory tools', async () => {
     const toolNames = tools.map((t) => t.name);
     expect(toolNames).toEqual(
       expect.arrayContaining([
-        'save_memory',
-        'get_memory',
         'list_recent_memories',
         'recall_memory',
         'trace_memory',
         'assemble_context',
+        'remember',
+        'import_memories',
+        'reflect_memories',
+        'confirm_memory',
         'keyword_search',
         'semantic_search',
         'graph_query',

--- a/tests/uat/profile-key-permissions.spec.ts
+++ b/tests/uat/profile-key-permissions.spec.ts
@@ -103,10 +103,9 @@ test('read-only profile key only sees and calls read-scoped MCP tools', async ({
     const list = listResponse as { result: { tools: Array<{ name: string }> } };
     const toolNames = list.result.tools.map((tool) => tool.name);
 
-    expect(toolNames).toContain('recall_memory');
-    expect(toolNames).not.toContain('remember');
-    expect(toolNames).not.toContain('save_memory');
-    expect(toolNames).not.toContain('confirm_memory');
+	expect(toolNames).toContain('recall_memory');
+	expect(toolNames).not.toContain('remember');
+	expect(toolNames).not.toContain('confirm_memory');
 
     const writeCall = await mcp.call('tools/call', {
       name: 'remember',

--- a/tests/uat/testenv.go
+++ b/tests/uat/testenv.go
@@ -362,7 +362,6 @@ func (te *TestEnv) Setup(ctx context.Context) error {
 	fragmentDeleteSvc := fragmentservice.NewDeleteFragmentService(profileScopeEnforcer, readerAdapter, fragmentAuditor, slog.Default())
 
 	toolRegistry, err := registry.BuildDefault(registry.Dependencies{
-		FragmentGet:  fragmentGetSvc,
 		FragmentList: fragmentListSvc,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove redundant MCP tool entrypoints: `save_memory`, `get_memory`, `dreaming_status`, and `run_dreaming_cycle`.
- Keep `remember` as the memory write entrypoint and keep scheduled/internal dreaming service support.
- Update OpenAPI discoverability, docs, and UAT/unit tests to match the new tool surface.

## Why

The memory API should have one AI-facing write path through `remember`, which already calls the fragment creation path that generates embeddings. Direct fragment lookup and manual dreaming-cycle controls should not be exposed as MCP tools.

## Validation

- `go test ./cmd/server ./cmd/demo-server ./internal/tools/registry ./internal/openapi ./internal/mcp ./internal/http/handler`
- `go test ./internal/service/memoryservice`
- `go test -tags uat ./tests/uat/discoverability -run TestUAT10_ToolCatalogAndOpenAPI -count=1`
- `go test -tags uat ./tests/uat -run '^$'`
- `git diff --check`
- Push hook ran broader lint/test/coverage and reported coverage 90.3% meets required 90.0%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardized the `remember` tool for persisting and retrieving memory fragments.
* **Refactor**
  * Replaced `save_memory`/`get_memory` with `remember` across the tool catalog, MCP, and API surface.
  * Removed `dreaming_status` and `run_dreaming_cycle` from the available tools and OpenAPI output.
  * Updated fragment operations exposure and OpenAPI spec generation (including explicit request/response schemas in Full).
* **Documentation**
  * Updated Memory Workflow docs to reflect the new tool list and naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->