### PR TITLE
[codex] Add dream pagination and date sorting

### DIFF
--- a/.lint/package-lock.json
+++ b/.lint/package-lock.json
@@ -1288,9 +1288,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1509,10 +1509,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/internal/http/control_portal_observability.go
+++ b/internal/http/control_portal_observability.go
@@ -91,6 +91,9 @@ func (h *controlPortalHandler) listTeamDreams(c echo.Context) error {
 	}
 	dreams, nextCursor, err := h.dreams.List(c.Request().Context(), profileID.String(), opts)
 	if err != nil {
+		if errors.Is(err, dreamservice.ErrInvalidDreamCursor) {
+			return httperr.New(httperr.VALIDATION_ERROR, "invalid cursor")
+		}
 		return err
 	}
 	return c.JSON(nethttp.StatusOK, map[string]any{"data": controlDreamListResponse{Items: dreams, NextCursor: nextCursor}})
@@ -163,10 +166,24 @@ func controlDreamListOptions(c echo.Context) (dreamservice.ListOptions, error) {
 	if status != "" && !domain.DreamStatus(status).IsValid() {
 		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "status must be one of proposed, reinforced, stale, rejected, promoted")
 	}
+	sort := strings.TrimSpace(c.QueryParam("sort"))
+	switch sort {
+	case "", dreamservice.DreamSortUpdatedAt, dreamservice.DreamSortCreatedAt, dreamservice.DreamSortLastEvaluatedAt:
+	default:
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "sort must be updated_at, created_at, or last_evaluated_at")
+	}
+	direction := strings.TrimSpace(c.QueryParam("direction"))
+	switch direction {
+	case "", dreamservice.DreamDirectionAsc, dreamservice.DreamDirectionDesc:
+	default:
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "direction must be asc or desc")
+	}
 	return dreamservice.ListOptions{
-		Limit:  limit,
-		Status: status,
-		Cursor: strings.TrimSpace(c.QueryParam("cursor")),
+		Limit:     limit,
+		Status:    status,
+		Cursor:    strings.TrimSpace(c.QueryParam("cursor")),
+		Sort:      sort,
+		Direction: direction,
 	}, nil
 }
 

--- a/internal/http/control_portal_observability_test.go
+++ b/internal/http/control_portal_observability_test.go
@@ -46,6 +46,7 @@ type controlDreamServiceStub struct {
 	runsLimit  int
 	profileID  string
 	getErr     error
+	listErr    error
 }
 
 func (s *controlDreamServiceStub) RunCycle(context.Context, string, dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -55,6 +56,9 @@ func (s *controlDreamServiceStub) RunCycle(context.Context, string, dreamservice
 func (s *controlDreamServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
 	s.profileID = profileID
 	s.listOpts = opts
+	if s.listErr != nil {
+		return nil, "", s.listErr
+	}
 	return s.dreams, s.nextCursor, nil
 }
 
@@ -168,12 +172,12 @@ func TestControlPortalObservabilityRoutes(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"run_id":"run-1"`)
 	assert.Equal(t, 3, dreams.runsLimit)
 
-	rec = do("/control/api/teams/" + teamID.String() + "/dreams?limit=4&status=proposed&cursor=next")
+	rec = do("/control/api/teams/" + teamID.String() + "/dreams?limit=4&status=proposed&cursor=next&sort=last_evaluated_at&direction=asc")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), "A control dream appears")
 	assert.Contains(t, rec.Body.String(), `"next_cursor":"after-control-dream-1"`)
 	assert.Equal(t, teamID.String(), dreams.profileID)
-	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next"}, dreams.listOpts)
+	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next", Sort: "last_evaluated_at", Direction: "asc"}, dreams.listOpts)
 
 	rec = do("/control/api/teams/" + teamID.String() + "/dreams/dream-1")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
@@ -213,6 +217,16 @@ func TestControlPortalObservabilityValidation(t *testing.T) {
 	c = e.NewContext(req, rec)
 	_, err = controlDreamListOptions(c)
 	require.ErrorContains(t, err, "status must be one of")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/dreams?sort=bad", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlDreamListOptions(c)
+	require.ErrorContains(t, err, "sort must be updated_at")
+
+	req = httptest.NewRequest(http.MethodGet, "/control/api/dreams?direction=sideways", nil)
+	c = e.NewContext(req, rec)
+	_, err = controlDreamListOptions(c)
+	require.ErrorContains(t, err, "direction must be asc or desc")
 }
 
 func TestControlPortalObservabilityUnavailableAndNotFound(t *testing.T) {
@@ -237,6 +251,15 @@ func TestControlPortalObservabilityUnavailableAndNotFound(t *testing.T) {
 	c.SetParamValues(teamID.String(), "dream-missing")
 	err := h.getTeamDream(c)
 	require.ErrorContains(t, err, "dream not found")
+
+	h.dreams = &controlDreamServiceStub{listErr: dreamservice.ErrInvalidDreamCursor}
+	req = httptest.NewRequest(http.MethodGet, "/control/api/teams/"+teamID.String()+"/dreams?cursor=bad", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	c.SetParamNames("teamId")
+	c.SetParamValues(teamID.String())
+	err = h.listTeamDreams(c)
+	require.ErrorContains(t, err, "invalid cursor")
 }
 
 func TestControlDependencySnapshotErrorAndDegraded(t *testing.T) {

--- a/internal/http/handler/dream_handler.go
+++ b/internal/http/handler/dream_handler.go
@@ -72,6 +72,9 @@ func (h *DreamHandler) List(c echo.Context) error {
 	}
 	dreams, nextCursor, err := h.svc.List(c.Request().Context(), profileID.String(), opts)
 	if err != nil {
+		if errors.Is(err, dreamservice.ErrInvalidDreamCursor) {
+			return httperr.New(httperr.VALIDATION_ERROR, "invalid cursor")
+		}
 		return err
 	}
 	return response.SuccessOK(c, dreamListResponse{Items: dreams, NextCursor: nextCursor})
@@ -105,10 +108,24 @@ func dreamListOptions(c echo.Context) (dreamservice.ListOptions, error) {
 	if status != "" && !domain.DreamStatus(status).IsValid() {
 		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "status must be one of proposed, reinforced, stale, rejected, promoted")
 	}
+	sort := strings.TrimSpace(c.QueryParam("sort"))
+	switch sort {
+	case "", dreamservice.DreamSortUpdatedAt, dreamservice.DreamSortCreatedAt, dreamservice.DreamSortLastEvaluatedAt:
+	default:
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "sort must be updated_at, created_at, or last_evaluated_at")
+	}
+	direction := strings.TrimSpace(c.QueryParam("direction"))
+	switch direction {
+	case "", dreamservice.DreamDirectionAsc, dreamservice.DreamDirectionDesc:
+	default:
+		return dreamservice.ListOptions{}, httperr.New(httperr.VALIDATION_ERROR, "direction must be asc or desc")
+	}
 	return dreamservice.ListOptions{
-		Limit:  limit,
-		Status: status,
-		Cursor: strings.TrimSpace(c.QueryParam("cursor")),
+		Limit:     limit,
+		Status:    status,
+		Cursor:    strings.TrimSpace(c.QueryParam("cursor")),
+		Sort:      sort,
+		Direction: direction,
 	}, nil
 }
 

--- a/internal/http/handler/dream_handler_test.go
+++ b/internal/http/handler/dream_handler_test.go
@@ -29,6 +29,7 @@ type dreamHandlerServiceStub struct {
 	runsLimit  int
 	profileIDs []string
 	getErr     error
+	listErr    error
 }
 
 func (s *dreamHandlerServiceStub) RunCycle(context.Context, string, dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -38,6 +39,9 @@ func (s *dreamHandlerServiceStub) RunCycle(context.Context, string, dreamservice
 func (s *dreamHandlerServiceStub) List(_ context.Context, profileID string, opts dreamservice.ListOptions) ([]*domain.Dream, string, error) {
 	s.profileIDs = append(s.profileIDs, profileID)
 	s.listOpts = opts
+	if s.listErr != nil {
+		return nil, "", s.listErr
+	}
 	return s.dreams, s.nextCursor, nil
 }
 
@@ -121,7 +125,7 @@ func TestDreamHandlerRoutes(t *testing.T) {
 	}{
 		{path: "/api/v1/dreaming/status", want: `"pending_count":2`},
 		{path: "/api/v1/dreaming/runs?limit=3", want: `"run_id":"run-1"`},
-		{path: "/api/v1/dreams?limit=4&status=proposed&cursor=next", want: `"next_cursor":"after-dream-1"`},
+		{path: "/api/v1/dreams?limit=4&status=proposed&cursor=next&sort=created_at&direction=asc", want: `"next_cursor":"after-dream-1"`},
 		{path: "/api/v1/dreams/dream-1", want: `"dream_id":"dream-1"`},
 	}
 	for _, tt := range tests {
@@ -132,7 +136,7 @@ func TestDreamHandlerRoutes(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), tt.want)
 	}
 	assert.Equal(t, 3, svc.runsLimit)
-	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next"}, svc.listOpts)
+	assert.Equal(t, dreamservice.ListOptions{Limit: 4, Status: "proposed", Cursor: "next", Sort: "created_at", Direction: "asc"}, svc.listOpts)
 	assert.Contains(t, svc.profileIDs, profileID.String())
 }
 
@@ -173,6 +177,25 @@ func TestDreamHandlerValidationAndNotFound(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 	assert.Contains(t, rec.Body.String(), "status must be one of")
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams?sort=bad", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "sort must be updated_at")
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams?direction=sideways", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "direction must be asc or desc")
+
+	svc.listErr = dreamservice.ErrInvalidDreamCursor
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams?cursor=bad", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid cursor")
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/dreams/dream-missing", nil)
 	rec = httptest.NewRecorder()

--- a/internal/service/dreamservice/list.go
+++ b/internal/service/dreamservice/list.go
@@ -1,0 +1,104 @@
+package dreamservice
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+const (
+	defaultListLimit = 20
+	maxListLimit     = 100
+
+	DreamSortUpdatedAt       = "updated_at"
+	DreamSortCreatedAt       = "created_at"
+	DreamSortLastEvaluatedAt = "last_evaluated_at"
+	DreamDirectionAsc        = "asc"
+	DreamDirectionDesc       = "desc"
+)
+
+var ErrInvalidDreamCursor = errors.New("invalid cursor")
+
+type dreamCursor struct {
+	Sort      string
+	Direction string
+	SortAt    time.Time
+	DreamID   string
+}
+
+func normalizeDreamSort(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case DreamSortCreatedAt:
+		return DreamSortCreatedAt
+	case DreamSortLastEvaluatedAt:
+		return DreamSortLastEvaluatedAt
+	default:
+		return DreamSortUpdatedAt
+	}
+}
+
+func normalizeDreamDirection(value string) string {
+	if strings.ToLower(strings.TrimSpace(value)) == DreamDirectionAsc {
+		return DreamDirectionAsc
+	}
+	return DreamDirectionDesc
+}
+
+func encodeDreamCursor(c dreamCursor) string {
+	raw := fmt.Sprintf("%s|%s|%s|%s", c.Sort, c.Direction, c.SortAt.UTC().Format(time.RFC3339Nano), c.DreamID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeDreamCursor(cursor string, sort string, direction string) (time.Time, string, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return time.Time{}, "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
+	}
+	parts := strings.SplitN(string(raw), "|", 4)
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return time.Time{}, "", ErrInvalidDreamCursor
+	}
+	if parts[0] != sort || parts[1] != direction {
+		return time.Time{}, "", fmt.Errorf("%w: sort changed", ErrInvalidDreamCursor)
+	}
+	sortAt, err := time.Parse(time.RFC3339Nano, parts[2])
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
+	}
+	return sortAt.UTC(), parts[3], nil
+}
+
+func dreamSortExpression(sort string) string {
+	switch sort {
+	case DreamSortCreatedAt:
+		return "d.created_at"
+	case DreamSortLastEvaluatedAt:
+		return "coalesce(d.last_evaluated_at, datetime({epochMillis: 0}))"
+	default:
+		return "d.updated_at"
+	}
+}
+
+func dreamSortTime(dream *domain.Dream, sort string) time.Time {
+	if dream == nil {
+		return time.Time{}
+	}
+	switch sort {
+	case DreamSortCreatedAt:
+		return dream.CreatedAt
+	case DreamSortLastEvaluatedAt:
+		if dream.LastEvaluatedAt != nil {
+			return *dream.LastEvaluatedAt
+		}
+		return time.Unix(0, 0).UTC()
+	default:
+		return dream.UpdatedAt
+	}
+}

--- a/internal/service/dreamservice/list_test.go
+++ b/internal/service/dreamservice/list_test.go
@@ -1,0 +1,64 @@
+package dreamservice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDreamServiceListSortsAndPaginates(t *testing.T) {
+	base := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
+	secondCreated := base.Add(time.Hour)
+	graph := &cycleRunGraphStub{
+		dreamRows: []map[string]any{
+			{"d": dreamTestNodeWithTimes("dream-1", "profile-1", base, base.Add(3*time.Hour), base.Add(6*time.Hour))},
+			{"d": dreamTestNodeWithTimes("dream-2", "profile-1", secondCreated, base.Add(2*time.Hour), base.Add(5*time.Hour))},
+			{"d": dreamTestNodeWithTimes("dream-3", "profile-1", base.Add(2*time.Hour), base.Add(time.Hour), base.Add(4*time.Hour))},
+		},
+	}
+	svc := New(Dependencies{Graph: graph})
+
+	_, _, err := svc.List(context.Background(), "profile-1", ListOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Contains(t, graph.lastReadQuery, "WITH d, d.updated_at AS sort_at")
+	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at DESC, d.dream_id ASC")
+
+	dreams, next, err := svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Sort:      DreamSortCreatedAt,
+		Direction: DreamDirectionAsc,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, dreams, 2)
+	require.Equal(t, int64(3), graph.lastReadParams["limit"])
+	require.Contains(t, graph.lastReadQuery, "WITH d, d.created_at AS sort_at")
+	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at ASC, d.dream_id ASC")
+	require.NotEmpty(t, next)
+
+	cursorAt, cursorDreamID, err := decodeDreamCursor(next, DreamSortCreatedAt, DreamDirectionAsc)
+	require.NoError(t, err)
+	require.Equal(t, secondCreated, cursorAt)
+	require.Equal(t, "dream-2", cursorDreamID)
+
+	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Cursor:    next,
+		Sort:      DreamSortCreatedAt,
+		Direction: DreamDirectionAsc,
+	})
+	require.NoError(t, err)
+	require.Equal(t, secondCreated, graph.lastReadParams["cursorAt"])
+	require.Equal(t, "dream-2", graph.lastReadParams["cursorDreamID"])
+	require.Contains(t, graph.lastReadQuery, "sort_at > $cursorAt")
+
+	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Cursor:    next,
+		Sort:      DreamSortUpdatedAt,
+		Direction: DreamDirectionAsc,
+	})
+	require.ErrorIs(t, err, ErrInvalidDreamCursor)
+}

--- a/internal/service/dreamservice/service.go
+++ b/internal/service/dreamservice/service.go
@@ -3,8 +3,10 @@ package dreamservice
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -24,7 +26,22 @@ const (
 	defaultListLimit = 20
 	maxListLimit     = 100
 	lockTimeout      = 30 * time.Second
+
+	DreamSortUpdatedAt       = "updated_at"
+	DreamSortCreatedAt       = "created_at"
+	DreamSortLastEvaluatedAt = "last_evaluated_at"
+	DreamDirectionAsc        = "asc"
+	DreamDirectionDesc       = "desc"
 )
+
+var ErrInvalidDreamCursor = errors.New("invalid cursor")
+
+type dreamCursor struct {
+	Sort      string
+	Direction string
+	SortAt    time.Time
+	DreamID   string
+}
 
 type service struct {
 	deps Dependencies
@@ -42,6 +59,79 @@ func New(deps Dependencies) Service {
 		deps.Generator = NewHeuristicGenerator("")
 	}
 	return &service{deps: deps, now: now}
+}
+
+func normalizeDreamSort(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case DreamSortCreatedAt:
+		return DreamSortCreatedAt
+	case DreamSortLastEvaluatedAt:
+		return DreamSortLastEvaluatedAt
+	default:
+		return DreamSortUpdatedAt
+	}
+}
+
+func normalizeDreamDirection(value string) string {
+	if strings.ToLower(strings.TrimSpace(value)) == DreamDirectionAsc {
+		return DreamDirectionAsc
+	}
+	return DreamDirectionDesc
+}
+
+func encodeDreamCursor(c dreamCursor) string {
+	raw := fmt.Sprintf("%s|%s|%s|%s", c.Sort, c.Direction, c.SortAt.UTC().Format(time.RFC3339Nano), c.DreamID)
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeDreamCursor(cursor string, sort string, direction string) (time.Time, string, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return time.Time{}, "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
+	}
+	parts := strings.SplitN(string(raw), "|", 4)
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return time.Time{}, "", ErrInvalidDreamCursor
+	}
+	if parts[0] != sort || parts[1] != direction {
+		return time.Time{}, "", fmt.Errorf("%w: sort changed", ErrInvalidDreamCursor)
+	}
+	sortAt, err := time.Parse(time.RFC3339Nano, parts[2])
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
+	}
+	return sortAt.UTC(), parts[3], nil
+}
+
+func dreamSortExpression(sort string) string {
+	switch sort {
+	case DreamSortCreatedAt:
+		return "d.created_at"
+	case DreamSortLastEvaluatedAt:
+		return "coalesce(d.last_evaluated_at, datetime({epochMillis: 0}))"
+	default:
+		return "d.updated_at"
+	}
+}
+
+func dreamSortTime(dream *domain.Dream, sort string) time.Time {
+	if dream == nil {
+		return time.Time{}
+	}
+	switch sort {
+	case DreamSortCreatedAt:
+		return dream.CreatedAt
+	case DreamSortLastEvaluatedAt:
+		if dream.LastEvaluatedAt != nil {
+			return *dream.LastEvaluatedAt
+		}
+		return time.Unix(0, 0).UTC()
+	default:
+		return dream.UpdatedAt
+	}
 }
 
 func (s *service) RunCycle(ctx context.Context, profileID string, req RunCycleRequest) (*RunCycleResult, error) {
@@ -229,15 +319,39 @@ func (s *service) List(ctx context.Context, profileID string, opts ListOptions) 
 		limit = maxListLimit
 	}
 	statusFilter := strings.TrimSpace(opts.Status)
-	query := `
+	sortField := normalizeDreamSort(opts.Sort)
+	direction := normalizeDreamDirection(opts.Direction)
+	cursorAt, cursorDreamID, err := decodeDreamCursor(opts.Cursor, sortField, direction)
+	if err != nil {
+		return nil, "", fmt.Errorf("dream list: %w", err)
+	}
+	sortExpression := dreamSortExpression(sortField)
+	comparator := "<"
+	orderDirection := "DESC"
+	if direction == DreamDirectionAsc {
+		comparator = ">"
+		orderDirection = "ASC"
+	}
+	var cursorAtParam any
+	var cursorDreamIDParam any
+	if !cursorAt.IsZero() {
+		cursorAtParam = cursorAt
+		cursorDreamIDParam = cursorDreamID
+	}
+	query := fmt.Sprintf(`
 MATCH (d:Dream {team_id: $profileId})
+WITH d, %s AS sort_at
 WHERE ($status = '' OR d.status = $status)
+  AND ($cursorAt IS NULL OR sort_at %s $cursorAt
+       OR (sort_at = $cursorAt AND d.dream_id > $cursorDreamID))
 RETURN d
-ORDER BY d.updated_at DESC, d.dream_id ASC
-LIMIT $limit`
+ORDER BY sort_at %s, d.dream_id ASC
+LIMIT $limit`, sortExpression, comparator, orderDirection)
 	_, rows, err := s.deps.Graph.ScopedRead(ctx, profileID, query, map[string]any{
-		"status": statusFilter,
-		"limit":  int64(limit),
+		"status":        statusFilter,
+		"cursorAt":      cursorAtParam,
+		"cursorDreamID": cursorDreamIDParam,
+		"limit":         int64(limit + 1),
 	})
 	if err != nil {
 		return nil, "", fmt.Errorf("dream list: %w", err)
@@ -252,7 +366,18 @@ LIMIT $limit`
 			dreams = append(dreams, dream)
 		}
 	}
-	return dreams, "", nil
+	nextCursor := ""
+	if len(dreams) > limit {
+		last := dreams[limit-1]
+		nextCursor = encodeDreamCursor(dreamCursor{
+			Sort:      sortField,
+			Direction: direction,
+			SortAt:    dreamSortTime(last, sortField),
+			DreamID:   last.DreamID,
+		})
+		dreams = dreams[:limit]
+	}
+	return dreams, nextCursor, nil
 }
 
 func (s *service) Get(ctx context.Context, profileID, dreamID string) (*domain.Dream, error) {

--- a/internal/service/dreamservice/service.go
+++ b/internal/service/dreamservice/service.go
@@ -3,10 +3,8 @@ package dreamservice
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -23,25 +21,8 @@ import (
 )
 
 const (
-	defaultListLimit = 20
-	maxListLimit     = 100
-	lockTimeout      = 30 * time.Second
-
-	DreamSortUpdatedAt       = "updated_at"
-	DreamSortCreatedAt       = "created_at"
-	DreamSortLastEvaluatedAt = "last_evaluated_at"
-	DreamDirectionAsc        = "asc"
-	DreamDirectionDesc       = "desc"
+	lockTimeout = 30 * time.Second
 )
-
-var ErrInvalidDreamCursor = errors.New("invalid cursor")
-
-type dreamCursor struct {
-	Sort      string
-	Direction string
-	SortAt    time.Time
-	DreamID   string
-}
 
 type service struct {
 	deps Dependencies
@@ -59,79 +40,6 @@ func New(deps Dependencies) Service {
 		deps.Generator = NewHeuristicGenerator("")
 	}
 	return &service{deps: deps, now: now}
-}
-
-func normalizeDreamSort(value string) string {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case DreamSortCreatedAt:
-		return DreamSortCreatedAt
-	case DreamSortLastEvaluatedAt:
-		return DreamSortLastEvaluatedAt
-	default:
-		return DreamSortUpdatedAt
-	}
-}
-
-func normalizeDreamDirection(value string) string {
-	if strings.ToLower(strings.TrimSpace(value)) == DreamDirectionAsc {
-		return DreamDirectionAsc
-	}
-	return DreamDirectionDesc
-}
-
-func encodeDreamCursor(c dreamCursor) string {
-	raw := fmt.Sprintf("%s|%s|%s|%s", c.Sort, c.Direction, c.SortAt.UTC().Format(time.RFC3339Nano), c.DreamID)
-	return base64.RawURLEncoding.EncodeToString([]byte(raw))
-}
-
-func decodeDreamCursor(cursor string, sort string, direction string) (time.Time, string, error) {
-	if strings.TrimSpace(cursor) == "" {
-		return time.Time{}, "", nil
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(cursor)
-	if err != nil {
-		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
-	}
-	parts := strings.SplitN(string(raw), "|", 4)
-	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[3] == "" {
-		return time.Time{}, "", ErrInvalidDreamCursor
-	}
-	if parts[0] != sort || parts[1] != direction {
-		return time.Time{}, "", fmt.Errorf("%w: sort changed", ErrInvalidDreamCursor)
-	}
-	sortAt, err := time.Parse(time.RFC3339Nano, parts[2])
-	if err != nil {
-		return time.Time{}, "", fmt.Errorf("%w: %v", ErrInvalidDreamCursor, err)
-	}
-	return sortAt.UTC(), parts[3], nil
-}
-
-func dreamSortExpression(sort string) string {
-	switch sort {
-	case DreamSortCreatedAt:
-		return "d.created_at"
-	case DreamSortLastEvaluatedAt:
-		return "coalesce(d.last_evaluated_at, datetime({epochMillis: 0}))"
-	default:
-		return "d.updated_at"
-	}
-}
-
-func dreamSortTime(dream *domain.Dream, sort string) time.Time {
-	if dream == nil {
-		return time.Time{}
-	}
-	switch sort {
-	case DreamSortCreatedAt:
-		return dream.CreatedAt
-	case DreamSortLastEvaluatedAt:
-		if dream.LastEvaluatedAt != nil {
-			return *dream.LastEvaluatedAt
-		}
-		return time.Unix(0, 0).UTC()
-	default:
-		return dream.UpdatedAt
-	}
 }
 
 func (s *service) RunCycle(ctx context.Context, profileID string, req RunCycleRequest) (*RunCycleResult, error) {

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -288,61 +288,6 @@ func TestDreamServiceReadPaths(t *testing.T) {
 	require.Equal(t, "run-1", status.LatestRun.RunID)
 }
 
-func TestDreamServiceListSortsAndPaginates(t *testing.T) {
-	base := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
-	secondCreated := base.Add(time.Hour)
-	graph := &cycleRunGraphStub{
-		dreamRows: []map[string]any{
-			{"d": dreamTestNodeWithTimes("dream-1", "profile-1", base, base.Add(3*time.Hour), base.Add(6*time.Hour))},
-			{"d": dreamTestNodeWithTimes("dream-2", "profile-1", secondCreated, base.Add(2*time.Hour), base.Add(5*time.Hour))},
-			{"d": dreamTestNodeWithTimes("dream-3", "profile-1", base.Add(2*time.Hour), base.Add(time.Hour), base.Add(4*time.Hour))},
-		},
-	}
-	svc := New(Dependencies{Graph: graph})
-
-	_, _, err := svc.List(context.Background(), "profile-1", ListOptions{Limit: 2})
-	require.NoError(t, err)
-	require.Contains(t, graph.lastReadQuery, "WITH d, d.updated_at AS sort_at")
-	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at DESC, d.dream_id ASC")
-
-	dreams, next, err := svc.List(context.Background(), "profile-1", ListOptions{
-		Limit:     2,
-		Sort:      DreamSortCreatedAt,
-		Direction: DreamDirectionAsc,
-	})
-
-	require.NoError(t, err)
-	require.Len(t, dreams, 2)
-	require.Equal(t, int64(3), graph.lastReadParams["limit"])
-	require.Contains(t, graph.lastReadQuery, "WITH d, d.created_at AS sort_at")
-	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at ASC, d.dream_id ASC")
-	require.NotEmpty(t, next)
-
-	cursorAt, cursorDreamID, err := decodeDreamCursor(next, DreamSortCreatedAt, DreamDirectionAsc)
-	require.NoError(t, err)
-	require.Equal(t, secondCreated, cursorAt)
-	require.Equal(t, "dream-2", cursorDreamID)
-
-	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
-		Limit:     2,
-		Cursor:    next,
-		Sort:      DreamSortCreatedAt,
-		Direction: DreamDirectionAsc,
-	})
-	require.NoError(t, err)
-	require.Equal(t, secondCreated, graph.lastReadParams["cursorAt"])
-	require.Equal(t, "dream-2", graph.lastReadParams["cursorDreamID"])
-	require.Contains(t, graph.lastReadQuery, "sort_at > $cursorAt")
-
-	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
-		Limit:     2,
-		Cursor:    next,
-		Sort:      DreamSortUpdatedAt,
-		Direction: DreamDirectionAsc,
-	})
-	require.ErrorIs(t, err, ErrInvalidDreamCursor)
-}
-
 func TestDreamServiceResolveFeedback(t *testing.T) {
 	now := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
 	graph := &cycleRunGraphStub{executeWrites: true, dreamRows: []map[string]any{{"d": dreamTestNode("dream-1", "profile-1", now)}}}

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -288,6 +288,61 @@ func TestDreamServiceReadPaths(t *testing.T) {
 	require.Equal(t, "run-1", status.LatestRun.RunID)
 }
 
+func TestDreamServiceListSortsAndPaginates(t *testing.T) {
+	base := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
+	secondCreated := base.Add(time.Hour)
+	graph := &cycleRunGraphStub{
+		dreamRows: []map[string]any{
+			{"d": dreamTestNodeWithTimes("dream-1", "profile-1", base, base.Add(3*time.Hour), base.Add(6*time.Hour))},
+			{"d": dreamTestNodeWithTimes("dream-2", "profile-1", secondCreated, base.Add(2*time.Hour), base.Add(5*time.Hour))},
+			{"d": dreamTestNodeWithTimes("dream-3", "profile-1", base.Add(2*time.Hour), base.Add(time.Hour), base.Add(4*time.Hour))},
+		},
+	}
+	svc := New(Dependencies{Graph: graph})
+
+	_, _, err := svc.List(context.Background(), "profile-1", ListOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Contains(t, graph.lastReadQuery, "WITH d, d.updated_at AS sort_at")
+	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at DESC, d.dream_id ASC")
+
+	dreams, next, err := svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Sort:      DreamSortCreatedAt,
+		Direction: DreamDirectionAsc,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, dreams, 2)
+	require.Equal(t, int64(3), graph.lastReadParams["limit"])
+	require.Contains(t, graph.lastReadQuery, "WITH d, d.created_at AS sort_at")
+	require.Contains(t, graph.lastReadQuery, "ORDER BY sort_at ASC, d.dream_id ASC")
+	require.NotEmpty(t, next)
+
+	cursorAt, cursorDreamID, err := decodeDreamCursor(next, DreamSortCreatedAt, DreamDirectionAsc)
+	require.NoError(t, err)
+	require.Equal(t, secondCreated, cursorAt)
+	require.Equal(t, "dream-2", cursorDreamID)
+
+	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Cursor:    next,
+		Sort:      DreamSortCreatedAt,
+		Direction: DreamDirectionAsc,
+	})
+	require.NoError(t, err)
+	require.Equal(t, secondCreated, graph.lastReadParams["cursorAt"])
+	require.Equal(t, "dream-2", graph.lastReadParams["cursorDreamID"])
+	require.Contains(t, graph.lastReadQuery, "sort_at > $cursorAt")
+
+	_, _, err = svc.List(context.Background(), "profile-1", ListOptions{
+		Limit:     2,
+		Cursor:    next,
+		Sort:      DreamSortUpdatedAt,
+		Direction: DreamDirectionAsc,
+	})
+	require.ErrorIs(t, err, ErrInvalidDreamCursor)
+}
+
 func TestDreamServiceResolveFeedback(t *testing.T) {
 	now := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
 	graph := &cycleRunGraphStub{executeWrites: true, dreamRows: []map[string]any{{"d": dreamTestNode("dream-1", "profile-1", now)}}}
@@ -676,12 +731,14 @@ type cycleRunGraphStub struct {
 	dreamRows      []map[string]any
 	runRows        []map[string]any
 	inputRows      []map[string]any
+	lastReadQuery  string
 	lastReadParams map[string]any
 	recordsFor     func(query string, params map[string]any) []*neo4j.Record
 }
 
 func (s *cycleRunGraphStub) ScopedRead(_ context.Context, _ string, query string, params map[string]any) (neo4j.ResultSummary, []map[string]any, error) {
 	s.readCalls++
+	s.lastReadQuery = query
 	s.lastReadParams = params
 	if s.readErr != nil && (s.readErrAfter == 0 || s.readCalls >= s.readErrAfter) {
 		return nil, nil, s.readErr
@@ -914,6 +971,10 @@ func (s *dreamFragmentCreateStub) Create(_ context.Context, profileID string, re
 }
 
 func dreamTestNode(dreamID, profileID string, now time.Time) neo4j.Node {
+	return dreamTestNodeWithTimes(dreamID, profileID, now, now, now)
+}
+
+func dreamTestNodeWithTimes(dreamID, profileID string, createdAt, updatedAt, lastEvaluatedAt time.Time) neo4j.Node {
 	return neo4j.Node{Props: map[string]any{
 		"dream_id":           dreamID,
 		"team_id":            profileID,
@@ -930,9 +991,9 @@ func dreamTestNode(dreamID, profileID string, now time.Time) neo4j.Node {
 		"content_hash":       "hash",
 		"source_refs_json":   `[{"type":"fact","id":"fact-1"}]`,
 		"invalidated_reason": "",
-		"created_at":         now,
-		"updated_at":         now,
-		"last_evaluated_at":  now,
+		"created_at":         createdAt,
+		"updated_at":         updatedAt,
+		"last_evaluated_at":  lastEvaluatedAt,
 	}}
 }
 

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -106,9 +106,11 @@ type RunCycleResult struct {
 }
 
 type ListOptions struct {
-	Limit  int
-	Cursor string
-	Status string
+	Limit     int
+	Cursor    string
+	Status    string
+	Sort      string
+	Direction string
 }
 
 type ResolveFeedbackRequest struct {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -198,9 +198,15 @@ describe("ControlApi", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const api = new ControlApi("secret", "/control/api");
-    const result = await api.listTeamDreams("team-1", { limit: 50, status: "proposed", cursor: "current-dream" });
+    const result = await api.listTeamDreams("team-1", {
+      limit: 50,
+      status: "proposed",
+      cursor: "current-dream",
+      sort: "created_at",
+      direction: "asc",
+    });
 
     expect(result.next_cursor).toBe("next-dream");
-    expect(fetchMock).toHaveBeenCalledWith("/control/api/teams/team-1/dreams?limit=50&status=proposed&cursor=current-dream", expect.any(Object));
+    expect(fetchMock).toHaveBeenCalledWith("/control/api/teams/team-1/dreams?limit=50&status=proposed&cursor=current-dream&sort=created_at&direction=asc", expect.any(Object));
   });
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -362,9 +362,13 @@ export type Dream = {
   generator_model?: string;
   source_refs?: Array<{ type: string; id: string }>;
   invalidated_reason?: string;
+  last_evaluated_at?: string;
   created_at: string;
   updated_at: string;
 };
+
+export type DreamSort = "updated_at" | "created_at" | "last_evaluated_at";
+export type DreamDirection = "asc" | "desc";
 
 export type DreamRun = {
   run_id: string;
@@ -395,6 +399,8 @@ export type DreamQuery = {
   limit?: number;
   status?: Dream["status"] | "";
   cursor?: string;
+  sort?: DreamSort;
+  direction?: DreamDirection;
 };
 
 export type DreamListResponse = {
@@ -626,6 +632,12 @@ export class ControlApi {
     }
     if (query.cursor) {
       params.set("cursor", query.cursor);
+    }
+    if (query.sort) {
+      params.set("sort", query.sort);
+    }
+    if (query.direction) {
+      params.set("direction", query.direction);
     }
     const suffix = params.toString() ? `?${params.toString()}` : "";
     return this.requestEnvelope<DreamListResponse>(`/teams/${teamId}/dreams${suffix}`);

--- a/web/src/control/DreamsPanel.tsx
+++ b/web/src/control/DreamsPanel.tsx
@@ -1,16 +1,25 @@
 import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { ControlApi, Dream, DreamRun, DreamStatus, Team } from "../api";
+import { ControlApi, Dream, DreamQuery, DreamRun, DreamSort, DreamStatus, Team } from "../api";
 import { InfoTooltip, SectionHeading } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
 const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
+const DREAM_PAGE_SIZES = [10, 25, 50, 100];
+const DREAM_SORTS: Array<{ value: DreamSort; label: string }> = [
+  { value: "updated_at", label: "Updated" },
+  { value: "created_at", label: "Created" },
+  { value: "last_evaluated_at", label: "Evaluated" },
+];
+const DEFAULT_DREAM_QUERY: DreamQuery = { status: "", limit: 25, sort: "updated_at", direction: "desc", cursor: "" };
 
 export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team }) {
   const [status, setStatus] = useState<DreamStatus | null>(null);
   const [runs, setRuns] = useState<DreamRun[]>([]);
   const [dreams, setDreams] = useState<Dream[]>([]);
-  const [dreamStatus, setDreamStatus] = useState("");
+  const [dreamQuery, setDreamQuery] = useState<DreamQuery>(DEFAULT_DREAM_QUERY);
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+  const [nextCursor, setNextCursor] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const requestSeqRef = useRef(0);
@@ -18,7 +27,7 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
 
   activeTeamIdRef.current = team.id;
 
-  async function loadData(nextStatus = dreamStatus) {
+  async function loadData(nextQuery = dreamQuery, nextCursorStack = cursorStack) {
     const requestSeq = requestSeqRef.current + 1;
     requestSeqRef.current = requestSeq;
     const requestTeamId = team.id;
@@ -28,7 +37,7 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
       const [nextStatusResult, nextRuns, nextDreams] = await Promise.all([
         api.getTeamDreamingStatus(requestTeamId),
         api.listTeamDreamingRuns(requestTeamId, 10),
-        api.listTeamDreams(requestTeamId, { status: nextStatus, limit: 50 }),
+        api.listTeamDreams(requestTeamId, nextQuery),
       ]);
       if (requestSeq !== requestSeqRef.current || requestTeamId !== activeTeamIdRef.current) {
         return;
@@ -36,6 +45,9 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
       setStatus(nextStatusResult);
       setRuns(nextRuns);
       setDreams(nextDreams.items);
+      setDreamQuery(nextQuery);
+      setCursorStack(nextCursorStack);
+      setNextCursor(nextDreams.next_cursor ?? "");
     } catch (err) {
       if (requestSeq !== requestSeqRef.current || requestTeamId !== activeTeamIdRef.current) {
         return;
@@ -49,8 +61,13 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
   }
 
   useEffect(() => {
-    void loadData();
+    void loadData({ ...dreamQuery, cursor: "" }, []);
   }, [team.id]);
+
+  const pageNumber = cursorStack.length + 1;
+  const dreamSort = dreamQuery.sort ?? "updated_at";
+  const dreamDirection = dreamQuery.direction ?? "desc";
+  const dreamLimit = dreamQuery.limit ?? DEFAULT_DREAM_QUERY.limit ?? 25;
 
   return (
     <>
@@ -76,20 +93,44 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
       </section>
 
       <section className="surface">
-        <SectionHeading title="Dream Outputs" meta={dreams.length} />
-        <div className="metrics-toolbar">
+        <SectionHeading title="Dream Outputs" meta={`Page ${pageNumber}`} />
+        <div className="metrics-toolbar dream-list-toolbar">
           <label>
             Status
             <select
-              value={dreamStatus}
+              value={dreamQuery.status ?? ""}
               onChange={(event) => {
-                setDreamStatus(event.target.value);
-                void loadData(event.target.value);
+                void loadData({ ...dreamQuery, status: event.target.value, cursor: "" }, []);
               }}
             >
               {DREAM_STATUSES.map((statusOption) => (
                 <option value={statusOption} key={statusOption}>{statusOption || "All"}</option>
               ))}
+            </select>
+          </label>
+          <label>
+            Sort
+            <select
+              value={dreamSort}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, sort: event.target.value as DreamSort, cursor: "" }, []);
+              }}
+            >
+              {DREAM_SORTS.map((sortOption) => (
+                <option value={sortOption.value} key={sortOption.value}>{sortOption.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Direction
+            <select
+              value={dreamDirection}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, direction: event.target.value as DreamQuery["direction"], cursor: "" }, []);
+              }}
+            >
+              <option value="desc">Desc</option>
+              <option value="asc">Asc</option>
             </select>
           </label>
         </div>
@@ -98,8 +139,46 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
         ) : dreams.length === 0 ? (
           <div className="table-placeholder">No dreams</div>
         ) : (
-          <DreamTable dreams={dreams} />
+          <DreamTable dreams={dreams} sort={dreamSort} />
         )}
+        <div className="table-actions">
+          <span className="form-meta">Page {pageNumber} · {dreams.length} rows</span>
+          <label className="table-page-size">
+            Rows
+            <select
+              value={dreamLimit}
+              disabled={loading}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, limit: Number(event.target.value), cursor: "" }, []);
+              }}
+            >
+              {DREAM_PAGE_SIZES.map((pageSize) => (
+                <option value={pageSize} key={pageSize}>{pageSize}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            className="ghost-button"
+            type="button"
+            disabled={loading || cursorStack.length === 0}
+            onClick={() => {
+              const previousStack = cursorStack.slice(0, -1);
+              void loadData({ ...dreamQuery, cursor: cursorStack[cursorStack.length - 1] ?? "" }, previousStack);
+            }}
+          >
+            Previous
+          </button>
+          <button
+            className="ghost-button"
+            type="button"
+            disabled={loading || !nextCursor}
+            onClick={() => {
+              void loadData({ ...dreamQuery, cursor: nextCursor }, [...cursorStack, dreamQuery.cursor ?? ""]);
+            }}
+          >
+            Next
+          </button>
+        </div>
       </section>
 
       <section className="surface">
@@ -119,13 +198,13 @@ function StatusItem({ label, value }: { label: string; value: string | number })
   );
 }
 
-function DreamTable({ dreams }: { dreams: Dream[] }) {
+function DreamTable({ dreams, sort }: { dreams: Dream[]; sort: DreamSort }) {
   return (
     <div className="table-wrap">
       <table className="data-table dreams-table">
         <thead>
           <tr>
-            <th>Updated</th>
+            <th>{dreamDateHeader(sort)}</th>
             <th>Status</th>
             <th>Hypothesis</th>
             <th>Confidence</th>
@@ -135,18 +214,18 @@ function DreamTable({ dreams }: { dreams: Dream[] }) {
         <tbody>
           {dreams.map((dream) => (
             <tr key={dream.dream_id}>
-              <td>{formatDate(dream.updated_at)}</td>
+              <td>{formatDreamDate(dream, sort)}</td>
               <td><span className={dreamStatusClass(dream.status)}>{dream.status}</span></td>
-	              <td>
-	                <div className="dream-hypothesis-cell">
-	                  <strong>{dream.hypothesis}</strong>
-	                  {dream.rationale && (
-	                    <InfoTooltip label={`Why this hypothesis: ${dream.hypothesis}`}>
-	                      {dream.rationale}
-	                    </InfoTooltip>
-	                  )}
-	                </div>
-	              </td>
+              <td>
+                <div className="dream-hypothesis-cell">
+                  <strong>{dream.hypothesis}</strong>
+                  {dream.rationale && (
+                    <InfoTooltip label={`Why this hypothesis: ${dream.hypothesis}`}>
+                      {dream.rationale}
+                    </InfoTooltip>
+                  )}
+                </div>
+              </td>
               <td>{Math.round(dream.confidence * 100)}%</td>
               <td><code>{dream.cycle_run_id?.slice(0, 8) || "-"}</code></td>
             </tr>
@@ -155,6 +234,19 @@ function DreamTable({ dreams }: { dreams: Dream[] }) {
       </table>
     </div>
   );
+}
+
+function dreamDateHeader(sort: DreamSort): string {
+  return DREAM_SORTS.find((option) => option.value === sort)?.label ?? "Updated";
+}
+
+function formatDreamDate(dream: Dream, sort: DreamSort): string {
+  const value = sort === "created_at"
+    ? dream.created_at
+    : sort === "last_evaluated_at"
+      ? dream.last_evaluated_at
+      : dream.updated_at;
+  return value ? formatDate(value) : "-";
 }
 
 function RunTable({ runs }: { runs: DreamRun[] }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -714,6 +714,17 @@ button:disabled {
   border-top: 1px solid var(--border);
 }
 
+.dream-list-toolbar {
+  grid-template-columns: repeat(3, minmax(130px, 190px));
+}
+
+.dream-list-toolbar label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .metrics-block {
   margin-top: 16px;
 }

--- a/web/src/user/DreamsPanel.tsx
+++ b/web/src/user/DreamsPanel.tsx
@@ -1,20 +1,29 @@
 import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { InfoTooltip, SectionHeading } from "../ui/components";
-import { Dream, DreamRun, DreamStatus, UserApi } from "./api";
+import { Dream, DreamQuery, DreamRun, DreamSort, DreamStatus, UserApi } from "./api";
 
 const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
+const DREAM_PAGE_SIZES = [10, 25, 50, 100];
+const DREAM_SORTS: Array<{ value: DreamSort; label: string }> = [
+  { value: "updated_at", label: "Updated" },
+  { value: "created_at", label: "Created" },
+  { value: "last_evaluated_at", label: "Evaluated" },
+];
+const DEFAULT_DREAM_QUERY: DreamQuery = { status: "", limit: 25, sort: "updated_at", direction: "desc", cursor: "" };
 
 export function UserDreamsPanel({ api }: { api: UserApi }) {
   const [status, setStatus] = useState<DreamStatus | null>(null);
   const [runs, setRuns] = useState<DreamRun[]>([]);
   const [dreams, setDreams] = useState<Dream[]>([]);
-  const [dreamStatus, setDreamStatus] = useState("");
+  const [dreamQuery, setDreamQuery] = useState<DreamQuery>(DEFAULT_DREAM_QUERY);
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+  const [nextCursor, setNextCursor] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const requestSeqRef = useRef(0);
 
-  async function loadData(nextStatus = dreamStatus) {
+  async function loadData(nextQuery = dreamQuery, nextCursorStack = cursorStack) {
     const requestSeq = requestSeqRef.current + 1;
     requestSeqRef.current = requestSeq;
     setLoading(true);
@@ -23,7 +32,7 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
       const [nextStatusResult, nextRuns, nextDreams] = await Promise.all([
         api.dreamingStatus(),
         api.listDreamingRuns(10),
-        api.listDreams(nextStatus, 50),
+        api.listDreams(nextQuery),
       ]);
       if (requestSeq !== requestSeqRef.current) {
         return;
@@ -31,6 +40,9 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
       setStatus(nextStatusResult);
       setRuns(nextRuns);
       setDreams(nextDreams.items);
+      setDreamQuery(nextQuery);
+      setCursorStack(nextCursorStack);
+      setNextCursor(nextDreams.next_cursor ?? "");
     } catch (err) {
       if (requestSeq !== requestSeqRef.current) {
         return;
@@ -44,8 +56,13 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
   }
 
   useEffect(() => {
-    void loadData();
+    void loadData({ ...dreamQuery, cursor: "" }, []);
   }, [api]);
+
+  const pageNumber = cursorStack.length + 1;
+  const dreamSort = dreamQuery.sort ?? "updated_at";
+  const dreamDirection = dreamQuery.direction ?? "desc";
+  const dreamLimit = dreamQuery.limit ?? DEFAULT_DREAM_QUERY.limit ?? 25;
 
   return (
     <>
@@ -70,20 +87,44 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
       </section>
 
       <section className="surface">
-        <SectionHeading title="Dream Outputs" meta={dreams.length} />
-        <div className="metrics-toolbar">
+        <SectionHeading title="Dream Outputs" meta={`Page ${pageNumber}`} />
+        <div className="metrics-toolbar dream-list-toolbar">
           <label>
             Status
             <select
-              value={dreamStatus}
+              value={dreamQuery.status ?? ""}
               onChange={(event) => {
-                setDreamStatus(event.target.value);
-                void loadData(event.target.value);
+                void loadData({ ...dreamQuery, status: event.target.value, cursor: "" }, []);
               }}
             >
               {DREAM_STATUSES.map((statusOption) => (
                 <option value={statusOption} key={statusOption}>{statusOption || "All"}</option>
               ))}
+            </select>
+          </label>
+          <label>
+            Sort
+            <select
+              value={dreamSort}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, sort: event.target.value as DreamSort, cursor: "" }, []);
+              }}
+            >
+              {DREAM_SORTS.map((sortOption) => (
+                <option value={sortOption.value} key={sortOption.value}>{sortOption.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Direction
+            <select
+              value={dreamDirection}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, direction: event.target.value as DreamQuery["direction"], cursor: "" }, []);
+              }}
+            >
+              <option value="desc">Desc</option>
+              <option value="asc">Asc</option>
             </select>
           </label>
         </div>
@@ -92,8 +133,46 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
         ) : dreams.length === 0 ? (
           <div className="table-placeholder">No dreams</div>
         ) : (
-          <DreamTable dreams={dreams} />
+          <DreamTable dreams={dreams} sort={dreamSort} />
         )}
+        <div className="table-actions">
+          <span className="form-meta">Page {pageNumber} · {dreams.length} rows</span>
+          <label className="table-page-size">
+            Rows
+            <select
+              value={dreamLimit}
+              disabled={loading}
+              onChange={(event) => {
+                void loadData({ ...dreamQuery, limit: Number(event.target.value), cursor: "" }, []);
+              }}
+            >
+              {DREAM_PAGE_SIZES.map((pageSize) => (
+                <option value={pageSize} key={pageSize}>{pageSize}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            className="ghost-button"
+            type="button"
+            disabled={loading || cursorStack.length === 0}
+            onClick={() => {
+              const previousStack = cursorStack.slice(0, -1);
+              void loadData({ ...dreamQuery, cursor: cursorStack[cursorStack.length - 1] ?? "" }, previousStack);
+            }}
+          >
+            Previous
+          </button>
+          <button
+            className="ghost-button"
+            type="button"
+            disabled={loading || !nextCursor}
+            onClick={() => {
+              void loadData({ ...dreamQuery, cursor: nextCursor }, [...cursorStack, dreamQuery.cursor ?? ""]);
+            }}
+          >
+            Next
+          </button>
+        </div>
       </section>
 
       <section className="surface">
@@ -119,13 +198,13 @@ function StatusItem({ label, value }: { label: string; value: string | number })
   );
 }
 
-function DreamTable({ dreams }: { dreams: Dream[] }) {
+function DreamTable({ dreams, sort }: { dreams: Dream[]; sort: DreamSort }) {
   return (
     <div className="table-wrap">
       <table className="data-table dreams-table">
         <thead>
           <tr>
-            <th>Updated</th>
+            <th>{dreamDateHeader(sort)}</th>
             <th>Status</th>
             <th>Hypothesis</th>
             <th>Confidence</th>
@@ -135,18 +214,18 @@ function DreamTable({ dreams }: { dreams: Dream[] }) {
         <tbody>
           {dreams.map((dream) => (
             <tr key={dream.dream_id}>
-              <td>{formatDate(dream.updated_at)}</td>
+              <td>{formatDreamDate(dream, sort)}</td>
               <td><span className={dreamStatusClass(dream.status)}>{dream.status}</span></td>
-	              <td>
-	                <div className="dream-hypothesis-cell">
-	                  <strong>{dream.hypothesis}</strong>
-	                  {dream.rationale && (
-	                    <InfoTooltip label={`Why this hypothesis: ${dream.hypothesis}`}>
-	                      {dream.rationale}
-	                    </InfoTooltip>
-	                  )}
-	                </div>
-	              </td>
+              <td>
+                <div className="dream-hypothesis-cell">
+                  <strong>{dream.hypothesis}</strong>
+                  {dream.rationale && (
+                    <InfoTooltip label={`Why this hypothesis: ${dream.hypothesis}`}>
+                      {dream.rationale}
+                    </InfoTooltip>
+                  )}
+                </div>
+              </td>
               <td>{Math.round(dream.confidence * 100)}%</td>
               <td><code>{dream.cycle_run_id?.slice(0, 8) || "-"}</code></td>
             </tr>
@@ -155,6 +234,19 @@ function DreamTable({ dreams }: { dreams: Dream[] }) {
       </table>
     </div>
   );
+}
+
+function dreamDateHeader(sort: DreamSort): string {
+  return DREAM_SORTS.find((option) => option.value === sort)?.label ?? "Updated";
+}
+
+function formatDreamDate(dream: Dream, sort: DreamSort): string {
+  const value = sort === "created_at"
+    ? dream.created_at
+    : sort === "last_evaluated_at"
+      ? dream.last_evaluated_at
+      : dream.updated_at;
+  return value ? formatDate(value) : "-";
 }
 
 function RunTable({ runs }: { runs: DreamRun[] }) {

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -69,10 +69,16 @@ describe("UserApi", () => {
     }), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await new UserApi("dm_key").listDreams("proposed", 50, "current-dream");
+    const result = await new UserApi("dm_key").listDreams({
+      status: "proposed",
+      limit: 50,
+      cursor: "current-dream",
+      sort: "last_evaluated_at",
+      direction: "desc",
+    });
 
     expect(result.next_cursor).toBe("next-dream");
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/dreams?limit=50&status=proposed&cursor=current-dream", expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/dreams?limit=50&status=proposed&cursor=current-dream&sort=last_evaluated_at&direction=desc", expect.objectContaining({
       headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
     }));
   });

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -169,8 +169,20 @@ export type Dream = {
   generator_model?: string;
   source_refs?: Array<{ type: string; id: string }>;
   invalidated_reason?: string;
+  last_evaluated_at?: string;
   created_at: string;
   updated_at: string;
+};
+
+export type DreamSort = "updated_at" | "created_at" | "last_evaluated_at";
+export type DreamDirection = "asc" | "desc";
+
+export type DreamQuery = {
+  limit?: number;
+  status?: Dream["status"] | "";
+  cursor?: string;
+  sort?: DreamSort;
+  direction?: DreamDirection;
 };
 
 export type DreamRun = {
@@ -338,13 +350,19 @@ export class UserApi {
     return payload.data;
   }
 
-  async listDreams(status = "", limit = 20, cursor = ""): Promise<ListResponse<Dream>> {
-    const params = new URLSearchParams({ limit: String(limit) });
-    if (status) {
-      params.set("status", status);
+  async listDreams(query: DreamQuery = {}): Promise<ListResponse<Dream>> {
+    const params = new URLSearchParams({ limit: String(query.limit ?? 20) });
+    if (query.status) {
+      params.set("status", query.status);
     }
-    if (cursor) {
-      params.set("cursor", cursor);
+    if (query.cursor) {
+      params.set("cursor", query.cursor);
+    }
+    if (query.sort) {
+      params.set("sort", query.sort);
+    }
+    if (query.direction) {
+      params.set("direction", query.direction);
     }
     const payload = await this.request<Envelope<ListResponse<Dream>>>(`/api/v1/dreams?${params.toString()}`);
     return payload.data;


### PR DESCRIPTION
## Summary

- Add paginated dream output browsing with date sorting in both the control portal and `/ui` portal.
- Add backend dream list sort/direction query handling with opaque keyset cursors and invalid-cursor validation.
- Include the existing dev branch updates for recall/dream feedback discoverability, telemetry, verifier config, and npm audit cleanup.
- Split dream list pagination helpers/tests into focused files to satisfy the line-count lint gate.

## Impact

Dream results in the portals can now be filtered, sorted by updated/created/last evaluated date, and paged with Previous/Next controls. The API supports the same behavior through `sort`, `direction`, `limit`, and `cursor` query parameters.

## Validation

- `go test ./internal/service/dreamservice ./internal/http/handler ./internal/http`
- `npm --prefix web run typecheck`
- `npm --prefix web test`
- `npm run --prefix .lint lint:lines`
- Pre-push hook passed, including repo line lint, Go tests, and coverage gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting capabilities for dream listings (by updated date, created date, or last evaluated date) in ascending or descending order
  * Implemented cursor-based pagination with "Previous" and "Next" navigation controls
  * Enhanced validation with clear error messages for invalid sort, direction, and cursor parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->