### PR TITLE
[codex] remove dev branch workflow routing

### DIFF
--- a/.github/workflows/automatic-pr-review.yml
+++ b/.github/workflows/automatic-pr-review.yml
@@ -5,7 +5,6 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     branches:
-      - dev
       - main
 
 concurrency:
@@ -21,7 +20,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: markhuangai/git-vibe/.github/workflows/review.yml@dev
+    uses: markhuangai/git-vibe/.github/workflows/review.yml@main
     with:
       pr-number: ${{ format('{0}', github.event.pull_request.number) }}
       runner: docker-runner

--- a/.github/workflows/automatic-pr-review.yml
+++ b/.github/workflows/automatic-pr-review.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: markhuangai/git-vibe/.github/workflows/review.yml@main
+    uses: markhuangai/git-vibe/.github/workflows/review.yml@d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c
     with:
       pr-number: ${{ format('{0}', github.event.pull_request.number) }}
       runner: docker-runner

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: markhuangai/git-vibe/.github/workflows/investigate.yml@dev
+    uses: markhuangai/git-vibe/.github/workflows/investigate.yml@main
     with:
       issue-number: ${{ github.event.inputs.issue-number }}
       runner: docker-runner

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: markhuangai/git-vibe/.github/workflows/investigate.yml@main
+    uses: markhuangai/git-vibe/.github/workflows/investigate.yml@d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c
     with:
       issue-number: ${{ github.event.inputs.issue-number }}
       runner: docker-runner

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       discussions: write
       issues: write
-    uses: markhuangai/git-vibe/.github/workflows/materialize.yml@dev
+    uses: markhuangai/git-vibe/.github/workflows/materialize.yml@main
     with:
       discussion-number: ${{ github.event.inputs.discussion-number }}
       runner: docker-runner

--- a/.github/workflows/materialize.yml
+++ b/.github/workflows/materialize.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       discussions: write
       issues: write
-    uses: markhuangai/git-vibe/.github/workflows/materialize.yml@main
+    uses: markhuangai/git-vibe/.github/workflows/materialize.yml@d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c
     with:
       discussion-number: ${{ github.event.inputs.discussion-number }}
       runner: docker-runner

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -10,8 +10,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: release-prerelease-main
@@ -25,6 +24,8 @@ jobs:
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push'
       }}
+    permissions:
+      contents: write
     runs-on: docker-runner
     outputs:
       tag: ${{ steps.version.outputs.tag }}
@@ -169,6 +170,9 @@ jobs:
     name: Publish prerelease image
     needs: prepare-prerelease
     if: needs.prepare-prerelease.outputs.should_publish == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/publish-image.yml
     with:
       tag: ${{ needs.prepare-prerelease.outputs.tag }}
@@ -177,6 +181,9 @@ jobs:
     name: Publish demo image
     needs: prepare-prerelease
     if: needs.prepare-prerelease.outputs.should_publish == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/publish-demo-image.yml
     with:
       tag: ${{ needs.prepare-prerelease.outputs.tag }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -7,14 +7,14 @@ on:
     types:
       - completed
     branches:
-      - dev
+      - main
 
 permissions:
   contents: write
   packages: write
 
 concurrency:
-  group: release-prerelease-dev
+  group: release-prerelease-main
   cancel-in-progress: false
 
 jobs:
@@ -47,12 +47,12 @@ jobs:
 
           git fetch --tags --force origin \
             '+refs/tags/*:refs/tags/*' \
-            '+refs/heads/dev:refs/remotes/origin/dev'
+            '+refs/heads/main:refs/remotes/origin/main'
           git rev-parse --verify "${HEAD_SHA}^{commit}" >/dev/null
 
-          current_dev="$(git rev-parse refs/remotes/origin/dev)"
-          if [[ "${current_dev}" != "${HEAD_SHA}" ]]; then
-            echo "dev advanced to ${current_dev}; skipping stale CI head ${HEAD_SHA}"
+          current_main="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "${current_main}" != "${HEAD_SHA}" ]]; then
+            echo "main advanced to ${current_main}; skipping stale CI head ${HEAD_SHA}"
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: markhuangai/git-vibe/.github/workflows/review.yml@main
+    uses: markhuangai/git-vibe/.github/workflows/review.yml@d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c
     with:
       pr-number: ${{ github.event.inputs.pr-number }}
       runner: docker-runner

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: markhuangai/git-vibe/.github/workflows/review.yml@dev
+    uses: markhuangai/git-vibe/.github/workflows/review.yml@main
     with:
       pr-number: ${{ github.event.inputs.pr-number }}
       runner: docker-runner

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
       discussions: write
       issues: write
-    uses: markhuangai/git-vibe/.github/workflows/validate.yml@main
+    uses: markhuangai/git-vibe/.github/workflows/validate.yml@d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c
     with:
       issue-number: ${{ github.event.inputs.issue-number }}
       discussion-number: ${{ github.event.inputs.discussion-number }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
       discussions: write
       issues: write
-    uses: markhuangai/git-vibe/.github/workflows/validate.yml@dev
+    uses: markhuangai/git-vibe/.github/workflows/validate.yml@main
     with:
       issue-number: ${{ github.event.inputs.issue-number }}
       discussion-number: ${{ github.event.inputs.discussion-number }}


### PR DESCRIPTION
## Summary
- route PR and push workflows through `main` only
- create prereleases from successful `main` CI pushes instead of `dev`
- pin GitVibe reusable workflow refs to `d0f38d4f8ec3c037eb015aeaa4a6325bb703e21c`
- scope prerelease workflow token permissions per job

## Validation
- `git diff --check`
- parsed `.github/workflows/*.yml` with repo-vendored `js-yaml`
- pre-push hook: repository lint, `go test ./...`, coverage gate at 90.2%
- PR checks: CodeRabbit pass, Go unit tests pass, GitVibe security/plan checks pass; GitVibe review member matrix still pending

## Follow-up
After this PR lands on `main`, remove `refs/heads/dev` from the `no-delete` ruleset and delete the remote/local `dev` branch.