### PR TITLE
[codex] Redesign resource explorer UI

### DIFF
--- a/web/src/App.recall-feedback.test.tsx
+++ b/web/src/App.recall-feedback.test.tsx
@@ -130,7 +130,7 @@ it("shows recall feedback query, params, result ids, and resolved state", async 
 
   render(<App />);
   await screen.findByRole("button", { name: /Default/ });
-  await userEvent.click(screen.getByRole("button", { name: /^recall feedback$/i }));
+  await userEvent.click(screen.getByRole("button", { name: /^feedback$/i }));
 
   expect(await screen.findByText("Why was recall bad?")).toBeInTheDocument();
   expect(screen.queryByText("Pending recall waiting")).not.toBeInTheDocument();

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -516,6 +516,18 @@ describe("App", () => {
     });
   });
 
+  it("marks team overview metrics unavailable when metrics cannot load", async () => {
+    mockPortalFetch({ teams: [profileA], keys: [keyA()], metrics: "error" });
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    await screen.findByRole("button", { name: /Default/ });
+
+    expect(await screen.findByLabelText("Team overview")).toHaveTextContent("Metrics unavailable");
+    expect(screen.getByLabelText("Team activity")).toHaveTextContent("unavailable");
+    expect(screen.getByLabelText("Top signals")).toHaveTextContent("n/a");
+  });
+
   it("shows operation log details, raw log expansion, and page size selection", async () => {
     const fetchMock = mockPortalFetch({ teams: [profileA], keys: [keyA()] });
     sessionStorage.setItem("denseMem.controlToken", "secret");
@@ -734,6 +746,7 @@ function mockPortalFetch({
   bans = [],
   logs = operationLogsSnapshot,
   dreams = [dreamSnapshot],
+  metrics = metricsSnapshot,
 }: {
   teams: Team[];
   keys: TeamProfile[];
@@ -741,6 +754,7 @@ function mockPortalFetch({
   bans?: SecurityBan[];
   logs?: OperationLog[];
   dreams?: Dream[];
+  metrics?: ControlMetrics | "error";
 }) {
   let currentProfiles = teams;
   let currentKeys = keys;
@@ -762,7 +776,10 @@ function mockPortalFetch({
       return jsonResponse({ data: telemetrySnapshot });
     }
     if (url.includes("/metrics") && method === "GET") {
-      return jsonResponse({ data: metricsSnapshot });
+      if (metrics === "error") {
+        return jsonResponse({ code: "METRICS_UNAVAILABLE", message: "metrics unavailable", details: null }, 503);
+      }
+      return jsonResponse({ data: metrics });
     }
     if (url.endsWith("/config/general") && method === "GET") {
       return jsonResponse({ data: currentGeneralConfig });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -299,7 +299,8 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
-    await userEvent.type(screen.getByLabelText("Name", { selector: "#new-team-name" }), "ab");
+    await userEvent.click(screen.getByRole("button", { name: "New Team" }));
+    await userEvent.type(screen.getByLabelText("Name", { selector: "input#new-team-name" }), "ab");
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Name must be at least 3 characters.");
@@ -317,8 +318,9 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
-    await userEvent.type(screen.getByLabelText("Name", { selector: "#new-team-name" }), "Work Team");
-    await userEvent.type(screen.getByLabelText("Description", { selector: "#new-team-description" }), "for work");
+    await userEvent.click(screen.getByRole("button", { name: "New Team" }));
+    await userEvent.type(screen.getByLabelText("Name", { selector: "input#new-team-name" }), "Work Team");
+    await userEvent.type(screen.getByLabelText("Description", { selector: "input#new-team-description" }), "for work");
     await userEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
     expect(await screen.findByRole("heading", { name: "Work Team" })).toBeInTheDocument();

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -332,7 +332,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
-    await userEvent.click(screen.getByRole("button", { name: /profiles & api keys/i }));
+    await userEvent.click(screen.getByRole("button", { name: /team profiles/i }));
     await userEvent.click(screen.getByRole("button", { name: /create profile/i }));
 
     expect(await screen.findByDisplayValue("dm_plain_once")).toHaveAccessibleName("Generated API key");
@@ -365,6 +365,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
+    await userEvent.click(screen.getByRole("button", { name: /team settings/i }));
 
     const teamName = screen.getByLabelText("Name", { selector: "#team-name" });
     await userEvent.clear(teamName);
@@ -372,7 +373,7 @@ describe("App", () => {
     await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
     expect(await screen.findByRole("heading", { name: "Renamed Team" })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /profiles & api keys/i }));
+    await userEvent.click(screen.getByRole("button", { name: /team profiles/i }));
     const profileName = await screen.findByLabelText("Profile name default profile");
     await userEvent.clear(profileName);
     await userEvent.type(profileName, "Research profile");
@@ -425,6 +426,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
+    await userEvent.click(screen.getByRole("button", { name: /team settings/i }));
 
     const scheduledToggle = screen.getByLabelText("Scheduled cycle", { selector: "input" });
     expect(scheduledToggle).not.toBeChecked();
@@ -450,7 +452,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
-    await userEvent.click(screen.getByRole("button", { name: /profiles & api keys/i }));
+    await userEvent.click(screen.getByRole("button", { name: /team profiles/i }));
 
     expect(await screen.findByText("******abc123")).toBeInTheDocument();
     const keyRow = screen.getByText("******abc123").closest("tr");
@@ -546,7 +548,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
-    await userEvent.click(screen.getByRole("button", { name: /^dreams$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /team dreams/i }));
 
     expect(await screen.findByText("A may affect B.")).toBeInTheDocument();
     expect(screen.getByLabelText("Dreaming status")).toHaveTextContent("Global force");
@@ -716,6 +718,7 @@ describe("App", () => {
 
     render(<App />);
     await screen.findByRole("button", { name: /Default/ });
+    await userEvent.click(screen.getByRole("button", { name: /team settings/i }));
     await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,8 @@ import {
   Team,
   TeamProfile,
 } from "./api";
+import { TeamOverviewPanel, TeamWorkspaceShell } from "./control/TeamWorkspace";
+import type { TeamWorkspaceTab } from "./control/TeamWorkspace";
 import { TeamDreamingConfigForm } from "./teamDreamingConfig";
 import { displayKeySuffix, formatDate, profilePermissionLabel, profileRoleLabel, readError, shortId } from "./control/utils";
 import { AuthShell, PortalShell, SecretBox, SectionHeading } from "./ui/components";
@@ -89,7 +91,7 @@ export function App() {
       <AuthShell
         theme={theme}
         title="Dense-Mem Control"
-        icon={<ShieldCheck size={20} aria-hidden="true" />}
+        icon={<span className="brand-initials" aria-hidden="true">DM</span>}
         onSubmit={submitToken}
         actions={(
           <button
@@ -136,6 +138,7 @@ function Portal({
   const [teams, setTeams] = useState<Team[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState("");
   const [activeTab, setActiveTab] = useState<PortalTab>("teams");
+  const [teamWorkspaceTab, setTeamWorkspaceTab] = useState<TeamWorkspaceTab>("overview");
   const [creatingTeam, setCreatingTeam] = useState(false);
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState("");
@@ -166,11 +169,21 @@ function Portal({
   const selectedTeam = teams.find((team) => team.id === selectedTeamId) ?? null;
   const teamScopedTab = activeTab === "teams" || activeTab === "profiles" || activeTab === "dreams";
 
+  function openTeamWorkspace(nextTab: TeamWorkspaceTab) {
+    setCreatingTeam(false);
+    setTeamWorkspaceTab(nextTab);
+    if (nextTab === "profiles" || nextTab === "dreams") {
+      setActiveTab(nextTab);
+    } else {
+      setActiveTab("teams");
+    }
+  }
+
   return (
     <PortalShell
       theme={theme}
       title="Dense-Mem Control"
-      icon={<ShieldCheck size={20} aria-hidden="true" />}
+      icon={<span className="brand-initials" aria-hidden="true">DM</span>}
       topbarActions={(
         <>
           <button
@@ -199,7 +212,7 @@ function Portal({
           label: "Teams",
           icon: <Users size={17} aria-hidden="true" />,
           active: activeTab === "teams",
-          onClick: () => setActiveTab("teams"),
+          onClick: () => openTeamWorkspace("overview"),
         },
         {
           id: "metrics",
@@ -210,7 +223,7 @@ function Portal({
         },
         {
           id: "recall-feedback",
-          label: "Recall Feedback",
+          label: "Feedback",
           icon: <MessageSquare size={17} aria-hidden="true" />,
           active: activeTab === "recall-feedback",
           onClick: () => setActiveTab("recall-feedback"),
@@ -221,7 +234,7 @@ function Portal({
           icon: <Moon size={17} aria-hidden="true" />,
           active: activeTab === "dreams",
           disabled: !selectedTeam,
-          onClick: () => setActiveTab("dreams"),
+          onClick: () => openTeamWorkspace("dreams"),
         },
         {
           id: "logs",
@@ -232,11 +245,11 @@ function Portal({
         },
         {
           id: "profiles",
-          label: "Profiles & API Keys",
+          label: "Profiles",
           icon: <KeyRound size={17} aria-hidden="true" />,
           active: activeTab === "profiles",
           disabled: !selectedTeam,
-          onClick: () => setActiveTab("profiles"),
+          onClick: () => openTeamWorkspace("profiles"),
         },
         {
           id: "security",
@@ -268,6 +281,7 @@ function Portal({
           loading={loadState === "loading"}
           onCreate={() => {
             setActiveTab("teams");
+            setTeamWorkspaceTab("overview");
             setCreatingTeam(true);
             window.requestAnimationFrame(() => document.getElementById("new-team-name")?.focus());
           }}
@@ -280,7 +294,7 @@ function Portal({
       error={error}
     >
       <Suspense fallback={<LazyPanelFallback />}>
-        {activeTab === "teams" && (
+        {teamScopedTab && (
           <>
             {creatingTeam && (
               <section className="surface">
@@ -302,9 +316,11 @@ function Portal({
               </section>
             )}
             {selectedTeam ? (
-              <TeamEditor
+              <TeamWorkspace
                 api={api}
                 team={selectedTeam}
+                activeTab={teamWorkspaceTab}
+                onSelectTab={openTeamWorkspace}
                 onUpdated={(team) => {
                   setTeams((current) => current.map((item) => (item.id === team.id ? team : item)));
                 }}
@@ -314,12 +330,6 @@ function Portal({
               <div className="empty-state">{loadState === "loading" ? "Loading" : "No teams"}</div>
             )}
           </>
-        )}
-        {activeTab === "profiles" && (
-          selectedTeam ? <TeamProfilesPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
-        )}
-        {activeTab === "dreams" && (
-          selectedTeam ? <ControlDreamsPanel api={api} team={selectedTeam} /> : <div className="empty-state">Select a team</div>
         )}
         {activeTab === "metrics" && <MetricsPanel api={api} teams={teams} />}
         {activeTab === "recall-feedback" && <RecallFeedbackPanel api={api} teams={teams} />}
@@ -463,6 +473,38 @@ function TeamResourceRail({
   );
 }
 
+function TeamWorkspace({
+  api,
+  team,
+  activeTab,
+  onSelectTab,
+  onUpdated,
+  onDeleted,
+}: {
+  api: ControlApi;
+  team: Team;
+  activeTab: TeamWorkspaceTab;
+  onSelectTab: (tab: TeamWorkspaceTab) => void;
+  onUpdated: (team: Team) => void;
+  onDeleted: () => void;
+}) {
+  return (
+    <TeamWorkspaceShell team={team} activeTab={activeTab} onSelectTab={onSelectTab}>
+      {activeTab === "overview" && <TeamOverviewPanel api={api} team={team} onOpenSettings={() => onSelectTab("settings")} />}
+      {activeTab === "profiles" && <TeamProfilesPanel api={api} team={team} embedded />}
+      {activeTab === "dreams" && <ControlDreamsPanel api={api} team={team} />}
+      {activeTab === "settings" && (
+        <TeamEditor
+          api={api}
+          team={team}
+          onUpdated={onUpdated}
+          onDeleted={onDeleted}
+        />
+      )}
+    </TeamWorkspaceShell>
+  );
+}
+
 function TeamEditor({
   api,
   team,
@@ -519,19 +561,7 @@ function TeamEditor({
   }
 
   return (
-    <section className="surface team-detail-surface">
-      <div className="team-detail-header">
-        <span className="team-mark" aria-hidden="true">
-          <Users size={24} />
-        </span>
-        <div>
-          <div className="team-title-row">
-            <h2>{team.name}</h2>
-            <span className="status-pill neutral">Active</span>
-          </div>
-          <p>Created {formatDate(team.created_at)} | Team ID {shortId(team.id)}</p>
-        </div>
-      </div>
+    <section className="team-detail-surface">
       <SectionHeading title="Team settings" />
       <form className="edit-grid" onSubmit={save}>
         <label htmlFor="team-name">Name</label>
@@ -565,7 +595,7 @@ function TeamEditor({
   );
 }
 
-function TeamProfilesPanel({ api, team }: { api: ControlApi; team: Team }) {
+function TeamProfilesPanel({ api, team, embedded = false }: { api: ControlApi; team: Team; embedded?: boolean }) {
   const [keys, setKeys] = useState<TeamProfile[]>([]);
   const [createdKey, setCreatedKey] = useState<CreatedTeamProfile | null>(null);
   const [error, setError] = useState("");
@@ -668,7 +698,7 @@ function TeamProfilesPanel({ api, team }: { api: ControlApi; team: Team }) {
   }
 
   return (
-    <section className="surface">
+    <section className={embedded ? "team-embedded-panel" : "surface"}>
       <SectionHeading title="Profiles" meta={keys.length} />
       {createdKey && <CreatedKeyNotice createdKey={createdKey} onDismiss={() => setCreatedKey(null)} />}
       {error && <div className="banner error" role="alert">{error}</div>}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -192,6 +192,7 @@ function Portal({
         </>
       )}
       navLabel="Control navigation"
+      navItemsLabel="Control sections"
       navItems={[
         {
           id: "teams",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ const THEME_STORAGE_KEY = "denseMem.controlTheme";
 
 type LoadState = "idle" | "loading" | "error";
 type Theme = "light" | "dark";
-type PortalTab = "teams" | "dreams" | "metrics" | "recall-feedback" | "logs" | "profiles" | "security" | "sso" | "config";
+type PortalTab = "teams" | "metrics" | "recall-feedback" | "logs" | "security" | "sso" | "config";
 type ProfilePermission = "read" | "read_write";
 
 export function App() {
@@ -167,16 +167,12 @@ function Portal({
   }, []);
 
   const selectedTeam = teams.find((team) => team.id === selectedTeamId) ?? null;
-  const teamScopedTab = activeTab === "teams" || activeTab === "profiles" || activeTab === "dreams";
+  const teamScopedTab = activeTab === "teams";
 
   function openTeamWorkspace(nextTab: TeamWorkspaceTab) {
     setCreatingTeam(false);
     setTeamWorkspaceTab(nextTab);
-    if (nextTab === "profiles" || nextTab === "dreams") {
-      setActiveTab(nextTab);
-    } else {
-      setActiveTab("teams");
-    }
+    setActiveTab("teams");
   }
 
   return (
@@ -211,7 +207,7 @@ function Portal({
           id: "teams",
           label: "Teams",
           icon: <Users size={17} aria-hidden="true" />,
-          active: activeTab === "teams",
+          active: activeTab === "teams" && (teamWorkspaceTab === "overview" || teamWorkspaceTab === "settings"),
           onClick: () => openTeamWorkspace("overview"),
         },
         {
@@ -232,7 +228,7 @@ function Portal({
           id: "dreams",
           label: "Dreams",
           icon: <Moon size={17} aria-hidden="true" />,
-          active: activeTab === "dreams",
+          active: activeTab === "teams" && teamWorkspaceTab === "dreams",
           disabled: !selectedTeam,
           onClick: () => openTeamWorkspace("dreams"),
         },
@@ -247,7 +243,7 @@ function Portal({
           id: "profiles",
           label: "Profiles",
           icon: <KeyRound size={17} aria-hidden="true" />,
-          active: activeTab === "profiles",
+          active: activeTab === "teams" && teamWorkspaceTab === "profiles",
           disabled: !selectedTeam,
           onClick: () => openTeamWorkspace("profiles"),
         },
@@ -492,7 +488,11 @@ function TeamWorkspace({
     <TeamWorkspaceShell team={team} activeTab={activeTab} onSelectTab={onSelectTab}>
       {activeTab === "overview" && <TeamOverviewPanel api={api} team={team} onOpenSettings={() => onSelectTab("settings")} />}
       {activeTab === "profiles" && <TeamProfilesPanel api={api} team={team} embedded />}
-      {activeTab === "dreams" && <ControlDreamsPanel api={api} team={team} />}
+      {activeTab === "dreams" && (
+        <Suspense fallback={<div className="team-embedded-panel"><div className="table-placeholder">Loading</div></div>}>
+          <ControlDreamsPanel api={api} team={team} embedded />
+        </Suspense>
+      )}
       {activeTab === "settings" && (
         <TeamEditor
           api={api}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,7 +28,7 @@ import { TeamOverviewPanel, TeamWorkspaceShell } from "./control/TeamWorkspace";
 import type { TeamWorkspaceTab } from "./control/TeamWorkspace";
 import { TeamDreamingConfigForm } from "./teamDreamingConfig";
 import { displayKeySuffix, formatDate, profilePermissionLabel, profileRoleLabel, readError, shortId } from "./control/utils";
-import { AuthShell, PortalShell, SecretBox, SectionHeading } from "./ui/components";
+import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading } from "./ui/components";
 
 const MetricsPanel = lazy(() => import("./control/MetricsPanel").then((module) => ({ default: module.MetricsPanel })));
 const SecurityPanel = lazy(() => import("./control/SecurityPanel").then((module) => ({ default: module.SecurityPanel })));
@@ -323,7 +323,7 @@ function Portal({
                 onDeleted={() => void loadTeams()}
               />
             ) : (
-              <div className="empty-state">{loadState === "loading" ? "Loading" : "No teams"}</div>
+              loadState === "loading" ? <LoadingState label="Loading teams" /> : <div className="empty-state">No teams</div>
             )}
           </>
         )}
@@ -339,7 +339,7 @@ function Portal({
 }
 
 function LazyPanelFallback() {
-  return <div className="table-placeholder">Loading</div>;
+  return <LoadingState label="Loading panel" />;
 }
 
 function readTheme(): Theme {
@@ -411,7 +411,7 @@ function TeamResourceRail({
 
   const listContent = (() => {
     if (loading && teams.length === 0) {
-      return <div className="table-placeholder compact">Loading</div>;
+      return <LoadingState label="Loading teams" compact />;
     }
 
     if (teams.length === 0) {
@@ -488,8 +488,8 @@ function TeamWorkspace({
     <TeamWorkspaceShell team={team} activeTab={activeTab} onSelectTab={onSelectTab}>
       {activeTab === "overview" && <TeamOverviewPanel api={api} team={team} onOpenSettings={() => onSelectTab("settings")} />}
       {activeTab === "profiles" && <TeamProfilesPanel api={api} team={team} embedded />}
-      {activeTab === "dreams" && (
-        <Suspense fallback={<div className="team-embedded-panel"><div className="table-placeholder">Loading</div></div>}>
+        {activeTab === "dreams" && (
+        <Suspense fallback={<div className="team-embedded-panel"><LoadingState label="Loading dreams" /></div>}>
           <ControlDreamsPanel api={api} team={team} embedded />
         </Suspense>
       )}
@@ -712,7 +712,7 @@ function TeamProfilesPanel({ api, team, embedded = false }: { api: ControlApi; t
           void loadKeys();
         }}
       />
-      {loading && <div className="table-placeholder">Loading</div>}
+      {loading && <LoadingState label="Loading profiles" />}
       {!loading && (
         <TeamProfileTable
           keys={keys}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   Plus,
   RefreshCw,
+  Search,
   Settings,
   ShieldCheck,
   Sun,
@@ -135,6 +136,7 @@ function Portal({
   const [teams, setTeams] = useState<Team[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState("");
   const [activeTab, setActiveTab] = useState<PortalTab>("teams");
+  const [creatingTeam, setCreatingTeam] = useState(false);
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState("");
 
@@ -162,6 +164,7 @@ function Portal({
   }, []);
 
   const selectedTeam = teams.find((team) => team.id === selectedTeamId) ?? null;
+  const teamScopedTab = activeTab === "teams" || activeTab === "profiles" || activeTab === "dreams";
 
   return (
     <PortalShell
@@ -256,26 +259,47 @@ function Portal({
           onClick: () => setActiveTab("config"),
         },
       ]}
-      sidebarTitle="Teams"
-      sidebarMeta={teams.length}
-      sidebarBody={(
-        <TeamSelectList
+      resourceRailLabel="Teams"
+      resourceRail={teamScopedTab ? (
+        <TeamResourceRail
           teams={teams}
           selectedTeamId={selectedTeamId}
           loading={loadState === "loading"}
-          onSelect={setSelectedTeamId}
+          onCreate={() => {
+            setActiveTab("teams");
+            setCreatingTeam(true);
+            window.requestAnimationFrame(() => document.getElementById("new-team-name")?.focus());
+          }}
+          onSelect={(teamId) => {
+            setSelectedTeamId(teamId);
+          }}
         />
-      )}
-      detailLabel="Team details"
+      ) : undefined}
+      detailLabel="Control details"
       error={error}
     >
       <Suspense fallback={<LazyPanelFallback />}>
         {activeTab === "teams" && (
           <>
-            <section className="surface">
-              <SectionHeading title="Create team" />
-              <TeamCreateForm api={api} onCreated={(team) => void loadTeams(team.id)} />
-            </section>
+            {creatingTeam && (
+              <section className="surface">
+                <SectionHeading
+                  title="Create team"
+                  actions={(
+                    <button className="text-button" type="button" onClick={() => setCreatingTeam(false)}>
+                      Cancel
+                    </button>
+                  )}
+                />
+                <TeamCreateForm
+                  api={api}
+                  onCreated={(team) => {
+                    setCreatingTeam(false);
+                    void loadTeams(team.id);
+                  }}
+                />
+              </section>
+            )}
             {selectedTeam ? (
               <TeamEditor
                 api={api}
@@ -356,38 +380,84 @@ function TeamCreateForm({ api, onCreated }: { api: ControlApi; onCreated: (team:
   );
 }
 
-function TeamSelectList({
+function TeamResourceRail({
   teams,
   selectedTeamId,
   loading,
+  onCreate,
   onSelect,
 }: {
   teams: Team[];
   selectedTeamId: string;
   loading: boolean;
+  onCreate: () => void;
   onSelect: (teamId: string) => void;
 }) {
-  if (loading && teams.length === 0) {
-    return <div className="table-placeholder compact">Loading</div>;
-  }
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const visibleTeams = normalizedQuery
+    ? teams.filter((team) => (
+      team.name.toLocaleLowerCase().includes(normalizedQuery)
+        || team.id.toLocaleLowerCase().includes(normalizedQuery)
+    ))
+    : teams;
 
-  if (teams.length === 0) {
-    return <div className="table-placeholder compact">No teams</div>;
-  }
+  const listContent = (() => {
+    if (loading && teams.length === 0) {
+      return <div className="table-placeholder compact">Loading</div>;
+    }
+
+    if (teams.length === 0) {
+      return <div className="table-placeholder compact">No teams</div>;
+    }
+
+    if (visibleTeams.length === 0) {
+      return <div className="table-placeholder compact">No matching teams</div>;
+    }
+
+    return (
+      <div className="team-list">
+        {visibleTeams.map((team) => (
+          <button
+            key={team.id}
+            className={team.id === selectedTeamId ? "team-list-item selected" : "team-list-item"}
+            type="button"
+            onClick={() => onSelect(team.id)}
+          >
+            <span className="team-list-primary">
+              <span className="status-dot" aria-hidden="true" />
+              <span>{team.name}</span>
+            </span>
+            <small>{formatDate(team.updated_at)}</small>
+          </button>
+        ))}
+      </div>
+    );
+  })();
 
   return (
-    <div className="team-list">
-      {teams.map((team) => (
-        <button
-          key={team.id}
-          className={team.id === selectedTeamId ? "team-list-item selected" : "team-list-item"}
-          type="button"
-          onClick={() => onSelect(team.id)}
-        >
-          <span>{team.name}</span>
-          <small>{formatDate(team.updated_at)}</small>
-        </button>
-      ))}
+    <div className="resource-panel team-resource-panel">
+      <SectionHeading
+        title="Teams"
+        meta={teams.length}
+        actions={(
+          <button className="primary-button compact" type="button" onClick={onCreate}>
+            <Plus size={16} aria-hidden="true" />
+            New Team
+          </button>
+        )}
+      />
+      <label className="resource-search">
+        <Search size={16} aria-hidden="true" />
+        <span className="sr-only">Search teams</span>
+        <input
+          aria-label="Search teams"
+          placeholder="Search teams..."
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </label>
+      {listContent}
     </div>
   );
 }
@@ -448,8 +518,20 @@ function TeamEditor({
   }
 
   return (
-    <section className="surface">
-      <SectionHeading title={team.name} meta={shortId(team.id)} />
+    <section className="surface team-detail-surface">
+      <div className="team-detail-header">
+        <span className="team-mark" aria-hidden="true">
+          <Users size={24} />
+        </span>
+        <div>
+          <div className="team-title-row">
+            <h2>{team.name}</h2>
+            <span className="status-pill neutral">Active</span>
+          </div>
+          <p>Created {formatDate(team.created_at)} | Team ID {shortId(team.id)}</p>
+        </div>
+      </div>
+      <SectionHeading title="Team settings" />
       <form className="edit-grid" onSubmit={save}>
         <label htmlFor="team-name">Name</label>
         <input id="team-name" value={name} onChange={(event) => setName(event.target.value)} />

--- a/web/src/admin-dashboard-components.css
+++ b/web/src/admin-dashboard-components.css
@@ -1,0 +1,556 @@
+.data-table {
+  font-size: 13px;
+}
+
+.data-table th {
+  color: var(--subtle);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-muted) 84%, var(--panel)) 0%, color-mix(in srgb, var(--panel-muted) 56%, var(--panel)) 100%);
+  font-size: 11px;
+  font-weight: 780;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.data-table td {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.data-table tbody tr {
+  transition: background 140ms ease;
+}
+
+.data-table tbody tr:hover td {
+  background: color-mix(in srgb, var(--panel-hover) 58%, transparent);
+}
+
+.table-placeholder,
+.empty-state {
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--panel-strong) 88%, transparent) 0%, var(--panel) 100%);
+  border-style: dashed;
+}
+
+.loading-state {
+  position: relative;
+  grid-template-columns: auto minmax(82px, max-content) minmax(96px, 180px);
+  justify-content: center;
+  gap: 12px;
+  border-style: solid;
+  background:
+    linear-gradient(115deg, color-mix(in srgb, var(--panel-strong) 84%, transparent) 0%, color-mix(in srgb, var(--panel) 96%, var(--accent-soft)) 42%, var(--panel) 100%);
+}
+
+.loading-state.compact {
+  min-height: 72px;
+  grid-template-columns: auto minmax(70px, max-content) minmax(72px, 128px);
+  gap: 9px;
+}
+
+.loading-orbit {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  border: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 999px;
+  box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 22%, transparent);
+  animation: loading-spin 760ms linear infinite;
+}
+
+.loading-orbit::after {
+  position: absolute;
+  inset: 6px;
+  content: "";
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+  border-radius: inherit;
+  animation: loading-pulse 980ms ease-in-out infinite;
+}
+
+.loading-copy {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 720;
+}
+
+.loading-skeleton {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+}
+
+.loading-skeleton span {
+  height: 6px;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--border) 70%, transparent) 0%, color-mix(in srgb, var(--accent) 24%, transparent) 42%, color-mix(in srgb, var(--border) 70%, transparent) 84%);
+  background-size: 220% 100%;
+  animation: loading-sheen 1.2s ease-in-out infinite;
+}
+
+.loading-skeleton span:nth-child(2) {
+  width: 78%;
+  animation-delay: 120ms;
+}
+
+.loading-skeleton span:nth-child(3) {
+  width: 52%;
+  animation-delay: 240ms;
+}
+
+.inline-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-strong);
+}
+
+.inline-loading::before {
+  width: 7px;
+  height: 7px;
+  content: "";
+  background: var(--accent);
+  border-radius: 999px;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent);
+  animation: loading-pulse 980ms ease-in-out infinite;
+}
+
+.summary-strip {
+  background: var(--panel);
+  overflow: hidden;
+}
+
+.summary-strip .summary-item {
+  min-height: 102px;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.summary-item,
+.metric-card {
+  position: relative;
+  min-width: 0;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 98%, var(--panel-strong)) 0%, var(--panel) 100%);
+}
+
+.summary-item::before,
+.metric-card::before {
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 3px;
+  height: 100%;
+  content: "";
+  background: linear-gradient(180deg, var(--accent), var(--accent-alt));
+  border-radius: 8px 0 0 8px;
+}
+
+.summary-item strong,
+.metric-card strong {
+  color: var(--text);
+  letter-spacing: 0;
+}
+
+.metrics-toolbar,
+.telemetry-toolbar,
+.dream-list-toolbar {
+  border-color: var(--border);
+}
+
+.checkbox-row input[type="checkbox"],
+.filter-row input[type="checkbox"],
+.check-row input[type="checkbox"] {
+  width: 17px;
+  min-height: 17px;
+  height: 17px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  appearance: none;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.checkbox-row input[type="checkbox"]:checked,
+.filter-row input[type="checkbox"]:checked,
+.check-row input[type="checkbox"]:checked {
+  border-color: var(--accent);
+  background:
+    linear-gradient(135deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 44% 55% / 8px 8px no-repeat,
+    linear-gradient(45deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 38% 62% / 6px 6px no-repeat,
+    var(--accent);
+}
+
+.toggle-row input {
+  width: 42px;
+  min-height: 24px;
+  height: 24px;
+  border-color: var(--border);
+  background: var(--panel-muted);
+  box-shadow: inset 0 1px 2px rgba(31, 46, 56, 0.14);
+}
+
+.toggle-row input::after {
+  width: 18px;
+  height: 18px;
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(31, 46, 56, 0.18);
+}
+
+.toggle-row input:checked {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+}
+
+.knowledge-explorer {
+  min-width: 0;
+  min-height: calc(100vh - 118px);
+  background: var(--panel);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  animation: card-rise 360ms ease both;
+}
+
+.knowledge-filter-panel,
+.knowledge-results-panel,
+.knowledge-inspector {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.knowledge-filter-panel,
+.knowledge-inspector {
+  top: 100px;
+  max-height: calc(100vh - 118px);
+  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+}
+
+.knowledge-filter-panel {
+  border-right: 1px solid var(--border);
+}
+
+.knowledge-inspector {
+  border-left: 1px solid var(--border);
+}
+
+.knowledge-results-panel {
+  background:
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--accent) 8%, transparent), transparent 26%),
+    color-mix(in srgb, var(--bg) 86%, var(--panel));
+}
+
+.knowledge-commandbar,
+.knowledge-results-toolbar {
+  background: color-mix(in srgb, var(--panel) 97%, var(--panel-strong));
+  border-bottom: 1px solid var(--border);
+}
+
+.knowledge-list {
+  gap: 10px;
+  padding: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--border-strong) 70%, transparent) transparent;
+}
+
+.knowledge-list.dense {
+  gap: 8px;
+}
+
+.knowledge-item {
+  border-color: var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-control);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.knowledge-result-option:hover {
+  border-color: var(--border-strong);
+  background: var(--panel);
+  box-shadow: var(--shadow-soft);
+  transform: translateY(-2px);
+}
+
+.knowledge-item.selected {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 68%, var(--panel)) 0%, color-mix(in srgb, var(--panel) 84%, var(--accent-alt)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-soft);
+}
+
+.inspector-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  padding: 8px;
+  background: color-mix(in srgb, var(--panel-muted) 70%, var(--panel));
+  border-bottom: 1px solid var(--border);
+}
+
+.inspector-tab {
+  min-height: 34px;
+  font-size: 12px;
+  font-weight: 730;
+  cursor: pointer;
+}
+
+.inspector-tab.active::after {
+  display: none;
+}
+
+.inspector-section,
+.filter-stack {
+  border-color: var(--border);
+}
+
+.evidence-list div,
+.inspector-details div {
+  border-radius: 8px;
+}
+
+.confidence-bar {
+  background:
+    linear-gradient(90deg, var(--accent) var(--confidence), color-mix(in srgb, var(--border-strong) 54%, transparent) 0);
+}
+
+.info-tooltip-trigger {
+  color: var(--subtle);
+}
+
+.info-tooltip-content {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.secret-box {
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
+}
+
+.secret-value {
+  border-radius: 8px;
+}
+
+@keyframes sidebar-in {
+  from {
+    opacity: 0;
+    transform: translateX(-12px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes topbar-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes card-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes loading-pulse {
+  0%,
+  100% {
+    transform: scale(0.76);
+    opacity: 0.55;
+  }
+
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes loading-sheen {
+  0% {
+    background-position: 120% 0;
+  }
+
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}
+
+@media (max-width: 1180px) {
+  .workspace,
+  .workspace.has-resource-rail {
+    grid-template-columns: minmax(210px, 232px) minmax(0, 1fr);
+  }
+
+  .portal-content.has-resource-rail {
+    grid-template-columns: minmax(236px, 286px) minmax(0, 1fr);
+  }
+
+  .knowledge-explorer,
+  .knowledge-explorer.inspector-closed {
+    grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
+  }
+
+  .knowledge-inspector {
+    position: static;
+    grid-column: 1 / -1;
+    max-height: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    padding: 14px;
+  }
+
+  .workspace,
+  .workspace.has-resource-rail,
+  .workspace.top-nav-workspace {
+    min-height: auto;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .primary-rail,
+  .resource-rail,
+  .topbar,
+  .knowledge-filter-panel {
+    position: static;
+    max-height: none;
+  }
+
+  .primary-rail {
+    min-height: auto;
+    grid-template-rows: auto auto;
+  }
+
+  .rail-brand {
+    padding-bottom: 12px;
+  }
+
+  .rail-tabs {
+    grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
+  }
+
+  .rail-tab-button {
+    width: 100%;
+  }
+
+  .portal-content,
+  .portal-content.has-resource-rail,
+  .knowledge-explorer,
+  .search-form:not(.stacked),
+  .key-detail-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .resource-rail {
+    order: -1;
+  }
+
+  .topbar {
+    justify-content: flex-start;
+  }
+
+  .topbar-actions {
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .app-shell {
+    padding: 10px;
+  }
+
+  .workspace {
+    gap: 12px;
+  }
+
+  .primary-rail,
+  .topbar,
+  .surface,
+  .resource-rail,
+  .knowledge-filter-panel,
+  .knowledge-results-panel,
+  .knowledge-inspector,
+  .team-workspace-body {
+    padding: 14px;
+  }
+
+  .topbar-actions,
+  .list-toolbar,
+  .button-row {
+    flex-wrap: wrap;
+  }
+
+  .rail-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rail-tab-button {
+    min-height: 42px;
+    padding-inline: 10px;
+  }
+
+  .config-tabs .tab-button {
+    flex: 1 1 calc(33.333% - 5px);
+    min-width: 0;
+  }
+
+  .team-workspace-header {
+    padding: 12px 12px 0;
+  }
+
+  .team-workspace-tabs {
+    gap: 5px;
+  }
+
+  .team-workspace-tab {
+    flex: 1 1 calc(25% - 5px);
+    min-width: 0;
+    padding-inline: 5px;
+    font-size: 12px;
+  }
+}

--- a/web/src/admin-system.css
+++ b/web/src/admin-system.css
@@ -251,8 +251,6 @@ body {
 .button-row,
 .secret-actions,
 .toolbar-actions,
-.result-actions,
-.inspector-actions,
 .table-actions {
   min-width: 0;
   display: flex;

--- a/web/src/admin-system.css
+++ b/web/src/admin-system.css
@@ -1,127 +1,250 @@
 :root {
   color-scheme: light;
-  background: #edf1ef;
+  background: #eef3f7;
+}
+
+html {
+  background: #eef3f7;
 }
 
 body {
   background:
-    radial-gradient(circle at 16% 0%, rgba(45, 127, 116, 0.08), transparent 30%),
-    linear-gradient(180deg, #f7f9f8 0%, #edf1ef 46%, #e8eeeb 100%);
+    radial-gradient(circle at 9% 5%, rgba(14, 166, 163, 0.18), transparent 28%),
+    radial-gradient(circle at 88% 0%, rgba(47, 111, 228, 0.13), transparent 26%),
+    radial-gradient(circle at 80% 88%, rgba(245, 158, 11, 0.10), transparent 24%),
+    linear-gradient(145deg, #f7fafd 0%, #eef3f7 45%, #e9f1f0 100%);
 }
 
 .auth-shell,
 .app-shell {
-  --bg: #edf1ef;
+  --bg: #eef3f7;
+  --canvas: #f7fafd;
   --panel: #ffffff;
-  --panel-strong: #f8faf9;
-  --panel-muted: #eef3f0;
-  --panel-hover: #edf5f1;
-  --border: #d9e3df;
-  --border-strong: #b7c8c0;
-  --text: #13201d;
-  --muted: #53635e;
-  --subtle: #7c8a85;
-  --accent: #0c8176;
-  --accent-strong: #06675f;
-  --accent-soft: #dff3ef;
-  --danger: #b42318;
-  --danger-strong: #911a12;
-  --danger-soft: #fff0ed;
-  --warning: #a15c07;
-  --warning-soft: #fff6df;
-  --success: #0b7a45;
-  --success-soft: #e3f7ed;
-  --focus: rgba(12, 129, 118, 0.18);
-  --shadow: 0 18px 40px rgba(29, 45, 41, 0.10);
-  --shadow-soft: 0 1px 2px rgba(29, 45, 41, 0.07), 0 12px 26px rgba(29, 45, 41, 0.05);
-  --shadow-control: 0 1px 1px rgba(29, 45, 41, 0.05);
+  --panel-strong: #f9fbfd;
+  --panel-muted: #eef5f5;
+  --panel-hover: #e7f1f4;
+  --border: #dbe6eb;
+  --border-strong: #b7c8d1;
+  --text: #15202b;
+  --muted: #5d6c78;
+  --subtle: #87949f;
+  --accent: #0ea6a3;
+  --accent-strong: #087e86;
+  --accent-alt: #2f6fe4;
+  --accent-warm: #f59e0b;
+  --danger: #d64055;
+  --danger-strong: #b91f3c;
+  --danger-soft: #fff0f2;
+  --warning: #b76b05;
+  --warning-soft: #fff6dd;
+  --success: #0d9f6e;
+  --success-soft: #e5f8f0;
+  --accent-soft: #dff6f3;
+  --focus: rgba(14, 166, 163, 0.22);
+  --rail-bg: #14211f;
+  --rail-panel: #1b2d2a;
+  --rail-text: #d9f0ec;
+  --rail-muted: #8fb3ad;
+  --rail-border: rgba(255, 255, 255, 0.13);
+  --shadow: 0 22px 58px rgba(31, 46, 56, 0.14);
+  --shadow-soft: 0 10px 28px rgba(31, 46, 56, 0.08);
+  --shadow-control: 0 2px 7px rgba(31, 46, 56, 0.08);
+  --shadow-glow: 0 18px 42px rgba(14, 166, 163, 0.18);
 
+  background: transparent;
+  color: var(--text);
   font-feature-settings: "cv02", "cv03", "cv04";
-  background: var(--bg);
 }
 
 .auth-shell[data-theme="dark"],
 .app-shell[data-theme="dark"] {
   color-scheme: dark;
-  --bg: #101412;
-  --panel: #171d1a;
-  --panel-strong: #1d2420;
-  --panel-muted: #222c27;
-  --panel-hover: #26332d;
-  --border: #2f3d37;
-  --border-strong: #4a5d55;
-  --text: #eef6f3;
-  --muted: #aebcb6;
-  --subtle: #7f9189;
-  --accent: #34c7b6;
-  --accent-strong: #8de9dc;
-  --accent-soft: rgba(52, 199, 182, 0.14);
-  --danger: #ff8a7d;
-  --danger-strong: #ffb4ac;
-  --danger-soft: rgba(255, 138, 125, 0.12);
-  --warning: #f7c667;
-  --warning-soft: rgba(247, 198, 103, 0.14);
-  --success: #56d68f;
-  --success-soft: rgba(86, 214, 143, 0.14);
-  --focus: rgba(52, 199, 182, 0.24);
-  --shadow: 0 22px 56px rgba(0, 0, 0, 0.34);
-  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.30), 0 14px 28px rgba(0, 0, 0, 0.18);
-  --shadow-control: 0 1px 1px rgba(0, 0, 0, 0.22);
+  --bg: #0f1517;
+  --canvas: #151d20;
+  --panel: #182225;
+  --panel-strong: #1d292d;
+  --panel-muted: #233136;
+  --panel-hover: #27383d;
+  --border: #304248;
+  --border-strong: #4a6068;
+  --text: #eef7f6;
+  --muted: #b4c2c5;
+  --subtle: #84959a;
+  --accent: #36d2c6;
+  --accent-strong: #9ff3ea;
+  --accent-alt: #80a7ff;
+  --accent-warm: #ffc766;
+  --danger: #ff8494;
+  --danger-strong: #ffb1bd;
+  --danger-soft: rgba(255, 132, 148, 0.13);
+  --warning: #ffd175;
+  --warning-soft: rgba(255, 209, 117, 0.14);
+  --success: #72dea9;
+  --success-soft: rgba(114, 222, 169, 0.14);
+  --accent-soft: rgba(54, 210, 198, 0.15);
+  --focus: rgba(54, 210, 198, 0.26);
+  --rail-bg: #0b1112;
+  --rail-panel: #142022;
+  --rail-text: #e6fbf8;
+  --rail-muted: #89aaa7;
+  --rail-border: rgba(255, 255, 255, 0.10);
+  --shadow: 0 22px 64px rgba(0, 0, 0, 0.38);
+  --shadow-soft: 0 12px 32px rgba(0, 0, 0, 0.24);
+  --shadow-control: 0 2px 9px rgba(0, 0, 0, 0.25);
+  --shadow-glow: 0 18px 42px rgba(54, 210, 198, 0.16);
 }
 
 .app-shell {
   min-width: 0;
+  min-height: 100vh;
+  padding: 18px;
+  background:
+    radial-gradient(circle at 10% 2%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 27%),
+    radial-gradient(circle at 92% 3%, color-mix(in srgb, var(--accent-alt) 14%, transparent), transparent 24%),
+    radial-gradient(circle at 84% 92%, color-mix(in srgb, var(--accent-warm) 10%, transparent), transparent 22%),
+    linear-gradient(145deg, var(--canvas) 0%, var(--bg) 100%);
 }
 
-.auth-panel,
-.surface,
-.resource-rail,
-.knowledge-explorer,
-.knowledge-filter-panel,
-.knowledge-results-panel,
-.knowledge-inspector,
-.overview-panel,
-.team-list-item,
-.summary-strip,
-.table-wrap,
-.banner,
-.secret-box,
-.telemetry-chart,
-.summary-item,
-.metric-card {
-  border-color: var(--border);
-  box-shadow: var(--shadow-soft);
+.workspace,
+.topbar,
+.app-shell > .banner {
+  width: 100%;
+  max-width: none;
+  margin-inline: 0;
 }
 
-.surface,
-.auth-panel,
-.knowledge-explorer {
-  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+.workspace {
+  width: min(1680px, 100%);
+  min-height: calc(100vh - 36px);
+  display: grid;
+  grid-template-columns: minmax(226px, 252px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+  margin-inline: auto;
 }
 
-.overview-panel,
-.summary-item,
-.metric-card,
-.telemetry-chart,
-.knowledge-item,
-.inspector-details div,
-.secret-box {
-  background: var(--panel-strong);
+.workspace.has-resource-rail,
+.workspace.top-nav-workspace {
+  grid-template-columns: minmax(226px, 252px) minmax(0, 1fr);
 }
 
-.topbar {
-  background: color-mix(in srgb, var(--panel) 90%, transparent);
-  backdrop-filter: blur(18px);
+.workspace.top-nav-workspace {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.portal-main {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 16px;
+}
+
+.portal-content {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.portal-content.has-resource-rail {
+  grid-template-columns: minmax(270px, 320px) minmax(0, 1fr);
+}
+
+.portal-content.has-top-nav {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.portal-content.has-top-nav .top-nav-bar {
+  grid-column: 1 / -1;
+}
+
+.primary-rail {
+  position: sticky;
+  top: 18px;
+  min-width: 0;
+  min-height: calc(100vh - 36px);
+  max-height: calc(100vh - 36px);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  align-content: start;
+  gap: 18px;
+  padding: 16px;
+  color: var(--rail-text);
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.08), transparent 28%),
+    radial-gradient(circle at 15% 8%, rgba(14, 166, 163, 0.34), transparent 30%),
+    radial-gradient(circle at 82% 0%, rgba(47, 111, 228, 0.28), transparent 26%),
+    linear-gradient(180deg, var(--rail-panel) 0%, var(--rail-bg) 100%);
+  border: 1px solid var(--rail-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  overflow: hidden auto;
+  animation: sidebar-in 420ms ease both;
+}
+
+.rail-brand {
+  position: relative;
+  z-index: 1;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--rail-border);
+}
+
+.rail-brand .brand-row {
+  gap: 12px;
+}
+
+.rail-brand .brand-row h1 {
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 780;
+  letter-spacing: 0;
 }
 
 .brand-mark {
-  border-radius: 6px;
-  background: linear-gradient(145deg, #087f88 0%, #0b726b 58%, #24536a 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 8px 18px rgba(5, 91, 93, 0.18);
+  width: 38px;
+  height: 38px;
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.24), transparent 36%),
+    linear-gradient(135deg, var(--accent) 0%, var(--accent-alt) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 8px;
+  box-shadow: 0 12px 26px rgba(14, 166, 163, 0.28);
 }
 
-.brand-row h1 {
+.brand-initials {
+  font-size: 12px;
+  font-weight: 820;
   letter-spacing: 0;
+}
+
+.topbar {
+  position: sticky;
+  top: 18px;
+  z-index: 16;
+  min-height: 66px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
+  animation: topbar-drop 360ms ease both;
+}
+
+.topbar .brand-row {
+  flex: 0 0 auto;
+}
+
+.topbar-context {
+  min-width: 0;
+  flex: 1 1 320px;
 }
 
 .topbar-actions,
@@ -129,98 +252,287 @@ body {
 .secret-actions,
 .toolbar-actions,
 .result-actions,
-.inspector-actions {
+.inspector-actions,
+.table-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.topbar-actions {
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.top-nav-bar {
+  position: static;
+  display: flex;
+  min-width: 0;
+  padding: 10px;
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.top-nav-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
 }
 
-.primary-rail,
-.resource-rail,
-.top-nav-bar {
-  background: color-mix(in srgb, var(--panel) 94%, var(--panel-muted));
+.resource-rail {
+  position: sticky;
+  top: 100px;
+  min-width: 0;
+  max-height: calc(100vh - 118px);
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 98%, var(--panel-muted)) 0%, var(--panel) 100%);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  overflow: hidden auto;
+  animation: card-rise 340ms ease both;
 }
 
-.primary-rail {
-  padding: 12px 9px;
+.detail-pane {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  padding: 0;
+  background: transparent;
 }
 
 .rail-tabs {
-  gap: 7px;
+  position: relative;
+  z-index: 1;
+  display: grid;
+  align-content: start;
+  gap: 8px;
 }
 
 .rail-tab-button {
   position: relative;
-  min-height: 54px;
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 11px;
+  padding: 0 12px;
+  color: var(--rail-muted);
+  background: transparent;
   border: 1px solid transparent;
   border-radius: 8px;
-  color: var(--muted);
-  background: transparent;
-}
-
-.rail-tab-button:hover {
-  color: var(--text);
-  background: color-mix(in srgb, var(--panel-hover) 78%, transparent);
-  border-color: color-mix(in srgb, var(--border) 72%, transparent);
-}
-
-.rail-tab-button.active {
-  color: var(--accent-strong);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 82%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 44%, var(--panel)) 100%);
-  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
-  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
+  font-size: 13px;
+  font-weight: 730;
+  line-height: 1.15;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .top-nav-tabs .rail-tab-button {
-  min-height: 34px;
-  border-radius: 6px;
-  box-shadow: none;
+  width: auto;
+  min-height: 38px;
+  color: var(--muted);
+  background: var(--panel-strong);
+  border-color: var(--border);
+  box-shadow: var(--shadow-control);
+}
+
+.rail-tab-button svg {
+  flex: 0 0 auto;
+  transition: transform 160ms ease;
+}
+
+.rail-tab-button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rail-tab-button:hover {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.10);
+  border-color: rgba(255, 255, 255, 0.14);
+  transform: translateY(-1px);
+}
+
+.top-nav-tabs .rail-tab-button:hover {
+  color: var(--text);
+  background: var(--panel-hover);
+  border-color: var(--border-strong);
+}
+
+.rail-tab-button:hover svg,
+.rail-tab-button.active svg {
+  transform: translateX(1px);
+}
+
+.rail-tab-button.active {
+  color: #ffffff;
+  background:
+    linear-gradient(135deg, rgba(14, 166, 163, 0.95), rgba(47, 111, 228, 0.90));
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 13px 30px rgba(14, 166, 163, 0.24);
 }
 
 .top-nav-tabs .rail-tab-button.active {
-  box-shadow: inset 0 -2px 0 var(--accent);
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+  border-color: transparent;
+  box-shadow: var(--shadow-glow);
 }
 
-.resource-rail {
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--border-strong) 70%, transparent) transparent;
+.rail-tab-button:disabled {
+  opacity: 0.50;
+  cursor: not-allowed;
+  transform: none;
 }
 
-.resource-panel .section-heading h2,
+.auth-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background:
+    radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--accent) 20%, transparent), transparent 30%),
+    radial-gradient(circle at 82% 12%, color-mix(in srgb, var(--accent-alt) 14%, transparent), transparent 25%),
+    linear-gradient(145deg, var(--canvas), var(--bg));
+}
+
+.auth-panel,
+.surface,
+.knowledge-explorer,
+.overview-panel,
+.table-wrap,
+.summary-strip,
+.telemetry-chart,
+.metric-card,
+.summary-item,
+.secret-box,
+.banner,
+.empty-state,
+.table-placeholder {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.auth-panel,
+.surface,
+.knowledge-explorer {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 98%, var(--panel-strong)) 0%, var(--panel) 100%);
+}
+
+.auth-panel {
+  width: min(430px, 100%);
+  gap: 18px;
+  padding: 30px;
+  box-shadow: var(--shadow);
+  animation: card-rise 360ms ease both;
+}
+
+.surface {
+  min-width: 0;
+  padding: 20px;
+  animation: card-rise 340ms ease both;
+}
+
+.overview-panel,
+.metric-card,
+.summary-item,
+.telemetry-chart,
+.secret-box,
+.knowledge-item,
+.inspector-details div {
+  background: var(--panel);
+}
+
+.surface-section {
+  min-width: 0;
+}
+
+.team-management-surface .surface-section + .surface-section {
+  margin-top: 22px;
+  padding-top: 22px;
+  border-top: 1px solid var(--border);
+}
+
+.section-heading {
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
 .section-heading h2,
+.resource-panel .section-heading h2,
 .list-toolbar h3,
-.knowledge-results-toolbar h2 {
-  font-size: 16px;
-  font-weight: 760;
+.knowledge-results-toolbar h2,
+.inspector-head h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 17px;
+  font-weight: 780;
   letter-spacing: 0;
 }
 
 .section-heading span,
 .list-toolbar span,
 .knowledge-results-toolbar span,
-.form-meta {
+.form-meta,
+.section-subtitle {
   color: var(--subtle);
-  font-size: 11px;
-  font-weight: 720;
-  letter-spacing: 0.02em;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0;
 }
 
 label,
 legend {
   color: var(--muted);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 720;
   letter-spacing: 0;
 }
 
 input,
 select,
-textarea {
-  min-height: 38px;
-  border-color: var(--border);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
-  box-shadow: inset 0 1px 0 color-mix(in srgb, #ffffff 60%, transparent);
-  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+textarea,
+.resource-search,
+.search-input-wrap,
+.session-context,
+.team-select-chip,
+.select-like {
+  min-width: 0;
+  min-height: 40px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel-strong) 82%, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #ffffff 70%, transparent);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .app-shell[data-theme="dark"] input,
@@ -228,62 +540,66 @@ textarea {
 .app-shell[data-theme="dark"] textarea,
 .auth-shell[data-theme="dark"] input,
 .auth-shell[data-theme="dark"] select,
-.auth-shell[data-theme="dark"] textarea {
+.auth-shell[data-theme="dark"] textarea,
+.app-shell[data-theme="dark"] .resource-search,
+.app-shell[data-theme="dark"] .search-input-wrap,
+.app-shell[data-theme="dark"] .session-context,
+.app-shell[data-theme="dark"] .team-select-chip,
+.app-shell[data-theme="dark"] .select-like {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 select {
   appearance: none;
-  padding-right: 34px;
+  padding-right: 36px;
   background-image:
     linear-gradient(45deg, transparent 50%, var(--subtle) 50%),
     linear-gradient(135deg, var(--subtle) 50%, transparent 50%);
   background-position:
-    calc(100% - 16px) 50%,
-    calc(100% - 11px) 50%;
+    calc(100% - 17px) 50%,
+    calc(100% - 12px) 50%;
   background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
 }
 
 input:hover,
 select:hover,
-textarea:hover {
-  border-color: var(--border-strong);
-  background: var(--panel);
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
-  background: var(--panel);
-  box-shadow: 0 0 0 3px var(--focus);
-}
-
-.resource-search,
-.search-input-wrap,
-.session-context,
-.team-select-chip,
-.select-like {
-  border-color: var(--border);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--panel-strong) 92%, var(--panel));
-  box-shadow: var(--shadow-control);
-}
-
+textarea:hover,
 .resource-search:hover,
 .search-input-wrap:hover,
 .session-context:hover,
 .team-select-chip:hover,
 .select-like:hover {
-  border-color: var(--border-strong);
   background: var(--panel);
+  border-color: var(--border-strong);
 }
 
+input:focus,
+select:focus,
+textarea:focus,
 .resource-search:focus-within,
 .search-input-wrap:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  background: var(--panel);
+  border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--focus);
+}
+
+.resource-search,
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 12px;
+  color: var(--subtle);
+}
+
+.resource-search input,
+.search-input-wrap input {
+  min-height: 38px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-inline: 0;
 }
 
 .primary-button,
@@ -302,26 +618,33 @@ textarea:focus {
 .ghost-button,
 .danger-button,
 .icon-button {
-  min-height: 36px;
-  border-radius: 6px;
+  min-height: 38px;
+  border-radius: 8px;
   box-shadow: var(--shadow-control);
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .primary-button {
   color: #ffffff;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, #19a896) 0%, var(--accent-strong) 100%);
-  border: 1px solid color-mix(in srgb, var(--accent-strong) 72%, transparent);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-alt) 100%);
+  border: 1px solid transparent;
+  box-shadow: var(--shadow-glow);
 }
 
 .primary-button:hover {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--accent-strong) 88%, #22b8a7) 0%, var(--accent-strong) 100%);
   transform: translateY(-1px);
+  box-shadow: 0 18px 38px color-mix(in srgb, var(--accent) 26%, transparent);
 }
 
 .ghost-button,
 .icon-button {
   color: var(--text);
-  background: color-mix(in srgb, var(--panel) 94%, var(--panel-strong));
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
   border: 1px solid var(--border);
 }
 
@@ -333,26 +656,52 @@ textarea:focus {
 }
 
 .danger-button {
+  color: var(--danger-strong);
+  background: color-mix(in srgb, var(--danger-soft) 78%, var(--panel));
   border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
-  background: color-mix(in srgb, var(--danger-soft) 76%, var(--panel));
+}
+
+.danger-button:hover {
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--danger), var(--danger-strong));
+  transform: translateY(-1px);
 }
 
 .text-button {
-  border-radius: 5px;
+  min-height: 32px;
+  padding: 0 9px;
   color: var(--accent-strong);
+  border-radius: 7px;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    transform 160ms ease;
 }
 
 .text-button:hover {
   color: var(--accent);
   background: var(--accent-soft);
+  transform: translateY(-1px);
 }
 
 .icon-button {
-  width: 36px;
+  width: 38px;
 }
 
 .icon-button.bare {
+  width: 28px;
+  min-height: 28px;
+  color: var(--subtle);
+  background: transparent;
+  border-color: transparent;
   box-shadow: none;
+}
+
+.icon-button.active {
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+  border-color: transparent;
+  box-shadow: var(--shadow-glow);
 }
 
 button:focus-visible,
@@ -374,77 +723,222 @@ textarea:disabled {
   transform: none;
 }
 
+.config-tabs,
+.team-workspace-tabs,
+.inspector-tabs {
+  min-width: 0;
+}
+
+.config-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  padding: 3px;
+  background: color-mix(in srgb, var(--panel-muted) 74%, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-control);
+}
+
 .tab-button,
 .config-tabs .tab-button,
 .team-workspace-tab,
 .inspector-tab {
   color: var(--muted);
   background: transparent;
-}
-
-.config-tabs {
-  gap: 4px 8px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .config-tabs .tab-button {
-  min-height: 34px;
-  padding-inline: 12px;
-  border-radius: 6px 6px 0 0;
+  width: auto;
+  min-height: 32px;
+  padding-inline: 10px;
+  font-size: 13px;
+  font-weight: 720;
 }
 
+.tab-button:hover,
 .config-tabs .tab-button:hover,
 .team-workspace-tab:hover,
 .inspector-tab:hover {
   color: var(--text);
-  background: color-mix(in srgb, var(--panel-hover) 70%, transparent);
+  background: color-mix(in srgb, var(--panel-hover) 78%, transparent);
+  transform: translateY(-1px);
 }
 
+.tab-button.active,
 .config-tabs .tab-button.active,
 .team-workspace-tab.active,
 .inspector-tab.active {
-  color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent-soft) 44%, transparent);
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+  border-color: transparent;
+  box-shadow: var(--shadow-control);
 }
 
-.team-workspace-header,
-.knowledge-commandbar,
-.knowledge-results-toolbar {
-  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+.team-workspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.team-workspace-header {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 12px 16px 0;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 98%, var(--panel-strong)) 0%, var(--panel) 100%);
+  border-bottom: 1px solid var(--border);
+}
+
+.team-detail-header.compact {
+  min-height: 44px;
+  gap: 11px;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.team-detail-header.compact .team-mark {
+  width: 44px;
+  height: 44px;
+}
+
+.team-title-row h2,
+.team-detail-header.compact .team-title-row h2 {
+  color: var(--text);
+  font-size: 19px;
+  font-weight: 780;
+  letter-spacing: 0;
+}
+
+.team-detail-header p {
+  color: var(--subtle);
 }
 
 .team-mark {
+  color: var(--accent-strong);
   background:
-    radial-gradient(circle at 32% 20%, color-mix(in srgb, var(--accent-soft) 90%, #ffffff), transparent 52%),
-    var(--panel-strong);
-  border-color: color-mix(in srgb, var(--accent) 26%, var(--border));
+    radial-gradient(circle at 28% 20%, color-mix(in srgb, var(--accent) 22%, #ffffff), transparent 52%),
+    linear-gradient(145deg, var(--panel), var(--panel-muted));
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+  box-shadow: var(--shadow-control);
+}
+
+.team-workspace-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  padding-bottom: 8px;
+}
+
+.team-workspace-tab {
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-weight: 720;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.team-workspace-tab.active::after {
+  display: none;
+}
+
+.team-workspace-body {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  padding: 16px;
+  overflow: hidden auto;
+}
+
+.team-overview,
+.team-detail-surface,
+.team-embedded-panel {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+  padding: 0;
+}
+
+.resource-panel,
+.team-resource-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.team-list {
+  display: grid;
+  gap: 8px;
 }
 
 .team-list-item {
-  border-radius: 7px;
+  min-height: 58px;
+  padding: 10px 12px;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  box-shadow: none;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .team-list-item:hover {
+  color: var(--text);
+  background: var(--panel);
   border-color: var(--border);
-  background: var(--panel-hover);
+  transform: translateY(-1px);
 }
 
 .team-list-item.selected {
-  color: var(--accent-strong);
+  color: var(--text);
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 72%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 38%, var(--panel)) 100%);
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 76%, var(--panel)) 0%, color-mix(in srgb, var(--panel) 88%, var(--accent-alt)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
   box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
+}
+
+.team-list-primary span:last-child {
+  font-weight: 720;
+}
+
+.status-dot {
+  background: var(--success);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--success) 16%, transparent);
 }
 
 .status-pill,
 .log-detail-chip {
+  min-height: 22px;
   display: inline-flex;
   align-items: center;
-  min-height: 22px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 46%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--panel-muted) 72%, var(--panel));
+  gap: 5px;
+  padding: 0 8px;
   color: var(--muted);
+  background: color-mix(in srgb, var(--panel-muted) 72%, var(--panel));
+  border: 1px solid color-mix(in srgb, var(--border-strong) 48%, transparent);
+  border-radius: 999px;
   font-size: 11px;
   font-weight: 720;
   letter-spacing: 0;
@@ -453,30 +947,31 @@ textarea:disabled {
 .status-pill.success {
   color: var(--success);
   background: var(--success-soft);
-  border-color: color-mix(in srgb, var(--success) 28%, transparent);
+  border-color: color-mix(in srgb, var(--success) 30%, transparent);
 }
 
 .status-pill.warning {
   color: var(--warning);
   background: var(--warning-soft);
-  border-color: color-mix(in srgb, var(--warning) 28%, transparent);
+  border-color: color-mix(in srgb, var(--warning) 30%, transparent);
 }
 
 .status-pill.error,
 .status-pill.danger {
   color: var(--danger);
   background: var(--danger-soft);
-  border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .banner {
-  border-radius: 7px;
-  box-shadow: var(--shadow-control);
+  padding: 12px 14px;
+  animation: card-rise 280ms ease both;
 }
 
 .banner.error {
-  border-color: color-mix(in srgb, var(--danger) 24%, var(--border));
-  background: color-mix(in srgb, var(--danger-soft) 70%, var(--panel));
+  color: var(--danger-strong);
+  background: color-mix(in srgb, var(--danger-soft) 78%, var(--panel));
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--border));
 }
 
 .banner.neutral {
@@ -484,196 +979,7 @@ textarea:disabled {
 }
 
 .table-wrap {
-  border-radius: 7px;
+  min-width: 0;
   background: var(--panel);
   box-shadow: var(--shadow-control);
-}
-
-.data-table {
-  font-size: 13px;
-}
-
-.data-table th {
-  color: var(--subtle);
-  background: color-mix(in srgb, var(--panel-muted) 70%, var(--panel));
-  font-size: 11px;
-  font-weight: 760;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.data-table td {
-  color: var(--text);
-  border-color: var(--border);
-}
-
-.data-table tbody tr:hover td {
-  background: color-mix(in srgb, var(--panel-hover) 58%, transparent);
-}
-
-.table-placeholder,
-.empty-state {
-  min-height: 112px;
-  color: var(--muted);
-  border-color: color-mix(in srgb, var(--border-strong) 62%, var(--border));
-  border-radius: 7px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--panel-strong) 86%, transparent) 0%, var(--panel) 100%);
-}
-
-.summary-strip {
-  border-radius: 7px;
-}
-
-.summary-strip .summary-item {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 72%, var(--panel)) 0%, var(--panel) 100%);
-}
-
-.summary-item strong,
-.metric-card strong {
-  letter-spacing: 0;
-}
-
-.metrics-toolbar,
-.telemetry-toolbar,
-.dream-list-toolbar {
-  border-color: var(--border);
-}
-
-.checkbox-row input[type="checkbox"],
-.filter-row input[type="checkbox"],
-.check-row input[type="checkbox"] {
-  width: 16px;
-  min-height: 16px;
-  height: 16px;
-  margin: 0;
-  padding: 0;
-  border: 1px solid var(--border-strong);
-  border-radius: 4px;
-  appearance: none;
-  background: var(--panel);
-  cursor: pointer;
-}
-
-.checkbox-row input[type="checkbox"]:checked,
-.filter-row input[type="checkbox"]:checked,
-.check-row input[type="checkbox"]:checked {
-  border-color: var(--accent);
-  background:
-    linear-gradient(135deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 43% 55% / 8px 8px no-repeat,
-    linear-gradient(45deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 38% 62% / 6px 6px no-repeat,
-    var(--accent);
-}
-
-.toggle-row input {
-  width: 40px;
-  height: 22px;
-  border-color: var(--border);
-  background: var(--panel-muted);
-  box-shadow: inset 0 1px 2px rgba(29, 45, 41, 0.12);
-}
-
-.toggle-row input::after {
-  width: 16px;
-  height: 16px;
-  background: #ffffff;
-}
-
-.toggle-row input:checked {
-  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
-  background: var(--accent);
-}
-
-.knowledge-explorer {
-  background: var(--panel);
-  border-radius: 8px;
-}
-
-.knowledge-filter-panel,
-.knowledge-inspector {
-  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
-}
-
-.knowledge-results-panel {
-  background: color-mix(in srgb, var(--bg) 86%, var(--panel));
-}
-
-.knowledge-list {
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--border-strong) 70%, transparent) transparent;
-}
-
-.knowledge-item {
-  border-radius: 7px;
-  box-shadow: var(--shadow-control);
-  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
-}
-
-.knowledge-result-option:hover {
-  border-color: var(--border-strong);
-  background: var(--panel);
-  transform: translateY(-1px);
-}
-
-.knowledge-item.selected {
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 64%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 28%, var(--panel)) 100%);
-  border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
-  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
-}
-
-.inspector-tabs {
-  gap: 4px;
-  padding-inline: 8px;
-}
-
-.inspector-section,
-.filter-stack {
-  border-color: var(--border);
-}
-
-.evidence-list div,
-.inspector-details div {
-  border-radius: 7px;
-}
-
-.confidence-bar {
-  background:
-    linear-gradient(90deg, var(--accent) var(--confidence), color-mix(in srgb, var(--border-strong) 54%, transparent) 0);
-}
-
-.info-tooltip-trigger {
-  color: var(--subtle);
-}
-
-.info-tooltip-content {
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--panel);
-  box-shadow: var(--shadow);
-}
-
-@media (max-width: 980px) {
-  .primary-rail {
-    padding: 10px;
-  }
-
-  .rail-tab-button {
-    min-height: 48px;
-  }
-}
-
-@media (max-width: 620px) {
-  .topbar {
-    gap: 10px;
-    padding-inline: 14px;
-  }
-
-  .primary-button,
-  .ghost-button,
-  .danger-button,
-  .icon-button {
-    min-height: 36px;
-  }
 }

--- a/web/src/admin-system.css
+++ b/web/src/admin-system.css
@@ -35,6 +35,7 @@ body {
   --shadow: 0 18px 40px rgba(29, 45, 41, 0.10);
   --shadow-soft: 0 1px 2px rgba(29, 45, 41, 0.07), 0 12px 26px rgba(29, 45, 41, 0.05);
   --shadow-control: 0 1px 1px rgba(29, 45, 41, 0.05);
+
   font-feature-settings: "cv02", "cv03", "cv04";
   background: var(--bg);
 }

--- a/web/src/admin-system.css
+++ b/web/src/admin-system.css
@@ -1,0 +1,678 @@
+:root {
+  color-scheme: light;
+  background: #edf1ef;
+}
+
+body {
+  background:
+    radial-gradient(circle at 16% 0%, rgba(45, 127, 116, 0.08), transparent 30%),
+    linear-gradient(180deg, #f7f9f8 0%, #edf1ef 46%, #e8eeeb 100%);
+}
+
+.auth-shell,
+.app-shell {
+  --bg: #edf1ef;
+  --panel: #ffffff;
+  --panel-strong: #f8faf9;
+  --panel-muted: #eef3f0;
+  --panel-hover: #edf5f1;
+  --border: #d9e3df;
+  --border-strong: #b7c8c0;
+  --text: #13201d;
+  --muted: #53635e;
+  --subtle: #7c8a85;
+  --accent: #0c8176;
+  --accent-strong: #06675f;
+  --accent-soft: #dff3ef;
+  --danger: #b42318;
+  --danger-strong: #911a12;
+  --danger-soft: #fff0ed;
+  --warning: #a15c07;
+  --warning-soft: #fff6df;
+  --success: #0b7a45;
+  --success-soft: #e3f7ed;
+  --focus: rgba(12, 129, 118, 0.18);
+  --shadow: 0 18px 40px rgba(29, 45, 41, 0.10);
+  --shadow-soft: 0 1px 2px rgba(29, 45, 41, 0.07), 0 12px 26px rgba(29, 45, 41, 0.05);
+  --shadow-control: 0 1px 1px rgba(29, 45, 41, 0.05);
+  font-feature-settings: "cv02", "cv03", "cv04";
+  background: var(--bg);
+}
+
+.auth-shell[data-theme="dark"],
+.app-shell[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #101412;
+  --panel: #171d1a;
+  --panel-strong: #1d2420;
+  --panel-muted: #222c27;
+  --panel-hover: #26332d;
+  --border: #2f3d37;
+  --border-strong: #4a5d55;
+  --text: #eef6f3;
+  --muted: #aebcb6;
+  --subtle: #7f9189;
+  --accent: #34c7b6;
+  --accent-strong: #8de9dc;
+  --accent-soft: rgba(52, 199, 182, 0.14);
+  --danger: #ff8a7d;
+  --danger-strong: #ffb4ac;
+  --danger-soft: rgba(255, 138, 125, 0.12);
+  --warning: #f7c667;
+  --warning-soft: rgba(247, 198, 103, 0.14);
+  --success: #56d68f;
+  --success-soft: rgba(86, 214, 143, 0.14);
+  --focus: rgba(52, 199, 182, 0.24);
+  --shadow: 0 22px 56px rgba(0, 0, 0, 0.34);
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.30), 0 14px 28px rgba(0, 0, 0, 0.18);
+  --shadow-control: 0 1px 1px rgba(0, 0, 0, 0.22);
+}
+
+.app-shell {
+  min-width: 0;
+}
+
+.auth-panel,
+.surface,
+.resource-rail,
+.knowledge-explorer,
+.knowledge-filter-panel,
+.knowledge-results-panel,
+.knowledge-inspector,
+.overview-panel,
+.team-list-item,
+.summary-strip,
+.table-wrap,
+.banner,
+.secret-box,
+.telemetry-chart,
+.summary-item,
+.metric-card {
+  border-color: var(--border);
+  box-shadow: var(--shadow-soft);
+}
+
+.surface,
+.auth-panel,
+.knowledge-explorer {
+  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+}
+
+.overview-panel,
+.summary-item,
+.metric-card,
+.telemetry-chart,
+.knowledge-item,
+.inspector-details div,
+.secret-box {
+  background: var(--panel-strong);
+}
+
+.topbar {
+  background: color-mix(in srgb, var(--panel) 90%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.brand-mark {
+  border-radius: 6px;
+  background: linear-gradient(145deg, #087f88 0%, #0b726b 58%, #24536a 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 8px 18px rgba(5, 91, 93, 0.18);
+}
+
+.brand-row h1 {
+  letter-spacing: 0;
+}
+
+.topbar-actions,
+.button-row,
+.secret-actions,
+.toolbar-actions,
+.result-actions,
+.inspector-actions {
+  min-width: 0;
+}
+
+.primary-rail,
+.resource-rail,
+.top-nav-bar {
+  background: color-mix(in srgb, var(--panel) 94%, var(--panel-muted));
+}
+
+.primary-rail {
+  padding: 12px 9px;
+}
+
+.rail-tabs {
+  gap: 7px;
+}
+
+.rail-tab-button {
+  position: relative;
+  min-height: 54px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--muted);
+  background: transparent;
+}
+
+.rail-tab-button:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel-hover) 78%, transparent);
+  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.rail-tab-button.active {
+  color: var(--accent-strong);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 82%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 44%, var(--panel)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
+}
+
+.top-nav-tabs .rail-tab-button {
+  min-height: 34px;
+  border-radius: 6px;
+  box-shadow: none;
+}
+
+.top-nav-tabs .rail-tab-button.active {
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.resource-rail {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--border-strong) 70%, transparent) transparent;
+}
+
+.resource-panel .section-heading h2,
+.section-heading h2,
+.list-toolbar h3,
+.knowledge-results-toolbar h2 {
+  font-size: 16px;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.section-heading span,
+.list-toolbar span,
+.knowledge-results-toolbar span,
+.form-meta {
+  color: var(--subtle);
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0.02em;
+}
+
+label,
+legend {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+input,
+select,
+textarea {
+  min-height: 38px;
+  border-color: var(--border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #ffffff 60%, transparent);
+  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.app-shell[data-theme="dark"] input,
+.app-shell[data-theme="dark"] select,
+.app-shell[data-theme="dark"] textarea,
+.auth-shell[data-theme="dark"] input,
+.auth-shell[data-theme="dark"] select,
+.auth-shell[data-theme="dark"] textarea {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+select {
+  appearance: none;
+  padding-right: 34px;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--subtle) 50%),
+    linear-gradient(135deg, var(--subtle) 50%, transparent 50%);
+  background-position:
+    calc(100% - 16px) 50%,
+    calc(100% - 11px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+  border-color: var(--border-strong);
+  background: var(--panel);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  background: var(--panel);
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+.resource-search,
+.search-input-wrap,
+.session-context,
+.team-select-chip,
+.select-like {
+  border-color: var(--border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--panel-strong) 92%, var(--panel));
+  box-shadow: var(--shadow-control);
+}
+
+.resource-search:hover,
+.search-input-wrap:hover,
+.session-context:hover,
+.team-select-chip:hover,
+.select-like:hover {
+  border-color: var(--border-strong);
+  background: var(--panel);
+}
+
+.resource-search:focus-within,
+.search-input-wrap:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+.primary-button,
+.ghost-button,
+.danger-button,
+.icon-button,
+.text-button,
+.tab-button,
+.team-workspace-tab,
+.inspector-tab,
+.select-like {
+  user-select: none;
+}
+
+.primary-button,
+.ghost-button,
+.danger-button,
+.icon-button {
+  min-height: 36px;
+  border-radius: 6px;
+  box-shadow: var(--shadow-control);
+}
+
+.primary-button {
+  color: #ffffff;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, #19a896) 0%, var(--accent-strong) 100%);
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 72%, transparent);
+}
+
+.primary-button:hover {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent-strong) 88%, #22b8a7) 0%, var(--accent-strong) 100%);
+  transform: translateY(-1px);
+}
+
+.ghost-button,
+.icon-button {
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel) 94%, var(--panel-strong));
+  border: 1px solid var(--border);
+}
+
+.ghost-button:hover,
+.icon-button:hover {
+  background: var(--panel-hover);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+
+.danger-button {
+  border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
+  background: color-mix(in srgb, var(--danger-soft) 76%, var(--panel));
+}
+
+.text-button {
+  border-radius: 5px;
+  color: var(--accent-strong);
+}
+
+.text-button:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.icon-button {
+  width: 36px;
+}
+
+.icon-button.bare {
+  box-shadow: none;
+}
+
+button:focus-visible,
+.knowledge-result-option:focus-visible,
+.team-list-item:focus-visible,
+.rail-tab-button:focus-visible,
+.tab-button:focus-visible,
+.team-workspace-tab:focus-visible,
+.inspector-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  opacity: 0.52;
+  transform: none;
+}
+
+.tab-button,
+.config-tabs .tab-button,
+.team-workspace-tab,
+.inspector-tab {
+  color: var(--muted);
+  background: transparent;
+}
+
+.config-tabs {
+  gap: 4px 8px;
+}
+
+.config-tabs .tab-button {
+  min-height: 34px;
+  padding-inline: 12px;
+  border-radius: 6px 6px 0 0;
+}
+
+.config-tabs .tab-button:hover,
+.team-workspace-tab:hover,
+.inspector-tab:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel-hover) 70%, transparent);
+}
+
+.config-tabs .tab-button.active,
+.team-workspace-tab.active,
+.inspector-tab.active {
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent-soft) 44%, transparent);
+}
+
+.team-workspace-header,
+.knowledge-commandbar,
+.knowledge-results-toolbar {
+  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+}
+
+.team-mark {
+  background:
+    radial-gradient(circle at 32% 20%, color-mix(in srgb, var(--accent-soft) 90%, #ffffff), transparent 52%),
+    var(--panel-strong);
+  border-color: color-mix(in srgb, var(--accent) 26%, var(--border));
+}
+
+.team-list-item {
+  border-radius: 7px;
+}
+
+.team-list-item:hover {
+  border-color: var(--border);
+  background: var(--panel-hover);
+}
+
+.team-list-item.selected {
+  color: var(--accent-strong);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 72%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 38%, var(--panel)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
+}
+
+.status-pill,
+.log-detail-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 46%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-muted) 72%, var(--panel));
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0;
+}
+
+.status-pill.success {
+  color: var(--success);
+  background: var(--success-soft);
+  border-color: color-mix(in srgb, var(--success) 28%, transparent);
+}
+
+.status-pill.warning {
+  color: var(--warning);
+  background: var(--warning-soft);
+  border-color: color-mix(in srgb, var(--warning) 28%, transparent);
+}
+
+.status-pill.error,
+.status-pill.danger {
+  color: var(--danger);
+  background: var(--danger-soft);
+  border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+}
+
+.banner {
+  border-radius: 7px;
+  box-shadow: var(--shadow-control);
+}
+
+.banner.error {
+  border-color: color-mix(in srgb, var(--danger) 24%, var(--border));
+  background: color-mix(in srgb, var(--danger-soft) 70%, var(--panel));
+}
+
+.banner.neutral {
+  background: color-mix(in srgb, var(--panel-muted) 74%, var(--panel));
+}
+
+.table-wrap {
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: var(--shadow-control);
+}
+
+.data-table {
+  font-size: 13px;
+}
+
+.data-table th {
+  color: var(--subtle);
+  background: color-mix(in srgb, var(--panel-muted) 70%, var(--panel));
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.data-table td {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.data-table tbody tr:hover td {
+  background: color-mix(in srgb, var(--panel-hover) 58%, transparent);
+}
+
+.table-placeholder,
+.empty-state {
+  min-height: 112px;
+  color: var(--muted);
+  border-color: color-mix(in srgb, var(--border-strong) 62%, var(--border));
+  border-radius: 7px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--panel-strong) 86%, transparent) 0%, var(--panel) 100%);
+}
+
+.summary-strip {
+  border-radius: 7px;
+}
+
+.summary-strip .summary-item {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 72%, var(--panel)) 0%, var(--panel) 100%);
+}
+
+.summary-item strong,
+.metric-card strong {
+  letter-spacing: 0;
+}
+
+.metrics-toolbar,
+.telemetry-toolbar,
+.dream-list-toolbar {
+  border-color: var(--border);
+}
+
+.checkbox-row input[type="checkbox"],
+.filter-row input[type="checkbox"],
+.check-row input[type="checkbox"] {
+  width: 16px;
+  min-height: 16px;
+  height: 16px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  appearance: none;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.checkbox-row input[type="checkbox"]:checked,
+.filter-row input[type="checkbox"]:checked,
+.check-row input[type="checkbox"]:checked {
+  border-color: var(--accent);
+  background:
+    linear-gradient(135deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 43% 55% / 8px 8px no-repeat,
+    linear-gradient(45deg, transparent 42%, #ffffff 42% 58%, transparent 58%) 38% 62% / 6px 6px no-repeat,
+    var(--accent);
+}
+
+.toggle-row input {
+  width: 40px;
+  height: 22px;
+  border-color: var(--border);
+  background: var(--panel-muted);
+  box-shadow: inset 0 1px 2px rgba(29, 45, 41, 0.12);
+}
+
+.toggle-row input::after {
+  width: 16px;
+  height: 16px;
+  background: #ffffff;
+}
+
+.toggle-row input:checked {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  background: var(--accent);
+}
+
+.knowledge-explorer {
+  background: var(--panel);
+  border-radius: 8px;
+}
+
+.knowledge-filter-panel,
+.knowledge-inspector {
+  background: color-mix(in srgb, var(--panel) 96%, var(--panel-strong));
+}
+
+.knowledge-results-panel {
+  background: color-mix(in srgb, var(--bg) 86%, var(--panel));
+}
+
+.knowledge-list {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--border-strong) 70%, transparent) transparent;
+}
+
+.knowledge-item {
+  border-radius: 7px;
+  box-shadow: var(--shadow-control);
+  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.knowledge-result-option:hover {
+  border-color: var(--border-strong);
+  background: var(--panel);
+  transform: translateY(-1px);
+}
+
+.knowledge-item.selected {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 64%, var(--panel)) 0%, color-mix(in srgb, var(--accent-soft) 28%, var(--panel)) 100%);
+  border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent), var(--shadow-control);
+}
+
+.inspector-tabs {
+  gap: 4px;
+  padding-inline: 8px;
+}
+
+.inspector-section,
+.filter-stack {
+  border-color: var(--border);
+}
+
+.evidence-list div,
+.inspector-details div {
+  border-radius: 7px;
+}
+
+.confidence-bar {
+  background:
+    linear-gradient(90deg, var(--accent) var(--confidence), color-mix(in srgb, var(--border-strong) 54%, transparent) 0);
+}
+
+.info-tooltip-trigger {
+  color: var(--subtle);
+}
+
+.info-tooltip-content {
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+@media (max-width: 980px) {
+  .primary-rail {
+    padding: 10px;
+  }
+
+  .rail-tab-button {
+    min-height: 48px;
+  }
+}
+
+@media (max-width: 620px) {
+  .topbar {
+    gap: 10px;
+    padding-inline: 14px;
+  }
+
+  .primary-button,
+  .ghost-button,
+  .danger-button,
+  .icon-button {
+    min-height: 36px;
+  }
+}

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import { Check, Clock, ListFilter, MessageSquare, Moon, Network, RefreshCw, Settings, X } from "lucide-react";
 import { CommunityDetectionConfig, CommunityDetectionConfigItem, ControlApi, DreamingConfig, DreamingConfigItem, GeneralConfig, GeneralConfigItem, OperationLogConfig, OperationLogConfigItem, RecallFeedbackConfig, RecallFeedbackConfigItem, SSOConfig, SSOConfigItem } from "../api";
-import { SectionHeading } from "../ui/components";
+import { LoadingState, SectionHeading } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
 type ConfigTab = "general" | "sso" | "dreaming" | "community" | "operation-logs" | "recall-feedback";
@@ -293,7 +293,7 @@ function RuntimeConfigPanel<T extends RuntimeConfig>({
       {error && <div className="banner error" role="alert">{error}</div>}
       {message && <div className="banner neutral">{message}</div>}
       {loading && !config ? (
-        <div className="table-placeholder compact">Loading</div>
+        <LoadingState label="Loading config" compact />
       ) : (
         <form className="edit-grid" onSubmit={saveConfig}>
           {(config?.items ?? []).map((item) => (

--- a/web/src/control/DreamsPanel.tsx
+++ b/web/src/control/DreamsPanel.tsx
@@ -13,7 +13,7 @@ const DREAM_SORTS: Array<{ value: DreamSort; label: string }> = [
 ];
 const DEFAULT_DREAM_QUERY: DreamQuery = { status: "", limit: 25, sort: "updated_at", direction: "desc", cursor: "" };
 
-export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team }) {
+export function ControlDreamsPanel({ api, team, embedded = false }: { api: ControlApi; team: Team; embedded?: boolean }) {
   const [status, setStatus] = useState<DreamStatus | null>(null);
   const [runs, setRuns] = useState<DreamRun[]>([]);
   const [dreams, setDreams] = useState<Dream[]>([]);
@@ -68,10 +68,11 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
   const dreamSort = dreamQuery.sort ?? "updated_at";
   const dreamDirection = dreamQuery.direction ?? "desc";
   const dreamLimit = dreamQuery.limit ?? DEFAULT_DREAM_QUERY.limit ?? 25;
+  const panelClassName = embedded ? "overview-panel" : "surface";
 
   return (
     <>
-      <section className="surface">
+      <section className={panelClassName}>
         <SectionHeading
           title="Dreaming"
           meta={team.name}
@@ -92,7 +93,7 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
         )}
       </section>
 
-      <section className="surface">
+      <section className={panelClassName}>
         <SectionHeading title="Dream Outputs" meta={`Page ${pageNumber}`} />
         <div className="metrics-toolbar dream-list-toolbar">
           <label>
@@ -181,7 +182,7 @@ export function ControlDreamsPanel({ api, team }: { api: ControlApi; team: Team 
         </div>
       </section>
 
-      <section className="surface">
+      <section className={panelClassName}>
         <SectionHeading title="Cycle Runs" meta={runs.length} />
         {runs.length === 0 ? <div className="table-placeholder">No runs</div> : <RunTable runs={runs} />}
       </section>

--- a/web/src/control/DreamsPanel.tsx
+++ b/web/src/control/DreamsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { ControlApi, Dream, DreamQuery, DreamRun, DreamSort, DreamStatus, Team } from "../api";
-import { InfoTooltip, SectionHeading } from "../ui/components";
+import { InfoTooltip, LoadingState, SectionHeading } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
 const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
@@ -136,7 +136,7 @@ export function ControlDreamsPanel({ api, team, embedded = false }: { api: Contr
           </label>
         </div>
         {loading && dreams.length === 0 ? (
-          <div className="table-placeholder">Loading</div>
+          <LoadingState label="Loading dreams" />
         ) : dreams.length === 0 ? (
           <div className="table-placeholder">No dreams</div>
         ) : (
@@ -184,7 +184,13 @@ export function ControlDreamsPanel({ api, team, embedded = false }: { api: Contr
 
       <section className={panelClassName}>
         <SectionHeading title="Cycle Runs" meta={runs.length} />
-        {runs.length === 0 ? <div className="table-placeholder">No runs</div> : <RunTable runs={runs} />}
+        {loading && runs.length === 0 ? (
+          <LoadingState label="Loading runs" />
+        ) : runs.length === 0 ? (
+          <div className="table-placeholder">No runs</div>
+        ) : (
+          <RunTable runs={runs} />
+        )}
       </section>
     </>
   );

--- a/web/src/control/LogsPanel.tsx
+++ b/web/src/control/LogsPanel.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Braces, RefreshCw } from "lucide-react";
 import { ControlApi, OperationLog, OperationLogQuery, Team } from "../api";
-import { SectionHeading } from "../ui/components";
+import { LoadingState, SectionHeading } from "../ui/components";
 import { formatDate, readError, shortId } from "./utils";
 
 const SEVERITIES = ["", "DEBUG", "INFO", "WARN", "ERROR"];
@@ -126,7 +126,7 @@ export function LogsPanel({ api, teams }: { api: ControlApi; teams: Team[] }) {
         </label>
       </div>
       {loading && logs.length === 0 ? (
-        <div className="table-placeholder">Loading</div>
+        <LoadingState label="Loading logs" />
       ) : logs.length === 0 ? (
         <div className="table-placeholder">No logs</div>
       ) : (

--- a/web/src/control/MetricsPanel.tsx
+++ b/web/src/control/MetricsPanel.tsx
@@ -3,7 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { ControlApi, ControlMetrics, Team, TeamProfile } from "../api";
 import { TelemetryDashboard } from "../telemetry/TelemetryDashboard";
 import { TelemetrySnapshot, TelemetryWindowKey } from "../telemetry/types";
-import { SectionHeading, SummaryCard } from "../ui/components";
+import { LoadingState, SectionHeading, SummaryCard } from "../ui/components";
 import { dependencyStatusClass, formatCount, formatDate, formatLatency, formatPercent, readError, shortId } from "./utils";
 
 type TelemetryControlScope = "system" | "team" | "profile";
@@ -187,7 +187,7 @@ export function MetricsPanel({ api, teams }: { api: ControlApi; teams: Team[] })
         </select>
       </div>
 
-      {loading && !metrics && <div className="table-placeholder">Loading</div>}
+      {loading && !metrics && <LoadingState label="Loading usage rollup" />}
       {metrics && (
         <>
           <MetricsSummary metrics={metrics} />

--- a/web/src/control/RecallFeedbackPanel.tsx
+++ b/web/src/control/RecallFeedbackPanel.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Braces, RefreshCw } from "lucide-react";
 import { ControlApi, RecallFeedbackEvent, RecallFeedbackEventQuery, RecallFeedbackResolvedResult, RecallFeedbackResultRef, Team } from "../api";
-import { SectionHeading } from "../ui/components";
+import { LoadingState, SectionHeading } from "../ui/components";
 import { formatDate, readError, shortId } from "./utils";
 
 const PAGE_SIZES = [25, 50, 100, 250, 500];
@@ -182,7 +182,7 @@ export function RecallFeedbackPanel({ api, teams }: { api: ControlApi; teams: Te
         </label>
       </div>
       {loading && events.length === 0 ? (
-        <div className="table-placeholder">Loading</div>
+        <LoadingState label="Loading recall feedback" />
       ) : events.length === 0 ? (
         <div className="table-placeholder">No recall feedback</div>
       ) : (
@@ -240,7 +240,7 @@ export function RecallFeedbackPanel({ api, teams }: { api: ControlApi; teams: Te
                       <tr className="log-raw-row">
                         <td colSpan={7}>
                           {detailLoading === event.recall_id && !detail ? (
-                            <div className="table-placeholder compact">Loading</div>
+                            <LoadingState label="Loading details" compact />
                           ) : (
                             <RecallFeedbackDetail event={detail ?? event} />
                           )}

--- a/web/src/control/SecurityPanel.tsx
+++ b/web/src/control/SecurityPanel.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import { Ban, RefreshCw, Trash2 } from "lucide-react";
 import { ControlApi, SecurityBan, SecuritySettings } from "../api";
-import { SectionHeading, SummaryCard } from "../ui/components";
+import { LoadingState, SectionHeading, SummaryCard } from "../ui/components";
 import { formatDate, readError } from "./utils";
 
 export function SecurityPanel({ api }: { api: ControlApi }) {
@@ -98,7 +98,7 @@ export function SecurityPanel({ api }: { api: ControlApi }) {
             <SummaryCard label="Ban duration" value={settings.ban_duration_seconds === 0 ? "Permanent" : `${settings.ban_duration_seconds}s`} />
           </>
         ) : (
-          <div className="table-placeholder compact">Loading rules</div>
+          <LoadingState label="Loading rules" compact />
         )}
       </div>
 

--- a/web/src/control/TeamWorkspace.tsx
+++ b/web/src/control/TeamWorkspace.tsx
@@ -134,7 +134,7 @@ export function TeamOverviewPanel({
   const requestValue = metricsReady ? compactNumber(requests) : loading ? "..." : "n/a";
   const errorValue = metricsReady ? compactNumber(errors) : loading ? "..." : "n/a";
   const healthValue = metricsReady ? `${health.toFixed(1)}%` : loading ? "..." : "n/a";
-  const healthDetail = loading ? "Loading" : metricsFailed ? "Metrics unavailable" : "Operational";
+  const healthDetail = loading ? <span className="inline-loading">Loading</span> : metricsFailed ? "Metrics unavailable" : "Operational";
   const latencyValue = metricsReady ? `${Math.round(teamMetrics?.avg_latency_ms ?? metrics.system.avg_latency_ms)} ms` : "n/a";
   const maxLatencyValue = metricsReady ? `${Math.round(teamMetrics?.max_latency_ms ?? metrics.system.max_latency_ms)} ms` : "n/a";
 
@@ -153,7 +153,7 @@ export function TeamOverviewPanel({
 
       <div className="overview-grid">
         <section className="overview-panel" aria-label="Team activity">
-          <SectionHeading title="Team Activity (1h)" meta={loading ? "loading" : metricsFailed ? "metrics unavailable" : undefined} />
+          <SectionHeading title="Team Activity (1h)" meta={loading ? <span className="inline-loading">Loading</span> : metricsFailed ? "metrics unavailable" : undefined} />
           <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="HTTP requests" value={requestValue} trend={metricsReady ? requests > 0 ? "+ active" : "idle" : "unavailable"} tone={metricsFailed ? "warning" : "neutral"} />
           <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="Errors" value={errorValue} trend={metricsReady ? errors > 0 ? "review" : "clear" : "unavailable"} tone={errors > 0 ? "danger" : metricsFailed ? "warning" : "neutral"} />
           <MetricRow icon={<Users size={15} aria-hidden="true" />} label="Writable profiles" value={readWriteCount} trend={`${profiles.length} total`} />

--- a/web/src/control/TeamWorkspace.tsx
+++ b/web/src/control/TeamWorkspace.tsx
@@ -1,0 +1,248 @@
+import { CSSProperties, ReactNode, useEffect, useState } from "react";
+import { Activity, CheckCircle2, Moon, Users } from "lucide-react";
+import { ControlApi, Team, TeamProfile } from "../api";
+import { SectionHeading, SummaryCard } from "../ui/components";
+import { formatDate, profilePermissionLabel, profileRoleLabel, shortId } from "./utils";
+
+export type TeamWorkspaceTab = "overview" | "profiles" | "dreams" | "settings";
+
+export function TeamWorkspaceShell({
+  team,
+  activeTab,
+  onSelectTab,
+  children,
+}: {
+  team: Team;
+  activeTab: TeamWorkspaceTab;
+  onSelectTab: (tab: TeamWorkspaceTab) => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="surface team-workspace">
+      <TeamWorkspaceHeader team={team} activeTab={activeTab} onSelectTab={onSelectTab} />
+      {children}
+    </section>
+  );
+}
+
+function TeamWorkspaceHeader({
+  team,
+  activeTab,
+  onSelectTab,
+}: {
+  team: Team;
+  activeTab: TeamWorkspaceTab;
+  onSelectTab: (tab: TeamWorkspaceTab) => void;
+}) {
+  const tabs: Array<{ id: TeamWorkspaceTab; label: string }> = [
+    { id: "overview", label: "Overview" },
+    { id: "profiles", label: "Profiles" },
+    { id: "dreams", label: "Dreams" },
+    { id: "settings", label: "Settings" },
+  ];
+
+  return (
+    <header className="team-workspace-header">
+      <div className="team-detail-header compact">
+        <span className="team-mark" aria-hidden="true">
+          <Users size={24} />
+        </span>
+        <div>
+          <div className="team-title-row">
+            <h2>{team.name}</h2>
+            <span className="status-pill neutral">Active</span>
+          </div>
+          <p>Created {formatDate(team.created_at)} · Team ID {shortId(team.id)}</p>
+        </div>
+      </div>
+      <nav className="team-workspace-tabs" aria-label={`${team.name} sections`}>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            className={tab.id === activeTab ? "team-workspace-tab active" : "team-workspace-tab"}
+            type="button"
+            aria-label={`Team ${tab.label}`}
+            aria-current={tab.id === activeTab ? "page" : undefined}
+            onClick={() => onSelectTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+    </header>
+  );
+}
+
+export function TeamOverviewPanel({
+  api,
+  team,
+  onOpenSettings,
+}: {
+  api: ControlApi;
+  team: Team;
+  onOpenSettings: () => void;
+}) {
+  const [profiles, setProfiles] = useState<TeamProfile[]>([]);
+  const [metrics, setMetrics] = useState<Awaited<ReturnType<ControlApi["getMetrics"]>> | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    Promise.all([
+      api.listTeamProfiles(team.id).then((page) => page.data).catch(() => [] as TeamProfile[]),
+      api.getMetrics({ team_id: team.id, window_minutes: 60 }).catch(() => null),
+    ])
+      .then(([nextProfiles, nextMetrics]) => {
+        if (!active) {
+          return;
+        }
+        setProfiles(nextProfiles);
+        setMetrics(nextMetrics);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, team.id]);
+
+  const teamMetrics = metrics?.teams.find((item) => item.team_id === team.id);
+  const requests = teamMetrics?.requests ?? metrics?.system.requests ?? 0;
+  const errors = teamMetrics?.errors ?? metrics?.system.errors ?? 0;
+  const health = requests === 0 ? 100 : Math.max(0, 100 - (errors / requests) * 100);
+  const dependencies = metrics?.dependencies ?? [];
+  const degradedDependencies = dependencies.filter((dependency) => dependency.status !== "ok");
+  const managerCount = profiles.filter((profile) => profile.role === "manager").length;
+  const readWriteCount = profiles.filter((profile) => profile.scopes?.includes("write")).length;
+  const recentProfiles = [...profiles].sort((left, right) => right.created_at.localeCompare(left.created_at)).slice(0, 5);
+
+  return (
+    <div className="team-overview" aria-label="Team overview">
+      <div className="summary-strip" aria-label="Summary">
+        <SummaryCard label="Profiles" value={profiles.length} detail={`${managerCount} managers`} />
+        <SummaryCard label="Requests" value={compactNumber(requests)} detail="Last hour" />
+        <SummaryCard label="Recall health" value={`${health.toFixed(1)}%`} detail={loading ? "Loading" : "Operational"} />
+        <div className="health-stack" aria-label="Health summary">
+          <HealthLine label="Healthy" value={Math.max(0, dependencies.length - degradedDependencies.length)} tone="healthy" />
+          <HealthLine label="Degraded" value={degradedDependencies.length} tone={degradedDependencies.length > 0 ? "warning" : "healthy"} />
+          <HealthLine label="Errors" value={errors} tone={errors > 0 ? "danger" : "healthy"} />
+        </div>
+      </div>
+
+      <div className="overview-grid">
+        <section className="overview-panel" aria-label="Team activity">
+          <SectionHeading title="Team Activity (1h)" meta={loading ? "loading" : undefined} />
+          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="HTTP requests" value={compactNumber(requests)} trend={requests > 0 ? "+ active" : "idle"} />
+          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="Errors" value={compactNumber(errors)} trend={errors > 0 ? "review" : "clear"} tone={errors > 0 ? "danger" : "neutral"} />
+          <MetricRow icon={<Users size={15} aria-hidden="true" />} label="Writable profiles" value={readWriteCount} trend={`${profiles.length} total`} />
+          <MetricRow icon={<Moon size={15} aria-hidden="true" />} label="Dreaming" value={team.dreaming_effective?.enabled ? "Enabled" : "Inherited"} trend={team.dreaming_effective?.source ?? "global"} />
+        </section>
+
+        <section className="overview-panel" aria-label="Top signals">
+          <SectionHeading title="Top Signals" />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Average latency" value={`${Math.round(teamMetrics?.avg_latency_ms ?? metrics?.system.avg_latency_ms ?? 0)} ms`} trend="p95 proxy" />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Max latency" value={`${Math.round(teamMetrics?.max_latency_ms ?? metrics?.system.max_latency_ms ?? 0)} ms`} trend="last hour" />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Dependency checks" value={dependencies.length || "n/a"} trend={degradedDependencies.length ? "attention" : "healthy"} tone={degradedDependencies.length ? "warning" : "neutral"} />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Profile freshness" value={recentProfiles[0] ? formatDate(recentProfiles[0].created_at) : "No profiles"} trend="latest" />
+        </section>
+      </div>
+
+      <section className="overview-panel" aria-label="Recent alerts">
+        <SectionHeading title="Recent Alerts" actions={<button className="text-button" type="button" onClick={onOpenSettings}>Open settings</button>} />
+        <div className="mini-table">
+          <MiniTableRow columns={["Time", "Severity", "Alert", "Scope", "Status"]} heading />
+          {errors > 0 && <MiniTableRow columns={["Now", "High", "Request errors detected", "Team", "Open"]} />}
+          {degradedDependencies.map((dependency) => (
+            <MiniTableRow
+              key={dependency.name}
+              columns={["Now", "Medium", `${dependency.name} ${dependency.status}`, "Dependency", "Open"]}
+            />
+          ))}
+          {errors === 0 && degradedDependencies.length === 0 && (
+            <MiniTableRow columns={[formatDate(team.updated_at), "Low", "No active alerts", "Team", "Clear"]} />
+          )}
+        </div>
+      </section>
+
+      <section className="overview-panel" aria-label="Recent profile changes">
+        <SectionHeading title="Recent Profile Changes" meta={profiles.length} />
+        <div className="mini-table">
+          <MiniTableRow columns={["Profile", "Permission", "Role", "Created"]} heading />
+          {recentProfiles.length > 0 ? recentProfiles.map((profile) => (
+            <MiniTableRow
+              key={profile.id}
+              columns={[
+                profile.name,
+                profilePermissionLabel(profile.scopes),
+                profileRoleLabel(profile.role),
+                formatDate(profile.created_at),
+              ]}
+            />
+          )) : (
+            <MiniTableRow columns={["No profiles", "-", "-", "-"]} />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function HealthLine({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "healthy" | "warning" | "danger";
+}) {
+  return (
+    <div className={`health-line ${tone}`}>
+      <span aria-hidden="true" />
+      <small>{label}</small>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function MetricRow({
+  icon,
+  label,
+  value,
+  trend,
+  tone = "neutral",
+}: {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+  trend: string;
+  tone?: "neutral" | "warning" | "danger";
+}) {
+  return (
+    <div className={`metric-row ${tone}`}>
+      <span className="metric-icon">{icon}</span>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{trend}</small>
+    </div>
+  );
+}
+
+function MiniTableRow({ columns, heading = false }: { columns: ReactNode[]; heading?: boolean }) {
+  return (
+    <div
+      className={heading ? "mini-table-row heading" : "mini-table-row"}
+      style={{ "--mini-cols": columns.length } as CSSProperties}
+    >
+      {columns.map((column, index) => <span key={index}>{column}</span>)}
+    </div>
+  );
+}
+
+function compactNumber(value: number): string {
+  return new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}

--- a/web/src/control/TeamWorkspace.tsx
+++ b/web/src/control/TeamWorkspace.tsx
@@ -20,7 +20,9 @@ export function TeamWorkspaceShell({
   return (
     <section className="surface team-workspace">
       <TeamWorkspaceHeader team={team} activeTab={activeTab} onSelectTab={onSelectTab} />
-      {children}
+      <div className="team-workspace-body">
+        {children}
+      </div>
     </section>
   );
 }

--- a/web/src/control/TeamWorkspace.tsx
+++ b/web/src/control/TeamWorkspace.tsx
@@ -84,14 +84,21 @@ export function TeamOverviewPanel({
 }) {
   const [profiles, setProfiles] = useState<TeamProfile[]>([]);
   const [metrics, setMetrics] = useState<Awaited<ReturnType<ControlApi["getMetrics"]>> | null>(null);
+  const [metricsUnavailable, setMetricsUnavailable] = useState(false);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let active = true;
     setLoading(true);
+    setMetricsUnavailable(false);
     Promise.all([
       api.listTeamProfiles(team.id).then((page) => page.data).catch(() => [] as TeamProfile[]),
-      api.getMetrics({ team_id: team.id, window_minutes: 60 }).catch(() => null),
+      api.getMetrics({ team_id: team.id, window_minutes: 60 }).catch(() => {
+        if (active) {
+          setMetricsUnavailable(true);
+        }
+        return null;
+      }),
     ])
       .then(([nextProfiles, nextMetrics]) => {
         if (!active) {
@@ -99,6 +106,7 @@ export function TeamOverviewPanel({
         }
         setProfiles(nextProfiles);
         setMetrics(nextMetrics);
+        setMetricsUnavailable(nextMetrics === null);
       })
       .finally(() => {
         if (active) {
@@ -110,43 +118,51 @@ export function TeamOverviewPanel({
     };
   }, [api, team.id]);
 
-  const teamMetrics = metrics?.teams.find((item) => item.team_id === team.id);
-  const requests = teamMetrics?.requests ?? metrics?.system.requests ?? 0;
-  const errors = teamMetrics?.errors ?? metrics?.system.errors ?? 0;
+  const metricsReady = metrics !== null && !metricsUnavailable;
+  const metricsFailed = metricsUnavailable && !loading;
+  const teamMetrics = metricsReady ? metrics.teams.find((item) => item.team_id === team.id) : undefined;
+  const requests = metricsReady ? teamMetrics?.requests ?? metrics.system.requests : 0;
+  const errors = metricsReady ? teamMetrics?.errors ?? metrics.system.errors : 0;
   const health = requests === 0 ? 100 : Math.max(0, 100 - (errors / requests) * 100);
-  const dependencies = metrics?.dependencies ?? [];
+  const dependencies = metricsReady ? metrics.dependencies : [];
   const degradedDependencies = dependencies.filter((dependency) => dependency.status !== "ok");
   const managerCount = profiles.filter((profile) => profile.role === "manager").length;
   const readWriteCount = profiles.filter((profile) => profile.scopes?.includes("write")).length;
   const recentProfiles = [...profiles].sort((left, right) => right.created_at.localeCompare(left.created_at)).slice(0, 5);
+  const requestValue = metricsReady ? compactNumber(requests) : loading ? "..." : "n/a";
+  const errorValue = metricsReady ? compactNumber(errors) : loading ? "..." : "n/a";
+  const healthValue = metricsReady ? `${health.toFixed(1)}%` : loading ? "..." : "n/a";
+  const healthDetail = loading ? "Loading" : metricsFailed ? "Metrics unavailable" : "Operational";
+  const latencyValue = metricsReady ? `${Math.round(teamMetrics?.avg_latency_ms ?? metrics.system.avg_latency_ms)} ms` : "n/a";
+  const maxLatencyValue = metricsReady ? `${Math.round(teamMetrics?.max_latency_ms ?? metrics.system.max_latency_ms)} ms` : "n/a";
 
   return (
     <div className="team-overview" aria-label="Team overview">
       <div className="summary-strip" aria-label="Summary">
         <SummaryCard label="Profiles" value={profiles.length} detail={`${managerCount} managers`} />
-        <SummaryCard label="Requests" value={compactNumber(requests)} detail="Last hour" />
-        <SummaryCard label="Recall health" value={`${health.toFixed(1)}%`} detail={loading ? "Loading" : "Operational"} />
+        <SummaryCard label="Requests" value={requestValue} detail="Last hour" tone={metricsFailed ? "warning" : "neutral"} />
+        <SummaryCard label="Recall health" value={healthValue} detail={healthDetail} tone={metricsFailed ? "warning" : "neutral"} />
         <div className="health-stack" aria-label="Health summary">
-          <HealthLine label="Healthy" value={Math.max(0, dependencies.length - degradedDependencies.length)} tone="healthy" />
-          <HealthLine label="Degraded" value={degradedDependencies.length} tone={degradedDependencies.length > 0 ? "warning" : "healthy"} />
-          <HealthLine label="Errors" value={errors} tone={errors > 0 ? "danger" : "healthy"} />
+          <HealthLine label="Healthy" value={metricsReady ? Math.max(0, dependencies.length - degradedDependencies.length) : "n/a"} tone={metricsFailed ? "warning" : "healthy"} />
+          <HealthLine label="Degraded" value={metricsReady ? degradedDependencies.length : "n/a"} tone={metricsFailed || degradedDependencies.length > 0 ? "warning" : "healthy"} />
+          <HealthLine label="Errors" value={metricsReady ? errors : "n/a"} tone={errors > 0 ? "danger" : metricsFailed ? "warning" : "healthy"} />
         </div>
       </div>
 
       <div className="overview-grid">
         <section className="overview-panel" aria-label="Team activity">
-          <SectionHeading title="Team Activity (1h)" meta={loading ? "loading" : undefined} />
-          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="HTTP requests" value={compactNumber(requests)} trend={requests > 0 ? "+ active" : "idle"} />
-          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="Errors" value={compactNumber(errors)} trend={errors > 0 ? "review" : "clear"} tone={errors > 0 ? "danger" : "neutral"} />
+          <SectionHeading title="Team Activity (1h)" meta={loading ? "loading" : metricsFailed ? "metrics unavailable" : undefined} />
+          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="HTTP requests" value={requestValue} trend={metricsReady ? requests > 0 ? "+ active" : "idle" : "unavailable"} tone={metricsFailed ? "warning" : "neutral"} />
+          <MetricRow icon={<Activity size={15} aria-hidden="true" />} label="Errors" value={errorValue} trend={metricsReady ? errors > 0 ? "review" : "clear" : "unavailable"} tone={errors > 0 ? "danger" : metricsFailed ? "warning" : "neutral"} />
           <MetricRow icon={<Users size={15} aria-hidden="true" />} label="Writable profiles" value={readWriteCount} trend={`${profiles.length} total`} />
           <MetricRow icon={<Moon size={15} aria-hidden="true" />} label="Dreaming" value={team.dreaming_effective?.enabled ? "Enabled" : "Inherited"} trend={team.dreaming_effective?.source ?? "global"} />
         </section>
 
         <section className="overview-panel" aria-label="Top signals">
           <SectionHeading title="Top Signals" />
-          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Average latency" value={`${Math.round(teamMetrics?.avg_latency_ms ?? metrics?.system.avg_latency_ms ?? 0)} ms`} trend="p95 proxy" />
-          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Max latency" value={`${Math.round(teamMetrics?.max_latency_ms ?? metrics?.system.max_latency_ms ?? 0)} ms`} trend="last hour" />
-          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Dependency checks" value={dependencies.length || "n/a"} trend={degradedDependencies.length ? "attention" : "healthy"} tone={degradedDependencies.length ? "warning" : "neutral"} />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Average latency" value={latencyValue} trend={metricsReady ? "p95 proxy" : "unavailable"} tone={metricsFailed ? "warning" : "neutral"} />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Max latency" value={maxLatencyValue} trend={metricsReady ? "last hour" : "unavailable"} tone={metricsFailed ? "warning" : "neutral"} />
+          <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Dependency checks" value={metricsReady ? dependencies.length || "n/a" : "n/a"} trend={metricsReady ? degradedDependencies.length ? "attention" : "healthy" : "unavailable"} tone={metricsFailed || degradedDependencies.length ? "warning" : "neutral"} />
           <MetricRow icon={<CheckCircle2 size={15} aria-hidden="true" />} label="Profile freshness" value={recentProfiles[0] ? formatDate(recentProfiles[0].created_at) : "No profiles"} trend="latest" />
         </section>
       </div>
@@ -155,14 +171,15 @@ export function TeamOverviewPanel({
         <SectionHeading title="Recent Alerts" actions={<button className="text-button" type="button" onClick={onOpenSettings}>Open settings</button>} />
         <div className="mini-table">
           <MiniTableRow columns={["Time", "Severity", "Alert", "Scope", "Status"]} heading />
-          {errors > 0 && <MiniTableRow columns={["Now", "High", "Request errors detected", "Team", "Open"]} />}
+          {metricsFailed && <MiniTableRow columns={["Now", "Medium", "Metrics unavailable", "Team", "Open"]} />}
+          {!metricsFailed && errors > 0 && <MiniTableRow columns={["Now", "High", "Request errors detected", "Team", "Open"]} />}
           {degradedDependencies.map((dependency) => (
             <MiniTableRow
               key={dependency.name}
               columns={["Now", "Medium", `${dependency.name} ${dependency.status}`, "Dependency", "Open"]}
             />
           ))}
-          {errors === 0 && degradedDependencies.length === 0 && (
+          {!metricsFailed && errors === 0 && degradedDependencies.length === 0 && (
             <MiniTableRow columns={[formatDate(team.updated_at), "Low", "No active alerts", "Team", "Clear"]} />
           )}
         </div>
@@ -197,7 +214,7 @@ function HealthLine({
   tone,
 }: {
   label: string;
-  value: number;
+  value: ReactNode;
   tone: "healthy" | "warning" | "danger";
 }) {
   return (

--- a/web/src/knowledge-explorer.css
+++ b/web/src/knowledge-explorer.css
@@ -62,9 +62,7 @@
 }
 
 .toolbar-actions,
-.result-kicker,
-.result-actions,
-.inspector-actions {
+.result-kicker {
   display: flex;
   align-items: center;
   gap: 8px;

--- a/web/src/knowledge-explorer.css
+++ b/web/src/knowledge-explorer.css
@@ -1,0 +1,220 @@
+.knowledge-explorer {
+  grid-template-columns: minmax(210px, 250px) minmax(480px, 1fr) minmax(300px, 360px);
+  gap: 0;
+  min-height: calc(100vh - 80px);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.knowledge-filter-panel,
+.knowledge-results-panel,
+.knowledge-inspector {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.knowledge-filter-panel,
+.knowledge-inspector {
+  top: 64px;
+  max-height: calc(100vh - 80px);
+}
+
+.knowledge-filter-panel {
+  border-right: 1px solid var(--border);
+}
+
+.knowledge-inspector {
+  border-left: 1px solid var(--border);
+}
+
+.knowledge-results-panel {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  padding: 0;
+  background: var(--bg);
+}
+
+.knowledge-commandbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.search-input-wrap.large {
+  min-height: 40px;
+}
+
+.knowledge-results-toolbar {
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.toolbar-actions,
+.result-kicker,
+.result-actions,
+.inspector-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.knowledge-list {
+  gap: 10px;
+  padding: 12px 14px;
+}
+
+.knowledge-item {
+  padding: 13px 14px;
+  background: var(--panel);
+  border-radius: 6px;
+}
+
+.knowledge-item.selected {
+  background: color-mix(in srgb, var(--panel) 84%, var(--accent-soft));
+  border-color: color-mix(in srgb, var(--accent) 64%, var(--border));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.status-pill.success {
+  color: #15803d;
+  background: color-mix(in srgb, #22c55e 14%, transparent);
+  border: 1px solid color-mix(in srgb, #22c55e 28%, transparent);
+}
+
+.status-pill.warning {
+  color: #b45309;
+  background: color-mix(in srgb, #f59e0b 16%, transparent);
+  border: 1px solid color-mix(in srgb, #f59e0b 30%, transparent);
+}
+
+.status-pill.danger {
+  color: #b91c1c;
+  background: color-mix(in srgb, #ef4444 14%, transparent);
+  border: 1px solid color-mix(in srgb, #ef4444 28%, transparent);
+}
+
+.icon-button.bare {
+  width: 26px;
+  min-height: 26px;
+  color: var(--subtle);
+  background: transparent;
+  border: 0;
+}
+
+.result-meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  color: var(--subtle);
+  font-size: 12px;
+}
+
+.inspector-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.inspector-head h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 760;
+}
+
+.inspector-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border);
+}
+
+.inspector-tab {
+  position: relative;
+  min-height: 38px;
+  color: var(--muted);
+  background: transparent;
+  font-size: 12px;
+  font-weight: 740;
+  cursor: pointer;
+}
+
+.inspector-tab.active {
+  color: var(--accent-strong);
+}
+
+.inspector-tab.active::after {
+  position: absolute;
+  right: 10px;
+  bottom: -1px;
+  left: 10px;
+  height: 2px;
+  content: "";
+  background: var(--accent);
+}
+
+.inspector-status-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.inspector-section {
+  display: grid;
+  gap: 10px;
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.inspector-section h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.evidence-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.evidence-list div {
+  display: grid;
+  grid-template-columns: minmax(86px, auto) minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.evidence-list dt {
+  color: var(--subtle);
+  font-size: 12px;
+}
+
+.evidence-list dd {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+  margin: 0;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.confidence-bar {
+  width: 92px;
+  height: 5px;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, var(--accent) var(--confidence), var(--border) 0);
+}

--- a/web/src/knowledge-explorer.css
+++ b/web/src/knowledge-explorer.css
@@ -8,6 +8,10 @@
   overflow: hidden;
 }
 
+.knowledge-explorer.inspector-closed {
+  grid-template-columns: minmax(210px, 250px) minmax(480px, 1fr);
+}
+
 .knowledge-filter-panel,
 .knowledge-results-panel,
 .knowledge-inspector {
@@ -72,16 +76,34 @@
   padding: 12px 14px;
 }
 
+.knowledge-list.dense {
+  gap: 7px;
+}
+
 .knowledge-item {
   padding: 13px 14px;
   background: var(--panel);
   border-radius: 6px;
 }
 
+.knowledge-list.dense .knowledge-item {
+  padding: 10px 12px;
+}
+
+.knowledge-list.dense .knowledge-item p {
+  display: none;
+}
+
 .knowledge-item.selected {
   background: color-mix(in srgb, var(--panel) 84%, var(--accent-soft));
   border-color: color-mix(in srgb, var(--accent) 64%, var(--border));
   box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.icon-button.active {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
 }
 
 .status-pill.success {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
+import "./resource-explorer.css";
 import "./observability.css";
 import "./responsive.css";
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import "./knowledge-explorer.css";
 import "./observability.css";
 import "./responsive.css";
 import "./admin-system.css";
+import "./admin-dashboard-components.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
 import "./resource-explorer.css";
+import "./knowledge-explorer.css";
 import "./observability.css";
 import "./responsive.css";
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import "./resource-explorer.css";
 import "./knowledge-explorer.css";
 import "./observability.css";
 import "./responsive.css";
+import "./admin-system.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/observability.css
+++ b/web/src/observability.css
@@ -79,26 +79,30 @@
 .config-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-  padding-bottom: 4px;
+  gap: 2px 6px;
+  align-items: end;
+  min-width: 0;
+  padding-bottom: 0;
   border-bottom: 1px solid var(--border);
 }
 
 .config-tabs .tab-button {
   justify-content: center;
-  min-height: 38px;
+  flex: 0 1 auto;
+  gap: 6px;
+  min-height: 34px;
   width: auto;
-  min-width: 112px;
-  border: 1px solid transparent;
-  border-radius: 7px;
+  min-width: 0;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 0;
+  font-size: 13px;
 }
 
 .config-tabs .tab-button.active {
-  color: var(--text);
-  background: var(--panel);
-  border-color: var(--border);
-  box-shadow: var(--shadow-soft);
+  color: var(--accent-strong);
+  background: transparent;
+  box-shadow: inset 0 -2px 0 var(--accent);
 }
 
 .table-page-size {

--- a/web/src/resource-explorer.css
+++ b/web/src/resource-explorer.css
@@ -35,7 +35,7 @@
   display: grid;
   gap: 12px;
   max-height: calc(100vh - 48px);
-  overflow: auto;
+  overflow: hidden auto;
   padding: 14px;
   background: var(--panel);
   border: 1px solid var(--border);
@@ -52,6 +52,7 @@
 .detail-pane {
   min-width: 0;
   display: grid;
+  align-content: start;
   gap: 18px;
 }
 
@@ -637,10 +638,10 @@
 
 .top-nav-tabs {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 4px;
   min-width: 0;
-  overflow-x: auto;
 }
 
 .top-nav-tabs .rail-tab-button {
@@ -710,6 +711,7 @@
 
 .team-workspace {
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 0;
   padding: 0;
   overflow: hidden;
@@ -717,33 +719,61 @@
 
 .team-workspace-header {
   display: grid;
-  gap: 14px;
-  padding: 18px 20px 0;
+  align-content: start;
+  gap: 10px;
+  padding: 12px 16px 0;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
 }
 
 .team-detail-header.compact {
+  gap: 10px;
+  min-height: 42px;
   padding-bottom: 0;
   border-bottom: 0;
 }
 
+.team-detail-header.compact > div { min-width: 0; }
+
+.team-detail-header.compact .team-mark {
+  width: 42px;
+  height: 42px;
+}
+
+.team-detail-header.compact .team-title-row {
+  flex-wrap: nowrap;
+}
+
+.team-detail-header.compact .team-title-row h2 {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 19px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-detail-header.compact p { margin-top: 3px; }
+
 .team-workspace-tabs {
   display: flex;
-  gap: 28px;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 22px;
+  min-height: 34px;
   min-width: 0;
-  overflow-x: auto;
 }
 
 .team-workspace-tab {
   position: relative;
-  min-height: 42px;
+  flex: 0 0 auto;
+  min-height: 34px;
   padding: 0;
   color: var(--muted);
   background: transparent;
   border: 0;
   font-size: 13px;
   font-weight: 720;
+  line-height: 1;
   cursor: pointer;
 }
 
@@ -765,12 +795,31 @@
   background: var(--accent);
 }
 
+.team-workspace-body {
+  min-height: 0;
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 14px;
+  overflow: hidden auto;
+  padding: 14px 16px;
+}
+
 .team-overview,
 .team-detail-surface,
 .team-embedded-panel {
+  min-width: 0;
   display: grid;
   gap: 14px;
-  padding: 18px 20px;
+  padding: 0;
+}
+
+.team-workspace-body > .overview-panel {
+  min-width: 0;
+}
+
+.team-workspace-body .table-wrap {
+  min-width: 0;
 }
 
 .summary-strip {

--- a/web/src/resource-explorer.css
+++ b/web/src/resource-explorer.css
@@ -246,6 +246,14 @@
   border-radius: 8px;
 }
 
+.session-context.compact {
+  max-width: min(420px, 38vw);
+  background: transparent;
+  border-color: transparent;
+  border-radius: 0;
+  padding-inline: 0;
+}
+
 .session-context strong,
 .session-context span:not(.context-label):not(.context-divider) {
   min-width: 0;
@@ -255,6 +263,16 @@
   font-weight: 740;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.team-select-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
 }
 
 .session-context select {
@@ -383,6 +401,18 @@
   font-size: 12px;
 }
 
+.filter-stack select,
+.filter-stack input[type="date"] {
+  min-height: 36px;
+  width: 100%;
+  padding: 0 10px;
+  color: var(--text);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+}
+
 .knowledge-list {
   display: grid;
   gap: 10px;
@@ -491,4 +521,427 @@
   color: var(--text);
   font-size: 12px;
   font-weight: 760;
+}
+
+.app-shell {
+  padding: 0;
+}
+
+.topbar,
+.workspace,
+.app-shell > .banner {
+  width: 100%;
+  max-width: none;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  min-height: 48px;
+  padding: 0 16px;
+  background: color-mix(in srgb, var(--panel) 94%, var(--panel-muted));
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(23, 35, 34, 0.04);
+}
+
+.topbar-actions {
+  grid-column: 3;
+  justify-self: end;
+}
+
+.brand-mark {
+  width: 32px;
+  height: 32px;
+  color: #ffffff;
+  background: linear-gradient(180deg, #088391, #086b73);
+  border-color: color-mix(in srgb, #086b73 64%, var(--border));
+  border-radius: 4px;
+}
+
+.brand-initials {
+  font-size: 12px;
+  font-weight: 860;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.brand-row h1 {
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.workspace {
+  min-height: calc(100vh - 48px);
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 0;
+  align-items: stretch;
+}
+
+.workspace.has-resource-rail {
+  grid-template-columns: 72px minmax(260px, 316px) minmax(0, 1fr);
+}
+
+.primary-rail,
+.resource-rail {
+  position: sticky;
+  top: 48px;
+  max-height: calc(100vh - 48px);
+}
+
+.primary-rail {
+  min-height: calc(100vh - 48px);
+  padding: 10px 8px;
+  background: color-mix(in srgb, var(--panel) 84%, var(--panel-muted));
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.resource-rail {
+  padding: 16px;
+  background: var(--panel);
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.detail-pane {
+  padding: 16px 20px 28px;
+  background: var(--bg);
+}
+
+.workspace.top-nav-workspace {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
+  align-items: stretch;
+}
+
+.workspace.top-nav-workspace .detail-pane {
+  padding-top: 16px;
+}
+
+.top-nav-bar {
+  position: sticky;
+  top: 48px;
+  z-index: 12;
+  display: flex;
+  min-width: 0;
+  padding: 8px 20px;
+  background: color-mix(in srgb, var(--panel) 94%, var(--panel-muted));
+  border-bottom: 1px solid var(--border);
+}
+
+.top-nav-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.top-nav-tabs .rail-tab-button {
+  width: auto;
+  flex: 0 0 auto;
+  flex-direction: row;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 6px;
+  gap: 7px;
+  font-size: 12px;
+}
+
+.top-nav-tabs .rail-tab-button.active {
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.top-nav-tabs .rail-tab-button span {
+  overflow: visible;
+}
+
+.rail-tabs {
+  gap: 10px;
+}
+
+.rail-tab-button {
+  min-height: 58px;
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.rail-tab-button.active {
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent-soft) 80%, var(--panel));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.resource-panel .section-heading {
+  align-items: center;
+}
+
+.resource-panel .section-heading h2 {
+  font-size: 18px;
+  font-weight: 720;
+}
+
+.team-list {
+  gap: 8px;
+}
+
+.team-list-item {
+  min-height: 56px;
+  padding: 10px;
+  border-color: transparent;
+  border-radius: 6px;
+}
+
+.team-list-item.selected {
+  background: color-mix(in srgb, var(--accent-soft) 70%, var(--panel));
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
+}
+
+.team-list-primary span:last-child {
+  font-weight: 650;
+}
+
+.team-workspace {
+  display: grid;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.team-workspace-header {
+  display: grid;
+  gap: 14px;
+  padding: 18px 20px 0;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.team-detail-header.compact {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.team-workspace-tabs {
+  display: flex;
+  gap: 28px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.team-workspace-tab {
+  position: relative;
+  min-height: 42px;
+  padding: 0;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  font-size: 13px;
+  font-weight: 720;
+  cursor: pointer;
+}
+
+.team-workspace-tab:hover {
+  color: var(--text);
+}
+
+.team-workspace-tab.active {
+  color: var(--accent-strong);
+}
+
+.team-workspace-tab.active::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  content: "";
+  background: var(--accent);
+}
+
+.team-overview,
+.team-detail-surface,
+.team-embedded-panel {
+  display: grid;
+  gap: 14px;
+  padding: 18px 20px;
+}
+
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(190px, 240px);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--panel);
+}
+
+.summary-strip .summary-item {
+  min-height: 100px;
+  padding: 18px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.summary-strip .summary-item strong {
+  font-size: 22px;
+}
+
+.health-stack {
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 16px;
+}
+
+.health-line {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.health-line > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #16a34a;
+}
+
+.health-line.warning > span {
+  background: #f59e0b;
+}
+
+.health-line.danger > span {
+  background: #dc2626;
+}
+
+.health-line strong {
+  color: var(--text);
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.overview-panel {
+  min-width: 0;
+  padding: 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.overview-panel .section-heading {
+  margin-bottom: 12px;
+}
+
+.metric-row {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 32px;
+  color: var(--muted);
+  font-size: 13px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+}
+
+.metric-row:first-of-type {
+  border-top: 0;
+}
+
+.metric-icon {
+  display: inline-grid;
+  place-items: center;
+  color: var(--accent-strong);
+}
+
+.metric-row strong {
+  color: var(--text);
+  font-weight: 760;
+}
+
+.metric-row small {
+  color: var(--subtle);
+  font-size: 12px;
+}
+
+.metric-row.danger small,
+.metric-row.danger strong {
+  color: var(--danger);
+}
+
+.metric-row.warning small,
+.metric-row.warning strong {
+  color: var(--warning);
+}
+
+.mini-table {
+  display: grid;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.mini-table-row {
+  display: grid;
+  grid-template-columns: repeat(var(--mini-cols, 5), minmax(0, 1fr));
+  min-height: 34px;
+  border-top: 1px solid var(--border);
+}
+
+.mini-table-row:first-child {
+  border-top: 0;
+}
+
+.mini-table-row span {
+  min-width: 0;
+  padding: 9px 10px;
+  color: var(--muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mini-table-row.heading span {
+  color: var(--subtle);
+  background: var(--panel-strong);
+  font-weight: 780;
+}
+
+.select-like {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 36px;
+  width: 100%;
+  padding: 0 10px;
+  color: var(--text);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.select-like.compact {
+  width: auto;
+  min-height: 32px;
 }

--- a/web/src/resource-explorer.css
+++ b/web/src/resource-explorer.css
@@ -405,15 +405,14 @@
   border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
 }
 
-.knowledge-result-button {
-  width: 100%;
-  min-width: 0;
-  display: block;
-  color: inherit;
-  background: transparent;
-  padding: 0;
-  text-align: left;
+.knowledge-result-option {
   cursor: pointer;
+  outline: none;
+}
+
+.knowledge-result-option:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 64%, var(--border));
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .knowledge-item-head {

--- a/web/src/resource-explorer.css
+++ b/web/src/resource-explorer.css
@@ -1,0 +1,495 @@
+.topbar-context {
+  min-width: 0;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.workspace.has-resource-rail {
+  grid-template-columns: 72px minmax(260px, 314px) minmax(0, 1fr);
+}
+
+.primary-rail,
+.resource-rail {
+  position: sticky;
+  top: 16px;
+  min-width: 0;
+}
+
+.primary-rail {
+  min-height: calc(100vh - 48px);
+  display: grid;
+  align-content: start;
+  padding: 8px;
+  background: color-mix(in srgb, var(--panel) 88%, var(--panel-muted));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.resource-rail {
+  display: grid;
+  gap: 12px;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.resource-panel,
+.team-resource-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.detail-pane {
+  min-width: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.team-detail-surface {
+  display: grid;
+  gap: 18px;
+}
+
+.team-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.team-mark {
+  width: 54px;
+  height: 54px;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  color: var(--accent-strong);
+  background: var(--panel-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+}
+
+.team-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.team-title-row h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.team-detail-header p {
+  margin: 5px 0 0;
+  color: var(--subtle);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.rail-tabs {
+  display: grid;
+  gap: 8px;
+}
+
+.rail-tab-button,
+.team-list-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  border-radius: 8px;
+  color: var(--muted);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rail-tab-button {
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  min-height: 58px;
+  padding: 7px 4px;
+  font-size: 11px;
+  line-height: 1.1;
+  font-weight: 760;
+}
+
+.rail-tab-button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rail-tab-button:hover,
+.team-list-item:hover {
+  color: var(--text);
+  background: var(--panel-hover);
+}
+
+.rail-tab-button.active,
+.team-list-item.selected {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+.rail-tab-button:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.team-list {
+  display: grid;
+  gap: 6px;
+}
+
+.team-list-item {
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 48px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+}
+
+.team-list-item.selected {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+
+.team-list-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.team-list-primary span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 760;
+}
+
+.team-list-item small {
+  flex: 0 0 auto;
+  color: var(--subtle);
+  font-size: 11px;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #16a34a;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #16a34a 14%, transparent);
+}
+
+.resource-search,
+.search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--subtle);
+  background: var(--panel-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  padding: 0 10px;
+}
+
+.resource-search input,
+.search-input-wrap input {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-inline: 0;
+}
+
+.resource-search:focus-within,
+.search-input-wrap:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus);
+}
+
+.session-context {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  max-width: min(640px, 52vw);
+  min-height: 38px;
+  padding: 0 10px;
+  color: var(--muted);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.session-context strong,
+.session-context span:not(.context-label):not(.context-divider) {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 740;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-context select {
+  width: min(220px, 32vw);
+  min-height: 30px;
+  padding-block: 5px;
+}
+
+.context-label {
+  color: var(--subtle);
+  font-size: 11px;
+  font-weight: 780;
+  text-transform: uppercase;
+}
+
+.context-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+}
+
+.search-form {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.search-form.stacked {
+  grid-template-columns: 1fr;
+  align-items: stretch;
+}
+
+.entity-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.knowledge-explorer {
+  display: grid;
+  grid-template-columns: minmax(210px, 250px) minmax(360px, 1fr) minmax(260px, 330px);
+  gap: 12px;
+  align-items: start;
+}
+
+.knowledge-filter-panel,
+.knowledge-results-panel,
+.knowledge-inspector {
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+}
+
+.knowledge-filter-panel,
+.knowledge-inspector {
+  position: sticky;
+  top: 16px;
+  display: grid;
+  gap: 14px;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 14px;
+}
+
+.knowledge-results-panel {
+  padding: 14px;
+}
+
+.knowledge-results-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.knowledge-results-toolbar h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.knowledge-results-toolbar span {
+  color: var(--subtle);
+  font-size: 12px;
+  font-weight: 780;
+  text-transform: uppercase;
+}
+
+.filter-stack {
+  display: grid;
+  gap: 9px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.filter-stack strong {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 780;
+}
+
+.filter-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.filter-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.filter-row small {
+  color: var(--subtle);
+  font-size: 12px;
+}
+
+.knowledge-list {
+  display: grid;
+  gap: 10px;
+}
+
+.compact-list {
+  gap: 8px;
+}
+
+.knowledge-item {
+  min-width: 0;
+  padding: 13px;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.knowledge-item.selected {
+  background: color-mix(in srgb, var(--accent-soft) 44%, var(--panel));
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+}
+
+.knowledge-result-button {
+  width: 100%;
+  min-width: 0;
+  display: block;
+  color: inherit;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.knowledge-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.knowledge-item-head small {
+  color: var(--subtle);
+  font-size: 12px;
+  font-weight: 740;
+}
+
+.knowledge-item h3 {
+  margin: 0 0 6px;
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.25;
+  font-weight: 780;
+}
+
+.knowledge-item p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.inspector-card {
+  min-width: 0;
+}
+
+.inspector-card h3 {
+  margin: 0 0 8px;
+  color: var(--text);
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.inspector-card p {
+  margin: 0 0 14px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.inspector-details {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.inspector-details div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.inspector-details dt {
+  color: var(--subtle);
+  font-size: 12px;
+  font-weight: 740;
+}
+
+.inspector-details dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 760;
+}

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -44,7 +44,12 @@
   }
 
   .topbar {
+    position: static;
     justify-items: start;
+  }
+
+  .topbar-actions {
+    grid-column: auto;
   }
 
   .topbar-context,
@@ -55,9 +60,18 @@
 
   .primary-rail,
   .resource-rail,
+  .top-nav-bar,
   .knowledge-filter-panel {
     position: static;
     max-height: none;
+  }
+
+  .top-nav-bar {
+    padding-inline: 0;
+  }
+
+  .top-nav-tabs {
+    width: 100%;
   }
 
   .primary-rail {
@@ -167,7 +181,11 @@
 
   .data-table th,
   .data-table td {
-    padding: 9px 8px;
+    padding: 9px 6px;
+  }
+
+  .table-wrap {
+    border-width: 0;
   }
 
   .key-table,

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -17,6 +17,10 @@
     grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
   }
 
+  .knowledge-explorer.inspector-closed {
+    grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
+  }
+
   .knowledge-inspector {
     position: static;
     grid-column: 1 / -1;

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -245,7 +245,6 @@
   .logs-table td {
     border-bottom: 0;
     overflow-wrap: anywhere;
-    word-break: break-word;
   }
 
   .key-table .actions-cell,

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -80,12 +80,12 @@
 
   .primary-rail {
     min-height: auto;
-    overflow-x: auto;
   }
 
   .rail-tabs {
     display: flex;
-    min-width: max-content;
+    flex-wrap: wrap;
+    min-width: 0;
   }
 
   .rail-tab-button {
@@ -151,7 +151,6 @@
   }
 
   .rail-tabs,
-  .config-tabs,
   .security-summary,
   .metrics-summary,
   .dreaming-effective-grid,
@@ -167,8 +166,9 @@
   }
 
   .config-tabs .tab-button {
-    flex: 1 1 100%;
-    width: 100%;
+    flex: 1 1 calc(33.333% - 6px);
+    min-width: 88px;
+    width: auto;
   }
 
   .table-actions {
@@ -196,7 +196,9 @@
   .dreams-table,
   .dream-runs-table,
   .logs-table {
+    max-width: 100%;
     min-width: 0;
+    overflow: hidden;
   }
 
   .key-table thead,
@@ -223,7 +225,10 @@
   .logs-table tr,
   .logs-table td {
     display: block;
+    max-width: 100%;
+    min-width: 0;
     width: 100%;
+    overflow: hidden;
   }
 
   .key-table tr,
@@ -239,6 +244,8 @@
   .dream-runs-table td,
   .logs-table td {
     border-bottom: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .key-table .actions-cell,

--- a/web/src/responsive.css
+++ b/web/src/responsive.css
@@ -6,7 +6,21 @@
   }
 
   .workspace {
-    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .workspace.has-resource-rail {
+    grid-template-columns: 64px minmax(230px, 280px) minmax(0, 1fr);
+  }
+
+  .knowledge-explorer {
+    grid-template-columns: minmax(190px, 230px) minmax(0, 1fr);
+  }
+
+  .knowledge-inspector {
+    position: static;
+    grid-column: 1 / -1;
+    max-height: none;
   }
 
   .telemetry-card-grid {
@@ -25,12 +39,39 @@
     grid-template-columns: 1fr;
   }
 
-  .control-sidebar {
-    position: static;
+  .workspace.has-resource-rail {
+    grid-template-columns: 1fr;
   }
 
-  .portal-tabs {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+  .topbar {
+    justify-items: start;
+  }
+
+  .topbar-context,
+  .session-context {
+    width: 100%;
+    max-width: none;
+  }
+
+  .primary-rail,
+  .resource-rail,
+  .knowledge-filter-panel {
+    position: static;
+    max-height: none;
+  }
+
+  .primary-rail {
+    min-height: auto;
+    overflow-x: auto;
+  }
+
+  .rail-tabs {
+    display: flex;
+    min-width: max-content;
+  }
+
+  .rail-tab-button {
+    width: 76px;
   }
 
   .tab-button {
@@ -59,7 +100,8 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  .search-form,
+  .search-form:not(.stacked),
+  .knowledge-explorer,
   .key-detail-grid {
     grid-template-columns: 1fr;
   }
@@ -74,12 +116,15 @@
 
   .auth-panel,
   .surface,
-  .control-sidebar {
+  .resource-rail,
+  .knowledge-filter-panel,
+  .knowledge-results-panel,
+  .knowledge-inspector {
     padding: 14px;
   }
 
   .brand-row h1 {
-    font-size: 19px;
+    font-size: 15px;
   }
 
   .topbar-actions,
@@ -87,7 +132,7 @@
     flex-wrap: wrap;
   }
 
-  .portal-tabs,
+  .rail-tabs,
   .config-tabs,
   .security-summary,
   .metrics-summary,
@@ -98,8 +143,9 @@
     grid-template-columns: 1fr;
   }
 
-  .tab-button {
-    justify-content: flex-start;
+  .rail-tab-button {
+    width: 68px;
+    min-height: 54px;
   }
 
   .config-tabs .tab-button {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -106,22 +106,23 @@ button {
 }
 
 .app-shell {
-  padding: 20px 0 32px;
+  padding: 16px 0 32px;
 }
 
 .topbar,
 .workspace,
 .app-shell > .banner {
-  width: min(1420px, calc(100vw - 40px));
+  width: min(1540px, calc(100vw - 32px));
   margin-inline: auto;
 }
 
 .topbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(max-content, 1fr) auto max-content;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
-  padding: 0 0 18px;
+  min-height: 52px;
+  padding: 0 0 12px;
 }
 
 .brand-row {
@@ -134,14 +135,14 @@ button {
 .brand-row h1 {
   margin: 0;
   color: var(--text);
-  font-size: 22px;
+  font-size: 16px;
   line-height: 1.15;
   font-weight: 780;
 }
 
 .brand-mark {
-  width: 38px;
-  height: 38px;
+  width: 34px;
+  height: 34px;
   display: inline-grid;
   place-items: center;
   flex: 0 0 auto;
@@ -159,39 +160,12 @@ button {
   gap: 8px;
 }
 
-.workspace {
-  display: grid;
-  grid-template-columns: minmax(250px, 294px) minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
-}
-
-.control-sidebar,
 .surface {
   min-width: 0;
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: var(--shadow-soft);
-}
-
-.control-sidebar {
-  position: sticky;
-  top: 20px;
-  display: grid;
-  gap: 16px;
-  padding: 14px;
-}
-
-.sidebar-panel {
-  display: grid;
-  gap: 12px;
-}
-
-.detail-pane {
-  min-width: 0;
-  display: grid;
-  gap: 18px;
 }
 
 .surface {
@@ -208,15 +182,7 @@ button {
   border-top: 1px solid var(--border);
 }
 
-.portal-tabs {
-  display: grid;
-  gap: 6px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid var(--border);
-}
-
-.tab-button,
-.team-list-item {
+.tab-button {
   width: 100%;
   display: flex;
   align-items: center;
@@ -243,14 +209,12 @@ button {
   white-space: nowrap;
 }
 
-.tab-button:hover,
-.team-list-item:hover {
+.tab-button:hover {
   color: var(--text);
   background: var(--panel-hover);
 }
 
-.tab-button.active,
-.team-list-item.selected {
+.tab-button.active {
   color: var(--accent-strong);
   background: var(--accent-soft);
 }
@@ -264,42 +228,16 @@ button {
   color: var(--danger);
 }
 
-.team-list {
-  display: grid;
-  gap: 6px;
-}
-
-.key-summary select {
-  width: 100%;
-  min-width: 0;
-}
-
-.team-list-item {
-  justify-content: space-between;
-  gap: 10px;
-  min-height: 42px;
-  padding: 8px 10px;
-  border: 1px solid transparent;
-}
-
-.team-list-item.selected {
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
-}
-
-.team-list-item span {
-  min-width: 0;
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  clip: rect(0, 0, 0, 0);
   white-space: nowrap;
-  color: inherit;
-  font-size: 14px;
-  font-weight: 760;
-}
-
-.team-list-item small {
-  flex: 0 0 auto;
-  color: var(--subtle);
-  font-size: 11px;
+  border: 0;
 }
 
 .section-heading {
@@ -430,7 +368,8 @@ textarea:focus {
 .primary-button,
 .ghost-button,
 .danger-button,
-.icon-button {
+.icon-button,
+.text-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -493,6 +432,18 @@ textarea:focus {
 
 .icon-button.danger {
   color: var(--danger);
+}
+
+.text-button {
+  min-height: 30px;
+  color: var(--accent-strong);
+  background: transparent;
+  padding: 0;
+  font-size: 12px;
+}
+
+.text-button:hover {
+  color: var(--text);
 }
 
 button:disabled {
@@ -760,83 +711,6 @@ button:disabled {
   margin-top: 7px;
   color: var(--muted);
   font-size: 12px;
-}
-
-.key-summary {
-  display: grid;
-  gap: 8px;
-  padding: 12px;
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.key-summary span {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 760;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.search-form {
-  display: grid;
-  grid-template-columns: 92px minmax(0, 1fr) auto;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 14px;
-}
-
-.entity-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 14px;
-}
-
-.knowledge-list {
-  display: grid;
-  gap: 10px;
-}
-
-.knowledge-item {
-  min-width: 0;
-  padding: 13px;
-  background: var(--panel-strong);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
-.knowledge-item-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-
-.knowledge-item-head small {
-  color: var(--subtle);
-  font-size: 12px;
-  font-weight: 740;
-}
-
-.knowledge-item h3 {
-  margin: 0 0 6px;
-  color: var(--text);
-  font-size: 15px;
-  line-height: 1.25;
-  font-weight: 780;
-}
-
-.knowledge-item p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1.45;
-  overflow-wrap: anywhere;
 }
 
 .key-detail-grid {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -235,7 +235,7 @@ button {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -494,7 +494,6 @@ button:disabled {
   background: var(--panel);
 }
 
-.sso-provider-table-wrap { overflow-x: visible; }
 .sso-provider-table-wrap .actions-cell { width: 108px; }
 .sso-provider-table-wrap .button-row { justify-content: flex-end; }
 .sso-provider-table-wrap + .edit-grid { margin-top: 14px; }

--- a/web/src/telemetry/TelemetryDashboard.tsx
+++ b/web/src/telemetry/TelemetryDashboard.tsx
@@ -10,7 +10,7 @@ import {
 } from "recharts";
 import { RefreshCw } from "lucide-react";
 import { TelemetrySnapshot, TelemetryWindowKey, telemetryWindowOptions } from "./types";
-import { SectionHeading, SummaryCard } from "../ui/components";
+import { LoadingState, SectionHeading, SummaryCard } from "../ui/components";
 import "./telemetry.css";
 
 const currentStateCardIds = new Set([
@@ -75,7 +75,7 @@ export function TelemetryDashboard({
 
       {error && <div className="banner error" role="alert">{error}</div>}
       {snapshot?.message && <div className="banner neutral">{snapshot.message}</div>}
-      {loading && !snapshot && <div className="table-placeholder compact">Loading telemetry</div>}
+      {loading && !snapshot && <LoadingState label="Loading telemetry" compact />}
 
       {snapshot && (
         <>

--- a/web/src/ui/components.test.tsx
+++ b/web/src/ui/components.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SecretBox } from "./components";
+import { LoadingState, SecretBox } from "./components";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -34,5 +34,18 @@ describe("SecretBox", () => {
     });
 
     expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
+  });
+});
+
+describe("LoadingState", () => {
+  it("announces the loading label and renders animation parts", () => {
+    render(<LoadingState label="Loading telemetry" compact />);
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Loading telemetry");
+    expect(status).toHaveClass("loading-state");
+    expect(status).toHaveClass("compact");
+    expect(status.querySelector(".loading-orbit")).toBeInTheDocument();
+    expect(status.querySelectorAll(".loading-skeleton span")).toHaveLength(3);
   });
 });

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -28,6 +28,7 @@ type PortalShellProps = BrandProps & {
   theme: ThemeName;
   topbarActions: ReactNode;
   navLabel: string;
+  navItemsLabel: string;
   navItems: PortalNavItem[];
   contextBar?: ReactNode;
   resourceRail?: ReactNode;
@@ -100,6 +101,7 @@ export function PortalShell({
   icon,
   topbarActions,
   navLabel,
+  navItemsLabel,
   navItems,
   contextBar,
   resourceRail,
@@ -120,7 +122,7 @@ export function PortalShell({
 
       <section className={resourceRail ? "workspace has-resource-rail" : "workspace"}>
         <aside className="primary-rail" aria-label={navLabel}>
-          <nav className="rail-tabs" aria-label={navLabel.replace("navigation", "sections")}>
+          <nav className="rail-tabs" aria-label={navItemsLabel}>
             {navItems.map((item) => (
               <TabButton
                 key={item.id}

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -30,6 +30,7 @@ type PortalShellProps = BrandProps & {
   navLabel: string;
   navItemsLabel: string;
   navItems: PortalNavItem[];
+  navPlacement?: "rail" | "top";
   contextBar?: ReactNode;
   resourceRail?: ReactNode;
   resourceRailLabel?: string;
@@ -103,6 +104,7 @@ export function PortalShell({
   navLabel,
   navItemsLabel,
   navItems,
+  navPlacement = "rail",
   contextBar,
   resourceRail,
   resourceRailLabel,
@@ -110,6 +112,13 @@ export function PortalShell({
   error,
   children,
 }: PortalShellProps) {
+  const topNav = navPlacement === "top";
+  const workspaceClassName = [
+    "workspace",
+    resourceRail ? "has-resource-rail" : "",
+    topNav ? "top-nav-workspace" : "",
+  ].filter(Boolean).join(" ");
+
   return (
     <main className="app-shell" data-theme={theme}>
       <header className="topbar">
@@ -120,21 +129,38 @@ export function PortalShell({
 
       {error && <div className="banner error" role="alert">{error}</div>}
 
-      <section className={resourceRail ? "workspace has-resource-rail" : "workspace"}>
-        <aside className="primary-rail" aria-label={navLabel}>
-          <nav className="rail-tabs" aria-label={navItemsLabel}>
-            {navItems.map((item) => (
-              <TabButton
-                key={item.id}
-                active={item.active}
-                disabled={item.disabled}
-                icon={item.icon}
-                label={item.label}
-                onClick={item.onClick}
-              />
-            ))}
-          </nav>
-        </aside>
+      <section className={workspaceClassName}>
+        {topNav ? (
+          <div className="top-nav-bar" aria-label={navLabel}>
+            <nav className="top-nav-tabs" aria-label={navItemsLabel}>
+              {navItems.map((item) => (
+                <TabButton
+                  key={item.id}
+                  active={item.active}
+                  disabled={item.disabled}
+                  icon={item.icon}
+                  label={item.label}
+                  onClick={item.onClick}
+                />
+              ))}
+            </nav>
+          </div>
+        ) : (
+          <aside className="primary-rail" aria-label={navLabel}>
+            <nav className="rail-tabs" aria-label={navItemsLabel}>
+              {navItems.map((item) => (
+                <TabButton
+                  key={item.id}
+                  active={item.active}
+                  disabled={item.disabled}
+                  icon={item.icon}
+                  label={item.label}
+                  onClick={item.onClick}
+                />
+              ))}
+            </nav>
+          </aside>
+        )}
         {resourceRail && (
           <aside className="resource-rail" aria-label={resourceRailLabel ?? "Resources"}>
             {resourceRail}

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -72,6 +72,11 @@ type InfoTooltipProps = {
   children: ReactNode;
 };
 
+type LoadingStateProps = {
+  label?: string;
+  compact?: boolean;
+};
+
 export function Brand({ title, icon }: BrandProps) {
   return (
     <div className="brand-row">
@@ -118,35 +123,21 @@ export function PortalShell({
     resourceRail ? "has-resource-rail" : "",
     topNav ? "top-nav-workspace" : "",
   ].filter(Boolean).join(" ");
+  const portalContentClassName = [
+    "portal-content",
+    resourceRail ? "has-resource-rail" : "",
+    topNav ? "has-top-nav" : "",
+  ].filter(Boolean).join(" ");
+  const brand = <Brand title={title} icon={icon} />;
 
   return (
     <main className="app-shell" data-theme={theme}>
-      <header className="topbar">
-        <Brand title={title} icon={icon} />
-        {contextBar && <div className="topbar-context">{contextBar}</div>}
-        <div className="topbar-actions">{topbarActions}</div>
-      </header>
-
-      {error && <div className="banner error" role="alert">{error}</div>}
-
       <section className={workspaceClassName}>
         {topNav ? (
-          <div className="top-nav-bar" aria-label={navLabel}>
-            <nav className="top-nav-tabs" aria-label={navItemsLabel}>
-              {navItems.map((item) => (
-                <TabButton
-                  key={item.id}
-                  active={item.active}
-                  disabled={item.disabled}
-                  icon={item.icon}
-                  label={item.label}
-                  onClick={item.onClick}
-                />
-              ))}
-            </nav>
-          </div>
+          null
         ) : (
           <aside className="primary-rail" aria-label={navLabel}>
+            <div className="rail-brand">{brand}</div>
             <nav className="rail-tabs" aria-label={navItemsLabel}>
               {navItems.map((item) => (
                 <TabButton
@@ -161,15 +152,43 @@ export function PortalShell({
             </nav>
           </aside>
         )}
-        {resourceRail && (
-          <aside className="resource-rail" aria-label={resourceRailLabel ?? "Resources"}>
-            {resourceRail}
-          </aside>
-        )}
+        <div className="portal-main">
+          <header className="topbar">
+            {topNav && brand}
+            {contextBar && <div className="topbar-context">{contextBar}</div>}
+            <div className="topbar-actions">{topbarActions}</div>
+          </header>
 
-        <section className="detail-pane" aria-label={detailLabel}>
-          {children}
-        </section>
+          {error && <div className="banner error" role="alert">{error}</div>}
+
+          <div className={portalContentClassName}>
+            {topNav && (
+              <div className="top-nav-bar" aria-label={navLabel}>
+                <nav className="top-nav-tabs" aria-label={navItemsLabel}>
+                  {navItems.map((item) => (
+                    <TabButton
+                      key={item.id}
+                      active={item.active}
+                      disabled={item.disabled}
+                      icon={item.icon}
+                      label={item.label}
+                      onClick={item.onClick}
+                    />
+                  ))}
+                </nav>
+              </div>
+            )}
+            {resourceRail && (
+              <aside className="resource-rail" aria-label={resourceRailLabel ?? "Resources"}>
+                {resourceRail}
+              </aside>
+            )}
+
+            <section className="detail-pane" aria-label={detailLabel}>
+              {children}
+            </section>
+          </div>
+        </div>
       </section>
     </main>
   );
@@ -220,6 +239,24 @@ export function SummaryCard({ label, value, detail, tone = "neutral" }: SummaryC
       <span>{label}</span>
       <strong>{value}</strong>
       {detail && <small>{detail}</small>}
+    </div>
+  );
+}
+
+export function LoadingState({ label = "Loading", compact = false }: LoadingStateProps) {
+  return (
+    <div
+      className={compact ? "table-placeholder loading-state compact" : "table-placeholder loading-state"}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="loading-orbit" aria-hidden="true" />
+      <span className="loading-copy">{label}</span>
+      <span className="loading-skeleton" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </span>
     </div>
   );
 }

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -29,10 +29,9 @@ type PortalShellProps = BrandProps & {
   topbarActions: ReactNode;
   navLabel: string;
   navItems: PortalNavItem[];
-  sidebarTitle: ReactNode;
-  sidebarMeta?: ReactNode;
-  sidebarSubtitle?: ReactNode;
-  sidebarBody?: ReactNode;
+  contextBar?: ReactNode;
+  resourceRail?: ReactNode;
+  resourceRailLabel?: string;
   detailLabel: string;
   error?: string;
   children: ReactNode;
@@ -102,10 +101,9 @@ export function PortalShell({
   topbarActions,
   navLabel,
   navItems,
-  sidebarTitle,
-  sidebarMeta,
-  sidebarSubtitle,
-  sidebarBody,
+  contextBar,
+  resourceRail,
+  resourceRailLabel,
   detailLabel,
   error,
   children,
@@ -114,14 +112,15 @@ export function PortalShell({
     <main className="app-shell" data-theme={theme}>
       <header className="topbar">
         <Brand title={title} icon={icon} />
+        {contextBar && <div className="topbar-context">{contextBar}</div>}
         <div className="topbar-actions">{topbarActions}</div>
       </header>
 
       {error && <div className="banner error" role="alert">{error}</div>}
 
-      <section className="workspace">
-        <aside className="control-sidebar" aria-label={navLabel}>
-          <nav className="portal-tabs" aria-label={navLabel.replace("navigation", "sections")}>
+      <section className={resourceRail ? "workspace has-resource-rail" : "workspace"}>
+        <aside className="primary-rail" aria-label={navLabel}>
+          <nav className="rail-tabs" aria-label={navLabel.replace("navigation", "sections")}>
             {navItems.map((item) => (
               <TabButton
                 key={item.id}
@@ -133,11 +132,12 @@ export function PortalShell({
               />
             ))}
           </nav>
-          <div className="sidebar-panel">
-            <SectionHeading title={sidebarTitle} subtitle={sidebarSubtitle} meta={sidebarMeta} />
-            {sidebarBody}
-          </div>
         </aside>
+        {resourceRail && (
+          <aside className="resource-rail" aria-label={resourceRailLabel ?? "Resources"}>
+            {resourceRail}
+          </aside>
+        )}
 
         <section className="detail-pane" aria-label={detailLabel}>
           {children}
@@ -162,7 +162,7 @@ export function TabButton({
 }) {
   return (
     <button
-      className={active ? "tab-button active" : "tab-button"}
+      className={active ? "rail-tab-button active" : "rail-tab-button"}
       type="button"
       aria-current={active ? "page" : undefined}
       disabled={disabled}

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserPortalApp } from "./App";
-import { UserKey, UserSession } from "./api";
+import { Community, RecallHit, UserKey, UserSession } from "./api";
 
 const baseSession: UserSession = {
   team: {
@@ -45,6 +45,75 @@ const memberProfile: UserKey = {
   created_at: "2026-05-01T12:00:00Z",
 };
 
+const recallHits: RecallHit[] = [
+  {
+    tier: "canonical",
+    score: 0.94,
+    semantic_rank: 1,
+    keyword_rank: 1,
+    final_score: 0.94,
+    fact: {
+      fact_id: "fact-1",
+      subject: "Alice",
+      predicate: "works_on",
+      object: "project-x",
+      status: "active",
+      truth_score: 0.94,
+      recorded_at: "2026-05-02T12:00:00Z",
+    },
+  },
+  {
+    tier: "claim",
+    score: 0.84,
+    semantic_rank: 2,
+    keyword_rank: 2,
+    final_score: 0.84,
+    claim: {
+      claim_id: "claim-1",
+      subject: "Alice",
+      predicate: "uses",
+      object: "Dense-Mem",
+      modality: "assertion",
+      polarity: "+",
+      status: "validated",
+      entailment_verdict: "entailed",
+      extract_conf: 0.91,
+      resolution_conf: 0.88,
+      recorded_at: "2026-05-02T12:00:00Z",
+    },
+  },
+  {
+    tier: "raw",
+    score: 0.74,
+    semantic_rank: 3,
+    keyword_rank: 3,
+    final_score: 0.74,
+    fragment: {
+      id: "frag-1",
+      fragment_id: "frag-1",
+      content: "Alice is working on project-x with Dense-Mem.",
+      source_type: "manual",
+      source: "notes",
+      labels: ["project"],
+      status: "active",
+      created_at: "2026-05-02T12:00:00Z",
+      updated_at: "2026-05-02T12:00:00Z",
+    },
+  },
+];
+
+const recallCommunities: Community[] = [
+  {
+    community_id: "community-1",
+    level: 0,
+    summary: "Project work around Dense-Mem.",
+    member_count: 3,
+    top_entities: ["Alice", "project-x", "Dense-Mem"],
+    top_predicates: ["works_on", "uses"],
+    last_summarized_at: "2026-05-02T12:00:00Z",
+  },
+];
+
 beforeEach(() => {
   sessionStorage.clear();
   localStorage.clear();
@@ -85,6 +154,34 @@ describe("UserPortalApp", () => {
 
     expect(screen.queryByRole("button", { name: /usage/i })).not.toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([url]) => String(url).startsWith("/ui/api/telemetry"))).toBe(false);
+  });
+
+  it("filters recall results and updates the inspector selection", async () => {
+    mockUserFetch(baseSession, [], { recallHits, communities: recallCommunities });
+    sessionStorage.setItem("denseMem.userApiKey", "dm_read");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+    await userEvent.type(screen.getByLabelText("Keyword"), "project");
+    await userEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    const resultList = await screen.findByRole("listbox", { name: "Recall result list" });
+    expect(within(resultList).getAllByRole("option")).toHaveLength(3);
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Fact");
+
+    const claimResult = within(resultList).getByText("uses: Dense-Mem").closest("[role='option']");
+    expect(claimResult).not.toBeNull();
+    await userEvent.click(claimResult as HTMLElement);
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Claim");
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Tier claim");
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /claim/i }));
+    expect(screen.getByRole("listbox", { name: "Recall result list" })).not.toHaveTextContent("uses: Dense-Mem");
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Fact");
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /fact/i }));
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Fragment");
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Alice is working on project-x with Dense-Mem.");
   });
 
   it("labels write-member telemetry as key usage", async () => {
@@ -430,7 +527,7 @@ async function expectCurrentWorkspace(teamName: string) {
   expect(workspace).toHaveTextContent(teamName);
 }
 
-function mockUserFetch(session: UserSession, profiles: UserKey[] = []) {
+function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[]; communities?: Community[] } = {}) {
   let currentTeam = session.team;
   let currentProfiles = profiles;
   const rotatedSession = {
@@ -501,10 +598,10 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = []) {
       return jsonResponse({ data: { status: "deleted" } });
     }
     if (url.startsWith("/api/v1/communities")) {
-      return jsonResponse({ items: [] });
+      return jsonResponse({ items: options.communities ?? [] });
     }
     if (url.startsWith("/api/v1/recall")) {
-      return jsonResponse({ data: [] });
+      return jsonResponse({ data: options.recallHits ?? [] });
     }
     return jsonResponse({ message: "not found" }, 404);
   });

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -167,6 +167,10 @@ describe("UserPortalApp", () => {
 
     const resultList = await screen.findByRole("listbox", { name: "Recall result list" });
     expect(within(resultList).getAllByRole("option")).toHaveLength(3);
+    expect(screen.queryByRole("button", { name: /star/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add to collection" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create claim" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Inspector")).toHaveTextContent("Fact");
 
     const claimResult = within(resultList).getByText("uses: Dense-Mem").closest("[role='option']");

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -60,7 +60,7 @@ describe("UserPortalApp", () => {
     await userEvent.type(screen.getByLabelText(/api key/i), "dm_key");
     await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     expect(await screen.findByText("Mine")).toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/profiles"))).toBe(false);
   });
@@ -292,7 +292,7 @@ describe("UserPortalApp", () => {
 
     render(<UserPortalApp />);
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     expect(screen.getByRole("button", { name: /my key/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^team$/i })).not.toBeInTheDocument();
     const teamSelect = await screen.findByLabelText("Active team");
@@ -300,7 +300,7 @@ describe("UserPortalApp", () => {
 
     await userEvent.selectOptions(teamSelect, secondKey.id);
 
-    expect(await screen.findByRole("heading", { name: "Analytics Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Analytics Team");
     expect(screen.queryByRole("button", { name: /my key/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^team$/i })).toBeInTheDocument();
     await waitFor(() => {
@@ -339,13 +339,13 @@ describe("UserPortalApp", () => {
 
     render(<UserPortalApp />);
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     await userEvent.click(screen.getByRole("button", { name: /usage/i }));
     expect(await screen.findByLabelText("My key usage totals")).toHaveTextContent("4");
 
     await userEvent.selectOptions(screen.getByLabelText("Active team"), nextKey.id);
 
-    expect(await screen.findByRole("heading", { name: "Analytics Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Analytics Team");
     await waitFor(() => {
       expect(screen.getByLabelText("Team usage totals")).toHaveTextContent("9");
     });
@@ -362,11 +362,11 @@ describe("UserPortalApp", () => {
 
     render(<UserPortalApp />);
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     await userEvent.click(screen.getByRole("button", { name: /sign out/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("logout failed");
-    expect(screen.getByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Current workspace")).toHaveTextContent("Research Team");
     expect(screen.queryByLabelText(/api key/i)).not.toBeInTheDocument();
   });
 
@@ -384,7 +384,7 @@ describe("UserPortalApp", () => {
 
     render(<UserPortalApp />);
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     await userEvent.click(screen.getByRole("button", { name: /my key/i }));
     await userEvent.click(screen.getByRole("button", { name: /create api key/i }));
 
@@ -416,7 +416,7 @@ describe("UserPortalApp", () => {
 
     render(<UserPortalApp />);
 
-    expect(await screen.findByRole("heading", { name: "Research Team" })).toBeInTheDocument();
+    await expectCurrentWorkspace("Research Team");
     await userEvent.click(screen.getByRole("button", { name: /my key/i }));
     await userEvent.click(screen.getByRole("button", { name: /create api key/i }));
 
@@ -424,6 +424,11 @@ describe("UserPortalApp", () => {
     expect(screen.getByRole("button", { name: /regenerate key/i })).toBeDisabled();
   });
 });
+
+async function expectCurrentWorkspace(teamName: string) {
+  const workspace = await screen.findByLabelText("Current workspace");
+  expect(workspace).toHaveTextContent(teamName);
+}
 
 function mockUserFetch(session: UserSession, profiles: UserKey[] = []) {
   let currentTeam = session.team;

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -130,6 +130,8 @@ describe("UserPortalApp", () => {
     await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
     await expectCurrentWorkspace("Research Team");
+    expect(screen.getByLabelText("Knowledge navigation")).toHaveClass("top-nav-bar");
+    expect(screen.getByLabelText("Knowledge sections")).toHaveClass("top-nav-tabs");
     expect(screen.getByLabelText("Current workspace")).not.toHaveTextContent("Mine");
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/profiles"))).toBe(false);
   });

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -182,6 +182,38 @@ describe("UserPortalApp", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: /fact/i }));
     expect(screen.getByLabelText("Inspector")).toHaveTextContent("Fragment");
     expect(screen.getByLabelText("Inspector")).toHaveTextContent("Alice is working on project-x with Dense-Mem.");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Recall" }));
+    expect(screen.getByLabelText("Inspector")).toHaveTextContent("Final score");
+    await userEvent.click(screen.getByRole("button", { name: "Sort by date" }));
+    expect(screen.getByRole("button", { name: "Sort by relevance" })).toHaveTextContent("Sort: Date");
+    await userEvent.click(screen.getByRole("button", { name: "Use compact density" }));
+    expect(screen.getByRole("button", { name: "Use comfortable density" })).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(screen.getByRole("button", { name: "Close details panel" }));
+    expect(screen.queryByLabelText("Inspector")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Open details" }));
+    expect(screen.getByLabelText("Inspector")).toBeInTheDocument();
+  });
+
+  it("resets stale source filters after a new recall search", async () => {
+    mockUserFetch(baseSession, [], { recallHits: [recallHits, [recallHits[0]]], communities: recallCommunities });
+    sessionStorage.setItem("denseMem.userApiKey", "dm_read");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+    await userEvent.type(screen.getByLabelText("Keyword"), "project");
+    await userEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    await userEvent.selectOptions(await screen.findByLabelText("Source"), "notes");
+    expect(screen.getByRole("listbox", { name: "Recall result list" })).toHaveTextContent("Alice is working on project-x with Dense-Mem.");
+    expect(screen.getByRole("listbox", { name: "Recall result list" })).not.toHaveTextContent("works_on: project-x");
+
+    await userEvent.clear(screen.getByLabelText("Keyword"));
+    await userEvent.type(screen.getByLabelText("Keyword"), "alice");
+    await userEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByLabelText("Source")).toHaveValue("all");
+    expect(screen.getByRole("listbox", { name: "Recall result list" })).toHaveTextContent("works_on: project-x");
   });
 
   it("labels write-member telemetry as key usage", async () => {
@@ -527,9 +559,10 @@ async function expectCurrentWorkspace(teamName: string) {
   expect(workspace).toHaveTextContent(teamName);
 }
 
-function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[]; communities?: Community[] } = {}) {
+function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; communities?: Community[] } = {}) {
   let currentTeam = session.team;
   let currentProfiles = profiles;
+  let recallCallCount = 0;
   const rotatedSession = {
     ...session,
     key: { ...session.key, key_suffix: "new123", last_used_at: null },
@@ -601,12 +634,21 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
       return jsonResponse({ items: options.communities ?? [] });
     }
     if (url.startsWith("/api/v1/recall")) {
-      return jsonResponse({ data: options.recallHits ?? [] });
+      const configuredHits = options.recallHits ?? [];
+      const hits = isRecallSequence(configuredHits)
+        ? configuredHits[Math.min(recallCallCount, configuredHits.length - 1)] ?? []
+        : configuredHits;
+      recallCallCount += 1;
+      return jsonResponse({ data: hits });
     }
     return jsonResponse({ message: "not found" }, 404);
   });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+function isRecallSequence(value: RecallHit[] | RecallHit[][]): value is RecallHit[][] {
+  return Array.isArray(value[0]);
 }
 
 function telemetryForSession(session: UserSession) {

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -130,7 +130,7 @@ describe("UserPortalApp", () => {
     await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
     await expectCurrentWorkspace("Research Team");
-    expect(await screen.findByText("Mine")).toBeInTheDocument();
+    expect(screen.getByLabelText("Current workspace")).not.toHaveTextContent("Mine");
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/profiles"))).toBe(false);
   });
 

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -25,7 +25,7 @@ import {
   UserApi,
   UserSession,
 } from "./api";
-import { AuthShell, PortalShell, SecretBox, SectionHeading } from "../ui/components";
+import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading } from "../ui/components";
 import { SearchPanel } from "./SearchPanel";
 
 const TelemetryDashboard = lazy(() => import("../telemetry/TelemetryDashboard").then((module) => ({ default: module.TelemetryDashboard })));
@@ -349,7 +349,6 @@ function UserPortal({
       navLabel="Knowledge navigation"
       navItemsLabel="Knowledge sections"
       navItems={navItems}
-      navPlacement="top"
       contextBar={session && (
         <UserContextBar
           session={session}
@@ -479,7 +478,7 @@ class LazyPanelErrorBoundary extends Component<LazyPanelErrorBoundaryProps, Lazy
 }
 
 function LazyPanelFallback() {
-  return <div className="table-placeholder">Loading</div>;
+  return <LoadingState label="Loading panel" />;
 }
 
 function UserTelemetryPanel({ api, session }: { api: UserApi; session: UserSession }) {
@@ -525,7 +524,7 @@ function FactsPanel({ api }: { api: UserApi }) {
     <section className="surface">
       <PanelHeading title="Facts" count={data?.items.length ?? 0} onRefresh={reload} />
       {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <div className="table-placeholder">Loading</div>}
+      {loading && <LoadingState label="Loading facts" />}
       {!loading && <FactList items={data?.items ?? []} />}
     </section>
   );
@@ -537,7 +536,7 @@ function ClaimsPanel({ api }: { api: UserApi }) {
     <section className="surface">
       <PanelHeading title="Claims" count={data?.items.length ?? 0} onRefresh={reload} />
       {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <div className="table-placeholder">Loading</div>}
+      {loading && <LoadingState label="Loading claims" />}
       {!loading && <ClaimList items={data?.items ?? []} />}
     </section>
   );
@@ -549,7 +548,7 @@ function FragmentsPanel({ api }: { api: UserApi }) {
     <section className="surface">
       <PanelHeading title="Fragments" count={data?.items.length ?? 0} onRefresh={reload} />
       {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <div className="table-placeholder">Loading</div>}
+      {loading && <LoadingState label="Loading fragments" />}
       {!loading && <FragmentList items={data?.items ?? []} />}
     </section>
   );
@@ -561,7 +560,7 @@ function CommunitiesPanel({ api }: { api: UserApi }) {
     <section className="surface">
       <PanelHeading title="Communities" count={data?.items.length ?? 0} onRefresh={reload} />
       {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <div className="table-placeholder">Loading</div>}
+      {loading && <LoadingState label="Loading communities" />}
       {!loading && <CommunityList items={data?.items ?? []} />}
     </section>
   );

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -20,13 +20,13 @@ import {
   Community,
   Fact,
   Fragment,
-  RecallHit,
   RotateResponse,
   SSOProvider,
   UserApi,
   UserSession,
 } from "./api";
 import { AuthShell, PortalShell, SecretBox, SectionHeading } from "../ui/components";
+import { SearchPanel } from "./SearchPanel";
 
 const TelemetryDashboard = lazy(() => import("../telemetry/TelemetryDashboard").then((module) => ({ default: module.TelemetryDashboard })));
 const TeamManagementPanel = lazy(() => import("./TeamManagementPanel").then((module) => ({ default: module.TeamManagementPanel })));
@@ -348,26 +348,14 @@ function UserPortal({
       )}
       navLabel="Knowledge navigation"
       navItems={navItems}
-      sidebarTitle={session?.team.name ?? (loading ? "Loading" : "Team")}
-      sidebarSubtitle={session ? shortId(session.team.id) : undefined}
-      sidebarBody={session && (
-        <div className="key-summary">
-          {authMode === "sso" ? (
-            <select
-              aria-label="Active team"
-              value={session.key.id}
-              disabled={switchingTeam || ssoTeamOptions.length <= 1}
-              onChange={(event) => void switchSSOTeam(event.target.value)}
-            >
-              {ssoTeamOptions.map((item) => (
-                <option value={item.key.id} key={item.key.id}>{item.team.name}</option>
-              ))}
-            </select>
-          ) : (
-            <span>{session.key.name}</span>
-          )}
-          <code>{displayKeySuffix(session.key.key_suffix)}</code>
-        </div>
+      contextBar={session && (
+        <UserContextBar
+          session={session}
+          authMode={authMode}
+          switchingTeam={switchingTeam}
+          ssoTeamOptions={ssoTeamOptions}
+          onSwitchTeam={switchSSOTeam}
+        />
       )}
       detailLabel="Knowledge details"
       error={error}
@@ -419,6 +407,44 @@ function UserPortal({
         </Suspense>
       </LazyPanelErrorBoundary>
     </PortalShell>
+  );
+}
+
+function UserContextBar({
+  session,
+  authMode,
+  switchingTeam,
+  ssoTeamOptions,
+  onSwitchTeam,
+}: {
+  session: UserSession;
+  authMode: AuthMode;
+  switchingTeam: boolean;
+  ssoTeamOptions: UserSession["teams"];
+  onSwitchTeam: (profileId: string) => Promise<void>;
+}) {
+  return (
+    <div className="session-context" aria-label="Current workspace">
+      <span className="context-label">Team</span>
+      {authMode === "sso" ? (
+        <select
+          aria-label="Active team"
+          value={session.key.id}
+          disabled={switchingTeam || (ssoTeamOptions?.length ?? 0) <= 1}
+          onChange={(event) => void onSwitchTeam(event.target.value)}
+        >
+          {(ssoTeamOptions ?? []).map((item) => (
+            <option value={item.key.id} key={item.key.id}>{item.team.name}</option>
+          ))}
+        </select>
+      ) : (
+        <strong>{session.team.name}</strong>
+      )}
+      <span className="context-divider" aria-hidden="true" />
+      <span className="context-label">Key</span>
+      <span>{session.key.name}</span>
+      <code>{displayKeySuffix(session.key.key_suffix)}</code>
+    </div>
   );
 }
 
@@ -492,84 +518,6 @@ function UserTelemetryPanel({ api, session }: { api: UserApi; session: UserSessi
         onRefresh={() => void loadTelemetry()}
       />
     </section>
-  );
-}
-
-function SearchPanel({ api }: { api: UserApi }) {
-  const [query, setQuery] = useState("");
-  const [hits, setHits] = useState<RecallHit[]>([]);
-  const [communities, setCommunities] = useState<Community[]>([]);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const trimmed = query.trim();
-    if (!trimmed) {
-      setError("Query is required.");
-      return;
-    }
-    setLoading(true);
-    setError("");
-    try {
-      const [nextHits, nextCommunities] = await Promise.all([
-        api.recall(trimmed, 10),
-        api.listCommunities(20).catch(() => ({ items: [] as Community[] })),
-      ]);
-      setHits(nextHits);
-      setCommunities(nextCommunities.items);
-    } catch (err) {
-      setError(readError(err));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  const entities = deriveEntities(hits, communities);
-
-  return (
-    <section className="surface">
-      <SectionHeading title="Recall" meta={hits.length} />
-      <form className="search-form" onSubmit={submit}>
-        <label htmlFor="recall-query">Keyword</label>
-        <input id="recall-query" value={query} onChange={(event) => setQuery(event.target.value)} />
-        <button className="primary-button" type="submit" disabled={loading}>
-          <Search size={16} aria-hidden="true" />
-          Search
-        </button>
-      </form>
-      {error && <div className="banner error" role="alert">{error}</div>}
-      {entities.length > 0 && (
-        <div className="entity-strip" aria-label="Related entities">
-          {entities.map((entity) => <span className="status-pill neutral" key={entity}>{entity}</span>)}
-        </div>
-      )}
-      {loading && <div className="table-placeholder">Loading</div>}
-      {!loading && <RecallResults hits={hits} />}
-    </section>
-  );
-}
-
-function RecallResults({ hits }: { hits: RecallHit[] }) {
-  if (hits.length === 0) {
-    return <div className="table-placeholder">No recall results</div>;
-  }
-  return (
-    <div className="knowledge-list">
-      {hits.map((hit, index) => {
-        const item = hit.fact ?? hit.claim ?? hit.fragment;
-        return (
-          <article className="knowledge-item" key={recallKey(hit, index)}>
-            <div className="knowledge-item-head">
-              <span className="status-pill neutral">{tierLabel(hit)}</span>
-              <small>{scoreLabel(hit.score ?? hit.final_score)}</small>
-            </div>
-            <h3>{itemTitle(item)}</h3>
-            <p>{itemBody(item)}</p>
-          </article>
-        );
-      })}
-    </div>
   );
 }
 
@@ -876,65 +824,6 @@ function useKnowledge<T>(load: () => Promise<T>, deps: unknown[]) {
   }, deps);
 
   return { data, loading, error, reload };
-}
-
-function deriveEntities(hits: RecallHit[], communities: Community[]): string[] {
-  const values = new Set<string>();
-  for (const hit of hits) {
-    const source = hit.fact ?? hit.claim;
-    if (source) {
-      addEntity(values, source.subject);
-      addEntity(values, source.object);
-      addEntity(values, source.predicate);
-    }
-  }
-  for (const community of communities) {
-    for (const entity of community.top_entities ?? []) {
-      addEntity(values, entity);
-    }
-  }
-  return Array.from(values).slice(0, 20);
-}
-
-function addEntity(values: Set<string>, value: string | undefined) {
-  const trimmed = value?.trim();
-  if (trimmed) {
-    values.add(trimmed);
-  }
-}
-
-function itemTitle(item: Fact | Claim | Fragment | undefined): string {
-  if (!item) {
-    return "Result";
-  }
-  if ("content" in item) {
-    return item.source || shortId(item.fragment_id || item.id);
-  }
-  return item.subject;
-}
-
-function itemBody(item: Fact | Claim | Fragment | undefined): string {
-  if (!item) {
-    return "";
-  }
-  if ("content" in item) {
-    return item.content;
-  }
-  return `${item.predicate}: ${item.object}`;
-}
-
-function tierLabel(hit: RecallHit): string {
-  if (hit.fact) {
-    return "Fact";
-  }
-  if (hit.claim) {
-    return "Claim";
-  }
-  return "Fragment";
-}
-
-function recallKey(hit: RecallHit, index: number): string {
-  return hit.fact?.fact_id ?? hit.claim?.claim_id ?? hit.fragment?.fragment_id ?? String(index);
 }
 
 function scoreLabel(value: number | undefined): string {

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -347,6 +347,7 @@ function UserPortal({
         </>
       )}
       navLabel="Knowledge navigation"
+      navItemsLabel="Knowledge sections"
       navItems={navItems}
       contextBar={session && (
         <UserContextBar

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -349,6 +349,7 @@ function UserPortal({
       navLabel="Knowledge navigation"
       navItemsLabel="Knowledge sections"
       navItems={navItems}
+      navPlacement="top"
       contextBar={session && (
         <UserContextBar
           session={session}

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -152,7 +152,7 @@ export function UserPortalApp() {
       <AuthShell
         theme={theme}
         title="Dense-Mem Knowledge"
-        icon={<ShieldCheck size={20} aria-hidden="true" />}
+        icon={<span className="brand-initials" aria-hidden="true">DM</span>}
         onSubmit={submitToken}
         actions={(
           <button
@@ -320,8 +320,8 @@ function UserPortal({
   return (
     <PortalShell
       theme={theme}
-      title="Dense-Mem Knowledge"
-      icon={<ShieldCheck size={20} aria-hidden="true" />}
+      title="Knowledge"
+      icon={<span className="brand-initials" aria-hidden="true">DM</span>}
       topbarActions={(
         <>
           <button
@@ -349,6 +349,7 @@ function UserPortal({
       navLabel="Knowledge navigation"
       navItemsLabel="Knowledge sections"
       navItems={navItems}
+      navPlacement="top"
       contextBar={session && (
         <UserContextBar
           session={session}
@@ -425,7 +426,7 @@ function UserContextBar({
   onSwitchTeam: (profileId: string) => Promise<void>;
 }) {
   return (
-    <div className="session-context" aria-label="Current workspace">
+    <div className="session-context compact" aria-label="Current workspace">
       <span className="context-label">Team</span>
       {authMode === "sso" ? (
         <select
@@ -439,12 +440,8 @@ function UserContextBar({
           ))}
         </select>
       ) : (
-        <strong>{session.team.name}</strong>
+        <strong className="team-select-chip">{session.team.name}</strong>
       )}
-      <span className="context-divider" aria-hidden="true" />
-      <span className="context-label">Key</span>
-      <span>{session.key.name}</span>
-      <code>{displayKeySuffix(session.key.key_suffix)}</code>
     </div>
   );
 }

--- a/web/src/user/DreamsPanel.tsx
+++ b/web/src/user/DreamsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { InfoTooltip, SectionHeading } from "../ui/components";
+import { InfoTooltip, LoadingState, SectionHeading } from "../ui/components";
 import { Dream, DreamQuery, DreamRun, DreamSort, DreamStatus, UserApi } from "./api";
 
 const DREAM_STATUSES = ["", "proposed", "reinforced", "stale", "rejected", "promoted"];
@@ -129,7 +129,7 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
           </label>
         </div>
         {loading && dreams.length === 0 ? (
-          <div className="table-placeholder">Loading</div>
+          <LoadingState label="Loading dreams" />
         ) : dreams.length === 0 ? (
           <div className="table-placeholder">No dreams</div>
         ) : (
@@ -178,7 +178,7 @@ export function UserDreamsPanel({ api }: { api: UserApi }) {
       <section className="surface">
         <SectionHeading title="Cycle Runs" meta={runs.length} />
         {loading && runs.length === 0 ? (
-          <div className="table-placeholder">Loading</div>
+          <LoadingState label="Loading runs" />
         ) : runs.length === 0 ? (
           <div className="table-placeholder">No runs</div>
         ) : (

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -1,0 +1,308 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { SectionHeading } from "../ui/components";
+import { Claim, Community, Fact, Fragment, RecallHit, UserApi } from "./api";
+
+type RecallResultKind = "fact" | "claim" | "fragment";
+
+type IndexedRecallResult = {
+  hit: RecallHit;
+  key: string;
+  kind: RecallResultKind;
+};
+
+export function SearchPanel({ api }: { api: UserApi }) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<RecallHit[]>([]);
+  const [communities, setCommunities] = useState<Community[]>([]);
+  const [selectedKey, setSelectedKey] = useState("");
+  const [enabledTypes, setEnabledTypes] = useState<Record<RecallResultKind, boolean>>({
+    fact: true,
+    claim: true,
+    fragment: true,
+  });
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setError("Query is required.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const [nextHits, nextCommunities] = await Promise.all([
+        api.recall(trimmed, 10),
+        api.listCommunities(20).catch(() => ({ items: [] as Community[] })),
+      ]);
+      setHits(nextHits);
+      setCommunities(nextCommunities.items);
+      setSelectedKey(nextHits[0] ? recallKey(nextHits[0], 0) : "");
+    } catch (err) {
+      setError(readError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const entities = deriveEntities(hits, communities);
+  const indexedHits = useMemo(() => hits.map((hit, index) => ({
+    hit,
+    key: recallKey(hit, index),
+    kind: recallResultKind(hit),
+  })), [hits]);
+  const filteredHits = indexedHits.filter((item) => enabledTypes[item.kind]);
+  const selectedResult = filteredHits.find((item) => item.key === selectedKey) ?? filteredHits[0] ?? null;
+  const typeCounts = indexedHits.reduce<Record<RecallResultKind, number>>((counts, item) => ({
+    ...counts,
+    [item.kind]: counts[item.kind] + 1,
+  }), { fact: 0, claim: 0, fragment: 0 });
+
+  function toggleType(kind: RecallResultKind) {
+    setEnabledTypes((current) => ({
+      ...current,
+      [kind]: !current[kind],
+    }));
+  }
+
+  return (
+    <section className="knowledge-explorer" aria-label="Knowledge explorer">
+      <aside className="knowledge-filter-panel" aria-label="Knowledge filters">
+        <SectionHeading
+          title="Filters"
+          actions={(
+            <button
+              className="text-button"
+              type="button"
+              onClick={() => setEnabledTypes({ fact: true, claim: true, fragment: true })}
+            >
+              Reset
+            </button>
+          )}
+        />
+        <form className="search-form stacked" onSubmit={submit}>
+          <label htmlFor="recall-query">Keyword</label>
+          <div className="search-input-wrap">
+            <Search size={16} aria-hidden="true" />
+            <input
+              id="recall-query"
+              placeholder="Search knowledge..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+          <button className="primary-button" type="submit" disabled={loading}>
+            <Search size={16} aria-hidden="true" />
+            Search
+          </button>
+        </form>
+        <fieldset className="filter-stack">
+          <legend>Type</legend>
+          {(["fact", "claim", "fragment"] as RecallResultKind[]).map((kind) => (
+            <label className="filter-row" key={kind}>
+              <input
+                type="checkbox"
+                checked={enabledTypes[kind]}
+                onChange={() => toggleType(kind)}
+              />
+              <span>{recallResultKindLabel(kind)}</span>
+              <small>{typeCounts[kind]}</small>
+            </label>
+          ))}
+        </fieldset>
+        {entities.length > 0 && (
+          <div className="filter-stack" aria-label="Related entities">
+            <strong>Entities</strong>
+            <div className="entity-strip">
+              {entities.map((entity) => <span className="status-pill neutral" key={entity}>{entity}</span>)}
+            </div>
+          </div>
+        )}
+      </aside>
+
+      <section className="knowledge-results-panel" aria-label="Recall results">
+        <div className="knowledge-results-toolbar">
+          <div>
+            <h2>Recall</h2>
+            <span>{filteredHits.length} results</span>
+          </div>
+        </div>
+        {error && <div className="banner error" role="alert">{error}</div>}
+        {loading && <div className="table-placeholder">Loading</div>}
+        {!loading && (
+          <RecallResults
+            items={filteredHits}
+            selectedKey={selectedResult?.key ?? ""}
+            onSelect={setSelectedKey}
+          />
+        )}
+      </section>
+
+      <aside className="knowledge-inspector" aria-label="Inspector">
+        <SectionHeading
+          title="Inspector"
+          meta={selectedResult ? recallResultKindLabel(selectedResult.kind) : undefined}
+        />
+        <KnowledgeInspector result={selectedResult} />
+      </aside>
+    </section>
+  );
+}
+
+function RecallResults({
+  items,
+  selectedKey,
+  onSelect,
+}: {
+  items: IndexedRecallResult[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+}) {
+  if (items.length === 0) {
+    return <div className="table-placeholder">No recall results</div>;
+  }
+  return (
+    <div className="knowledge-list compact-list">
+      {items.map((result) => {
+        const item = result.hit.fact ?? result.hit.claim ?? result.hit.fragment;
+        return (
+          <article className={result.key === selectedKey ? "knowledge-item selected" : "knowledge-item"} key={result.key}>
+            <button className="knowledge-result-button" type="button" onClick={() => onSelect(result.key)}>
+              <div className="knowledge-item-head">
+                <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
+                <small>{tierLabel(result.hit)} | {scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
+              </div>
+              <h3>{itemTitle(item)}</h3>
+              <p>{itemBody(item)}</p>
+            </button>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function KnowledgeInspector({ result }: { result: IndexedRecallResult | null }) {
+  if (!result) {
+    return <div className="table-placeholder compact">Select a result</div>;
+  }
+
+  const item = result.hit.fact ?? result.hit.claim ?? result.hit.fragment;
+  return (
+    <article className="inspector-card">
+      <div className="knowledge-item-head">
+        <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
+        <small>{scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
+      </div>
+      <h3>{itemTitle(item)}</h3>
+      <p>{itemBody(item)}</p>
+      <dl className="inspector-details">
+        <div>
+          <dt>Tier</dt>
+          <dd>{tierLabel(result.hit)}</dd>
+        </div>
+        <div>
+          <dt>Type</dt>
+          <dd>{recallResultKindLabel(result.kind)}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function deriveEntities(hits: RecallHit[], communities: Community[]): string[] {
+  const values = new Set<string>();
+  for (const hit of hits) {
+    const source = hit.fact ?? hit.claim;
+    if (source) {
+      addEntity(values, source.subject);
+      addEntity(values, source.object);
+      addEntity(values, source.predicate);
+    }
+  }
+  for (const community of communities) {
+    for (const entity of community.top_entities ?? []) {
+      addEntity(values, entity);
+    }
+  }
+  return Array.from(values).slice(0, 20);
+}
+
+function addEntity(values: Set<string>, value: string | undefined) {
+  const trimmed = value?.trim();
+  if (trimmed) {
+    values.add(trimmed);
+  }
+}
+
+function itemTitle(item: Fact | Claim | Fragment | undefined): string {
+  if (!item) {
+    return "Result";
+  }
+  if ("content" in item) {
+    return item.source || shortId(item.fragment_id || item.id);
+  }
+  return item.subject;
+}
+
+function itemBody(item: Fact | Claim | Fragment | undefined): string {
+  if (!item) {
+    return "";
+  }
+  if ("content" in item) {
+    return item.content;
+  }
+  return `${item.predicate}: ${item.object}`;
+}
+
+function tierLabel(hit: RecallHit): string {
+  if (hit.fact) {
+    return "Fact";
+  }
+  if (hit.claim) {
+    return "Claim";
+  }
+  return "Fragment";
+}
+
+function recallResultKind(hit: RecallHit): RecallResultKind {
+  if (hit.fact) {
+    return "fact";
+  }
+  if (hit.claim) {
+    return "claim";
+  }
+  return "fragment";
+}
+
+function recallResultKindLabel(kind: RecallResultKind): string {
+  if (kind === "fact") {
+    return "Fact";
+  }
+  if (kind === "claim") {
+    return "Claim";
+  }
+  return "Fragment";
+}
+
+function recallKey(hit: RecallHit, index: number): string {
+  return hit.fact?.fact_id ?? hit.claim?.claim_id ?? hit.fragment?.fragment_id ?? String(index);
+}
+
+function scoreLabel(value: number | undefined): string {
+  if (value === undefined || Number.isNaN(value)) {
+    return "";
+  }
+  return value.toFixed(value >= 1 ? 0 : 3);
+}
+
+function readError(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+function shortId(id: string): string {
+  return id.length <= 8 ? id : id.slice(0, 8);
+}

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -17,6 +17,9 @@ import { Claim, Community, Fact, Fragment, RecallHit, UserApi } from "./api";
 
 type RecallResultKind = "fact" | "claim" | "fragment";
 type RecallResultStatus = "verified" | "provisional" | "disputed" | "deprecated";
+type RecallSortMode = "relevance" | "date";
+type ResultDensity = "comfortable" | "compact";
+type InspectorTab = "evidence" | "lineage" | "recall";
 
 type IndexedRecallResult = {
   hit: RecallHit;
@@ -44,6 +47,10 @@ export function SearchPanel({ api }: { api: UserApi }) {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [sourceFilter, setSourceFilter] = useState("all");
+  const [sortMode, setSortMode] = useState<RecallSortMode>("relevance");
+  const [density, setDensity] = useState<ResultDensity>("comfortable");
+  const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [inspectorTab, setInspectorTab] = useState<InspectorTab>("evidence");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -63,6 +70,9 @@ export function SearchPanel({ api }: { api: UserApi }) {
       ]);
       setHits(nextHits);
       setCommunities(nextCommunities.items);
+      setSourceFilter("all");
+      setInspectorOpen(true);
+      setInspectorTab("evidence");
       setSelectedKey(nextHits[0] ? recallKey(nextHits[0], 0) : "");
     } catch (err) {
       setError(readError(err));
@@ -87,9 +97,10 @@ export function SearchPanel({ api }: { api: UserApi }) {
         && dateMatches(item, dateMode, startDate, endDate);
     })
   ), [indexedHits, enabledTypes, enabledStatuses, sourceFilter, dateMode, startDate, endDate]);
+  const sortedHits = useMemo(() => sortRecallResults(filteredHits, sortMode), [filteredHits, sortMode]);
   const selectedResult = useMemo(() => (
-    filteredHits.find((item) => item.key === selectedKey) ?? filteredHits[0] ?? null
-  ), [filteredHits, selectedKey]);
+    sortedHits.find((item) => item.key === selectedKey) ?? sortedHits[0] ?? null
+  ), [sortedHits, selectedKey]);
   const typeCounts = useMemo(() => indexedHits.reduce<Record<RecallResultKind, number>>((counts, item) => ({
     ...counts,
     [item.kind]: counts[item.kind] + 1,
@@ -133,7 +144,7 @@ export function SearchPanel({ api }: { api: UserApi }) {
   }
 
   return (
-    <section className="knowledge-explorer" aria-label="Knowledge explorer">
+    <section className={inspectorOpen ? "knowledge-explorer" : "knowledge-explorer inspector-closed"} aria-label="Knowledge explorer">
       <aside className="knowledge-filter-panel" aria-label="Knowledge filters">
         <SectionHeading
           title="Filters"
@@ -225,28 +236,52 @@ export function SearchPanel({ api }: { api: UserApi }) {
             <span>{query.trim() ? `for "${query.trim()}"` : "Search across facts, claims, and memory"}</span>
           </div>
           <div className="toolbar-actions">
-            <button className="select-like compact" type="button">Sort: Relevance <ChevronDown size={14} aria-hidden="true" /></button>
-            <button className="icon-button" type="button" aria-label="List density"><FileText size={16} aria-hidden="true" /></button>
+            <button
+              className="select-like compact"
+              type="button"
+              aria-label={`Sort by ${sortMode === "relevance" ? "date" : "relevance"}`}
+              onClick={() => setSortMode((current) => (current === "relevance" ? "date" : "relevance"))}
+            >
+              Sort: {sortMode === "relevance" ? "Relevance" : "Date"} <ChevronDown size={14} aria-hidden="true" />
+            </button>
+            <button
+              className={density === "compact" ? "icon-button active" : "icon-button"}
+              type="button"
+              aria-label={density === "compact" ? "Use comfortable density" : "Use compact density"}
+              aria-pressed={density === "compact"}
+              onClick={() => setDensity((current) => (current === "comfortable" ? "compact" : "comfortable"))}
+            >
+              <FileText size={16} aria-hidden="true" />
+            </button>
+            {!inspectorOpen && (
+              <button className="ghost-button compact" type="button" onClick={() => setInspectorOpen(true)}>
+                <FileText size={15} aria-hidden="true" />
+                Open details
+              </button>
+            )}
           </div>
         </div>
         {error && <div className="banner error" role="alert">{error}</div>}
         {loading && <div className="table-placeholder">Loading</div>}
         {!loading && (
           <RecallResults
-            items={filteredHits}
+            items={sortedHits}
             selectedKey={selectedResult?.key ?? ""}
             onSelect={setSelectedKey}
+            density={density}
           />
         )}
       </section>
 
-      <aside className="knowledge-inspector" aria-label="Inspector">
-        <div className="inspector-head">
-          <h2>Inspector</h2>
-          <button className="icon-button" type="button" aria-label="Close details panel"><X size={16} aria-hidden="true" /></button>
-        </div>
-        <KnowledgeInspector result={selectedResult} />
-      </aside>
+      {inspectorOpen && (
+        <aside className="knowledge-inspector" aria-label="Inspector">
+          <div className="inspector-head">
+            <h2>Inspector</h2>
+            <button className="icon-button" type="button" aria-label="Close details panel" onClick={() => setInspectorOpen(false)}><X size={16} aria-hidden="true" /></button>
+          </div>
+          <KnowledgeInspector result={selectedResult} activeTab={inspectorTab} onSelectTab={setInspectorTab} />
+        </aside>
+      )}
     </section>
   );
 }
@@ -255,16 +290,18 @@ function RecallResults({
   items,
   selectedKey,
   onSelect,
+  density,
 }: {
   items: IndexedRecallResult[];
   selectedKey: string;
   onSelect: (key: string) => void;
+  density: ResultDensity;
 }) {
   if (items.length === 0) {
     return <div className="table-placeholder">No recall results</div>;
   }
   return (
-    <div className="knowledge-list compact-list" role="listbox" aria-label="Recall result list">
+    <div className={density === "compact" ? "knowledge-list compact-list dense" : "knowledge-list compact-list"} role="listbox" aria-label="Recall result list">
       {items.map((result) => {
         const item = resultItem(result.hit);
         const status = recallResultStatus(item);
@@ -315,49 +352,111 @@ function RecallResults({
   );
 }
 
-function KnowledgeInspector({ result }: { result: IndexedRecallResult | null }) {
+function KnowledgeInspector({
+  result,
+  activeTab,
+  onSelectTab,
+}: {
+  result: IndexedRecallResult | null;
+  activeTab: InspectorTab;
+  onSelectTab: (tab: InspectorTab) => void;
+}) {
   if (!result) {
     return <div className="table-placeholder compact">Select a result</div>;
   }
 
   const item = resultItem(result.hit);
   const status = recallResultStatus(item);
+  const tabs: Array<{ id: InspectorTab; label: string }> = [
+    { id: "evidence", label: "Evidence" },
+    { id: "lineage", label: "Lineage" },
+    { id: "recall", label: "Recall" },
+  ];
   return (
     <article className="inspector-card">
       <div className="inspector-tabs" role="tablist" aria-label="Result sections">
-        <button className="inspector-tab active" type="button" role="tab" aria-selected="true">Evidence</button>
-        <button className="inspector-tab" type="button" role="tab">Lineage</button>
-        <button className="inspector-tab" type="button" role="tab">Recall</button>
+        {tabs.map((tab) => (
+          <button
+            className={tab.id === activeTab ? "inspector-tab active" : "inspector-tab"}
+            type="button"
+            role="tab"
+            aria-selected={tab.id === activeTab}
+            key={tab.id}
+            onClick={() => onSelectTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
       <div className="inspector-status-row">
         <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
         <span className={statusPillClass(status)}>{recallResultStatusLabel(status)}</span>
       </div>
       <h3>{itemTitle(item)}</h3>
-      <div className="inspector-section">
-        <h4>Evidence</h4>
-        <p>{itemBody(item)}</p>
-        <dl className="evidence-list">
-          <div>
-            <dt>Source</dt>
-            <dd>
-              {sourceLabel(item)}
-              <ExternalLink size={13} aria-hidden="true" />
-            </dd>
-          </div>
-          <div>
-            <dt>Collected</dt>
-            <dd>{itemDate(item)}</dd>
-          </div>
-          <div>
-            <dt>Confidence</dt>
-            <dd>
-              <span>{scoreLabel(result.hit.score ?? result.hit.final_score) || "n/a"}</span>
-              <span className="confidence-bar" style={{ "--confidence": confidencePercent(result.hit) } as CSSProperties} />
-            </dd>
-          </div>
-        </dl>
-      </div>
+      {activeTab === "evidence" && (
+        <div className="inspector-section" role="tabpanel">
+          <h4>Evidence</h4>
+          <p>{itemBody(item)}</p>
+          <dl className="evidence-list">
+            <div>
+              <dt>Source</dt>
+              <dd>
+                {sourceLabel(item)}
+                <ExternalLink size={13} aria-hidden="true" />
+              </dd>
+            </div>
+            <div>
+              <dt>Collected</dt>
+              <dd>{itemDate(item)}</dd>
+            </div>
+            <div>
+              <dt>Confidence</dt>
+              <dd>
+                <span>{scoreLabel(result.hit.score ?? result.hit.final_score) || "n/a"}</span>
+                <span className="confidence-bar" style={{ "--confidence": confidencePercent(result.hit) } as CSSProperties} />
+              </dd>
+            </div>
+          </dl>
+        </div>
+      )}
+      {activeTab === "lineage" && (
+        <div className="inspector-section" role="tabpanel">
+          <h4>Lineage</h4>
+          <dl className="evidence-list">
+            <div>
+              <dt>Derived from</dt>
+              <dd>{sourceLabel(item)}</dd>
+            </div>
+            <div>
+              <dt>Recorded</dt>
+              <dd>{itemDate(item)}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{recallResultStatusLabel(status)}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+      {activeTab === "recall" && (
+        <div className="inspector-section" role="tabpanel">
+          <h4>Recall</h4>
+          <dl className="evidence-list">
+            <div>
+              <dt>Final score</dt>
+              <dd>{scoreLabel(result.hit.final_score ?? result.hit.score) || "n/a"}</dd>
+            </div>
+            <div>
+              <dt>Semantic rank</dt>
+              <dd>{rankLabel(result.hit.semantic_rank)}</dd>
+            </div>
+            <div>
+              <dt>Keyword rank</dt>
+              <dd>{rankLabel(result.hit.keyword_rank)}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
       <dl className="inspector-details">
         <div>
           <dt>Tier</dt>
@@ -524,6 +623,20 @@ function dateMatches(item: Fact | Claim | Fragment | undefined, dateMode: "all" 
   return true;
 }
 
+function sortRecallResults(items: IndexedRecallResult[], sortMode: RecallSortMode): IndexedRecallResult[] {
+  if (sortMode === "relevance") {
+    return items;
+  }
+  return [...items].sort((left, right) => {
+    return itemTimestamp(right) - itemTimestamp(left);
+  });
+}
+
+function itemTimestamp(result: IndexedRecallResult): number {
+  const value = new Date(itemRawDate(resultItem(result.hit))).getTime();
+  return Number.isNaN(value) ? 0 : value;
+}
+
 function itemRawDate(item: Fact | Claim | Fragment | undefined): string {
   if (!item) {
     return "";
@@ -581,6 +694,10 @@ function scoreLabel(value: number | undefined): string {
     return "";
   }
   return value.toFixed(value >= 1 ? 0 : 3);
+}
+
+function rankLabel(value: number | undefined): string {
+  return value === undefined ? "n/a" : String(value);
 }
 
 function readError(error: unknown): string {

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -1,9 +1,22 @@
-import { FormEvent, useMemo, useState } from "react";
-import { Search } from "lucide-react";
+import { CSSProperties, FormEvent, useMemo, useState } from "react";
+import {
+  Bookmark,
+  ChevronDown,
+  ExternalLink,
+  FileText,
+  GitBranch,
+  MoreVertical,
+  Plus,
+  Search,
+  ShieldCheck,
+  Star,
+  X,
+} from "lucide-react";
 import { SectionHeading } from "../ui/components";
 import { Claim, Community, Fact, Fragment, RecallHit, UserApi } from "./api";
 
 type RecallResultKind = "fact" | "claim" | "fragment";
+type RecallResultStatus = "verified" | "provisional" | "disputed" | "deprecated";
 
 type IndexedRecallResult = {
   hit: RecallHit;
@@ -21,6 +34,16 @@ export function SearchPanel({ api }: { api: UserApi }) {
     claim: true,
     fragment: true,
   });
+  const [enabledStatuses, setEnabledStatuses] = useState<Record<RecallResultStatus, boolean>>({
+    verified: true,
+    provisional: true,
+    disputed: false,
+    deprecated: false,
+  });
+  const [dateMode, setDateMode] = useState<"all" | "custom">("all");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [sourceFilter, setSourceFilter] = useState("all");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -55,8 +78,15 @@ export function SearchPanel({ api }: { api: UserApi }) {
     kind: recallResultKind(hit),
   })), [hits]);
   const filteredHits = useMemo(() => (
-    indexedHits.filter((item) => enabledTypes[item.kind])
-  ), [indexedHits, enabledTypes]);
+    indexedHits.filter((indexed) => {
+      const item = resultItem(indexed.hit);
+      const status = recallResultStatus(item);
+      return enabledTypes[indexed.kind]
+        && enabledStatuses[status]
+        && sourceMatches(item, sourceFilter)
+        && dateMatches(item, dateMode, startDate, endDate);
+    })
+  ), [indexedHits, enabledTypes, enabledStatuses, sourceFilter, dateMode, startDate, endDate]);
   const selectedResult = useMemo(() => (
     filteredHits.find((item) => item.key === selectedKey) ?? filteredHits[0] ?? null
   ), [filteredHits, selectedKey]);
@@ -64,12 +94,42 @@ export function SearchPanel({ api }: { api: UserApi }) {
     ...counts,
     [item.kind]: counts[item.kind] + 1,
   }), { fact: 0, claim: 0, fragment: 0 }), [indexedHits]);
+  const statusCounts = useMemo(() => indexedHits.reduce<Record<RecallResultStatus, number>>((counts, indexed) => {
+    const status = recallResultStatus(resultItem(indexed.hit));
+    return {
+      ...counts,
+      [status]: counts[status] + 1,
+    };
+  }, { verified: 0, provisional: 0, disputed: 0, deprecated: 0 }), [indexedHits]);
+  const sourceOptions = useMemo(() => {
+    const values = new Set<string>();
+    for (const hit of indexedHits) {
+      values.add(sourceLabel(resultItem(hit.hit)));
+    }
+    return Array.from(values).sort((left, right) => left.localeCompare(right));
+  }, [indexedHits]);
 
   function toggleType(kind: RecallResultKind) {
     setEnabledTypes((current) => ({
       ...current,
       [kind]: !current[kind],
     }));
+  }
+
+  function toggleStatus(status: RecallResultStatus) {
+    setEnabledStatuses((current) => ({
+      ...current,
+      [status]: !current[status],
+    }));
+  }
+
+  function clearFilters() {
+    setEnabledTypes({ fact: true, claim: true, fragment: true });
+    setEnabledStatuses({ verified: true, provisional: true, disputed: false, deprecated: false });
+    setDateMode("all");
+    setStartDate("");
+    setEndDate("");
+    setSourceFilter("all");
   }
 
   return (
@@ -81,28 +141,12 @@ export function SearchPanel({ api }: { api: UserApi }) {
             <button
               className="text-button"
               type="button"
-              onClick={() => setEnabledTypes({ fact: true, claim: true, fragment: true })}
+              onClick={clearFilters}
             >
-              Reset
+              Clear all
             </button>
           )}
         />
-        <form className="search-form stacked" onSubmit={submit}>
-          <label htmlFor="recall-query">Keyword</label>
-          <div className="search-input-wrap">
-            <Search size={16} aria-hidden="true" />
-            <input
-              id="recall-query"
-              placeholder="Search knowledge..."
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
-          </div>
-          <button className="primary-button" type="submit" disabled={loading}>
-            <Search size={16} aria-hidden="true" />
-            Search
-          </button>
-        </form>
         <fieldset className="filter-stack">
           <legend>Type</legend>
           {(["fact", "claim", "fragment"] as RecallResultKind[]).map((kind) => (
@@ -117,9 +161,39 @@ export function SearchPanel({ api }: { api: UserApi }) {
             </label>
           ))}
         </fieldset>
+        <fieldset className="filter-stack">
+          <legend>Status</legend>
+          {(["verified", "provisional", "disputed", "deprecated"] as RecallResultStatus[]).map((status) => (
+            <label className="filter-row" key={status}>
+              <input type="checkbox" checked={enabledStatuses[status]} onChange={() => toggleStatus(status)} />
+              <span>{recallResultStatusLabel(status)}</span>
+              <small>{statusCounts[status]}</small>
+            </label>
+          ))}
+        </fieldset>
+        <div className="filter-stack">
+          <strong>Date</strong>
+          <select aria-label="Date range" value={dateMode} onChange={(event) => setDateMode(event.target.value as "all" | "custom")}>
+            <option value="all">All time</option>
+            <option value="custom">Custom</option>
+          </select>
+          {dateMode === "custom" && (
+            <>
+              <input aria-label="Start date" type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} />
+              <input aria-label="End date" type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} />
+            </>
+          )}
+        </div>
+        <div className="filter-stack">
+          <strong>Source</strong>
+          <select aria-label="Source" value={sourceFilter} onChange={(event) => setSourceFilter(event.target.value)}>
+            <option value="all">All sources</option>
+            {sourceOptions.map((source) => <option key={source} value={source}>{source}</option>)}
+          </select>
+        </div>
         {entities.length > 0 && (
           <div className="filter-stack" aria-label="Related entities">
-            <strong>Entities</strong>
+            <strong>Tag</strong>
             <div className="entity-strip">
               {entities.map((entity) => <span className="status-pill neutral" key={entity}>{entity}</span>)}
             </div>
@@ -128,10 +202,31 @@ export function SearchPanel({ api }: { api: UserApi }) {
       </aside>
 
       <section className="knowledge-results-panel" aria-label="Recall results">
+        <form className="knowledge-commandbar" onSubmit={submit}>
+          <label className="sr-only" htmlFor="recall-query">Keyword</label>
+          <div className="search-input-wrap large">
+            <Search size={17} aria-hidden="true" />
+            <input
+              id="recall-query"
+              aria-label="Keyword"
+              placeholder="Search knowledge..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+          <button className="primary-button compact" type="submit" disabled={loading}>
+            <Search size={16} aria-hidden="true" />
+            Search
+          </button>
+        </form>
         <div className="knowledge-results-toolbar">
           <div>
-            <h2>Recall</h2>
-            <span>{filteredHits.length} results</span>
+            <h2>{filteredHits.length.toLocaleString()} results</h2>
+            <span>{query.trim() ? `for "${query.trim()}"` : "Search across facts, claims, and memory"}</span>
+          </div>
+          <div className="toolbar-actions">
+            <button className="select-like compact" type="button">Sort: Relevance <ChevronDown size={14} aria-hidden="true" /></button>
+            <button className="icon-button" type="button" aria-label="List density"><FileText size={16} aria-hidden="true" /></button>
           </div>
         </div>
         {error && <div className="banner error" role="alert">{error}</div>}
@@ -146,10 +241,10 @@ export function SearchPanel({ api }: { api: UserApi }) {
       </section>
 
       <aside className="knowledge-inspector" aria-label="Inspector">
-        <SectionHeading
-          title="Inspector"
-          meta={selectedResult ? recallResultKindLabel(selectedResult.kind) : undefined}
-        />
+        <div className="inspector-head">
+          <h2>Inspector</h2>
+          <button className="icon-button" type="button" aria-label="Close details panel"><X size={16} aria-hidden="true" /></button>
+        </div>
         <KnowledgeInspector result={selectedResult} />
       </aside>
     </section>
@@ -171,7 +266,8 @@ function RecallResults({
   return (
     <div className="knowledge-list compact-list" role="listbox" aria-label="Recall result list">
       {items.map((result) => {
-        const item = result.hit.fact ?? result.hit.claim ?? result.hit.fragment;
+        const item = resultItem(result.hit);
+        const status = recallResultStatus(item);
         return (
           <article
             aria-selected={result.key === selectedKey}
@@ -192,11 +288,26 @@ function RecallResults({
             tabIndex={0}
           >
             <div className="knowledge-item-head">
-              <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
-              <small>{tierLabel(result.hit)} | {scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
+              <div className="result-kicker">
+                {resultIcon(result.kind)}
+                <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
+                <span className={statusPillClass(status)}>{recallResultStatusLabel(status)}</span>
+              </div>
+              <div className="result-actions">
+                <button className="icon-button bare" type="button" aria-label={`Star ${itemTitle(item)}`}>
+                  <Star size={15} aria-hidden="true" />
+                </button>
+                <button className="icon-button bare" type="button" aria-label={`More actions ${itemTitle(item)}`}>
+                  <MoreVertical size={15} aria-hidden="true" />
+                </button>
+              </div>
             </div>
             <h3>{itemTitle(item)}</h3>
             <p>{itemBody(item)}</p>
+            <div className="result-meta-row">
+              <span>Source: {sourceLabel(item)}</span>
+              <time>{itemDate(item)}</time>
+            </div>
           </article>
         );
       })}
@@ -209,15 +320,44 @@ function KnowledgeInspector({ result }: { result: IndexedRecallResult | null }) 
     return <div className="table-placeholder compact">Select a result</div>;
   }
 
-  const item = result.hit.fact ?? result.hit.claim ?? result.hit.fragment;
+  const item = resultItem(result.hit);
+  const status = recallResultStatus(item);
   return (
     <article className="inspector-card">
-      <div className="knowledge-item-head">
+      <div className="inspector-tabs" role="tablist" aria-label="Result sections">
+        <button className="inspector-tab active" type="button" role="tab" aria-selected="true">Evidence</button>
+        <button className="inspector-tab" type="button" role="tab">Lineage</button>
+        <button className="inspector-tab" type="button" role="tab">Recall</button>
+      </div>
+      <div className="inspector-status-row">
         <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
-        <small>{scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
+        <span className={statusPillClass(status)}>{recallResultStatusLabel(status)}</span>
       </div>
       <h3>{itemTitle(item)}</h3>
-      <p>{itemBody(item)}</p>
+      <div className="inspector-section">
+        <h4>Evidence</h4>
+        <p>{itemBody(item)}</p>
+        <dl className="evidence-list">
+          <div>
+            <dt>Source</dt>
+            <dd>
+              {sourceLabel(item)}
+              <ExternalLink size={13} aria-hidden="true" />
+            </dd>
+          </div>
+          <div>
+            <dt>Collected</dt>
+            <dd>{itemDate(item)}</dd>
+          </div>
+          <div>
+            <dt>Confidence</dt>
+            <dd>
+              <span>{scoreLabel(result.hit.score ?? result.hit.final_score) || "n/a"}</span>
+              <span className="confidence-bar" style={{ "--confidence": confidencePercent(result.hit) } as CSSProperties} />
+            </dd>
+          </div>
+        </dl>
+      </div>
       <dl className="inspector-details">
         <div>
           <dt>Tier</dt>
@@ -228,6 +368,16 @@ function KnowledgeInspector({ result }: { result: IndexedRecallResult | null }) 
           <dd>{recallResultKindLabel(result.kind)}</dd>
         </div>
       </dl>
+      <div className="inspector-actions">
+        <button className="ghost-button compact" type="button">
+          <Bookmark size={15} aria-hidden="true" />
+          Add to collection
+        </button>
+        <button className="ghost-button compact" type="button">
+          <Plus size={15} aria-hidden="true" />
+          Create claim
+        </button>
+      </div>
     </article>
   );
 }
@@ -305,8 +455,125 @@ function recallResultKindLabel(kind: RecallResultKind): string {
   return "Fragment";
 }
 
+function resultItem(hit: RecallHit): Fact | Claim | Fragment | undefined {
+  return hit.fact ?? hit.claim ?? hit.fragment;
+}
+
+function recallResultStatus(item: Fact | Claim | Fragment | undefined): RecallResultStatus {
+  const raw = item?.status?.toLowerCase() ?? "";
+  if (raw.includes("disputed") || raw.includes("contradicted") || raw.includes("rejected") || raw.includes("invalid")) {
+    return "disputed";
+  }
+  if (raw.includes("deprecated") || raw.includes("retracted") || raw.includes("stale") || raw.includes("superseded")) {
+    return "deprecated";
+  }
+  if (raw.includes("candidate") || raw.includes("pending") || raw.includes("provisional") || raw.includes("unverified") || raw.includes("draft")) {
+    return "provisional";
+  }
+  return "verified";
+}
+
+function recallResultStatusLabel(status: RecallResultStatus): string {
+  if (status === "verified") {
+    return "Verified";
+  }
+  if (status === "provisional") {
+    return "Provisional";
+  }
+  if (status === "disputed") {
+    return "Disputed";
+  }
+  return "Deprecated";
+}
+
+function statusPillClass(status: RecallResultStatus): string {
+  if (status === "verified") {
+    return "status-pill success";
+  }
+  if (status === "provisional") {
+    return "status-pill warning";
+  }
+  if (status === "disputed") {
+    return "status-pill danger";
+  }
+  return "status-pill neutral";
+}
+
+function sourceMatches(item: Fact | Claim | Fragment | undefined, sourceFilter: string): boolean {
+  return sourceFilter === "all" || sourceLabel(item) === sourceFilter;
+}
+
+function dateMatches(item: Fact | Claim | Fragment | undefined, dateMode: "all" | "custom", startDate: string, endDate: string): boolean {
+  if (dateMode === "all" || (!startDate && !endDate)) {
+    return true;
+  }
+  const raw = itemRawDate(item);
+  if (!raw) {
+    return false;
+  }
+  const itemTime = new Date(raw).getTime();
+  if (Number.isNaN(itemTime)) {
+    return false;
+  }
+  if (startDate && itemTime < startOfDay(startDate)) {
+    return false;
+  }
+  if (endDate && itemTime > endOfDay(endDate)) {
+    return false;
+  }
+  return true;
+}
+
+function itemRawDate(item: Fact | Claim | Fragment | undefined): string {
+  if (!item) {
+    return "";
+  }
+  return "content" in item ? item.created_at : item.recorded_at;
+}
+
+function startOfDay(value: string): number {
+  return new Date(`${value}T00:00:00`).getTime();
+}
+
+function endOfDay(value: string): number {
+  return new Date(`${value}T23:59:59.999`).getTime();
+}
+
+function resultIcon(kind: RecallResultKind) {
+  if (kind === "fact") {
+    return <ShieldCheck size={15} aria-hidden="true" />;
+  }
+  if (kind === "claim") {
+    return <GitBranch size={15} aria-hidden="true" />;
+  }
+  return <FileText size={15} aria-hidden="true" />;
+}
+
 function recallKey(hit: RecallHit, index: number): string {
   return hit.fact?.fact_id ?? hit.claim?.claim_id ?? hit.fragment?.fragment_id ?? String(index);
+}
+
+function sourceLabel(item: Fact | Claim | Fragment | undefined): string {
+  if (!item) {
+    return "unknown";
+  }
+  if ("content" in item) {
+    return item.source || item.source_type || "fragment";
+  }
+  return "knowledge graph";
+}
+
+function itemDate(item: Fact | Claim | Fragment | undefined): string {
+  if (!item) {
+    return "";
+  }
+  const raw = "content" in item ? item.created_at : item.recorded_at;
+  return new Date(raw).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function confidencePercent(hit: RecallHit): string {
+  const score = hit.score ?? hit.final_score ?? 0;
+  return `${Math.max(0, Math.min(1, score)) * 100}%`;
 }
 
 function scoreLabel(value: number | undefined): string {

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -48,18 +48,22 @@ export function SearchPanel({ api }: { api: UserApi }) {
     }
   }
 
-  const entities = deriveEntities(hits, communities);
+  const entities = useMemo(() => deriveEntities(hits, communities), [hits, communities]);
   const indexedHits = useMemo(() => hits.map((hit, index) => ({
     hit,
     key: recallKey(hit, index),
     kind: recallResultKind(hit),
   })), [hits]);
-  const filteredHits = indexedHits.filter((item) => enabledTypes[item.kind]);
-  const selectedResult = filteredHits.find((item) => item.key === selectedKey) ?? filteredHits[0] ?? null;
-  const typeCounts = indexedHits.reduce<Record<RecallResultKind, number>>((counts, item) => ({
+  const filteredHits = useMemo(() => (
+    indexedHits.filter((item) => enabledTypes[item.kind])
+  ), [indexedHits, enabledTypes]);
+  const selectedResult = useMemo(() => (
+    filteredHits.find((item) => item.key === selectedKey) ?? filteredHits[0] ?? null
+  ), [filteredHits, selectedKey]);
+  const typeCounts = useMemo(() => indexedHits.reduce<Record<RecallResultKind, number>>((counts, item) => ({
     ...counts,
     [item.kind]: counts[item.kind] + 1,
-  }), { fact: 0, claim: 0, fragment: 0 });
+  }), { fact: 0, claim: 0, fragment: 0 }), [indexedHits]);
 
   function toggleType(kind: RecallResultKind) {
     setEnabledTypes((current) => ({
@@ -259,13 +263,11 @@ function itemBody(item: Fact | Claim | Fragment | undefined): string {
 }
 
 function tierLabel(hit: RecallHit): string {
-  if (hit.fact) {
-    return "Fact";
+  const tier = hit.tier?.trim();
+  if (tier) {
+    return `Tier ${tier}`;
   }
-  if (hit.claim) {
-    return "Claim";
-  }
-  return "Fragment";
+  return recallResultKindLabel(recallResultKind(hit));
 }
 
 function recallResultKind(hit: RecallHit): RecallResultKind {

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -12,7 +12,7 @@ import {
   Star,
   X,
 } from "lucide-react";
-import { SectionHeading } from "../ui/components";
+import { LoadingState, SectionHeading } from "../ui/components";
 import { Claim, Community, Fact, Fragment, RecallHit, UserApi } from "./api";
 
 type RecallResultKind = "fact" | "claim" | "fragment";
@@ -262,7 +262,7 @@ export function SearchPanel({ api }: { api: UserApi }) {
           </div>
         </div>
         {error && <div className="banner error" role="alert">{error}</div>}
-        {loading && <div className="table-placeholder">Loading</div>}
+        {loading && <LoadingState label="Searching knowledge" />}
         {!loading && (
           <RecallResults
             items={sortedHits}

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -1,15 +1,11 @@
 import { CSSProperties, FormEvent, useMemo, useState } from "react";
 import {
-  Bookmark,
   ChevronDown,
   ExternalLink,
   FileText,
   GitBranch,
-  MoreVertical,
-  Plus,
   Search,
   ShieldCheck,
-  Star,
   X,
 } from "lucide-react";
 import { LoadingState, SectionHeading } from "../ui/components";
@@ -330,14 +326,6 @@ function RecallResults({
                 <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
                 <span className={statusPillClass(status)}>{recallResultStatusLabel(status)}</span>
               </div>
-              <div className="result-actions">
-                <button className="icon-button bare" type="button" aria-label={`Star ${itemTitle(item)}`}>
-                  <Star size={15} aria-hidden="true" />
-                </button>
-                <button className="icon-button bare" type="button" aria-label={`More actions ${itemTitle(item)}`}>
-                  <MoreVertical size={15} aria-hidden="true" />
-                </button>
-              </div>
             </div>
             <h3>{itemTitle(item)}</h3>
             <p>{itemBody(item)}</p>
@@ -467,16 +455,6 @@ function KnowledgeInspector({
           <dd>{recallResultKindLabel(result.kind)}</dd>
         </div>
       </dl>
-      <div className="inspector-actions">
-        <button className="ghost-button compact" type="button">
-          <Bookmark size={15} aria-hidden="true" />
-          Add to collection
-        </button>
-        <button className="ghost-button compact" type="button">
-          <Plus size={15} aria-hidden="true" />
-          Create claim
-        </button>
-      </div>
     </article>
   );
 }

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -169,19 +169,34 @@ function RecallResults({
     return <div className="table-placeholder">No recall results</div>;
   }
   return (
-    <div className="knowledge-list compact-list">
+    <div className="knowledge-list compact-list" role="listbox" aria-label="Recall result list">
       {items.map((result) => {
         const item = result.hit.fact ?? result.hit.claim ?? result.hit.fragment;
         return (
-          <article className={result.key === selectedKey ? "knowledge-item selected" : "knowledge-item"} key={result.key}>
-            <button className="knowledge-result-button" type="button" onClick={() => onSelect(result.key)}>
-              <div className="knowledge-item-head">
-                <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
-                <small>{tierLabel(result.hit)} | {scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
-              </div>
-              <h3>{itemTitle(item)}</h3>
-              <p>{itemBody(item)}</p>
-            </button>
+          <article
+            aria-selected={result.key === selectedKey}
+            className={
+              result.key === selectedKey
+                ? "knowledge-item knowledge-result-option selected"
+                : "knowledge-item knowledge-result-option"
+            }
+            key={result.key}
+            onClick={() => onSelect(result.key)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onSelect(result.key);
+              }
+            }}
+            role="option"
+            tabIndex={0}
+          >
+            <div className="knowledge-item-head">
+              <span className="status-pill neutral">{recallResultKindLabel(result.kind)}</span>
+              <small>{tierLabel(result.hit)} | {scoreLabel(result.hit.score ?? result.hit.final_score)}</small>
+            </div>
+            <h3>{itemTitle(item)}</h3>
+            <p>{itemBody(item)}</p>
           </article>
         );
       })}

--- a/web/src/user/TeamManagementPanel.tsx
+++ b/web/src/user/TeamManagementPanel.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { CreatedTeamProfile, UserApi, UserKey, UserSession, UserTeam } from "./api";
-import { SecretBox, SectionHeading } from "../ui/components";
+import { LoadingState, SecretBox, SectionHeading } from "../ui/components";
 import { TeamDreamingConfigForm } from "../teamDreamingConfig";
 
 type ProfilePermission = "read" | "read_write";
@@ -186,7 +186,7 @@ export function TeamManagementPanel({
             await loadProfiles();
           }}
         />
-        {loading && <div className="table-placeholder">Loading</div>}
+        {loading && <LoadingState label="Loading profiles" />}
         {!loading && (
           <ManagedProfileTable
             profiles={profiles}

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { UserPortalApp } from "./App";
 import "../styles.css";
+import "../resource-explorer.css";
 import "../observability.css";
 import "../responsive.css";
 

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -6,6 +6,7 @@ import "../resource-explorer.css";
 import "../knowledge-explorer.css";
 import "../observability.css";
 import "../responsive.css";
+import "../admin-system.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { UserPortalApp } from "./App";
 import "../styles.css";
 import "../resource-explorer.css";
+import "../knowledge-explorer.css";
 import "../observability.css";
 import "../responsive.css";
 

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -7,6 +7,7 @@ import "../knowledge-explorer.css";
 import "../observability.css";
 import "../responsive.css";
 import "../admin-system.css";
+import "../admin-dashboard-components.css";
 
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -72,6 +72,7 @@ test("control panel logs in against compose and creates a team", async ({ page }
   await expect(page.getByRole("button", { name: new RegExp(escapeRegExp(seedTeamName)) })).toBeVisible();
 
   const teamName = uniqueName("Compose Team", testInfo);
+  await page.getByRole("button", { name: "New Team" }).click();
   await page.getByLabel("Name").first().fill(teamName);
   await page.getByLabel("Description").first().fill("created by compose e2e");
   await page.getByRole("button", { name: /^Create$/ }).click();
@@ -562,7 +563,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 async function expectNoShellOverlap(page: Page) {
-  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+  const boxes = await page.locator(".topbar, .primary-rail, .resource-rail, .detail-pane").evaluateAll((elements) => (
     elements.map((element) => {
       const rect = element.getBoundingClientRect();
       return {

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -299,6 +299,8 @@ test("user portal logs in with a real API key and shows only that profile", asyn
   await openUserPortal(page, seedApiKey);
 
   await expect(page.getByText(seedTeamName)).toBeVisible();
+  await expect(page.getByLabel("Current workspace")).not.toContainText("default profile");
+  await page.getByRole("button", { name: /My key/i }).click();
   await expect(page.getByText("default profile")).toBeVisible();
   await expect(page.getByText(otherProfile.key.name)).toBeHidden();
 

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -302,8 +302,8 @@ test("responsive user portal layout", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Recall" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".primary-rail")).toHaveCount(0);
-  await expect(page.locator(".top-nav-bar")).toHaveCSS("border-bottom-width", "1px");
+  await expect(page.locator(".primary-rail")).toBeVisible();
+  await expect(page.locator(".top-nav-bar")).toHaveCount(0);
   await expect(page.locator(".resource-rail")).toHaveCount(0);
   await expect(page.locator(".knowledge-results-panel")).toHaveCSS("border-radius", "0px");
   await expectNoShellOverlap(page);

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -198,6 +198,16 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await expect(page.getByText("Dense-Mem").first()).toBeVisible();
   await expect(page.getByLabel("Knowledge filters")).toBeVisible();
   await expect(page.getByLabel("Inspector")).toContainText("Fact");
+  await expect(page.getByRole("listbox", { name: "Recall result list" }).getByRole("option")).toHaveCount(3);
+  await page.getByRole("option").filter({ hasText: "uses: Dense-Mem" }).click();
+  await expect(page.getByLabel("Inspector")).toContainText("Claim");
+  await expect(page.getByLabel("Inspector")).toContainText("Tier 1.5");
+  await page.getByRole("checkbox", { name: /Claim/ }).click();
+  await expect(page.getByRole("listbox", { name: "Recall result list" })).not.toContainText("uses: Dense-Mem");
+  await expect(page.getByLabel("Inspector")).toContainText("Fact");
+  await page.getByRole("checkbox", { name: /Fact/ }).click();
+  await expect(page.getByLabel("Inspector")).toContainText("Fragment");
+  await expect(page.getByLabel("Inspector")).toContainText("Alice is working on project-x with Dense-Mem.");
 
   await expect(page.getByRole("button", { name: "Usage" })).toHaveCount(0);
 

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -188,7 +188,7 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await openUserPortal(page, "dm_read");
 
   await expect(page.getByText("Research Team")).toBeVisible();
-  await expect(page.getByText("Mine")).toBeVisible();
+  await expect(page.getByLabel("Current workspace")).not.toContainText("Mine");
   await expect(page.getByText("Other profile")).toBeHidden();
 
   await page.getByLabel("Keyword").fill("project");
@@ -298,13 +298,14 @@ test("responsive user portal layout", async ({ page }) => {
   await mockUserApi(page, { key: readKey, canRotate: false });
   await openUserPortal(page, "dm_read");
 
-  await expect(page.getByRole("heading", { name: "Dense-Mem Knowledge" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Knowledge" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Recall" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".primary-rail")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".primary-rail")).toHaveCount(0);
+  await expect(page.locator(".top-nav-bar")).toHaveCSS("border-bottom-width", "1px");
   await expect(page.locator(".resource-rail")).toHaveCount(0);
-  await expect(page.locator(".knowledge-results-panel")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".knowledge-results-panel")).toHaveCSS("border-radius", "0px");
   await expectNoShellOverlap(page);
 
   if ((page.viewportSize()?.width ?? 1000) < 700) {
@@ -368,7 +369,7 @@ async function expectNoShellOverlap(page: Page) {
     expect(tableWrap.scrollWidth, `${tableWrap.className} overflowed horizontally`).toBeLessThanOrEqual(tableWrap.clientWidth + 1);
   }
 
-  const boxes = await page.locator(".topbar, .primary-rail, .resource-rail, .detail-pane").evaluateAll((elements) => (
+  const boxes = await page.locator(".topbar, .primary-rail, .top-nav-bar, .resource-rail, .detail-pane").evaluateAll((elements) => (
     elements.map((element) => {
       const rect = element.getBoundingClientRect();
       return {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -196,6 +196,8 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await expect(page.getByRole("heading", { name: "Alice" }).first()).toBeVisible();
   await expect(page.getByText("project-x").first()).toBeVisible();
   await expect(page.getByText("Dense-Mem").first()).toBeVisible();
+  await expect(page.getByLabel("Knowledge filters")).toBeVisible();
+  await expect(page.getByLabel("Inspector")).toContainText("Fact");
 
   await expect(page.getByRole("button", { name: "Usage" })).toHaveCount(0);
 
@@ -290,8 +292,9 @@ test("responsive user portal layout", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Recall" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".control-sidebar")).toHaveCSS("border-radius", "8px");
-  await expect(page.locator(".surface").first()).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".primary-rail")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".resource-rail")).toHaveCount(0);
+  await expect(page.locator(".knowledge-results-panel")).toHaveCSS("border-radius", "8px");
   await expectNoShellOverlap(page);
 
   if ((page.viewportSize()?.width ?? 1000) < 700) {
@@ -355,7 +358,7 @@ async function expectNoShellOverlap(page: Page) {
     expect(tableWrap.scrollWidth, `${tableWrap.className} overflowed horizontally`).toBeLessThanOrEqual(tableWrap.clientWidth + 1);
   }
 
-  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+  const boxes = await page.locator(".topbar, .primary-rail, .resource-rail, .detail-pane").evaluateAll((elements) => (
     elements.map((element) => {
       const rect = element.getBoundingClientRect();
       return {

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -316,7 +316,7 @@ test("API key creation shows plaintext once", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [] });
   await openPortal(page);
 
-  await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
+  await page.getByRole("button", { name: /Team Profiles/ }).click();
   await page.getByLabel("Role").selectOption("member");
   await page.getByLabel("Permission").selectOption("read");
   await page.getByRole("button", { name: "Create profile" }).click();
@@ -330,11 +330,12 @@ test("team and profile names update and profile key regenerates", async ({ page 
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
 
+  await page.getByRole("button", { name: /Team Settings/ }).click();
   await page.locator("#team-name").fill("Renamed Team");
   await page.getByRole("button", { name: /^Save$/ }).click();
   await expect(page.getByRole("heading", { name: "Renamed Team" })).toBeVisible();
 
-  await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
+  await page.getByRole("button", { name: /Team Profiles/ }).click();
   await page.getByLabel("Profile name default profile").fill("Research profile");
   await page.getByRole("button", { name: /Save profile default profile/ }).click();
   await expect(page.getByLabel("Profile name Research profile")).toHaveValue("Research profile");
@@ -348,7 +349,7 @@ test("team profile list and delete flow", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
 
-  await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
+  await page.getByRole("button", { name: /Team Profiles/ }).click();
   await expect(page.getByText("******abc123")).toBeVisible();
   const keyRow = page.getByRole("row", { name: /abc123/ });
   await expect(keyRow).toContainText("Read/write");
@@ -442,7 +443,7 @@ test("recall feedback tab renders query, params, result ids, and resolved state"
   const calls = await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
 
-  await page.getByRole("button", { name: /^Recall Feedback$/ }).click();
+  await page.getByRole("button", { name: /^Feedback$/ }).click();
 
   await expect(page.getByText("Why was recall bad?")).toBeVisible();
   await expect(page.getByText("Pending recall waiting")).toHaveCount(0);
@@ -466,7 +467,7 @@ test("dream outputs keep rationale behind info tooltip", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
 
-  await page.getByRole("button", { name: /^Dreams$/ }).click();
+  await page.getByRole("button", { name: /Team Dreams/ }).click();
   await expect(page.locator(".resource-rail")).toBeVisible();
 
   await expect(page.getByLabel("Dreaming status")).toContainText("Global force");
@@ -511,6 +512,7 @@ test("team delete flow", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
 
+  await page.getByRole("button", { name: /Team Settings/ }).click();
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: /^Delete$/ }).click();
 
@@ -537,10 +539,11 @@ test("responsive portal layout", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".primary-rail")).toHaveCSS("border-radius", "8px");
-  await expect(page.locator(".resource-rail")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".topbar")).toHaveCSS("border-bottom-width", "1px");
+  await expect(page.locator(".primary-rail")).toHaveCSS("border-right-width", "1px");
+  await expect(page.locator(".resource-rail")).toHaveCSS("border-right-width", "1px");
   await expect(page.locator(".surface").first()).toHaveCSS("border-radius", "8px");
-  await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
+  await page.getByRole("button", { name: /Team Profiles/ }).click();
   await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
   await expectNoShellOverlap(page);
 

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -304,6 +304,7 @@ test("team creation flow", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [] });
   await openPortal(page);
 
+  await page.getByRole("button", { name: "New Team" }).click();
   await page.getByLabel("Name").first().fill("Work Team");
   await page.getByLabel("Description").first().fill("for work");
   await page.getByRole("button", { name: /^Create$/ }).click();
@@ -378,6 +379,7 @@ test("metrics tab renders operational totals and filter queries", async ({ page 
   await openPortal(page);
 
   await page.getByRole("button", { name: /^Metrics$/ }).click();
+  await expect(page.locator(".resource-rail")).toHaveCount(0);
 
   const telemetryTotals = page.getByLabel("Telemetry totals");
   for (const card of telemetry.windowed_cards) {
@@ -422,6 +424,7 @@ test("logs tab renders structured details and raw output", async ({ page }) => {
   await openPortal(page);
 
   await page.getByRole("button", { name: /^Logs$/ }).click();
+  await expect(page.locator(".resource-rail")).toHaveCount(0);
 
   await expect(page.getByText("GET /control/api/logs status 200")).toBeVisible();
   await expect(page.getByText("event=control_http_request")).toBeVisible();
@@ -464,6 +467,7 @@ test("dream outputs keep rationale behind info tooltip", async ({ page }) => {
   await openPortal(page);
 
   await page.getByRole("button", { name: /^Dreams$/ }).click();
+  await expect(page.locator(".resource-rail")).toBeVisible();
 
   await expect(page.getByLabel("Dreaming status")).toContainText("Global force");
   await expect(page.getByText("A may affect B.")).toBeVisible();
@@ -510,7 +514,7 @@ test("team delete flow", async ({ page }) => {
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: /^Delete$/ }).click();
 
-  await expect(page.getByLabel("Team details").getByText("No teams")).toBeVisible();
+  await expect(page.getByLabel("Control details").getByText("No teams")).toBeVisible();
 });
 
 test("auth token failure", async ({ page }) => {
@@ -533,7 +537,8 @@ test("responsive portal layout", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Teams" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".control-sidebar")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".primary-rail")).toHaveCSS("border-radius", "8px");
+  await expect(page.locator(".resource-rail")).toHaveCSS("border-radius", "8px");
   await expect(page.locator(".surface").first()).toHaveCSS("border-radius", "8px");
   await page.getByRole("button", { name: /Profiles & API Keys/ }).click();
   await expect(page.getByRole("heading", { name: "Profiles" })).toBeVisible();
@@ -567,7 +572,7 @@ async function expectNoShellOverlap(page: Page) {
     expect(tableWrap.scrollWidth, `${tableWrap.className} overflowed horizontally`).toBeLessThanOrEqual(tableWrap.clientWidth + 1);
   }
 
-  const boxes = await page.locator(".topbar, .control-sidebar, .detail-pane").evaluateAll((elements) => (
+  const boxes = await page.locator(".topbar, .primary-rail, .resource-rail, .detail-pane").evaluateAll((elements) => (
     elements.map((element) => {
       const rect = element.getBoundingClientRect();
       return {

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -479,6 +479,23 @@ test("dream outputs keep rationale behind info tooltip", async ({ page }) => {
   await expect(rationale).toBeVisible();
 });
 
+test("team workspace header stays compact across team tabs", async ({ page }) => {
+  await mockApi(page, { teams: [team], keys: [key] });
+  await openPortal(page);
+
+  const heights: number[] = [];
+  const workspaceTabs = page.locator(".team-workspace-tabs");
+  for (const tab of ["Overview", "Profiles", "Dreams", "Settings"]) {
+    await workspaceTabs.getByRole("button", { name: `Team ${tab}` }).click();
+    const box = await page.locator(".team-workspace-header").boundingBox();
+    expect(box, `${tab} header was not rendered`).not.toBeNull();
+    heights.push(box?.height ?? 0);
+  }
+
+  expect(Math.max(...heights), `team header heights: ${heights.join(", ")}`).toBeLessThanOrEqual(125);
+  expect(Math.max(...heights) - Math.min(...heights), `team header heights: ${heights.join(", ")}`).toBeLessThanOrEqual(8);
+});
+
 test("config tab uses horizontal subnavigation", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
@@ -487,9 +504,14 @@ test("config tab uses horizontal subnavigation", async ({ page }) => {
 
   const tabs = page.getByRole("tablist", { name: "Config sections" });
   await expect(tabs).toBeVisible();
+  const tabsBox = await tabs.boundingBox();
+  expect(tabsBox, "config tabs were not rendered").not.toBeNull();
+  const maxTabsHeight = (page.viewportSize()?.width ?? 0) <= 620 ? 82 : 42;
+  expect(tabsBox?.height ?? 0).toBeLessThanOrEqual(maxTabsHeight);
   await expect.poll(() => tabs.evaluate((element) => element.closest(".surface") === null)).toBe(true);
   await tabs.getByRole("tab", { name: /^Logs$/ }).click();
   await expect(page.getByRole("heading", { name: "Operation Logs" })).toBeVisible();
+  await expectNoShellOverlap(page);
 });
 
 test("recall feedback retention config saves from control portal", async ({ page }) => {
@@ -569,10 +591,18 @@ async function expectNoShellOverlap(page: Page) {
       clientWidth: element.clientWidth,
       scrollWidth: element.scrollWidth,
     })),
+    navContainers: Array.from(document.querySelectorAll(".workspace, .detail-pane, .primary-rail, .top-nav-tabs, .rail-tabs, .team-workspace-tabs, .config-tabs")).map((element) => ({
+      className: element.className,
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    })),
   }));
   expect(overflow.documentWidth).toBeLessThanOrEqual(overflow.viewportWidth + 1);
   for (const tableWrap of overflow.tableWraps) {
     expect(tableWrap.scrollWidth, `${tableWrap.className} overflowed horizontally`).toBeLessThanOrEqual(tableWrap.clientWidth + 1);
+  }
+  for (const navContainer of overflow.navContainers) {
+    expect(navContainer.scrollWidth, `${navContainer.className} overflowed horizontally`).toBeLessThanOrEqual(navContainer.clientWidth + 1);
   }
 
   const boxes = await page.locator(".topbar, .primary-rail, .resource-rail, .detail-pane").evaluateAll((elements) => (


### PR DESCRIPTION
## Summary
- Redesign the shared portal shell into a primary navigation rail with an optional resource rail.
- Scope the Teams rail to team-specific control tabs only; global tabs no longer show team selection.
- Rework `/ui` into a knowledge explorer with filters, selectable recall results, and an inspector, while excluding unsupported avatar, notification, FAQ, or help affordances.
- Split the new explorer CSS and `/ui` recall panel into dedicated files to satisfy the repo line-limit lint rule.

## Validation
- `npm run typecheck`
- `npm run test`
- `npm run playwright:mock:control`
- `npm run playwright:mock:user`
- `npm run build`
- `scripts/ci-check.sh`
- `npx playwright test --config playwright.compose.config.ts` against `docker-compose.yml` using a temporary local OpenAI-compatible embedding mock for the compose recall path
- Manual light/dark screenshot review for `/control` and `/ui`

## Notes
- No user-avatar, notification, FAQ, or help-center UI was added.
- Compose was restored to the normal `docker-compose.yml` environment after the temporary embedding override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Teams workspace experience with tabs (Overview/Profiles/Dreams/Settings), a filterable Teams/resource rail, and guided **New Team** creation.
  * Introduced the **Knowledge explorer** (search panel with recall results, filters, and Inspector).
* **UI Improvements**
  * Refreshed portal navigation (including **Feedback**) and improved responsive layout/empty states.
  * Standardized loading placeholders using context-specific **LoadingState** labels.
* **Bug Fixes**
  * Team overview now shows **metrics unavailable** when metrics fail to load.
* **Tests**
  * Updated/expanded UI and E2E tests for the new navigation, workspace routing, metrics error paths, and recall interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->