### PR TITLE
[codex] Fix user portal telemetry scoping

### DIFF
--- a/internal/http/control_portal_test.go
+++ b/internal/http/control_portal_test.go
@@ -275,9 +275,11 @@ type controlTelemetrySvc struct {
 	snapshot *service.TelemetrySnapshot
 	filter   service.TelemetryFilter
 	err      error
+	calls    int
 }
 
 func (s *controlTelemetrySvc) Snapshot(_ context.Context, filter service.TelemetryFilter) (*service.TelemetrySnapshot, error) {
+	s.calls++
 	s.filter = filter
 	if s.err != nil {
 		return nil, s.err

--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -74,7 +74,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 	api.Use(httpmw.RateLimitMiddleware(deps.RateLimitSvc, deps.Config, deps.AuditSvc))
 	api.Use(httpmw.LastUsedMiddleware(deps.APIKeyRepo))
 	api.GET("/session", portal.session)
-	api.GET("/telemetry", portal.telemetrySnapshot, httpmw.RequireScopes("read"))
+	api.GET("/telemetry", portal.telemetrySnapshot, httpmw.RequireScopes("write"))
 	api.POST("/key/rotate", portal.rotateCurrentKey, httpmw.RequireScopes("write"))
 	if deps.SSOService != nil {
 		api.POST("/sso/team", portal.switchSSOTeam, httpmw.RequireScopes("read"))
@@ -180,21 +180,9 @@ func (h *userPortalHandler) telemetrySnapshot(c echo.Context) error {
 		return httperr.New(httperr.FORBIDDEN, "authentication required")
 	}
 
-	scope := strings.TrimSpace(c.QueryParam("scope"))
-	if scope == "" {
-		scope = "self"
-	}
-	if scope != "self" {
-		return httperr.New(httperr.FORBIDDEN, "user portal telemetry is limited to the authenticated profile")
-	}
-
-	teamID := principal.GetTeamID()
-	profileID := principal.GetKeyID()
-	filter := service.TelemetryFilter{
-		Window:    strings.TrimSpace(c.QueryParam("window")),
-		Scope:     scope,
-		TeamID:    &teamID,
-		ProfileID: &profileID,
+	filter, err := userPortalTelemetryFilter(principal, c.QueryParam("window"), c.QueryParam("scope"))
+	if err != nil {
+		return err
 	}
 
 	snapshot, err := h.telemetry.Snapshot(ctx, filter)
@@ -202,6 +190,36 @@ func (h *userPortalHandler) telemetrySnapshot(c echo.Context) error {
 		return err
 	}
 	return c.JSON(nethttp.StatusOK, map[string]any{"data": snapshot})
+}
+
+func userPortalTelemetryFilter(principal *httpmw.Principal, window, requestedScope string) (service.TelemetryFilter, error) {
+	teamID := principal.GetTeamID()
+	if teamID == uuid.Nil {
+		return service.TelemetryFilter{}, httperr.New(httperr.FORBIDDEN, "authenticated key is not team bound")
+	}
+
+	scope := "self"
+	var profileID *uuid.UUID
+	if principal.GetRole() == service.APIKeyRoleManager {
+		scope = "team"
+	} else {
+		keyID := principal.GetKeyID()
+		if keyID == uuid.Nil {
+			return service.TelemetryFilter{}, httperr.New(httperr.FORBIDDEN, "authenticated key is not profile bound")
+		}
+		profileID = &keyID
+	}
+
+	if requested := strings.TrimSpace(requestedScope); requested != "" && requested != scope {
+		return service.TelemetryFilter{}, httperr.New(httperr.FORBIDDEN, "user portal telemetry scope is determined by the authenticated key")
+	}
+
+	return service.TelemetryFilter{
+		Window:    strings.TrimSpace(window),
+		Scope:     scope,
+		TeamID:    &teamID,
+		ProfileID: profileID,
+	}, nil
 }
 
 func (h *userPortalHandler) rotateCurrentKey(c echo.Context) error {

--- a/internal/http/user_portal_test.go
+++ b/internal/http/user_portal_test.go
@@ -191,10 +191,10 @@ func TestUserPortalSessionShowsOnlyAuthenticatedKey(t *testing.T) {
 	require.NotContains(t, rec.Body.String(), "Other")
 }
 
-func TestUserPortalTelemetry(t *testing.T) {
+func TestUserPortalTelemetryMemberUsesSelfScope(t *testing.T) {
 	teamID := uuid.New()
 	keyID := uuid.New()
-	authKey, rawKey := userPortalTestKey(t, teamID, keyID, "Mine", []string{"read"})
+	authKey, rawKey := userPortalTestKey(t, teamID, keyID, "Mine", []string{"read", "write"})
 	telemetry := &controlTelemetrySvc{snapshot: &service.TelemetrySnapshot{
 		Available: true,
 		Window:    service.TelemetryWindow{Key: "15m"},
@@ -212,6 +212,7 @@ func TestUserPortalTelemetry(t *testing.T) {
 	require.Equal(t, "self", telemetry.filter.Scope)
 	require.Equal(t, teamID, *telemetry.filter.TeamID)
 	require.Equal(t, keyID, *telemetry.filter.ProfileID)
+	require.Equal(t, 1, telemetry.calls)
 
 	req = httptest.NewRequest(http.MethodGet, "/ui/api/telemetry?window=30m&scope=team", nil)
 	req.Header.Set("Authorization", "Bearer "+rawKey)
@@ -221,17 +222,80 @@ func TestUserPortalTelemetry(t *testing.T) {
 	require.Equal(t, "15m", telemetry.filter.Window)
 	require.Equal(t, "self", telemetry.filter.Scope)
 	require.Equal(t, keyID, *telemetry.filter.ProfileID)
+	require.Equal(t, 1, telemetry.calls)
 
 	req = httptest.NewRequest(http.MethodGet, "/ui/api/telemetry?scope=profile", nil)
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, 1, telemetry.calls)
+}
 
-	noTelemetry := userPortalTestServer(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "")
-	req = httptest.NewRequest(http.MethodGet, "/ui/api/telemetry", nil)
+func TestUserPortalTelemetryManagerUsesTeamScope(t *testing.T) {
+	teamID := uuid.New()
+	keyID := uuid.New()
+	authKey, rawKey := userPortalTestKey(t, teamID, keyID, "Manager", []string{"read", "write"})
+	authKey.Role = service.APIKeyRoleManager
+	telemetry := &controlTelemetrySvc{snapshot: &service.TelemetrySnapshot{
+		Available: true,
+		Window:    service.TelemetryWindow{Key: "30m"},
+		Cards:     []service.TelemetryCard{{ID: "http_requests", Label: "HTTP requests", Unit: "requests", Value: 9}},
+	}}
+	server := userPortalTestServerWithTelemetry(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", telemetry)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/telemetry?window=30m", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"available":true`)
+	require.Equal(t, "30m", telemetry.filter.Window)
+	require.Equal(t, "team", telemetry.filter.Scope)
+	require.Equal(t, teamID, *telemetry.filter.TeamID)
+	require.Nil(t, telemetry.filter.ProfileID)
+	require.Equal(t, 1, telemetry.calls)
+
+	req = httptest.NewRequest(http.MethodGet, "/ui/api/telemetry?window=15m&scope=team", nil)
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "15m", telemetry.filter.Window)
+	require.Equal(t, "team", telemetry.filter.Scope)
+	require.Nil(t, telemetry.filter.ProfileID)
+	require.Equal(t, 2, telemetry.calls)
+
+	req = httptest.NewRequest(http.MethodGet, "/ui/api/telemetry?scope=self", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, 2, telemetry.calls)
+}
+
+func TestUserPortalTelemetryReadOnlyForbidden(t *testing.T) {
+	teamID := uuid.New()
+	authKey, rawKey := userPortalTestKey(t, teamID, uuid.New(), "Read only", []string{"read"})
+	telemetry := &controlTelemetrySvc{snapshot: &service.TelemetrySnapshot{Available: true}}
+	server := userPortalTestServerWithTelemetry(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", telemetry)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/telemetry", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, 0, telemetry.calls)
+}
+
+func TestUserPortalTelemetryUnavailable(t *testing.T) {
+	teamID := uuid.New()
+	authKey, rawKey := userPortalTestKey(t, teamID, uuid.New(), "Mine", []string{"read", "write"})
+
+	noTelemetry := userPortalTestServer(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "")
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/telemetry", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec := httptest.NewRecorder()
 	noTelemetry.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/web/src/telemetry/TelemetryDashboard.tsx
+++ b/web/src/telemetry/TelemetryDashboard.tsx
@@ -45,6 +45,7 @@ export function TelemetryDashboard({
   const currentCards = snapshot ? telemetryCurrentCards(snapshot) : [];
   const activitySeries = snapshot ? telemetryActivitySeries(snapshot) : [];
   const stateSeries = snapshot ? telemetryStateSeries(snapshot) : [];
+  const windowControlId = `${title.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-|-$/g, "") || "telemetry"}-telemetry-window`;
 
   return (
     <div className="telemetry-dashboard">
@@ -59,9 +60,9 @@ export function TelemetryDashboard({
       />
 
       <div className="metrics-toolbar telemetry-toolbar">
-        <label htmlFor={`${title}-telemetry-window`}>Telemetry range</label>
+        <label htmlFor={windowControlId}>Telemetry range</label>
         <select
-          id={`${title}-telemetry-window`}
+          id={windowControlId}
           value={windowKey}
           onChange={(event) => onWindowChange(event.target.value as TelemetryWindowKey)}
         >

--- a/web/src/telemetry/types.ts
+++ b/web/src/telemetry/types.ts
@@ -56,7 +56,6 @@ export type ControlTelemetryQuery = {
 
 export type UserTelemetryQuery = {
   window?: TelemetryWindowKey;
-  scope?: "self";
 };
 
 export const telemetryWindowOptions: { value: TelemetryWindowKey; label: string }[] = [

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -76,6 +76,37 @@ describe("UserPortalApp", () => {
     expect(await screen.findByRole("button", { name: /regenerate key/i })).toBeDisabled();
   });
 
+  it("hides usage telemetry for read-only keys", async () => {
+    const fetchMock = mockUserFetch(baseSession);
+    sessionStorage.setItem("denseMem.userApiKey", "dm_read");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+
+    expect(screen.queryByRole("button", { name: /usage/i })).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith("/ui/api/telemetry"))).toBe(false);
+  });
+
+  it("labels write-member telemetry as key usage", async () => {
+    const writeSession = {
+      ...baseSession,
+      key: { ...baseSession.key, scopes: ["read", "write"] },
+      can_rotate: true,
+    };
+    const fetchMock = mockUserFetch(writeSession);
+    sessionStorage.setItem("denseMem.userApiKey", "dm_write");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+    await userEvent.click(screen.getByRole("button", { name: /usage/i }));
+
+    expect(await screen.findByLabelText("My key usage totals")).toHaveTextContent("HTTP requests");
+    expect(screen.queryByLabelText("Team usage totals")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/ui/api/telemetry?window=1h", expect.any(Object));
+    });
+  });
+
   it("rotates the current write-scoped key and stores the replacement", async () => {
     const writeSession = {
       ...baseSession,
@@ -229,6 +260,32 @@ describe("UserPortalApp", () => {
     expect(await screen.findByText("Saved")).toBeInTheDocument();
   });
 
+  it("labels manager telemetry as team usage", async () => {
+    const managerSession: UserSession = {
+      ...baseSession,
+      key: {
+        ...baseSession.key,
+        name: "Manager",
+        scopes: ["read", "write"],
+        role: "manager",
+      },
+      can_rotate: true,
+      can_manage_team: true,
+    };
+    const fetchMock = mockUserFetch(managerSession, [{ ...managerSession.key }]);
+    sessionStorage.setItem("denseMem.userApiKey", "dm_manager");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+    await userEvent.click(screen.getByRole("button", { name: /usage/i }));
+
+    expect(await screen.findByLabelText("Team usage totals")).toHaveTextContent("HTTP requests");
+    expect(screen.queryByLabelText("My key usage totals")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/ui/api/telemetry?window=1h", expect.any(Object));
+    });
+  });
+
   it("uses server auth method for SSO cookie sessions and switches teams", async () => {
     const { initial, switched, secondKey } = ssoSessions();
     const fetchMock = mockSSOUserFetch(initial, switched);
@@ -358,6 +415,9 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = []) {
         },
       });
     }
+    if (url.startsWith("/ui/api/telemetry") && method === "GET") {
+      return jsonResponse({ data: telemetryForSession(session) });
+    }
     if (url === `/api/v1/teams/${currentTeam.id}` && method === "PATCH") {
       const body = JSON.parse(String(init?.body));
       currentTeam = { ...currentTeam, name: body.name ?? currentTeam.name, description: body.description ?? currentTeam.description, config: body.config ?? currentTeam.config };
@@ -405,6 +465,25 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = []) {
   });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+function telemetryForSession(session: UserSession) {
+  const teamScope = session.can_manage_team;
+  return {
+    available: true,
+    window: {
+      key: "1h",
+      from: "2026-05-02T12:00:00Z",
+      to: "2026-05-02T13:00:00Z",
+      step_seconds: 60,
+      retention_days: 30,
+    },
+    scope: teamScope
+      ? { type: "team", team_id: session.team.id }
+      : { type: "self", team_id: session.team.id, profile_id: session.key.id },
+    cards: [{ id: "http_requests", label: "HTTP requests", unit: "requests", value: 4 }],
+    series: [],
+  };
 }
 
 function ssoSessions() {

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -316,6 +316,46 @@ describe("UserPortalApp", () => {
     expect(sessionStorage.getItem("denseMem.userApiKey")).toBeNull();
   });
 
+  it("reloads usage telemetry after switching SSO teams", async () => {
+    const { initial, switched, secondKey } = ssoSessions();
+    const firstKey = { ...initial.key, scopes: ["read", "write"] };
+    const nextKey = { ...secondKey, scopes: ["read", "write"] };
+    const writeInitial: UserSession = {
+      ...initial,
+      key: firstKey,
+      can_rotate: true,
+      teams: [
+        { team: initial.team, key: firstKey, can_rotate: true, can_manage_team: false },
+        { team: switched.team, key: nextKey, can_rotate: true, can_manage_team: true },
+      ],
+    };
+    const writeSwitched: UserSession = {
+      ...switched,
+      key: nextKey,
+      can_rotate: true,
+      teams: writeInitial.teams,
+    };
+    const fetchMock = mockSSOUserFetch(writeInitial, writeSwitched);
+
+    render(<UserPortalApp />);
+
+    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /usage/i }));
+    expect(await screen.findByLabelText("My key usage totals")).toHaveTextContent("4");
+
+    await userEvent.selectOptions(screen.getByLabelText("Active team"), nextKey.id);
+
+    expect(await screen.findByRole("heading", { name: "Analytics Team" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Team usage totals")).toHaveTextContent("9");
+    });
+    expect(screen.queryByLabelText("My key usage totals")).not.toBeInTheDocument();
+    await waitFor(() => {
+      const telemetryCalls = fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/ui/api/telemetry?window=1h"));
+      expect(telemetryCalls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   it("keeps the SSO portal open when logout fails", async () => {
     const { initial, switched } = ssoSessions();
     mockSSOUserFetch(initial, switched, { logoutStatus: 500 });
@@ -481,7 +521,7 @@ function telemetryForSession(session: UserSession) {
     scope: teamScope
       ? { type: "team", team_id: session.team.id }
       : { type: "self", team_id: session.team.id, profile_id: session.key.id },
-    cards: [{ id: "http_requests", label: "HTTP requests", unit: "requests", value: 4 }],
+    cards: [{ id: "http_requests", label: "HTTP requests", unit: "requests", value: teamScope ? 9 : 4 }],
     series: [],
   };
 }
@@ -535,6 +575,9 @@ function mockSSOUserFetch(initial: UserSession, switched: UserSession, options: 
     if (url === "/ui/api/sso/team" && method === "POST") {
       current = switched;
       return jsonResponse({ data: current });
+    }
+    if (url.startsWith("/ui/api/telemetry") && method === "GET") {
+      return jsonResponse({ data: telemetryForSession(current) });
     }
     if (url === "/ui/api/sso/key" && method === "POST") {
       const body = JSON.parse(String(init?.body));

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -54,6 +54,14 @@ function canShowMyKey(session: UserSession | null): boolean {
   return !session.can_manage_team && (session.can_create_personal_key || Boolean(session.personal_key));
 }
 
+function canShowUsage(session: UserSession | null): boolean {
+  return Boolean(session?.key.scopes.includes("write"));
+}
+
+function userTelemetryTitle(session: UserSession): string {
+  return session.can_manage_team ? "Team usage" : "My key usage";
+}
+
 export function UserPortalApp() {
   const [token, setToken] = useState(() => sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? "");
   const [draftToken, setDraftToken] = useState(token);
@@ -279,10 +287,18 @@ function UserPortal({
     }
   }, [activeTab, session]);
 
+  useEffect(() => {
+    if (!canShowUsage(session) && activeTab === "usage") {
+      setActiveTab("search");
+    }
+  }, [activeTab, session]);
+
   const navItems = [
     { id: "search", label: "Recall", icon: <Search size={17} aria-hidden="true" />, active: activeTab === "search", onClick: () => setActiveTab("search") },
     { id: "dreams", label: "Dreams", icon: <Moon size={17} aria-hidden="true" />, active: activeTab === "dreams", onClick: () => setActiveTab("dreams") },
-    { id: "usage", label: "Usage", icon: <BarChart3 size={17} aria-hidden="true" />, active: activeTab === "usage", onClick: () => setActiveTab("usage") },
+    ...(canShowUsage(session) ? [
+      { id: "usage", label: "Usage", icon: <BarChart3 size={17} aria-hidden="true" />, active: activeTab === "usage", onClick: () => setActiveTab("usage") },
+    ] : []),
     { id: "facts", label: "Facts", icon: <ShieldCheck size={17} aria-hidden="true" />, active: activeTab === "facts", onClick: () => setActiveTab("facts") },
     { id: "claims", label: "Claims", icon: <GitBranch size={17} aria-hidden="true" />, active: activeTab === "claims", onClick: () => setActiveTab("claims") },
     { id: "fragments", label: "Fragments", icon: <FileText size={17} aria-hidden="true" />, active: activeTab === "fragments", onClick: () => setActiveTab("fragments") },
@@ -355,7 +371,7 @@ function UserPortal({
         <Suspense fallback={<LazyPanelFallback />}>
           {activeTab === "search" && <SearchPanel api={api} />}
           {activeTab === "dreams" && <UserDreamsPanel api={api} />}
-          {activeTab === "usage" && <UserTelemetryPanel api={api} />}
+          {activeTab === "usage" && session && canShowUsage(session) && <UserTelemetryPanel api={api} session={session} />}
           {activeTab === "facts" && <FactsPanel api={api} />}
           {activeTab === "claims" && <ClaimsPanel api={api} />}
           {activeTab === "fragments" && <FragmentsPanel api={api} />}
@@ -435,7 +451,7 @@ function LazyPanelFallback() {
   return <div className="table-placeholder">Loading</div>;
 }
 
-function UserTelemetryPanel({ api }: { api: UserApi }) {
+function UserTelemetryPanel({ api, session }: { api: UserApi; session: UserSession }) {
   const [snapshot, setSnapshot] = useState<TelemetrySnapshot | null>(null);
   const [windowKey, setWindowKey] = useState<TelemetryWindowKey>("1h");
   const [error, setError] = useState("");
@@ -460,7 +476,7 @@ function UserTelemetryPanel({ api }: { api: UserApi }) {
   return (
     <section className="surface">
       <TelemetryDashboard
-        title="Usage"
+        title={userTelemetryTitle(session)}
         snapshot={snapshot}
         windowKey={windowKey}
         loading={loading}

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -62,6 +62,11 @@ function userTelemetryTitle(session: UserSession): string {
   return session.can_manage_team ? "Team usage" : "My key usage";
 }
 
+function userTelemetryIdentity(session: UserSession): string {
+  const scope = session.can_manage_team ? "team" : "self";
+  return `${scope}:${session.team.id}:${session.key.id}`;
+}
+
 export function UserPortalApp() {
   const [token, setToken] = useState(() => sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? "");
   const [draftToken, setDraftToken] = useState(token);
@@ -371,7 +376,9 @@ function UserPortal({
         <Suspense fallback={<LazyPanelFallback />}>
           {activeTab === "search" && <SearchPanel api={api} />}
           {activeTab === "dreams" && <UserDreamsPanel api={api} />}
-          {activeTab === "usage" && session && canShowUsage(session) && <UserTelemetryPanel api={api} session={session} />}
+          {activeTab === "usage" && session && canShowUsage(session) && (
+            <UserTelemetryPanel key={userTelemetryIdentity(session)} api={api} session={session} />
+          )}
           {activeTab === "facts" && <FactsPanel api={api} />}
           {activeTab === "claims" && <ClaimsPanel api={api} />}
           {activeTab === "fragments" && <FragmentsPanel api={api} />}

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -41,7 +41,7 @@ describe("UserApi", () => {
     }));
   });
 
-  it("requests self-scoped telemetry", async () => {
+  it("requests role-derived telemetry", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: {
         available: true,

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -310,9 +310,6 @@ export class UserApi {
     if (query.window) {
       params.set("window", query.window);
     }
-    if (query.scope) {
-      params.set("scope", query.scope);
-    }
     const suffix = params.toString() ? `?${params.toString()}` : "";
     const payload = await this.request<Envelope<TelemetrySnapshot>>(`/ui/api/telemetry${suffix}`);
     return payload.data;

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -30,16 +30,35 @@ type PrometheusQueryResponse = {
 };
 
 type TelemetryResponse = {
-	  data?: {
-	    available?: boolean;
-	    cards?: unknown;
-	    windowed_cards?: unknown;
-	    current_cards?: unknown;
-	    series?: unknown;
-	    activity_series?: unknown;
-	    state_series?: unknown;
-	  };
-	};
+  data?: {
+    available?: boolean;
+    scope?: {
+      type?: string;
+      team_id?: string;
+      profile_id?: string;
+    };
+    cards?: unknown;
+    windowed_cards?: unknown;
+    current_cards?: unknown;
+    series?: unknown;
+    activity_series?: unknown;
+    state_series?: unknown;
+  };
+};
+
+type UserSessionResponse = {
+  data?: {
+    can_manage_team?: boolean;
+    key?: {
+      id?: string;
+      scopes?: string[];
+      role?: string;
+    };
+    team?: {
+      id?: string;
+    };
+  };
+};
 
 type TelemetryCard = {
   id?: string;
@@ -101,6 +120,10 @@ test("control panel keeps security settings display-only against compose", async
 test("prometheus telemetry is scraped and rendered in control panel and user portal", async ({ page, request }) => {
   const sessionResponse = await request.get(`${userUrl}/ui/api/session`, { headers: bearer(seedApiKey) });
   expect(sessionResponse.status()).toBe(200);
+  const sessionBody = await sessionResponse.json() as UserSessionResponse;
+  expect(sessionBody.data?.key?.scopes).toEqual(expect.arrayContaining(["write"]));
+  const expectedScope = sessionBody.data?.can_manage_team ? "team" : "self";
+  const expectedUsageTitle = sessionBody.data?.can_manage_team ? "Team usage" : "My key usage";
 
   await expect.poll(
     () => prometheusResultCount(request, `densemem_http_requests_total{route="/ui/api/session"}`),
@@ -113,44 +136,49 @@ test("prometheus telemetry is scraped and rendered in control panel and user por
   const telemetryResponse = await request.get(`${userUrl}/ui/api/telemetry?window=15m`, { headers: bearer(seedApiKey) });
   expect(telemetryResponse.status()).toBe(200);
   const telemetryBody = await telemetryResponse.json() as TelemetryResponse;
-	  expect(telemetryBody.data?.available).toBe(true);
-	  expect(Array.isArray(telemetryBody.data?.cards)).toBe(true);
-	  expect(Array.isArray(telemetryBody.data?.windowed_cards)).toBe(true);
-	  expect(Array.isArray(telemetryBody.data?.current_cards)).toBe(true);
-	  assertTelemetrySeries(telemetryBody);
-	  const windowedCardLabels = telemetryLabels(telemetryBody.data?.windowed_cards);
-	  const currentCardLabels = telemetryLabels(telemetryBody.data?.current_cards);
-	  const activitySeriesLabels = telemetryLabels(telemetryBody.data?.activity_series);
-	  const stateSeriesLabels = telemetryLabels(telemetryBody.data?.state_series);
-	  expect(windowedCardLabels.length).toBeGreaterThan(0);
-	  expect(currentCardLabels.length).toBeGreaterThan(0);
-	  expect(activitySeriesLabels.length).toBeGreaterThan(0);
-	  expect(stateSeriesLabels.length).toBeGreaterThan(0);
+  expect(telemetryBody.data?.available).toBe(true);
+  expect(telemetryBody.data?.scope?.type).toBe(expectedScope);
+  expect(telemetryBody.data?.scope?.team_id).toBe(sessionBody.data?.team?.id);
+  if (expectedScope === "self") {
+    expect(telemetryBody.data?.scope?.profile_id).toBe(sessionBody.data?.key?.id);
+  }
+  expect(Array.isArray(telemetryBody.data?.cards)).toBe(true);
+  expect(Array.isArray(telemetryBody.data?.windowed_cards)).toBe(true);
+  expect(Array.isArray(telemetryBody.data?.current_cards)).toBe(true);
+  assertTelemetrySeries(telemetryBody);
+  const windowedCardLabels = telemetryLabels(telemetryBody.data?.windowed_cards);
+  const currentCardLabels = telemetryLabels(telemetryBody.data?.current_cards);
+  const activitySeriesLabels = telemetryLabels(telemetryBody.data?.activity_series);
+  const stateSeriesLabels = telemetryLabels(telemetryBody.data?.state_series);
+  expect(windowedCardLabels.length).toBeGreaterThan(0);
+  expect(currentCardLabels.length).toBeGreaterThan(0);
+  expect(activitySeriesLabels.length).toBeGreaterThan(0);
+  expect(stateSeriesLabels.length).toBeGreaterThan(0);
 
-	  await openControlPanel(page);
-	  await page.getByRole("button", { name: /^Metrics$/ }).click();
-	  await expect(page.getByRole("heading", { name: "Telemetry" })).toBeVisible();
-	  await expect(page.getByLabel("Telemetry totals")).toContainText("HTTP requests");
-	  await expect(page.getByLabel("Telemetry current state")).toContainText("Pending claims");
-	  await expect(page.getByLabel("Telemetry charts")).toContainText("HTTP requests");
-	  await expect(page.getByLabel("Telemetry state history")).toContainText("Pending claims");
+  await openControlPanel(page);
+  await page.getByRole("button", { name: /^Metrics$/ }).click();
+  await expect(page.getByRole("heading", { name: "Telemetry" })).toBeVisible();
+  await expect(page.getByLabel("Telemetry totals")).toContainText("HTTP requests");
+  await expect(page.getByLabel("Telemetry current state")).toContainText("Pending claims");
+  await expect(page.getByLabel("Telemetry charts")).toContainText("HTTP requests");
+  await expect(page.getByLabel("Telemetry state history")).toContainText("Pending claims");
 
-	  await openUserPortal(page, seedApiKey);
-	  await page.getByRole("button", { name: "Usage" }).click();
-	  for (const label of windowedCardLabels) {
-	    await expect(page.getByLabel("Usage totals")).toContainText(label);
-	  }
-	  for (const label of currentCardLabels) {
-	    await expect(page.getByLabel("Usage current state")).toContainText(label);
-	  }
-	  for (const label of activitySeriesLabels) {
-	    await expect(page.getByLabel("Usage charts")).toContainText(label);
-	  }
-	  for (const label of stateSeriesLabels) {
-	    await expect(page.getByLabel("Usage state history")).toContainText(label);
-	  }
-	  await expectNoShellOverlap(page);
-	});
+  await openUserPortal(page, seedApiKey);
+  await page.getByRole("button", { name: "Usage" }).click();
+  for (const label of windowedCardLabels) {
+    await expect(page.getByLabel(`${expectedUsageTitle} totals`)).toContainText(label);
+  }
+  for (const label of currentCardLabels) {
+    await expect(page.getByLabel(`${expectedUsageTitle} current state`)).toContainText(label);
+  }
+  for (const label of activitySeriesLabels) {
+    await expect(page.getByLabel(`${expectedUsageTitle} charts`)).toContainText(label);
+  }
+  for (const label of stateSeriesLabels) {
+    await expect(page.getByLabel(`${expectedUsageTitle} state history`)).toContainText(label);
+  }
+  await expectNoShellOverlap(page);
+});
 
 test("MCP recall feedback is submitted and surfaced through compose telemetry", async ({ page, request }) => {
   const recallFeedbackWasEnabled = await recallFeedbackEnabled(request);
@@ -253,7 +281,8 @@ test("MCP recall feedback is submitted and surfaced through compose telemetry", 
 
     await openUserPortal(page, seedApiKey);
     await page.getByRole("button", { name: "Usage" }).click();
-    const usageTotals = page.getByLabel("Usage totals");
+    const usageTitle = await userUsageTitle(request, seedApiKey);
+    const usageTotals = page.getByLabel(`${usageTitle} totals`);
     await expect(usageTotals).toContainText("LLM recall used");
     await expect(usageTotals).toContainText("LLM answer supported");
     await expect(usageTotals).toContainText("LLM recall quality");
@@ -293,9 +322,13 @@ test("read-only user key cannot regenerate itself", async ({ page, request }, te
   const readOnly = await createTeamProfile(request, uniqueName("Read only", testInfo), ["read"]);
 
   await openUserPortal(page, readOnly.api_key);
+  await expect(page.getByRole("button", { name: "Usage" })).toHaveCount(0);
   await page.getByRole("button", { name: /My key/i }).click();
 
   await expect(page.getByRole("button", { name: /Regenerate key/i })).toBeDisabled();
+
+  const telemetryResponse = await request.get(`${userUrl}/ui/api/telemetry?window=15m`, { headers: bearer(readOnly.api_key) });
+  expect(telemetryResponse.status()).toBe(403);
 });
 
 test("write user key regenerates itself and invalidates the old key", async ({ page, request }, testInfo) => {
@@ -497,6 +530,15 @@ async function userTelemetry(request: APIRequestContext) {
     throw new Error(`user telemetry failed: ${response.status()} ${await response.text()}`);
   }
   return await response.json() as TelemetryResponse;
+}
+
+async function userUsageTitle(request: APIRequestContext, apiKey: string) {
+  const response = await request.get(`${userUrl}/ui/api/session`, { headers: bearer(apiKey) });
+  if (response.status() !== 200) {
+    throw new Error(`user session failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = await response.json() as UserSessionResponse;
+  return body.data?.can_manage_team ? "Team usage" : "My key usage";
 }
 
 async function telemetryCardValue(request: APIRequestContext, id: string) {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -197,23 +197,7 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await expect(page.getByText("project-x").first()).toBeVisible();
   await expect(page.getByText("Dense-Mem").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "Usage" }).click();
-  const usageTotals = page.getByLabel("Usage totals");
-  for (const card of telemetry.windowed_cards) {
-    await expect(usageTotals).toContainText(card.label);
-  }
-  const usageCurrentState = page.getByLabel("Usage current state");
-  for (const card of telemetry.current_cards) {
-    await expect(usageCurrentState).toContainText(card.label);
-  }
-  const usageCharts = page.getByLabel("Usage charts");
-  for (const series of telemetry.activity_series) {
-    await expect(usageCharts).toContainText(series.label);
-  }
-  const usageStateHistory = page.getByLabel("Usage state history");
-  for (const series of telemetry.state_series) {
-    await expect(usageStateHistory).toContainText(series.label);
-  }
+  await expect(page.getByRole("button", { name: "Usage" })).toHaveCount(0);
 
   await page.getByRole("button", { name: "Facts" }).click();
   await expect(page.getByText("works_on: project-x")).toBeVisible();
@@ -227,6 +211,7 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await page.getByRole("button", { name: "Communities" }).click();
   await expect(page.getByText("Project work around Dense-Mem.")).toBeVisible();
   expect(calls.disallowedProfileCalls).toEqual([]);
+  expect(calls.telemetryRequests).toEqual([]);
 });
 
 test("read-only key cannot regenerate itself", async ({ page }) => {
@@ -251,6 +236,34 @@ test("write key regenerates only through the self-rotate endpoint", async ({ pag
   await expect.poll(() => page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBe("dm_new_plaintext");
   expect(calls.rotateBodies).toEqual(["{}"]);
   expect(calls.disallowedProfileCalls).toEqual([]);
+});
+
+test("write member key shows own usage telemetry", async ({ page }) => {
+  const calls = await mockUserApi(page, { key: writeKey, canRotate: true });
+  await openUserPortal(page, "dm_write");
+
+  await page.getByRole("button", { name: "Usage" }).click();
+  await expectUsageDashboard(page, "My key usage", telemetry);
+  expect(calls.telemetryRequests.length).toBeGreaterThan(0);
+  expect(calls.telemetryRequests.every((url) => url.includes("/ui/api/telemetry?window=1h"))).toBe(true);
+  expect(calls.telemetryRequests.every((url) => !url.includes("scope="))).toBe(true);
+  expect(calls.disallowedProfileCalls).toEqual([]);
+});
+
+test("manager key shows team usage telemetry", async ({ page }) => {
+  const calls = await mockUserApi(page, {
+    key: managerKey,
+    canManageTeam: true,
+    canRotate: true,
+    profiles: [managerKey, memberProfile],
+  });
+  await openUserPortal(page, "dm_manager");
+
+  await page.getByRole("button", { name: "Usage" }).click();
+  await expectUsageDashboard(page, "Team usage", telemetry);
+  expect(calls.telemetryRequests.length).toBeGreaterThan(0);
+  expect(calls.telemetryRequests.every((url) => url.includes("/ui/api/telemetry?window=1h"))).toBe(true);
+  expect(calls.telemetryRequests.every((url) => !url.includes("scope="))).toBe(true);
 });
 
 test("invalid API key shows login error", async ({ page }) => {
@@ -353,6 +366,25 @@ async function expectNoShellOverlap(page: Page) {
   }
 }
 
+async function expectUsageDashboard(page: Page, title: string, snapshot: typeof telemetry) {
+  const usageTotals = page.getByLabel(`${title} totals`);
+  for (const card of snapshot.windowed_cards) {
+    await expect(usageTotals).toContainText(card.label);
+  }
+  const usageCurrentState = page.getByLabel(`${title} current state`);
+  for (const card of snapshot.current_cards) {
+    await expect(usageCurrentState).toContainText(card.label);
+  }
+  const usageCharts = page.getByLabel(`${title} charts`);
+  for (const series of snapshot.activity_series) {
+    await expect(usageCharts).toContainText(series.label);
+  }
+  const usageStateHistory = page.getByLabel(`${title} state history`);
+  for (const series of snapshot.state_series) {
+    await expect(usageStateHistory).toContainText(series.label);
+  }
+}
+
 function rectanglesOverlap(
   first: { left: number; top: number; right: number; bottom: number },
   second: { left: number; top: number; right: number; bottom: number },
@@ -367,6 +399,7 @@ async function mockUserApi(
   const calls = {
     rotateBodies: [] as string[],
     disallowedProfileCalls: [] as string[],
+    telemetryRequests: [] as string[],
   };
   let currentTeam = { ...team };
   let currentKey = { ...state.key };
@@ -461,10 +494,11 @@ async function mockUserApi(
   });
 
   await page.route("**/ui/api/telemetry**", async (route) => {
+    calls.telemetryRequests.push(route.request().url());
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ data: telemetry }),
+      body: JSON.stringify({ data: telemetryForKey(currentKey) }),
     });
   });
 
@@ -499,4 +533,13 @@ async function mockUserApi(
   });
 
   return calls;
+}
+
+function telemetryForKey(key: TestKey) {
+  return {
+    ...telemetry,
+    scope: key.role === "manager"
+      ? { type: "team", team_id: team.id }
+      : { type: "self", team_id: team.id, profile_id: key.id },
+  };
 }


### PR DESCRIPTION
## Summary

- derive `/ui/api/telemetry` scope from the authenticated key instead of forcing every user portal request to `self`
- require `write` scope for user-portal telemetry so read-only keys do not see or access metrics
- label the user telemetry dashboard as `Team usage` for managers and `My key usage` for write-capable members
- add backend, React, mocked Playwright, and compose-backed e2e coverage for manager/team, member/self, and read-only-denied behavior

## Root Cause

The user portal telemetry endpoint always built a `TelemetryFilter` with `Scope: "self"` and the authenticated key ID. That made manager sessions see only the current key/profile metrics, even when the selected team had broader 30-day telemetry in Prometheus.

## Validation

- `go test ./internal/http/... ./internal/service`
- `npm run typecheck`
- `npm test -- src/user/App.test.tsx src/user/api.test.ts src/telemetry/TelemetryDashboard.test.tsx`
- `npm run playwright:mock`
- `npm run playwright`
- `go test ./...`
- `npm test`

The branch push also passed the local pre-push hooks, including text lint, Go tests, and coverage threshold checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based telemetry viewing: members see their own key usage totals, while managers see team usage totals.
  * Usage dashboard access is gated by write-scoped API keys.

* **Changes**
  * Telemetry API access now requires `write` scope (instead of `read`).
  * Telemetry scope is determined server-side from the authenticated role; the UI no longer sends a `scope` query parameter.
  * Usage tab label text now reflects the expected identity (“My key usage” vs “Team usage”).

* **Bug Fixes / Tests**
  * Updated UI and integration tests to assert correct telemetry behavior per role and permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->