### PR TITLE
[codex] Make skill export prompt portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ The older `*_skill_pack*` tool names remain accepted as hidden compatibility
 aliases, but new clients should use `*_memory_pack*`. Dense-Mem also exposes MCP
 prompts through `prompts/list` and `prompts/get`; the first bundled prompt,
 `export_memory_as_agent_skill`, guides an LLM to recall Dense-Mem experience and
-draft a shareable Agent Skill `SKILL.md` file without relying on memory-pack
+draft a self-contained, shareable Agent Skill `SKILL.md` file for recipients
+without access to the source memory instance, and without relying on memory-pack
 import/export.
 
 Memory moves through this path:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,8 +231,9 @@ Dense-Mem 不是 agent brain、planner，也不是外部真相裁判。它负责
 旧的 `*_skill_pack*` tool names 仍会作为隐藏兼容 alias 被接受，但新客户端应使用
 `*_memory_pack*`。Dense-Mem 也通过 `prompts/list` 和 `prompts/get` 暴露 MCP
 prompts；首个内置 prompt `export_memory_as_agent_skill` 会引导 LLM recall
-Dense-Mem 经验，并草拟可分享的 Agent Skill `SKILL.md` 文件，不依赖
-memory-pack import/export。
+Dense-Mem 经验，并草拟自包含、可分享的 Agent Skill `SKILL.md` 文件，
+让没有源 memory instance 访问权限的接收方也能使用，且不依赖 memory-pack
+import/export。
 
 记忆在系统里的主路径如下：
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -220,7 +220,16 @@ func TestMCP_PromptsListAndGet(t *testing.T) {
 		t.Fatalf("messages = %+v", getPayload.Messages)
 	}
 	text := getPayload.Messages[0].Content.Text
-	for _, want := range []string{"review workflows", "review-workflows", "SKILL.md", "Exclude secrets"} {
+	for _, want := range []string{
+		"review workflows",
+		"review-workflows",
+		"SKILL.md",
+		"Exclude secrets",
+		"self-contained",
+		"recipients who do not have access",
+		"Do not tell the generated skill to query Dense-Mem",
+		"portability and privacy checks",
+	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("rendered prompt missing %q: %s", want, text)
 		}

--- a/internal/promptcatalog/catalog_test.go
+++ b/internal/promptcatalog/catalog_test.go
@@ -42,7 +42,16 @@ func TestDefaultCatalogRenderValidatesAndRenders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	for _, want := range []string{"incident response", "incident-response", "internal runbooks only", "SKILL.md"} {
+	for _, want := range []string{
+		"incident response",
+		"incident-response",
+		"internal runbooks only",
+		"SKILL.md",
+		"self-contained",
+		"recipients who do not have access",
+		"Do not tell the generated skill to query Dense-Mem",
+		"portability and privacy checks",
+	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("rendered text missing %q: %s", want, text)
 		}

--- a/internal/promptcatalog/prompts/export_memory_as_agent_skill.md
+++ b/internal/promptcatalog/prompts/export_memory_as_agent_skill.md
@@ -1,18 +1,22 @@
-Use Dense-Mem to turn durable experience about "{{.topic}}" into a shareable Agent Skill file.
+Use Dense-Mem to turn durable experience about "{{.topic}}" into a self-contained, shareable Agent Skill file.
 
 {{if .skill_name}}Target skill name: {{.skill_name}}
 {{end}}{{if .scope_notes}}Scope notes: {{.scope_notes}}
 {{end}}
 Workflow:
 1. Recall relevant Dense-Mem context for the topic before drafting.
-2. Use only durable preferences, corrections, project decisions, proven workflows, and reusable instructions that are relevant to this skill.
-3. Exclude secrets, credentials, private personal details, temporary task state, speculation, and anything the user has not approved for sharing.
-4. Draft one `SKILL.md` compatible with the open Agent Skills format:
+2. Distill the recalled context into concrete rules, workflows, examples, constraints, validation steps, and failure handling that can live inside the skill.
+3. Make the generated skill portable for recipients who do not have access to the source Dense-Mem instance or MCP server.
+4. Do not tell the generated skill to query Dense-Mem, a memory MCP, or the source memory store during normal execution. Mention source memory only as optional provenance or review context outside the skill content.
+5. Use only durable preferences, corrections, project decisions, proven workflows, and reusable instructions that are relevant to this skill.
+6. Exclude secrets, credentials, private personal details, temporary task state, speculation, and anything the user has not approved for sharing.
+7. Draft one `SKILL.md` compatible with the open Agent Skills format:
    - YAML front matter with `name` and `description`.
    - Clear trigger boundaries in the description.
    - Imperative workflow steps the agent can follow.
    - Any required inputs, outputs, tools, verification steps, and failure handling.
-5. If supporting references are needed, include their filenames and short contents after the `SKILL.md` block.
-6. End with a short review checklist for the user to approve before sharing the file.
+   - Enough embedded detail that the skill remains useful without private memory access.
+8. If supporting references are needed, include their filenames and complete shareable contents after the `SKILL.md` block.
+9. End with a short review checklist for the user to approve before sharing the file, including portability and privacy checks.
 
 Return the skill content as markdown code blocks. Do not import the generated skill into memory automatically.


### PR DESCRIPTION
## Summary

- Strengthen `export_memory_as_agent_skill` so generated skills must be self-contained and portable without source Dense-Mem/MCP access.
- Document the portability contract in the English and Chinese READMEs.
- Add prompt rendering assertions so the self-contained/no-runtime-memory-query behavior is covered by tests.

## Validation

- `go test ./internal/promptcatalog ./internal/mcp`
- Pre-push hook ran textlint, Go tests, and coverage; total coverage reported 90.2% against the 90.0% threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the `export_memory_as_agent_skill` feature, clarifying that generated skills are self-contained and portable without requiring access to the source memory instance.
  * Expanded guidance on excluding sensitive information when creating shareable skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->