### PR TITLE
[codex] Improve telemetry dashboard coverage

### DIFF
--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -691,6 +691,7 @@ func main() {
 			usageMetricsService,
 			http.ControlPortalTelemetry{
 				Reader:        telemetryReader,
+				HTTPMetrics:   telemetryHTTPMetrics,
 				ScrapeHandler: telemetryScrapeHandler,
 				ScrapeToken:   cfg.GetTelemetryScrapeToken(),
 				SSO:           ssoService,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -627,6 +627,7 @@ func main() {
 		usageMetricsService,
 		http.ControlPortalTelemetry{
 			Reader:        telemetryReader,
+			HTTPMetrics:   telemetryHTTPMetrics,
 			ScrapeHandler: telemetryScrapeHandler,
 			ScrapeToken:   cfg.GetTelemetryScrapeToken(),
 			SSO:           ssoService,

--- a/internal/http/control_portal.go
+++ b/internal/http/control_portal.go
@@ -62,6 +62,7 @@ func NewControlPortalServerWithMetrics(
 
 type ControlPortalTelemetry struct {
 	Reader        service.TelemetryReader
+	HTTPMetrics   observability.HTTPMetrics
 	ScrapeHandler nethttp.Handler
 	ScrapeToken   string
 	SSO           *service.SSOService
@@ -134,6 +135,7 @@ func NewControlPortalServerWithMetricsAndTelemetry(
 	control := &controlPortalHandler{profiles: profileSvc, keys: apiKeySvc, security: securitySvc, metrics: metricsSvc, telemetry: telemetry.Reader, operationLogs: telemetry.Logs, dreams: telemetry.Dreams, health: health, sso: telemetry.SSO, appConfig: telemetry.Config}
 	api := e.Group("/control/api")
 	api.Use(controlPortalMiddleware(cfg.GetControlPortalToken(), securitySvc))
+	api.Use(httpmw.TelemetryHTTPMiddleware(telemetry.HTTPMetrics))
 	api.GET("/session", control.session)
 	api.GET("/metrics", control.getMetrics)
 	api.GET("/telemetry", control.getTelemetry)

--- a/internal/http/control_portal_telemetry_test.go
+++ b/internal/http/control_portal_telemetry_test.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+type controlHTTPMetricsRecorder struct {
+	events []controlHTTPMetricEvent
+}
+
+type controlHTTPMetricEvent struct {
+	route    string
+	method   string
+	status   int
+	duration time.Duration
+}
+
+func (r *controlHTTPMetricsRecorder) ObserveHTTPRequest(_ context.Context, route, method string, status int, duration time.Duration) {
+	r.events = append(r.events, controlHTTPMetricEvent{route: route, method: method, status: status, duration: duration})
+}
+
+func TestControlPortalTelemetry(t *testing.T) {
+	teamID := uuid.New()
+	telemetry := &controlTelemetrySvc{snapshot: &service.TelemetrySnapshot{
+		Available: true,
+		Window:    service.TelemetryWindow{Key: "1h"},
+		Scope:     service.TelemetryScope{Type: "team", TeamID: &teamID},
+		Cards:     []service.TelemetryCard{{ID: "http_requests", Label: "HTTP requests", Unit: "requests", Value: 3}},
+	}}
+	scrapeHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# HELP densemem_test metric\n"))
+	})
+	httpMetrics := &controlHTTPMetricsRecorder{}
+	e, err := NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
+		ControlHTTPAddr:    "127.0.0.1:8090",
+		ControlPortalToken: "secret",
+	}, &controlProfileSvc{}, &controlKeySvc{}, nil, ControlPortalTelemetry{
+		Reader:        telemetry,
+		HTTPMetrics:   httpMetrics,
+		ScrapeHandler: scrapeHandler,
+		ScrapeToken:   "scrape-secret",
+	}, HealthConfig{}, nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/control/api/telemetry?window=1h&scope=team&team_id="+teamID.String(), nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"available":true`)
+	require.Equal(t, "1h", telemetry.filter.Window)
+	require.Equal(t, "team", telemetry.filter.Scope)
+	require.Equal(t, teamID, *telemetry.filter.TeamID)
+	require.Len(t, httpMetrics.events, 1)
+	require.Equal(t, "/control/api/telemetry", httpMetrics.events[0].route)
+	require.Equal(t, http.MethodGet, httpMetrics.events[0].method)
+	require.Equal(t, http.StatusOK, httpMetrics.events[0].status)
+	require.GreaterOrEqual(t, httpMetrics.events[0].duration, time.Duration(0))
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("X-Telemetry-Scrape-Token", "scrape-secret")
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "densemem_test")
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer scrape-secret")
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	_, err = NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
+		ControlHTTPAddr:    "127.0.0.1:8090",
+		ControlPortalToken: "secret",
+	}, &controlProfileSvc{}, &controlKeySvc{}, nil, ControlPortalTelemetry{
+		ScrapeHandler: scrapeHandler,
+	}, HealthConfig{}, nil)
+	require.ErrorContains(t, err, "telemetry scrape token is required")
+}

--- a/internal/http/control_portal_test.go
+++ b/internal/http/control_portal_test.go
@@ -457,65 +457,6 @@ func TestControlPortalMetrics(t *testing.T) {
 	require.True(t, metrics.filter.To.After(metrics.filter.From))
 }
 
-func TestControlPortalTelemetry(t *testing.T) {
-	teamID := uuid.New()
-	telemetry := &controlTelemetrySvc{snapshot: &service.TelemetrySnapshot{
-		Available: true,
-		Window:    service.TelemetryWindow{Key: "1h"},
-		Scope:     service.TelemetryScope{Type: "team", TeamID: &teamID},
-		Cards:     []service.TelemetryCard{{ID: "http_requests", Label: "HTTP requests", Unit: "requests", Value: 3}},
-	}}
-	scrapeHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("# HELP densemem_test metric\n"))
-	})
-	e, err := NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
-		ControlHTTPAddr:    "127.0.0.1:8090",
-		ControlPortalToken: "secret",
-	}, &controlProfileSvc{}, &controlKeySvc{}, nil, ControlPortalTelemetry{
-		Reader:        telemetry,
-		ScrapeHandler: scrapeHandler,
-		ScrapeToken:   "scrape-secret",
-	}, HealthConfig{}, nil)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest(http.MethodGet, "/control/api/telemetry?window=1h&scope=team&team_id="+teamID.String(), nil)
-	req.Header.Set("Authorization", "Bearer secret")
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), `"available":true`)
-	require.Equal(t, "1h", telemetry.filter.Window)
-	require.Equal(t, "team", telemetry.filter.Scope)
-	require.Equal(t, teamID, *telemetry.filter.TeamID)
-
-	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
-	rec = httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusUnauthorized, rec.Code)
-
-	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
-	req.Header.Set("X-Telemetry-Scrape-Token", "scrape-secret")
-	rec = httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), "densemem_test")
-
-	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
-	req.Header.Set("Authorization", "Bearer scrape-secret")
-	rec = httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-
-	_, err = NewControlPortalServerWithMetricsAndTelemetry(&config.Config{
-		ControlHTTPAddr:    "127.0.0.1:8090",
-		ControlPortalToken: "secret",
-	}, &controlProfileSvc{}, &controlKeySvc{}, nil, ControlPortalTelemetry{
-		ScrapeHandler: scrapeHandler,
-	}, HealthConfig{}, nil)
-	require.ErrorContains(t, err, "telemetry scrape token is required")
-}
-
 func TestControlPortalProfileAndKeyFlows(t *testing.T) {
 	profiles, keys, server := testControlServer(t)
 

--- a/internal/service/telemetry_service.go
+++ b/internal/service/telemetry_service.go
@@ -46,12 +46,16 @@ type TelemetryFilter struct {
 }
 
 type TelemetrySnapshot struct {
-	Available bool              `json:"available"`
-	Message   string            `json:"message,omitempty"`
-	Window    TelemetryWindow   `json:"window"`
-	Scope     TelemetryScope    `json:"scope"`
-	Cards     []TelemetryCard   `json:"cards"`
-	Series    []TelemetrySeries `json:"series"`
+	Available      bool              `json:"available"`
+	Message        string            `json:"message,omitempty"`
+	Window         TelemetryWindow   `json:"window"`
+	Scope          TelemetryScope    `json:"scope"`
+	Cards          []TelemetryCard   `json:"cards"`
+	WindowedCards  []TelemetryCard   `json:"windowed_cards"`
+	CurrentCards   []TelemetryCard   `json:"current_cards"`
+	Series         []TelemetrySeries `json:"series"`
+	ActivitySeries []TelemetrySeries `json:"activity_series"`
+	StateSeries    []TelemetrySeries `json:"state_series"`
 }
 
 type TelemetryWindow struct {
@@ -69,10 +73,11 @@ type TelemetryScope struct {
 }
 
 type TelemetryCard struct {
-	ID    string  `json:"id"`
-	Label string  `json:"label"`
-	Unit  string  `json:"unit"`
-	Value float64 `json:"value"`
+	ID        string  `json:"id"`
+	Label     string  `json:"label"`
+	Unit      string  `json:"unit"`
+	Value     float64 `json:"value"`
+	Available bool    `json:"available"`
 }
 
 type TelemetrySeries struct {
@@ -147,9 +152,13 @@ func (s *PrometheusTelemetryService) Snapshot(ctx context.Context, filter Teleme
 			StepSeconds:   int64(windowDef.Step.Seconds()),
 			RetentionDays: TelemetryRetentionDays,
 		},
-		Scope:  scope,
-		Cards:  telemetryEmptyCards(),
-		Series: telemetryEmptySeries(),
+		Scope:          scope,
+		Cards:          telemetryEmptyCards(),
+		WindowedCards:  telemetryEmptyWindowedCards(),
+		CurrentCards:   telemetryEmptyCurrentCards(),
+		Series:         telemetryEmptySeries(),
+		ActivitySeries: telemetryEmptyActivitySeries(),
+		StateSeries:    telemetryEmptyStateSeries(),
 	}
 	if s == nil || s.baseURL == "" {
 		snapshot.Message = "telemetry backend is not configured"
@@ -161,34 +170,62 @@ func (s *PrometheusTelemetryService) Snapshot(ctx context.Context, filter Teleme
 
 	baseLabels := s.telemetryBaseLabels()
 	selector := telemetrySelector(scope, baseLabels)
-	cardSpecs := telemetryCardSpecs(scope, baseLabels, windowKey)
-	cards := make([]TelemetryCard, 0, len(cardSpecs))
-	for _, spec := range cardSpecs {
-		value, queryErr := s.queryInstant(queryCtx, spec.Query)
+	windowedCardSpecs := telemetryWindowedCardSpecs(scope, baseLabels, windowKey)
+	windowedCards := make([]TelemetryCard, 0, len(windowedCardSpecs))
+	for _, spec := range windowedCardSpecs {
+		scalar, queryErr := s.queryInstant(queryCtx, spec.Query)
 		if queryErr != nil {
 			s.logQueryFailure("instant", spec, windowKey, scope, queryErr)
 			snapshot.Message = "telemetry backend query failed"
 			return snapshot, nil
 		}
-		cards = append(cards, TelemetryCard{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Value: value})
+		windowedCards = append(windowedCards, TelemetryCard{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Value: scalar.Value, Available: scalar.Available})
 	}
 
-	seriesSpecs := telemetrySeriesSpecs(selector, windowDef.Rate)
-	series := make([]TelemetrySeries, 0, len(seriesSpecs))
-	for _, spec := range seriesSpecs {
+	currentCardSpecs := telemetryCurrentCardSpecs(scope, baseLabels)
+	currentCards := make([]TelemetryCard, 0, len(currentCardSpecs))
+	for _, spec := range currentCardSpecs {
+		scalar, queryErr := s.queryInstant(queryCtx, spec.Query)
+		if queryErr != nil {
+			s.logQueryFailure("instant", spec, windowKey, scope, queryErr)
+			snapshot.Message = "telemetry backend query failed"
+			return snapshot, nil
+		}
+		currentCards = append(currentCards, TelemetryCard{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Value: scalar.Value, Available: scalar.Available})
+	}
+
+	activitySpecs := telemetryActivitySeriesSpecs(selector, windowDef.Rate)
+	activitySeries := make([]TelemetrySeries, 0, len(activitySpecs))
+	for _, spec := range activitySpecs {
 		points, queryErr := s.queryRange(queryCtx, spec.Query, from, to, windowDef.Step)
 		if queryErr != nil {
 			s.logQueryFailure("range", spec, windowKey, scope, queryErr)
 			snapshot.Message = "telemetry backend query failed"
 			return snapshot, nil
 		}
-		series = append(series, TelemetrySeries{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Points: points})
+		activitySeries = append(activitySeries, TelemetrySeries{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Points: points})
+	}
+
+	stateSpecs := telemetryStateSeriesSpecs(selector)
+	stateSeries := make([]TelemetrySeries, 0, len(stateSpecs))
+	for _, spec := range stateSpecs {
+		points, queryErr := s.queryRange(queryCtx, spec.Query, from, to, windowDef.Step)
+		if queryErr != nil {
+			s.logQueryFailure("range", spec, windowKey, scope, queryErr)
+			snapshot.Message = "telemetry backend query failed"
+			return snapshot, nil
+		}
+		stateSeries = append(stateSeries, TelemetrySeries{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Points: points})
 	}
 
 	snapshot.Available = true
 	snapshot.Message = ""
-	snapshot.Cards = cards
-	snapshot.Series = series
+	snapshot.WindowedCards = windowedCards
+	snapshot.CurrentCards = currentCards
+	snapshot.Cards = appendTelemetryCards(windowedCards, currentCards)
+	snapshot.ActivitySeries = activitySeries
+	snapshot.StateSeries = stateSeries
+	snapshot.Series = appendTelemetrySeries(activitySeries, stateSeries)
 	return snapshot, nil
 }
 
@@ -230,12 +267,23 @@ func (s *PrometheusTelemetryService) telemetryBaseLabels() map[string]string {
 }
 
 func telemetryCardSpecs(scope TelemetryScope, baseLabels map[string]string, window string) []telemetryQuerySpec {
+	return appendTelemetryQuerySpecs(
+		telemetryWindowedCardSpecs(scope, baseLabels, window),
+		telemetryCurrentCardSpecs(scope, baseLabels),
+	)
+}
+
+func telemetryWindowedCardSpecs(scope TelemetryScope, baseLabels map[string]string, window string) []telemetryQuerySpec {
 	return []telemetryQuerySpec{
 		{ID: "http_requests", Label: "HTTP requests", Unit: "requests", Query: telemetryIncrease("densemem_http_requests_total", scope, baseLabels, nil, window)},
 		{ID: "http_errors", Label: "HTTP errors", Unit: "requests", Query: telemetryIncrease("densemem_http_requests_total", scope, baseLabels, map[string]string{"status_class": "~\"4xx|5xx\""}, window)},
-		{ID: "verifier_tokens", Label: "Verifier tokens", Unit: "tokens", Query: telemetryIncrease("densemem_verifier_tokens_total", scope, baseLabels, map[string]string{"kind": "total"}, window)},
-		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens", Query: telemetryIncrease("densemem_embedding_tokens_total", scope, baseLabels, map[string]string{"kind": "total"}, window)},
-		{ID: "recalls", Label: "Recall requests", Unit: "requests", Query: telemetryIncrease("densemem_recall_requests_total", scope, baseLabels, nil, window)},
+		{ID: "embedding_requests", Label: "Embedding requests", Unit: "requests", Query: telemetrySparseCounterIncrease("densemem_embedding_requests_total", scope, baseLabels, nil, window)},
+		{ID: "embedding_errors", Label: "Embedding errors", Unit: "errors", Query: telemetrySparseCounterIncrease("densemem_embedding_errors_total", scope, baseLabels, nil, window)},
+		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens", Query: telemetrySparseCounterIncrease("densemem_embedding_tokens_total", scope, baseLabels, map[string]string{"kind": "total"}, window)},
+		{ID: "verifier_requests", Label: "Verifier requests", Unit: "requests", Query: telemetrySparseCounterIncrease("densemem_verifier_requests_total", scope, baseLabels, nil, window)},
+		{ID: "verifier_tokens", Label: "Verifier tokens", Unit: "tokens", Query: telemetrySparseCounterIncrease("densemem_verifier_tokens_total", scope, baseLabels, map[string]string{"kind": "total"}, window)},
+		{ID: "verify_verdicts", Label: "Verify verdicts", Unit: "verdicts", Query: telemetrySparseCounterIncrease("densemem_verify_verdict_total", scope, baseLabels, nil, window)},
+		{ID: "recalls", Label: "Recall requests", Unit: "requests", Query: telemetrySparseCounterIncrease("densemem_recall_requests_total", scope, baseLabels, nil, window)},
 		{ID: "avg_recall_results", Label: "Avg recall results", Unit: "results", Query: telemetryHistogramAverage("densemem_recall_results", scope, baseLabels, nil, window, 1)},
 		{ID: "p95_recall_latency", Label: "P95 recall latency", Unit: "ms", Query: telemetryHistogramQuantile("densemem_recall_duration_seconds", scope, baseLabels, nil, window, 0.95, 1000)},
 		{ID: "llm_recall_used_rate", Label: "LLM recall used", Unit: "percent", Query: telemetryRecallFeedbackRate(scope, baseLabels, map[string]string{"used": "true"}, window)},
@@ -243,16 +291,29 @@ func telemetryCardSpecs(scope TelemetryScope, baseLabels map[string]string, wind
 		{ID: "llm_recall_quality_score", Label: "LLM recall quality", Unit: "percent", Query: telemetrySparseHistogramAverage("densemem_recall_feedback_quality_score", scope, baseLabels, nil, window, 100)},
 		{ID: "llm_recall_missing_context_rate", Label: "LLM missing context", Unit: "percent", Query: telemetryRecallFeedbackRate(scope, baseLabels, map[string]string{"missing_context": "true"}, window)},
 		{ID: "llm_recall_irrelevant_rate", Label: "LLM irrelevant recall", Unit: "percent", Query: telemetryRecallFeedbackRate(scope, baseLabels, map[string]string{"irrelevant": "true"}, window)},
-		{ID: "dream_feedbacks", Label: "Dream feedback", Unit: "events", Query: telemetryIncrease("densemem_dream_feedback_total", scope, baseLabels, nil, window)},
-		{ID: "dream_promote_candidates", Label: "Dream promote candidates", Unit: "events", Query: telemetryIncrease("densemem_dream_feedback_total", scope, baseLabels, map[string]string{"decision": "promote_candidate", "outcome": "ok"}, window)},
-		{ID: "promotions", Label: "Promotions", Unit: "promotions", Query: telemetryIncrease("densemem_promotion_outcome_total", scope, baseLabels, map[string]string{"outcome": "promoted"}, window)},
+		{ID: "dream_feedbacks", Label: "Dream feedback", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_dream_feedback_total", scope, baseLabels, nil, window)},
+		{ID: "dream_promote_candidates", Label: "Dream promote candidates", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_dream_feedback_total", scope, baseLabels, map[string]string{"decision": "promote_candidate", "outcome": "ok"}, window)},
+		{ID: "fragment_creates", Label: "Fragment creates", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_fragment_create_total", scope, baseLabels, nil, window)},
+		{ID: "claim_creates", Label: "Claim creates", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_claim_create_total", scope, baseLabels, nil, window)},
+		{ID: "promotions", Label: "Promotions", Unit: "promotions", Query: telemetrySparseCounterIncrease("densemem_promotion_outcome_total", scope, baseLabels, map[string]string{"outcome": "promoted"}, window)},
 		{ID: "promotion_rate", Label: "Promotion rate", Unit: "percent", Query: telemetryPromotionRate(scope, baseLabels, window)},
+		{ID: "retractions", Label: "Retractions", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_retractions_total", scope, baseLabels, nil, window)},
+		{ID: "facts_requeued", Label: "Facts requeued", Unit: "events", Query: telemetrySparseCounterIncrease("densemem_fact_needs_revalidation_total", scope, baseLabels, nil, window)},
+		{ID: "community_runs", Label: "Community runs", Unit: "runs", Query: telemetrySparseCounterIncrease("densemem_community_detect_total", scope, baseLabels, nil, window)},
 		{ID: "avg_http_latency", Label: "Avg HTTP latency", Unit: "ms", Query: telemetryAverageLatency("densemem_http_request_duration_seconds", scope, baseLabels, window)},
-		{ID: "avg_embedding_latency", Label: "Avg embedding latency", Unit: "ms", Query: telemetryAverageLatency("densemem_embedding_duration_seconds", scope, baseLabels, window)},
-		{ID: "avg_verifier_latency", Label: "Avg verifier latency", Unit: "ms", Query: telemetryAverageLatency("densemem_verifier_duration_seconds", scope, baseLabels, window)},
-		{ID: "avg_claim_verify_latency", Label: "Avg claim-to-verify", Unit: "ms", Query: telemetryHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "claim_to_verify"}, window, 1000)},
-		{ID: "avg_claim_promotion_latency", Label: "Avg claim-to-promote", Unit: "ms", Query: telemetryHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "claim_to_promotion"}, window, 1000)},
-		{ID: "avg_verify_promotion_latency", Label: "Avg verify-to-promote", Unit: "ms", Query: telemetryHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "verify_to_promotion"}, window, 1000)},
+		{ID: "avg_embedding_latency", Label: "Avg embedding latency", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_embedding_duration_seconds", scope, baseLabels, nil, window, 1000)},
+		{ID: "avg_verifier_latency", Label: "Avg verifier latency", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_verifier_duration_seconds", scope, baseLabels, nil, window, 1000)},
+		{ID: "avg_claim_verify_latency", Label: "Avg claim-to-verify", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "claim_to_verify"}, window, 1000)},
+		{ID: "avg_claim_promotion_latency", Label: "Avg claim-to-promote", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "claim_to_promotion"}, window, 1000)},
+		{ID: "avg_verify_promotion_latency", Label: "Avg verify-to-promote", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_memory_funnel_latency_seconds", scope, baseLabels, map[string]string{"stage": "verify_to_promotion"}, window, 1000)},
+		{ID: "avg_promote_lock_wait", Label: "Avg promote lock wait", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_promote_lock_wait_seconds", scope, baseLabels, nil, window, 1000)},
+		{ID: "avg_community_detect_latency", Label: "Avg community detect", Unit: "ms", Query: telemetrySparseHistogramAverage("densemem_community_detect_duration_seconds", scope, baseLabels, nil, window, 1000)},
+		{ID: "avg_community_projected_nodes", Label: "Avg community nodes", Unit: "nodes", Query: telemetrySparseHistogramAverage("densemem_community_detect_projected_nodes", scope, baseLabels, nil, window, 1)},
+	}
+}
+
+func telemetryCurrentCardSpecs(scope TelemetryScope, baseLabels map[string]string) []telemetryQuerySpec {
+	return []telemetryQuerySpec{
 		{ID: "pending_claims", Label: "Pending claims", Unit: "claims", Query: telemetryGaugeSum("densemem_knowledge_backlog_items", scope, baseLabels, map[string]string{"item": "claim_candidate"})},
 		{ID: "validated_claims", Label: "Validated claims", Unit: "claims", Query: telemetryGaugeSum("densemem_knowledge_backlog_items", scope, baseLabels, map[string]string{"item": "claim_validated"})},
 		{ID: "disputed_claims", Label: "Disputed claims", Unit: "claims", Query: telemetryGaugeSum("densemem_knowledge_backlog_items", scope, baseLabels, map[string]string{"item": "claim_disputed"})},
@@ -261,11 +322,22 @@ func telemetryCardSpecs(scope TelemetryScope, baseLabels map[string]string, wind
 }
 
 func telemetrySeriesSpecs(selector string, rateWindow string) []telemetryQuerySpec {
+	return appendTelemetryQuerySpecs(
+		telemetryActivitySeriesSpecs(selector, rateWindow),
+		telemetryStateSeriesSpecs(selector),
+	)
+}
+
+func telemetryActivitySeriesSpecs(selector string, rateWindow string) []telemetryQuerySpec {
 	return []telemetryQuerySpec{
 		{ID: "http_rps", Label: "HTTP requests", Unit: "rps", Query: fmt.Sprintf("sum(rate(densemem_http_requests_total%s[%s]))", selector, rateWindow)},
 		{ID: "http_errors_rps", Label: "HTTP errors", Unit: "rps", Query: fmt.Sprintf("sum(rate(densemem_http_requests_total%s[%s]))", telemetrySelectorWithRaw(selector, `status_class=~"4xx|5xx"`), rateWindow)},
+		{ID: "embedding_requests", Label: "Embedding requests", Unit: "requests/s", Query: fmt.Sprintf("sum(rate(densemem_embedding_requests_total%s[%s]))", selector, rateWindow)},
+		{ID: "embedding_errors", Label: "Embedding errors", Unit: "errors/s", Query: fmt.Sprintf("sum(rate(densemem_embedding_errors_total%s[%s]))", selector, rateWindow)},
 		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens/s", Query: fmt.Sprintf("sum(rate(densemem_embedding_tokens_total%s[%s]))", telemetrySelectorWithRaw(selector, `kind="total"`), rateWindow)},
+		{ID: "verifier_requests", Label: "Verifier requests", Unit: "requests/s", Query: fmt.Sprintf("sum(rate(densemem_verifier_requests_total%s[%s]))", selector, rateWindow)},
 		{ID: "verifier_tokens", Label: "Verifier tokens", Unit: "tokens/s", Query: fmt.Sprintf("sum(rate(densemem_verifier_tokens_total%s[%s]))", telemetrySelectorWithRaw(selector, `kind="total"`), rateWindow)},
+		{ID: "verify_verdicts", Label: "Verify verdicts", Unit: "verdicts/s", Query: fmt.Sprintf("sum(rate(densemem_verify_verdict_total%s[%s]))", selector, rateWindow)},
 		{ID: "recalls", Label: "Recall requests", Unit: "requests/s", Query: fmt.Sprintf("sum(rate(densemem_recall_requests_total%s[%s]))", selector, rateWindow)},
 		{ID: "promotions", Label: "Promotions", Unit: "promotions/s", Query: fmt.Sprintf("sum(rate(densemem_promotion_outcome_total%s[%s]))", telemetrySelectorWithRaw(selector, `outcome="promoted"`), rateWindow)},
 		{ID: "recall_results", Label: "Recall results", Unit: "results", Query: telemetryRangeHistogramAverage("densemem_recall_results", selector, "", rateWindow, 1)},
@@ -277,9 +349,22 @@ func telemetrySeriesSpecs(selector string, rateWindow string) []telemetryQuerySp
 		{ID: "llm_recall_irrelevant_rate", Label: "LLM irrelevant recall", Unit: "percent", Query: telemetryRangeRecallFeedbackRate(selector, `irrelevant="true"`, rateWindow)},
 		{ID: "dream_feedbacks", Label: "Dream feedback", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_dream_feedback_total%s[%s]))", selector, rateWindow)},
 		{ID: "dream_promote_candidates", Label: "Dream promote candidates", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_dream_feedback_total%s[%s]))", telemetrySelectorWithRaw(selector, `decision="promote_candidate",outcome="ok"`), rateWindow)},
+		{ID: "fragment_creates", Label: "Fragment creates", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_fragment_create_total%s[%s]))", selector, rateWindow)},
+		{ID: "claim_creates", Label: "Claim creates", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_claim_create_total%s[%s]))", selector, rateWindow)},
+		{ID: "retractions", Label: "Retractions", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_retractions_total%s[%s]))", selector, rateWindow)},
+		{ID: "facts_requeued", Label: "Facts requeued", Unit: "events/s", Query: fmt.Sprintf("sum(rate(densemem_fact_needs_revalidation_total%s[%s]))", selector, rateWindow)},
+		{ID: "community_runs", Label: "Community runs", Unit: "runs/s", Query: fmt.Sprintf("sum(rate(densemem_community_detect_total%s[%s]))", selector, rateWindow)},
 		{ID: "claim_verify_latency", Label: "Claim-to-verify", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="claim_to_verify"`, rateWindow, 1000)},
 		{ID: "claim_promotion_latency", Label: "Claim-to-promote", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="claim_to_promotion"`, rateWindow, 1000)},
 		{ID: "verify_promotion_latency", Label: "Verify-to-promote", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_memory_funnel_latency_seconds", selector, `stage="verify_to_promotion"`, rateWindow, 1000)},
+		{ID: "promote_lock_wait", Label: "Promote lock wait", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_promote_lock_wait_seconds", selector, "", rateWindow, 1000)},
+		{ID: "community_detect_latency", Label: "Community detect", Unit: "ms", Query: telemetryRangeHistogramAverage("densemem_community_detect_duration_seconds", selector, "", rateWindow, 1000)},
+		{ID: "community_projected_nodes", Label: "Community nodes", Unit: "nodes", Query: telemetryRangeHistogramAverage("densemem_community_detect_projected_nodes", selector, "", rateWindow, 1)},
+	}
+}
+
+func telemetryStateSeriesSpecs(selector string) []telemetryQuerySpec {
+	return []telemetryQuerySpec{
 		{ID: "pending_claims", Label: "Pending claims", Unit: "claims", Query: telemetryRangeGauge("densemem_knowledge_backlog_items", selector, `item="claim_candidate"`)},
 		{ID: "validated_claims", Label: "Validated claims", Unit: "claims", Query: telemetryRangeGauge("densemem_knowledge_backlog_items", selector, `item="claim_validated"`)},
 		{ID: "disputed_claims", Label: "Disputed claims", Unit: "claims", Query: telemetryRangeGauge("densemem_knowledge_backlog_items", selector, `item="claim_disputed"`)},
@@ -306,7 +391,7 @@ func telemetryHistogramQuantile(metric string, scope TelemetryScope, baseLabels 
 }
 
 func telemetryRecallFeedbackRate(scope TelemetryScope, baseLabels map[string]string, extra map[string]string, window string) string {
-	matched := telemetrySparseCounterIncrease("densemem_recall_feedback_total", scope, baseLabels, extra, window)
+	matched := telemetryOrZero(telemetrySparseCounterIncrease("densemem_recall_feedback_total", scope, baseLabels, extra, window))
 	all := telemetrySparseCounterIncrease("densemem_recall_feedback_total", scope, baseLabels, nil, window)
 	return fmt.Sprintf("100 * (%s) / (%s)", matched, all)
 }
@@ -352,7 +437,7 @@ func telemetryRangeHistogramQuantile(metric string, selector string, raw string,
 
 func telemetryRangeRecallFeedbackRate(selector string, raw string, rateWindow string) string {
 	matchedSelector := telemetrySelectorWithRaw(selector, raw)
-	matched := telemetrySparseCounterIncreaseForSelector("densemem_recall_feedback_total", matchedSelector, rateWindow)
+	matched := telemetryOrZero(telemetrySparseCounterIncreaseForSelector("densemem_recall_feedback_total", matchedSelector, rateWindow))
 	all := telemetrySparseCounterIncreaseForSelector("densemem_recall_feedback_total", selector, rateWindow)
 	return fmt.Sprintf("100 * (%s) / (%s)", matched, all)
 }
@@ -371,9 +456,13 @@ func telemetryRangeGauge(metric string, selector string, raw string) string {
 }
 
 func telemetryPromotionRate(scope TelemetryScope, baseLabels map[string]string, window string) string {
-	promoted := telemetryIncrease("densemem_promotion_outcome_total", scope, baseLabels, map[string]string{"outcome": "promoted"}, window)
-	all := telemetryIncrease("densemem_promotion_outcome_total", scope, baseLabels, nil, window)
+	promoted := telemetryOrZero(telemetrySparseCounterIncrease("densemem_promotion_outcome_total", scope, baseLabels, map[string]string{"outcome": "promoted"}, window))
+	all := telemetrySparseCounterIncrease("densemem_promotion_outcome_total", scope, baseLabels, nil, window)
 	return fmt.Sprintf("100 * (%s) / (%s)", promoted, all)
+}
+
+func telemetryOrZero(query string) string {
+	return fmt.Sprintf("((%s) or vector(0))", query)
 }
 
 func mergeTelemetryLabels(base map[string]string, extra map[string]string) map[string]string {
@@ -476,10 +565,15 @@ func (s *PrometheusTelemetryService) queryRange(ctx context.Context, query strin
 	return decodePrometheusPoints(resp.Data.Result[0].Values)
 }
 
-func (s *PrometheusTelemetryService) queryInstant(ctx context.Context, query string) (float64, error) {
+type telemetryScalar struct {
+	Value     float64
+	Available bool
+}
+
+func (s *PrometheusTelemetryService) queryInstant(ctx context.Context, query string) (telemetryScalar, error) {
 	endpoint, err := url.Parse(s.baseURL + "/api/v1/query")
 	if err != nil {
-		return 0, err
+		return telemetryScalar{}, err
 	}
 	params := endpoint.Query()
 	params.Set("query", query)
@@ -487,13 +581,13 @@ func (s *PrometheusTelemetryService) queryInstant(ctx context.Context, query str
 
 	var resp prometheusInstantResponse
 	if err := s.get(ctx, endpoint.String(), &resp); err != nil {
-		return 0, err
+		return telemetryScalar{}, err
 	}
 	if resp.Status != "success" {
-		return 0, fmt.Errorf("prometheus query failed: %s", resp.Error)
+		return telemetryScalar{}, fmt.Errorf("prometheus query failed: %s", resp.Error)
 	}
 	if len(resp.Data.Result) == 0 {
-		return 0, nil
+		return telemetryScalar{}, nil
 	}
 	return decodePrometheusValue(resp.Data.Result[0].Value)
 }
@@ -540,38 +634,42 @@ func decodePrometheusPoints(values [][]json.RawMessage) ([]TelemetryPoint, error
 		if len(value) < 2 {
 			continue
 		}
-		ts, metricValue, err := decodePrometheusPair(value)
+		ts, scalar, err := decodePrometheusPair(value)
 		if err != nil {
 			return nil, err
 		}
-		points = append(points, TelemetryPoint{Timestamp: ts.Format(time.RFC3339), Value: metricValue})
+		if !scalar.Available {
+			continue
+		}
+		points = append(points, TelemetryPoint{Timestamp: ts.Format(time.RFC3339), Value: scalar.Value})
 	}
 	return points, nil
 }
 
-func decodePrometheusValue(value []json.RawMessage) (float64, error) {
+func decodePrometheusValue(value []json.RawMessage) (telemetryScalar, error) {
 	if len(value) < 2 {
-		return 0, nil
+		return telemetryScalar{}, nil
 	}
-	_, metricValue, err := decodePrometheusPair(value)
-	return metricValue, err
+	_, scalar, err := decodePrometheusPair(value)
+	return scalar, err
 }
 
-func decodePrometheusPair(value []json.RawMessage) (time.Time, float64, error) {
+func decodePrometheusPair(value []json.RawMessage) (time.Time, telemetryScalar, error) {
 	var unixSeconds float64
 	if err := json.Unmarshal(value[0], &unixSeconds); err != nil {
-		return time.Time{}, 0, err
+		return time.Time{}, telemetryScalar{}, err
 	}
 	var raw string
 	if err := json.Unmarshal(value[1], &raw); err != nil {
-		return time.Time{}, 0, err
+		return time.Time{}, telemetryScalar{}, err
 	}
 	metricValue, err := strconv.ParseFloat(raw, 64)
 	if err != nil || math.IsNaN(metricValue) || math.IsInf(metricValue, 0) {
-		metricValue = 0
+		secs, frac := math.Modf(unixSeconds)
+		return time.Unix(int64(secs), int64(frac*1e9)).UTC(), telemetryScalar{}, nil
 	}
 	secs, frac := math.Modf(unixSeconds)
-	return time.Unix(int64(secs), int64(frac*1e9)).UTC(), nilIfNegative(metricValue), nil
+	return time.Unix(int64(secs), int64(frac*1e9)).UTC(), telemetryScalar{Value: nilIfNegative(metricValue), Available: true}, nil
 }
 
 func nilIfNegative(value float64) float64 {
@@ -582,60 +680,77 @@ func nilIfNegative(value float64) float64 {
 }
 
 func telemetryEmptyCards() []TelemetryCard {
-	return []TelemetryCard{
-		{ID: "http_requests", Label: "HTTP requests", Unit: "requests"},
-		{ID: "http_errors", Label: "HTTP errors", Unit: "requests"},
-		{ID: "verifier_tokens", Label: "Verifier tokens", Unit: "tokens"},
-		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens"},
-		{ID: "recalls", Label: "Recall requests", Unit: "requests"},
-		{ID: "avg_recall_results", Label: "Avg recall results", Unit: "results"},
-		{ID: "p95_recall_latency", Label: "P95 recall latency", Unit: "ms"},
-		{ID: "llm_recall_used_rate", Label: "LLM recall used", Unit: "percent"},
-		{ID: "llm_recall_answer_supported_rate", Label: "LLM answer supported", Unit: "percent"},
-		{ID: "llm_recall_quality_score", Label: "LLM recall quality", Unit: "percent"},
-		{ID: "llm_recall_missing_context_rate", Label: "LLM missing context", Unit: "percent"},
-		{ID: "llm_recall_irrelevant_rate", Label: "LLM irrelevant recall", Unit: "percent"},
-		{ID: "dream_feedbacks", Label: "Dream feedback", Unit: "events"},
-		{ID: "dream_promote_candidates", Label: "Dream promote candidates", Unit: "events"},
-		{ID: "promotions", Label: "Promotions", Unit: "promotions"},
-		{ID: "promotion_rate", Label: "Promotion rate", Unit: "percent"},
-		{ID: "avg_http_latency", Label: "Avg HTTP latency", Unit: "ms"},
-		{ID: "avg_embedding_latency", Label: "Avg embedding latency", Unit: "ms"},
-		{ID: "avg_verifier_latency", Label: "Avg verifier latency", Unit: "ms"},
-		{ID: "avg_claim_verify_latency", Label: "Avg claim-to-verify", Unit: "ms"},
-		{ID: "avg_claim_promotion_latency", Label: "Avg claim-to-promote", Unit: "ms"},
-		{ID: "avg_verify_promotion_latency", Label: "Avg verify-to-promote", Unit: "ms"},
-		{ID: "pending_claims", Label: "Pending claims", Unit: "claims"},
-		{ID: "validated_claims", Label: "Validated claims", Unit: "claims"},
-		{ID: "disputed_claims", Label: "Disputed claims", Unit: "claims"},
-		{ID: "revalidation_backlog", Label: "Revalidation backlog", Unit: "facts"},
-	}
+	return appendTelemetryCards(telemetryEmptyWindowedCards(), telemetryEmptyCurrentCards())
+}
+
+func telemetryEmptyWindowedCards() []TelemetryCard {
+	return telemetryEmptyCardsFromSpecs(telemetryWindowedCardSpecs(TelemetryScope{Type: "system"}, nil, "1h"))
+}
+
+func telemetryEmptyCurrentCards() []TelemetryCard {
+	return telemetryEmptyCardsFromSpecs(telemetryCurrentCardSpecs(TelemetryScope{Type: "system"}, nil))
 }
 
 func telemetryEmptySeries() []TelemetrySeries {
-	emptyPoints := []TelemetryPoint{}
-	return []TelemetrySeries{
-		{ID: "http_rps", Label: "HTTP requests", Unit: "rps", Points: emptyPoints},
-		{ID: "http_errors_rps", Label: "HTTP errors", Unit: "rps", Points: emptyPoints},
-		{ID: "embedding_tokens", Label: "Embedding tokens", Unit: "tokens/s", Points: emptyPoints},
-		{ID: "verifier_tokens", Label: "Verifier tokens", Unit: "tokens/s", Points: emptyPoints},
-		{ID: "recalls", Label: "Recall requests", Unit: "requests/s", Points: emptyPoints},
-		{ID: "promotions", Label: "Promotions", Unit: "promotions/s", Points: emptyPoints},
-		{ID: "recall_results", Label: "Recall results", Unit: "results", Points: emptyPoints},
-		{ID: "recall_p95_latency", Label: "Recall p95 latency", Unit: "ms", Points: emptyPoints},
-		{ID: "llm_recall_used_rate", Label: "LLM recall used", Unit: "percent", Points: emptyPoints},
-		{ID: "llm_recall_answer_supported_rate", Label: "LLM answer supported", Unit: "percent", Points: emptyPoints},
-		{ID: "llm_recall_quality_score", Label: "LLM recall quality", Unit: "percent", Points: emptyPoints},
-		{ID: "llm_recall_missing_context_rate", Label: "LLM missing context", Unit: "percent", Points: emptyPoints},
-		{ID: "llm_recall_irrelevant_rate", Label: "LLM irrelevant recall", Unit: "percent", Points: emptyPoints},
-		{ID: "dream_feedbacks", Label: "Dream feedback", Unit: "events/s", Points: emptyPoints},
-		{ID: "dream_promote_candidates", Label: "Dream promote candidates", Unit: "events/s", Points: emptyPoints},
-		{ID: "claim_verify_latency", Label: "Claim-to-verify", Unit: "ms", Points: emptyPoints},
-		{ID: "claim_promotion_latency", Label: "Claim-to-promote", Unit: "ms", Points: emptyPoints},
-		{ID: "verify_promotion_latency", Label: "Verify-to-promote", Unit: "ms", Points: emptyPoints},
-		{ID: "pending_claims", Label: "Pending claims", Unit: "claims", Points: emptyPoints},
-		{ID: "validated_claims", Label: "Validated claims", Unit: "claims", Points: emptyPoints},
-		{ID: "disputed_claims", Label: "Disputed claims", Unit: "claims", Points: emptyPoints},
-		{ID: "revalidation_backlog", Label: "Revalidation backlog", Unit: "facts", Points: emptyPoints},
+	return appendTelemetrySeries(telemetryEmptyActivitySeries(), telemetryEmptyStateSeries())
+}
+
+func telemetryEmptyActivitySeries() []TelemetrySeries {
+	return telemetryEmptySeriesFromSpecs(telemetryActivitySeriesSpecs("", "1m"))
+}
+
+func telemetryEmptyStateSeries() []TelemetrySeries {
+	return telemetryEmptySeriesFromSpecs(telemetryStateSeriesSpecs(""))
+}
+
+func telemetryEmptyCardsFromSpecs(specs []telemetryQuerySpec) []TelemetryCard {
+	cards := make([]TelemetryCard, 0, len(specs))
+	for _, spec := range specs {
+		cards = append(cards, TelemetryCard{ID: spec.ID, Label: spec.Label, Unit: spec.Unit})
 	}
+	return cards
+}
+
+func telemetryEmptySeriesFromSpecs(specs []telemetryQuerySpec) []TelemetrySeries {
+	series := make([]TelemetrySeries, 0, len(specs))
+	for _, spec := range specs {
+		series = append(series, TelemetrySeries{ID: spec.ID, Label: spec.Label, Unit: spec.Unit, Points: []TelemetryPoint{}})
+	}
+	return series
+}
+
+func appendTelemetryCards(groups ...[]TelemetryCard) []TelemetryCard {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	out := make([]TelemetryCard, 0, total)
+	for _, group := range groups {
+		out = append(out, group...)
+	}
+	return out
+}
+
+func appendTelemetrySeries(groups ...[]TelemetrySeries) []TelemetrySeries {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	out := make([]TelemetrySeries, 0, total)
+	for _, group := range groups {
+		out = append(out, group...)
+	}
+	return out
+}
+
+func appendTelemetryQuerySpecs(groups ...[]telemetryQuerySpec) []telemetryQuerySpec {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	out := make([]telemetryQuerySpec, 0, total)
+	for _, group := range groups {
+		out = append(out, group...)
+	}
+	return out
 }

--- a/internal/service/telemetry_service_test.go
+++ b/internal/service/telemetry_service_test.go
@@ -28,12 +28,21 @@ func TestPrometheusTelemetryService_UnconfiguredReturnsUnavailableSnapshot(t *te
 	require.Equal(t, "30m", snapshot.Window.Key)
 	require.Equal(t, "telemetry backend is not configured", snapshot.Message)
 	require.NotEmpty(t, snapshot.Cards)
+	require.NotEmpty(t, snapshot.WindowedCards)
+	require.NotEmpty(t, snapshot.CurrentCards)
 	require.NotEmpty(t, snapshot.Series)
+	require.NotEmpty(t, snapshot.ActivitySeries)
+	require.NotEmpty(t, snapshot.StateSeries)
+	require.False(t, snapshot.Cards[0].Available)
 
 	payload, err := json.Marshal(snapshot)
 	require.NoError(t, err)
 	require.Contains(t, string(payload), `"points":[]`)
 	require.NotContains(t, string(payload), `"points":null`)
+	require.Contains(t, string(payload), `"windowed_cards"`)
+	require.Contains(t, string(payload), `"current_cards"`)
+	require.Contains(t, string(payload), `"activity_series"`)
+	require.Contains(t, string(payload), `"state_series"`)
 }
 
 func TestPrometheusTelemetryService_QueriesTypedScope(t *testing.T) {
@@ -67,7 +76,15 @@ func TestPrometheusTelemetryService_QueriesTypedScope(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, snapshot.Available)
 	require.Equal(t, 42.0, snapshot.Cards[0].Value)
+	require.True(t, snapshot.Cards[0].Available)
 	require.Equal(t, 2, len(snapshot.Series[0].Points))
+	require.Len(t, snapshot.Cards, len(snapshot.WindowedCards)+len(snapshot.CurrentCards))
+	require.Len(t, snapshot.Series, len(snapshot.ActivitySeries)+len(snapshot.StateSeries))
+	require.NotNil(t, telemetrySpecByID(snapshot.WindowedCards, "http_requests"))
+	require.Nil(t, telemetrySpecByID(snapshot.WindowedCards, "pending_claims"))
+	require.NotNil(t, telemetrySpecByID(snapshot.CurrentCards, "pending_claims"))
+	require.Nil(t, telemetrySeriesByID(snapshot.ActivitySeries, "pending_claims"))
+	require.NotNil(t, telemetrySeriesByID(snapshot.StateSeries, "pending_claims"))
 	require.Condition(t, func() bool {
 		for _, query := range queries {
 			if strings.Contains(query, `team_id="`+teamID.String()+`"`) && strings.Contains(query, `profile_id="`+profileID.String()+`"`) {
@@ -193,13 +210,14 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 	qualityQuery := telemetrySparseHistogramAverage("densemem_recall_feedback_quality_score", TelemetryScope{}, nil, nil, "1h", 100)
 	require.Contains(t, qualityQuery, `min_over_time(densemem_recall_feedback_quality_score_sum[1h]) unless densemem_recall_feedback_quality_score_sum offset 1h`)
 	require.Contains(t, qualityQuery, `min_over_time(densemem_recall_feedback_quality_score_count[1h]) unless densemem_recall_feedback_quality_score_count offset 1h`)
+	require.Contains(t, feedbackRateQuery, `or vector(0)`)
 	rangeFeedbackQuery := telemetryRangeRecallFeedbackRate(`{job="dense-mem"}`, `used="true"`, "1m")
 	require.Contains(t, rangeFeedbackQuery, `min_over_time(densemem_recall_feedback_total{job="dense-mem",used="true"}[1m]) unless densemem_recall_feedback_total{job="dense-mem",used="true"} offset 1m`)
 	require.Contains(t, rangeFeedbackQuery, `count_over_time(densemem_recall_feedback_total{job="dense-mem",used="true"}[1m]) < bool on(job, instance) group_left() count_over_time(up[1m])`)
 	require.Condition(t, func() bool {
 		for _, spec := range telemetryCardSpecs(TelemetryScope{}, nil, "1h") {
 			if spec.ID == "dream_feedbacks" {
-				return strings.Contains(spec.Query, `densemem_dream_feedback_total`)
+				return strings.Contains(spec.Query, `min_over_time(densemem_dream_feedback_total[1h])`)
 			}
 		}
 		return false
@@ -213,6 +231,36 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 		return false
 	})
 	require.Equal(t, `1000 * histogram_quantile(0.95, sum(rate(densemem_recall_duration_seconds_bucket[1m])) by (le))`, telemetryRangeHistogramQuantile("densemem_recall_duration_seconds", "", "", "1m", 0.95, 1000))
+	require.Contains(t, telemetryPromotionRate(TelemetryScope{}, nil, "1h"), `min_over_time(densemem_promotion_outcome_total{outcome="promoted"}[1h])`)
+	require.Contains(t, telemetryPromotionRate(TelemetryScope{}, nil, "1h"), `or vector(0)`)
+	require.Subset(t, telemetryQuerySpecIDs(telemetryWindowedCardSpecs(TelemetryScope{}, nil, "1h")), []string{
+		"embedding_requests",
+		"embedding_errors",
+		"verifier_requests",
+		"verify_verdicts",
+		"fragment_creates",
+		"claim_creates",
+		"retractions",
+		"facts_requeued",
+		"community_runs",
+		"avg_promote_lock_wait",
+		"avg_community_detect_latency",
+		"avg_community_projected_nodes",
+	})
+	require.Subset(t, telemetryQuerySpecIDs(telemetryActivitySeriesSpecs("", "1m")), []string{
+		"embedding_requests",
+		"embedding_errors",
+		"verifier_requests",
+		"verify_verdicts",
+		"fragment_creates",
+		"claim_creates",
+		"retractions",
+		"facts_requeued",
+		"community_runs",
+		"promote_lock_wait",
+		"community_detect_latency",
+		"community_projected_nodes",
+	})
 
 	scope, err = normalizeTelemetryScope(TelemetryFilter{Scope: "self", TeamID: &teamID, ProfileID: &profileID})
 	require.NoError(t, err)
@@ -231,6 +279,7 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 		{json.RawMessage(`1770000000.5`), json.RawMessage(`"2.5"`)},
 		{json.RawMessage(`1770000001`)},
 		{json.RawMessage(`1770000002`), json.RawMessage(`"-1"`)},
+		{json.RawMessage(`1770000003`), json.RawMessage(`"NaN"`)},
 	})
 	require.NoError(t, err)
 	require.Len(t, points, 2)
@@ -239,7 +288,8 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 
 	value, err := decodePrometheusValue(nil)
 	require.NoError(t, err)
-	require.Equal(t, 0.0, value)
+	require.False(t, value.Available)
+	require.Equal(t, 0.0, value.Value)
 
 	_, _, err = decodePrometheusPair([]json.RawMessage{json.RawMessage(`"bad"`), json.RawMessage(`"1"`)})
 	require.Error(t, err)
@@ -247,7 +297,8 @@ func TestPrometheusTelemetryService_ValidationAndDecodeBranches(t *testing.T) {
 	require.Error(t, err)
 	_, value, err = decodePrometheusPair([]json.RawMessage{json.RawMessage(`1`), json.RawMessage(`"NaN"`)})
 	require.NoError(t, err)
-	require.Equal(t, 0.0, value)
+	require.False(t, value.Available)
+	require.Equal(t, 0.0, value.Value)
 }
 
 func TestPrometheusTelemetryService_QueryFailureBranches(t *testing.T) {
@@ -277,7 +328,8 @@ func TestPrometheusTelemetryService_QueryFailureBranches(t *testing.T) {
 
 	value, err := svc.queryInstant(context.Background(), "instant-empty")
 	require.NoError(t, err)
-	require.Equal(t, 0.0, value)
+	require.False(t, value.Available)
+	require.Equal(t, 0.0, value.Value)
 	_, err = svc.queryInstant(context.Background(), "instant-error")
 	require.ErrorContains(t, err, "bad instant")
 	_, err = svc.queryInstant(context.Background(), "bad-json")
@@ -368,6 +420,32 @@ func scopeLabels(scope TelemetryScope) map[string]string {
 		labels["profile_id"] = scope.ProfileID.String()
 	}
 	return labels
+}
+
+func telemetrySpecByID(cards []TelemetryCard, id string) *TelemetryCard {
+	for i := range cards {
+		if cards[i].ID == id {
+			return &cards[i]
+		}
+	}
+	return nil
+}
+
+func telemetrySeriesByID(series []TelemetrySeries, id string) *TelemetrySeries {
+	for i := range series {
+		if series[i].ID == id {
+			return &series[i]
+		}
+	}
+	return nil
+}
+
+func telemetryQuerySpecIDs(specs []telemetryQuerySpec) []string {
+	ids := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		ids = append(ids, spec.ID)
+	}
+	return ids
 }
 
 func mustMarshalStringMap(t *testing.T, value map[string]string) string {

--- a/web/src/telemetry/TelemetryDashboard.test.tsx
+++ b/web/src/telemetry/TelemetryDashboard.test.tsx
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { formatTelemetryAxisTick, telemetryChartPoints } from "./TelemetryDashboard";
+import {
+  formatTelemetryAxisTick,
+  formatTelemetryCardValue,
+  telemetryActivitySeries,
+  telemetryChartPoints,
+  telemetryCurrentCards,
+  telemetryStateSeries,
+  telemetryWindowedCards,
+} from "./TelemetryDashboard";
+import type { TelemetrySnapshot } from "./types";
 
 describe("TelemetryDashboard helpers", () => {
   it("keeps small per-second axis labels distinct", () => {
@@ -28,4 +37,61 @@ describe("TelemetryDashboard helpers", () => {
 
     expect(telemetryChartPoints(samples, "2026-05-02T11:00:00Z", "2026-05-02T13:00:00Z")).toBe(samples);
   });
+
+  it("splits legacy telemetry payloads into windowed and current state groups", () => {
+    const snapshot = telemetrySnapshot({
+      cards: [
+        { id: "http_requests", label: "HTTP requests", unit: "requests", value: 4 },
+        { id: "pending_claims", label: "Pending claims", unit: "claims", value: 2 },
+      ],
+      series: [
+        { id: "http_rps", label: "HTTP requests", unit: "rps", points: [] },
+        { id: "pending_claims", label: "Pending claims", unit: "claims", points: [] },
+      ],
+    });
+
+    expect(telemetryWindowedCards(snapshot).map((card) => card.id)).toEqual(["http_requests"]);
+    expect(telemetryCurrentCards(snapshot).map((card) => card.id)).toEqual(["pending_claims"]);
+    expect(telemetryActivitySeries(snapshot).map((series) => series.id)).toEqual(["http_rps"]);
+    expect(telemetryStateSeries(snapshot).map((series) => series.id)).toEqual(["pending_claims"]);
+  });
+
+  it("prefers explicit telemetry groups when the backend provides them", () => {
+    const snapshot = telemetrySnapshot({
+      cards: [{ id: "legacy", label: "Legacy", unit: "events", value: 1 }],
+      windowed_cards: [{ id: "dream_feedbacks", label: "Dream feedback", unit: "events", value: 1 }],
+      current_cards: [{ id: "pending_claims", label: "Pending claims", unit: "claims", value: 3 }],
+      series: [{ id: "legacy_series", label: "Legacy", unit: "events/s", points: [] }],
+      activity_series: [{ id: "dream_feedbacks", label: "Dream feedback", unit: "events/s", points: [] }],
+      state_series: [{ id: "pending_claims", label: "Pending claims", unit: "claims", points: [] }],
+    });
+
+    expect(telemetryWindowedCards(snapshot).map((card) => card.id)).toEqual(["dream_feedbacks"]);
+    expect(telemetryCurrentCards(snapshot).map((card) => card.id)).toEqual(["pending_claims"]);
+    expect(telemetryActivitySeries(snapshot).map((series) => series.id)).toEqual(["dream_feedbacks"]);
+    expect(telemetryStateSeries(snapshot).map((series) => series.id)).toEqual(["pending_claims"]);
+  });
+
+  it("formats unavailable telemetry cards as no data", () => {
+    expect(formatTelemetryCardValue({ unit: "requests", value: 0, available: false })).toBe("No data");
+    expect(formatTelemetryCardValue({ unit: "requests", value: 0, available: true })).toBe("0");
+    expect(formatTelemetryCardValue({ unit: "percent", value: 12.2 })).toBe("12%");
+  });
 });
+
+function telemetrySnapshot(overrides: Partial<TelemetrySnapshot>): TelemetrySnapshot {
+  return {
+    available: true,
+    window: {
+      key: "1h",
+      from: "2026-05-02T12:00:00Z",
+      to: "2026-05-02T13:00:00Z",
+      step_seconds: 60,
+      retention_days: 30,
+    },
+    scope: { type: "system" },
+    cards: [],
+    series: [],
+    ...overrides,
+  };
+}

--- a/web/src/telemetry/TelemetryDashboard.tsx
+++ b/web/src/telemetry/TelemetryDashboard.tsx
@@ -13,6 +13,13 @@ import { TelemetrySnapshot, TelemetryWindowKey, telemetryWindowOptions } from ".
 import { SectionHeading, SummaryCard } from "../ui/components";
 import "./telemetry.css";
 
+const currentStateCardIds = new Set([
+  "pending_claims",
+  "validated_claims",
+  "disputed_claims",
+  "revalidation_backlog",
+]);
+
 type TelemetryDashboardProps = {
   title: string;
   snapshot: TelemetrySnapshot | null;
@@ -34,6 +41,11 @@ export function TelemetryDashboard({
   onWindowChange,
   onRefresh,
 }: TelemetryDashboardProps) {
+  const windowedCards = snapshot ? telemetryWindowedCards(snapshot) : [];
+  const currentCards = snapshot ? telemetryCurrentCards(snapshot) : [];
+  const activitySeries = snapshot ? telemetryActivitySeries(snapshot) : [];
+  const stateSeries = snapshot ? telemetryStateSeries(snapshot) : [];
+
   return (
     <div className="telemetry-dashboard">
       <SectionHeading
@@ -66,80 +78,174 @@ export function TelemetryDashboard({
 
       {snapshot && (
         <>
-          <div className="telemetry-card-grid" aria-label={`${title} totals`}>
-            {snapshot.cards.map((card) => (
-              <SummaryCard key={card.id} label={card.label} value={formatTelemetryValue(card.value, card.unit)} />
-            ))}
-          </div>
-          <div className="telemetry-chart-grid" aria-label={`${title} charts`}>
-            {snapshot.series.map((series) => {
-              const samplePoints = Array.isArray(series.points) ? series.points : [];
-              const hasSamples = samplePoints.length > 0;
-              const chartPoints = telemetryChartPoints(samplePoints, snapshot.window.from, snapshot.window.to);
-
-              return (
-                <div className="telemetry-chart" key={series.id}>
-                  <div className="telemetry-chart-head">
-                    <h3>{series.label}</h3>
-                    <span>{series.unit}</span>
-                  </div>
-                  <div className="telemetry-chart-body">
-                    {!hasSamples && <div className="chart-empty-label">No samples</div>}
-                    <ResponsiveContainer
-                      width="100%"
-                      height="100%"
-                      minWidth={280}
-                      minHeight={180}
-                      initialDimension={{ width: 640, height: 240 }}
-                    >
-                      <LineChart data={chartPoints} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
-                        <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
-                        <XAxis
-                          dataKey="timestamp"
-                          tickFormatter={formatTelemetryTick}
-                          tick={{ fill: "var(--muted)", fontSize: 11 }}
-                          minTickGap={28}
-                        />
-                        <YAxis
-                          width={44}
-                          tick={{ fill: "var(--muted)", fontSize: 11 }}
-                          tickFormatter={(value) => formatTelemetryAxisTick(Number(value), series.unit)}
-                          domain={telemetryYAxisDomain(samplePoints)}
-                        />
-                        <Tooltip
-                          contentStyle={{
-                            background: "var(--panel)",
-                            border: "1px solid var(--border)",
-                            borderRadius: 7,
-                            color: "var(--text)",
-                          }}
-                          labelFormatter={(label) => formatTelemetryTime(String(label))}
-                          formatter={(value) => [formatTelemetryValue(Number(value), series.unit), series.label]}
-                        />
-                        {hasSamples && (
-                          <Line
-                            type="monotone"
-                            dataKey="value"
-                            stroke="var(--accent)"
-                            strokeWidth={2}
-                            dot={false}
-                            isAnimationActive={false}
-                          />
-                        )}
-                      </LineChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+          <TelemetryCardSection
+            title="Windowed activity"
+            ariaLabel={`${title} totals`}
+            cards={windowedCards}
+          />
+          <TelemetryCardSection
+            title="Current knowledge state"
+            ariaLabel={`${title} current state`}
+            cards={currentCards}
+          />
+          <TelemetryChartSection
+            title="Activity charts"
+            ariaLabel={`${title} charts`}
+            series={activitySeries}
+            from={snapshot.window.from}
+            to={snapshot.window.to}
+          />
+          <TelemetryChartSection
+            title="State history"
+            ariaLabel={`${title} state history`}
+            series={stateSeries}
+            from={snapshot.window.from}
+            to={snapshot.window.to}
+          />
         </>
       )}
     </div>
   );
 }
 
+function TelemetryCardSection({ title, ariaLabel, cards }: {
+  title: string;
+  ariaLabel: string;
+  cards: TelemetrySnapshot["cards"];
+}) {
+  if (cards.length === 0) {
+    return null;
+  }
+  return (
+    <section className="telemetry-section">
+      <h3>{title}</h3>
+      <div className="telemetry-card-grid" aria-label={ariaLabel}>
+        {cards.map((card) => (
+          <SummaryCard key={card.id} label={card.label} value={formatTelemetryCardValue(card)} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function TelemetryChartSection({ title, ariaLabel, series, from, to }: {
+  title: string;
+  ariaLabel: string;
+  series: TelemetrySnapshot["series"];
+  from: string;
+  to: string;
+}) {
+  if (series.length === 0) {
+    return null;
+  }
+  return (
+    <section className="telemetry-section">
+      <h3>{title}</h3>
+      <div className="telemetry-chart-grid" aria-label={ariaLabel}>
+        {series.map((item) => {
+          const samplePoints = Array.isArray(item.points) ? item.points : [];
+          const hasSamples = samplePoints.length > 0;
+          const chartPoints = telemetryChartPoints(samplePoints, from, to);
+
+          return (
+            <div className="telemetry-chart" key={item.id}>
+              <div className="telemetry-chart-head">
+                <h3>{item.label}</h3>
+                <span>{item.unit}</span>
+              </div>
+              <div className="telemetry-chart-body">
+                {!hasSamples && <div className="chart-empty-label">No samples</div>}
+                <ResponsiveContainer
+                  width="100%"
+                  height="100%"
+                  minWidth={280}
+                  minHeight={180}
+                  initialDimension={{ width: 640, height: 240 }}
+                >
+                  <LineChart data={chartPoints} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="timestamp"
+                      tickFormatter={formatTelemetryTick}
+                      tick={{ fill: "var(--muted)", fontSize: 11 }}
+                      minTickGap={28}
+                    />
+                    <YAxis
+                      width={44}
+                      tick={{ fill: "var(--muted)", fontSize: 11 }}
+                      tickFormatter={(value) => formatTelemetryAxisTick(Number(value), item.unit)}
+                      domain={telemetryYAxisDomain(samplePoints)}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        background: "var(--panel)",
+                        border: "1px solid var(--border)",
+                        borderRadius: 7,
+                        color: "var(--text)",
+                      }}
+                      labelFormatter={(label) => formatTelemetryTime(String(label))}
+                      formatter={(value) => [formatTelemetryValue(Number(value), item.unit), item.label]}
+                    />
+                    {hasSamples && (
+                      <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="var(--accent)"
+                        strokeWidth={2}
+                        dot={false}
+                        isAnimationActive={false}
+                      />
+                    )}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export function telemetryWindowedCards(snapshot: TelemetrySnapshot) {
+  if (Array.isArray(snapshot.windowed_cards)) {
+    return snapshot.windowed_cards;
+  }
+  return snapshot.cards.filter((card) => !currentStateCardIds.has(card.id));
+}
+
+export function telemetryCurrentCards(snapshot: TelemetrySnapshot) {
+  if (Array.isArray(snapshot.current_cards)) {
+    return snapshot.current_cards;
+  }
+  return snapshot.cards.filter((card) => currentStateCardIds.has(card.id));
+}
+
+export function telemetryActivitySeries(snapshot: TelemetrySnapshot) {
+  if (Array.isArray(snapshot.activity_series)) {
+    return snapshot.activity_series;
+  }
+  return snapshot.series.filter((series) => !currentStateCardIds.has(series.id));
+}
+
+export function telemetryStateSeries(snapshot: TelemetrySnapshot) {
+  if (Array.isArray(snapshot.state_series)) {
+    return snapshot.state_series;
+  }
+  return snapshot.series.filter((series) => currentStateCardIds.has(series.id));
+}
+
+export function formatTelemetryCardValue(card: Pick<TelemetrySnapshot["cards"][number], "available" | "unit" | "value">) {
+  if (card.available === false || !Number.isFinite(card.value)) {
+    return "No data";
+  }
+  return formatTelemetryValue(card.value, card.unit);
+}
+
 export function formatTelemetryValue(value: number, unit: string) {
+  if (!Number.isFinite(value)) {
+    return "No data";
+  }
   if (unit === "percent") {
     return `${value.toFixed(value >= 10 ? 0 : 1)}%`;
   }

--- a/web/src/telemetry/telemetry.css
+++ b/web/src/telemetry/telemetry.css
@@ -19,6 +19,17 @@
   margin-bottom: 16px;
 }
 
+.telemetry-section {
+  margin-top: 16px;
+}
+
+.telemetry-section > h3 {
+  margin: 0 0 10px;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.2;
+}
+
 .telemetry-chart-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/web/src/telemetry/types.ts
+++ b/web/src/telemetry/types.ts
@@ -19,6 +19,7 @@ export type TelemetryCard = {
   label: string;
   unit: string;
   value: number;
+  available?: boolean;
 };
 
 export type TelemetryPoint = {
@@ -39,7 +40,11 @@ export type TelemetrySnapshot = {
   window: TelemetryWindow;
   scope: TelemetryScope;
   cards: TelemetryCard[];
+  windowed_cards?: TelemetryCard[];
+  current_cards?: TelemetryCard[];
   series: TelemetrySeries[];
+  activity_series?: TelemetrySeries[];
+  state_series?: TelemetrySeries[];
 };
 
 export type ControlTelemetryQuery = {

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -30,12 +30,16 @@ type PrometheusQueryResponse = {
 };
 
 type TelemetryResponse = {
-  data?: {
-    available?: boolean;
-    cards?: unknown;
-    series?: unknown;
-  };
-};
+	  data?: {
+	    available?: boolean;
+	    cards?: unknown;
+	    windowed_cards?: unknown;
+	    current_cards?: unknown;
+	    series?: unknown;
+	    activity_series?: unknown;
+	    state_series?: unknown;
+	  };
+	};
 
 type TelemetryCard = {
   id?: string;
@@ -109,30 +113,44 @@ test("prometheus telemetry is scraped and rendered in control panel and user por
   const telemetryResponse = await request.get(`${userUrl}/ui/api/telemetry?window=15m`, { headers: bearer(seedApiKey) });
   expect(telemetryResponse.status()).toBe(200);
   const telemetryBody = await telemetryResponse.json() as TelemetryResponse;
-  expect(telemetryBody.data?.available).toBe(true);
-  expect(Array.isArray(telemetryBody.data?.cards)).toBe(true);
-  assertTelemetrySeries(telemetryBody);
-  const cardLabels = telemetryLabels(telemetryBody.data?.cards);
-  const seriesLabels = telemetryLabels(telemetryBody.data?.series);
-  expect(cardLabels.length).toBeGreaterThan(0);
-  expect(seriesLabels.length).toBeGreaterThan(0);
+	  expect(telemetryBody.data?.available).toBe(true);
+	  expect(Array.isArray(telemetryBody.data?.cards)).toBe(true);
+	  expect(Array.isArray(telemetryBody.data?.windowed_cards)).toBe(true);
+	  expect(Array.isArray(telemetryBody.data?.current_cards)).toBe(true);
+	  assertTelemetrySeries(telemetryBody);
+	  const windowedCardLabels = telemetryLabels(telemetryBody.data?.windowed_cards);
+	  const currentCardLabels = telemetryLabels(telemetryBody.data?.current_cards);
+	  const activitySeriesLabels = telemetryLabels(telemetryBody.data?.activity_series);
+	  const stateSeriesLabels = telemetryLabels(telemetryBody.data?.state_series);
+	  expect(windowedCardLabels.length).toBeGreaterThan(0);
+	  expect(currentCardLabels.length).toBeGreaterThan(0);
+	  expect(activitySeriesLabels.length).toBeGreaterThan(0);
+	  expect(stateSeriesLabels.length).toBeGreaterThan(0);
 
-  await openControlPanel(page);
-  await page.getByRole("button", { name: /^Metrics$/ }).click();
-  await expect(page.getByRole("heading", { name: "Telemetry" })).toBeVisible();
-  await expect(page.getByLabel("Telemetry totals")).toContainText("HTTP requests");
-  await expect(page.getByLabel("Telemetry charts")).toContainText("HTTP requests");
+	  await openControlPanel(page);
+	  await page.getByRole("button", { name: /^Metrics$/ }).click();
+	  await expect(page.getByRole("heading", { name: "Telemetry" })).toBeVisible();
+	  await expect(page.getByLabel("Telemetry totals")).toContainText("HTTP requests");
+	  await expect(page.getByLabel("Telemetry current state")).toContainText("Pending claims");
+	  await expect(page.getByLabel("Telemetry charts")).toContainText("HTTP requests");
+	  await expect(page.getByLabel("Telemetry state history")).toContainText("Pending claims");
 
-  await openUserPortal(page, seedApiKey);
-  await page.getByRole("button", { name: "Usage" }).click();
-  for (const label of cardLabels) {
-    await expect(page.getByLabel("Usage totals")).toContainText(label);
-  }
-  for (const label of seriesLabels) {
-    await expect(page.getByLabel("Usage charts")).toContainText(label);
-  }
-  await expectNoShellOverlap(page);
-});
+	  await openUserPortal(page, seedApiKey);
+	  await page.getByRole("button", { name: "Usage" }).click();
+	  for (const label of windowedCardLabels) {
+	    await expect(page.getByLabel("Usage totals")).toContainText(label);
+	  }
+	  for (const label of currentCardLabels) {
+	    await expect(page.getByLabel("Usage current state")).toContainText(label);
+	  }
+	  for (const label of activitySeriesLabels) {
+	    await expect(page.getByLabel("Usage charts")).toContainText(label);
+	  }
+	  for (const label of stateSeriesLabels) {
+	    await expect(page.getByLabel("Usage state history")).toContainText(label);
+	  }
+	  await expectNoShellOverlap(page);
+	});
 
 test("MCP recall feedback is submitted and surfaced through compose telemetry", async ({ page, request }) => {
   const recallFeedbackWasEnabled = await recallFeedbackEnabled(request);
@@ -447,11 +465,13 @@ function mcpToolPayload(response: Record<string, unknown>) {
 }
 
 function assertTelemetrySeries(body: TelemetryResponse) {
-  const series = body.data?.series;
-  expect(Array.isArray(series)).toBe(true);
-  if (!Array.isArray(series)) {
-    throw new Error("telemetry series must be an array");
-  }
+	const series = body.data?.series;
+	expect(Array.isArray(series)).toBe(true);
+	expect(Array.isArray(body.data?.activity_series)).toBe(true);
+	expect(Array.isArray(body.data?.state_series)).toBe(true);
+	if (!Array.isArray(series)) {
+		throw new Error("telemetry series must be an array");
+	}
   expect(series.length).toBeGreaterThan(0);
   for (const item of series) {
     expect(isRecord(item)).toBe(true);

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -163,6 +163,8 @@ const telemetrySeries = [
   ],
 }));
 
+const currentTelemetryIds = new Set(["pending_claims", "validated_claims", "disputed_claims", "revalidation_backlog"]);
+
 const telemetry = {
   available: true,
   window: {
@@ -174,7 +176,11 @@ const telemetry = {
   },
   scope: { type: "self", team_id: team.id, profile_id: readKey.id },
   cards: telemetryCards,
+  windowed_cards: telemetryCards.filter((card) => !currentTelemetryIds.has(card.id)),
+  current_cards: telemetryCards.filter((card) => currentTelemetryIds.has(card.id)),
   series: telemetrySeries,
+  activity_series: telemetrySeries.filter((series) => !currentTelemetryIds.has(series.id)),
+  state_series: telemetrySeries.filter((series) => currentTelemetryIds.has(series.id)),
 };
 
 test("API key login, recall, and read-only knowledge tabs", async ({ page }) => {
@@ -193,12 +199,20 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
 
   await page.getByRole("button", { name: "Usage" }).click();
   const usageTotals = page.getByLabel("Usage totals");
-  for (const card of telemetryCards) {
+  for (const card of telemetry.windowed_cards) {
     await expect(usageTotals).toContainText(card.label);
   }
+  const usageCurrentState = page.getByLabel("Usage current state");
+  for (const card of telemetry.current_cards) {
+    await expect(usageCurrentState).toContainText(card.label);
+  }
   const usageCharts = page.getByLabel("Usage charts");
-  for (const series of telemetrySeries) {
+  for (const series of telemetry.activity_series) {
     await expect(usageCharts).toContainText(series.label);
+  }
+  const usageStateHistory = page.getByLabel("Usage state history");
+  for (const series of telemetry.state_series) {
+    await expect(usageStateHistory).toContainText(series.label);
   }
 
   await page.getByRole("button", { name: "Facts" }).click();
@@ -232,7 +246,7 @@ test("write key regenerates only through the self-rotate endpoint", async ({ pag
   await page.getByRole("button", { name: /Regenerate key/i }).click();
 
   const details = page.getByLabel("Knowledge details");
-  await expect(details.getByText("dm_new_plaintext")).toBeVisible();
+  await expect(details.getByLabel("Generated API key")).toHaveValue("dm_new_plaintext");
   await expect(details.getByText("******new123")).toBeVisible();
   await expect.poll(() => page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBe("dm_new_plaintext");
   expect(calls.rotateBodies).toEqual(["{}"]);

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -140,6 +140,8 @@ const telemetrySeries = [
   ],
 }));
 
+const currentTelemetryIds = new Set(["pending_claims", "validated_claims", "disputed_claims", "revalidation_backlog"]);
+
 const telemetry = {
   available: true,
   window: {
@@ -151,7 +153,11 @@ const telemetry = {
   },
   scope: { type: "system" },
   cards: telemetryCards,
+  windowed_cards: telemetryCards.filter((card) => !currentTelemetryIds.has(card.id)),
+  current_cards: telemetryCards.filter((card) => currentTelemetryIds.has(card.id)),
   series: telemetrySeries,
+  activity_series: telemetrySeries.filter((series) => !currentTelemetryIds.has(series.id)),
+  state_series: telemetrySeries.filter((series) => currentTelemetryIds.has(series.id)),
 };
 
 const operationLogs = [
@@ -317,12 +323,20 @@ test("metrics tab renders operational totals and filter queries", async ({ page 
   await page.getByRole("button", { name: /^Metrics$/ }).click();
 
   const telemetryTotals = page.getByLabel("Telemetry totals");
-  for (const card of telemetryCards) {
+  for (const card of telemetry.windowed_cards) {
     await expect(telemetryTotals).toContainText(card.label);
   }
+  const telemetryCurrentState = page.getByLabel("Telemetry current state");
+  for (const card of telemetry.current_cards) {
+    await expect(telemetryCurrentState).toContainText(card.label);
+  }
   const telemetryCharts = page.getByLabel("Telemetry charts");
-  for (const series of telemetrySeries) {
+  for (const series of telemetry.activity_series) {
     await expect(telemetryCharts).toContainText(series.label);
+  }
+  const telemetryStateHistory = page.getByLabel("Telemetry state history");
+  for (const series of telemetry.state_series) {
+    await expect(telemetryStateHistory).toContainText(series.label);
   }
 
   const summary = page.getByLabel("Request metrics");


### PR DESCRIPTION
## Summary

- Split telemetry response data into windowed/current card groups and activity/state chart groups while keeping legacy `cards` and `series` populated.
- Mark empty or non-finite Prometheus scalar results as unavailable so the UI can show `No data` instead of conflating missing samples with real zeroes.
- Use sparse counter/histogram fallback queries for low-frequency telemetry cards and surface additional emitted Prometheus metrics.
- Include authenticated control portal API requests in Prometheus HTTP telemetry.
- Update telemetry dashboard, mock Playwright fixtures, compose checks, and focused Go/frontend tests.

## Verification

- `go test ./...`
- `npm test` in `web`
- `npm run build` in `web`
- `npm run playwright:mock` in `web`
- `npm run playwright` in `web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry metrics now display in categorized sections (usage totals, current state, charts, state history)
  * HTTP metrics included in telemetry collection
  * Unavailable telemetry values now display as "No data"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->