### PR TITLE
Add recall feedback measurement details

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,12 @@ scrape job when Prometheus is shared.
 Online recall-quality cards use `densemem_recall_feedback_total` and
 `densemem_recall_feedback_quality_score`. They stay at zero until
 recall feedback is enabled from the control portal config panel and a host LLM
-submits compact feedback for `recall_memory` results. Normal production recall
-traffic still contributes request volume, result count, and latency.
+submits feedback for `recall_memory` results. Negative feedback requires a
+bounded `failure_reason` and can include expected context plus irrelevant result
+refs for offline analysis. Prometheus still receives only bounded labels; the
+free-text details stay in the recall feedback investigation records. Normal
+production recall traffic still contributes request volume, result count, and
+latency.
 
 For the disposable demo image, keep the control portal disabled and use the
 demo telemetry overlay instead:

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ Online recall-quality cards use `densemem_recall_feedback_total` and
 `densemem_recall_feedback_quality_score`. They stay at zero until
 recall feedback is enabled from the control portal config panel and a host LLM
 submits feedback for `recall_memory` results. Negative feedback requires a
-bounded `failure_reason` and can include expected context plus irrelevant result
-refs for offline analysis. Prometheus still receives only bounded labels; the
-free-text details stay in the recall feedback investigation records. Normal
+bounded `failure_reason` enum and can include expected context plus irrelevant
+result refs for offline analysis. Prometheus still receives only bounded labels;
+the free-text details stay in the recall feedback investigation records. Normal
 production recall traffic still contributes request volume, result count, and
 latency.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,9 +150,11 @@ docker compose -f docker-compose.yml -f docker-compose.telemetry.yml up -d
 
 在线 recall quality 卡片使用 `densemem_recall_feedback_total` 和
 `densemem_recall_feedback_quality_score`。在 control portal config panel
-开启 recall feedback，并且宿主 LLM 为 `recall_memory` 结果提交 compact
-feedback 之前，这些卡片会保持为零。正常生产 recall 流量仍然会贡献请求量、
-结果数和延迟指标。
+开启 recall feedback，并且宿主 LLM 为 `recall_memory` 结果提交 feedback
+之前，这些卡片会保持为零。负向 feedback 需要有界的 `failure_reason`，
+也可以包含 expected context 和 irrelevant result refs，供离线分析使用。
+Prometheus 仍然只接收有界 labels；自由文本详情保存在 recall feedback
+investigation records 中。正常生产 recall 流量仍然会贡献请求量、结果数和延迟指标。
 
 对于一次性 demo image，保持 control portal 关闭，改用 demo telemetry
 overlay：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,7 +151,7 @@ docker compose -f docker-compose.yml -f docker-compose.telemetry.yml up -d
 在线 recall quality 卡片使用 `densemem_recall_feedback_total` 和
 `densemem_recall_feedback_quality_score`。在 control portal config panel
 开启 recall feedback，并且宿主 LLM 为 `recall_memory` 结果提交 feedback
-之前，这些卡片会保持为零。负向 feedback 需要有界的 `failure_reason`，
+之前，这些卡片会保持为零。负向 feedback 需要有界的 `failure_reason` enum，
 也可以包含 expected context 和 irrelevant result refs，供离线分析使用。
 Prometheus 仍然只接收有界 labels；自由文本详情保存在 recall feedback
 investigation records 中。正常生产 recall 流量仍然会贡献请求量、结果数和延迟指标。

--- a/internal/domain/recall_feedback_event.go
+++ b/internal/domain/recall_feedback_event.go
@@ -18,26 +18,29 @@ const (
 // RecallFeedbackEvent is the durable investigation record that connects a
 // recall_memory result set to deferred host-LLM session feedback.
 type RecallFeedbackEvent struct {
-	RecallID        string                         `json:"recall_id"`
-	CreatedAt       time.Time                      `json:"created_at"`
-	UpdatedAt       time.Time                      `json:"updated_at"`
-	FeedbackAt      *time.Time                     `json:"feedback_at,omitempty"`
-	TeamID          *uuid.UUID                     `json:"team_id,omitempty"`
-	ProfileID       *uuid.UUID                     `json:"profile_id,omitempty"`
-	KeyID           *uuid.UUID                     `json:"key_id,omitempty"`
-	AuthMethod      string                         `json:"auth_method"`
-	ToolName        string                         `json:"tool_name"`
-	Query           string                         `json:"query"`
-	ToolArgs        map[string]any                 `json:"tool_args"`
-	ResultRefs      []RecallFeedbackResultRef      `json:"result_refs"`
-	ResultCount     int                            `json:"result_count"`
-	SnapshotState   string                         `json:"snapshot_state"`
-	Used            *bool                          `json:"used,omitempty"`
-	AnswerSupported *bool                          `json:"answer_supported,omitempty"`
-	Quality         string                         `json:"quality,omitempty"`
-	MissingContext  *bool                          `json:"missing_context,omitempty"`
-	Irrelevant      *bool                          `json:"irrelevant,omitempty"`
-	ResolvedResults []RecallFeedbackResolvedResult `json:"resolved_results,omitempty"`
+	RecallID        string                          `json:"recall_id"`
+	CreatedAt       time.Time                       `json:"created_at"`
+	UpdatedAt       time.Time                       `json:"updated_at"`
+	FeedbackAt      *time.Time                      `json:"feedback_at,omitempty"`
+	TeamID          *uuid.UUID                      `json:"team_id,omitempty"`
+	ProfileID       *uuid.UUID                      `json:"profile_id,omitempty"`
+	KeyID           *uuid.UUID                      `json:"key_id,omitempty"`
+	AuthMethod      string                          `json:"auth_method"`
+	ToolName        string                          `json:"tool_name"`
+	Query           string                          `json:"query"`
+	ToolArgs        map[string]any                  `json:"tool_args"`
+	ResultRefs      []RecallFeedbackResultRef       `json:"result_refs"`
+	ResultCount     int                             `json:"result_count"`
+	SnapshotState   string                          `json:"snapshot_state"`
+	Used            *bool                           `json:"used,omitempty"`
+	AnswerSupported *bool                           `json:"answer_supported,omitempty"`
+	Quality         string                          `json:"quality,omitempty"`
+	MissingContext  *bool                           `json:"missing_context,omitempty"`
+	Irrelevant      *bool                           `json:"irrelevant,omitempty"`
+	FailureReason   string                          `json:"failure_reason,omitempty"`
+	ExpectedContext string                          `json:"expected_context,omitempty"`
+	IrrelevantRefs  []RecallFeedbackJudgedResultRef `json:"irrelevant_result_refs,omitempty"`
+	ResolvedResults []RecallFeedbackResolvedResult  `json:"resolved_results,omitempty"`
 }
 
 // RecallFeedbackResultRef is a content-free reference to one result returned by
@@ -68,6 +71,17 @@ type RecallFeedbackSubmission struct {
 	Quality         string
 	MissingContext  bool
 	Irrelevant      bool
+	FailureReason   string
+	ExpectedContext string
+	IrrelevantRefs  []RecallFeedbackJudgedResultRef
+}
+
+// RecallFeedbackJudgedResultRef is a host-LLM judgment about one returned
+// result, stored separately from bounded Prometheus labels.
+type RecallFeedbackJudgedResultRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Rank int    `json:"rank,omitempty"`
 }
 
 // RecallFeedbackEventFilter controls control-portal event listing.

--- a/internal/repository/recall_feedback_event_repository.go
+++ b/internal/repository/recall_feedback_event_repository.go
@@ -93,18 +93,24 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 	if err != nil {
 		return err
 	}
+	irrelevantRefs, err := marshalRecallFeedbackJudgedRefs(event.IrrelevantRefs)
+	if err != nil {
+		return err
+	}
 	err = r.withSystemTx(ctx, func(tx *gorm.DB) error {
 		return tx.Exec(`
 			INSERT INTO recall_feedback_events (
 				recall_id, created_at, updated_at, feedback_at, team_id, profile_id, key_id,
 				auth_method, tool_name, query, tool_args, result_refs,
 				result_count, snapshot_state, used, answer_supported,
-				quality, missing_context, irrelevant
+				quality, missing_context, irrelevant, failure_reason,
+				expected_context, irrelevant_result_refs
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7,
 				$8, $9, $10, $11::jsonb, $12::jsonb,
 				$13, $14, $15, $16,
-				$17, $18, $19
+				$17, $18, $19, $20,
+				$21, $22::jsonb
 			)
 			ON CONFLICT (recall_id) DO UPDATE SET
 				updated_at = EXCLUDED.updated_at,
@@ -120,7 +126,10 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 				answer_supported = EXCLUDED.answer_supported,
 				quality = EXCLUDED.quality,
 				missing_context = EXCLUDED.missing_context,
-				irrelevant = EXCLUDED.irrelevant
+				irrelevant = EXCLUDED.irrelevant,
+				failure_reason = EXCLUDED.failure_reason,
+				expected_context = EXCLUDED.expected_context,
+				irrelevant_result_refs = EXCLUDED.irrelevant_result_refs
 		`,
 			event.RecallID,
 			event.CreatedAt.UTC(),
@@ -141,6 +150,9 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 			event.Quality,
 			boolPtrValue(event.MissingContext),
 			boolPtrValue(event.Irrelevant),
+			event.FailureReason,
+			event.ExpectedContext,
+			string(irrelevantRefs),
 		).Error
 	})
 	if err != nil {
@@ -254,6 +266,8 @@ func normalizeRecallFeedbackEvent(event domain.RecallFeedbackEvent) domain.Recal
 	}
 	event.Query = strings.TrimSpace(event.Query)
 	event.Quality = strings.ToLower(strings.TrimSpace(event.Quality))
+	event.FailureReason = strings.TrimSpace(event.FailureReason)
+	event.ExpectedContext = strings.TrimSpace(event.ExpectedContext)
 	event.SnapshotState = strings.TrimSpace(event.SnapshotState)
 	if event.SnapshotState == "" {
 		event.SnapshotState = domain.RecallFeedbackSnapshotCaptured
@@ -263,6 +277,9 @@ func normalizeRecallFeedbackEvent(event domain.RecallFeedbackEvent) domain.Recal
 	}
 	if event.ResultRefs == nil {
 		event.ResultRefs = []domain.RecallFeedbackResultRef{}
+	}
+	if event.IrrelevantRefs == nil {
+		event.IrrelevantRefs = []domain.RecallFeedbackJudgedResultRef{}
 	}
 	event.ResultCount = len(event.ResultRefs)
 	now := time.Now().UTC()
@@ -329,7 +346,8 @@ func recallFeedbackEventColumns() string {
 		team_id::text, profile_id::text, key_id::text,
 		auth_method, tool_name, query, tool_args, result_refs,
 		result_count, snapshot_state, used, answer_supported,
-		quality, missing_context, irrelevant
+		quality, missing_context, irrelevant, failure_reason,
+		expected_context, irrelevant_result_refs
 	`
 }
 
@@ -346,6 +364,7 @@ func scanRecallFeedbackEvent(rows *sql.Rows) (domain.RecallFeedbackEvent, error)
 		answerSupportedRaw sql.NullBool
 		missingContextRaw  sql.NullBool
 		irrelevantRaw      sql.NullBool
+		irrelevantRefsRaw  []byte
 	)
 	if err := rows.Scan(
 		&event.RecallID,
@@ -367,6 +386,9 @@ func scanRecallFeedbackEvent(rows *sql.Rows) (domain.RecallFeedbackEvent, error)
 		&event.Quality,
 		&missingContextRaw,
 		&irrelevantRaw,
+		&event.FailureReason,
+		&event.ExpectedContext,
+		&irrelevantRefsRaw,
 	); err != nil {
 		return domain.RecallFeedbackEvent{}, err
 	}
@@ -392,6 +414,12 @@ func scanRecallFeedbackEvent(rows *sql.Rows) (domain.RecallFeedbackEvent, error)
 			return domain.RecallFeedbackEvent{}, fmt.Errorf("invalid recall_feedback_events.result_refs JSON: %w", err)
 		}
 	}
+	event.IrrelevantRefs = []domain.RecallFeedbackJudgedResultRef{}
+	if len(irrelevantRefsRaw) > 0 {
+		if err := json.Unmarshal(irrelevantRefsRaw, &event.IrrelevantRefs); err != nil {
+			return domain.RecallFeedbackEvent{}, fmt.Errorf("invalid recall_feedback_events.irrelevant_result_refs JSON: %w", err)
+		}
+	}
 	return event, nil
 }
 
@@ -409,6 +437,17 @@ func marshalRecallFeedbackPayload(event domain.RecallFeedbackEvent) ([]byte, []b
 		return nil, nil, fmt.Errorf("failed to encode recall feedback result refs: %w", err)
 	}
 	return toolArgs, resultRefs, nil
+}
+
+func marshalRecallFeedbackJudgedRefs(refs []domain.RecallFeedbackJudgedResultRef) ([]byte, error) {
+	if refs == nil {
+		refs = []domain.RecallFeedbackJudgedResultRef{}
+	}
+	encoded, err := json.Marshal(refs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode recall feedback irrelevant result refs: %w", err)
+	}
+	return encoded, nil
 }
 
 func nullableBoolPtr(raw sql.NullBool) *bool {

--- a/internal/repository/recall_feedback_event_repository_test.go
+++ b/internal/repository/recall_feedback_event_repository_test.go
@@ -13,15 +13,34 @@ import (
 )
 
 func TestScanRecallFeedbackEventRejectsMalformedToolArgsJSON(t *testing.T) {
-	rows := recallFeedbackEventRows(t, []byte("{bad-json"), []byte("[]"))
+	rows := recallFeedbackEventRows(t, []byte("{bad-json"), []byte("[]"), []byte("[]"))
 	_, err := scanRecallFeedbackEvent(rows)
 	require.ErrorContains(t, err, "invalid recall_feedback_events.tool_args JSON")
 }
 
 func TestScanRecallFeedbackEventRejectsMalformedResultRefsJSON(t *testing.T) {
-	rows := recallFeedbackEventRows(t, []byte("{}"), []byte("{bad-json"))
+	rows := recallFeedbackEventRows(t, []byte("{}"), []byte("{bad-json"), []byte("[]"))
 	_, err := scanRecallFeedbackEvent(rows)
 	require.ErrorContains(t, err, "invalid recall_feedback_events.result_refs JSON")
+}
+
+func TestScanRecallFeedbackEventRejectsMalformedIrrelevantResultRefsJSON(t *testing.T) {
+	rows := recallFeedbackEventRows(t, []byte("{}"), []byte("[]"), []byte("{bad-json"))
+	_, err := scanRecallFeedbackEvent(rows)
+	require.ErrorContains(t, err, "invalid recall_feedback_events.irrelevant_result_refs JSON")
+}
+
+func TestScanRecallFeedbackEventReadsFailureDetails(t *testing.T) {
+	rows := recallFeedbackEventRows(t, []byte("{}"), []byte("[]"), []byte(`[{"type":"fragment","id":"fragment-1","rank":1}]`))
+	got, err := scanRecallFeedbackEvent(rows)
+	require.NoError(t, err)
+	require.Equal(t, "missing expected context", got.FailureReason)
+	require.Equal(t, "knowledge explorer listbox pattern", got.ExpectedContext)
+	require.Equal(t, []domain.RecallFeedbackJudgedResultRef{{
+		Type: domain.RecallFeedbackResultTypeFragment,
+		ID:   "fragment-1",
+		Rank: 1,
+	}}, got.IrrelevantRefs)
 }
 
 func TestRecallFeedbackEventWhereExcludesPendingByDefault(t *testing.T) {
@@ -39,7 +58,7 @@ func TestRecallFeedbackEventWhereExcludesPendingByDefault(t *testing.T) {
 	require.Equal(t, []any{"low"}, args)
 }
 
-func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte) *sql.Rows {
+func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte, irrelevantRefs []byte) *sql.Rows {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -65,6 +84,9 @@ func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte) *
 		"quality",
 		"missing_context",
 		"irrelevant",
+		"failure_reason",
+		"expected_context",
+		"irrelevant_result_refs",
 	}).AddRow(
 		"rec_1",
 		time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC),
@@ -85,6 +107,9 @@ func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte) *
 		"",
 		nil,
 		nil,
+		"missing expected context",
+		"knowledge explorer listbox pattern",
+		irrelevantRefs,
 	)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	sqlRows, err := db.QueryContext(context.Background(), "SELECT")

--- a/internal/service/recall_feedback_event_service.go
+++ b/internal/service/recall_feedback_event_service.go
@@ -103,6 +103,9 @@ func (s *RecallFeedbackEventServiceImpl) RecordRecallFeedback(ctx context.Contex
 		Quality:         strings.ToLower(strings.TrimSpace(feedback.Quality)),
 		MissingContext:  &missingContext,
 		Irrelevant:      &irrelevant,
+		FailureReason:   strings.TrimSpace(feedback.FailureReason),
+		ExpectedContext: strings.TrimSpace(feedback.ExpectedContext),
+		IrrelevantRefs:  feedback.IrrelevantRefs,
 	})
 	if event.RecallID == "" {
 		return fmt.Errorf("recall feedback event recall_id is required")

--- a/internal/service/recall_feedback_event_service_test.go
+++ b/internal/service/recall_feedback_event_service_test.go
@@ -66,6 +66,13 @@ func TestRecallFeedbackEventServiceRecordsFeedbackOnlyAndPrunesRetention(t *test
 		Quality:         "low",
 		MissingContext:  true,
 		Irrelevant:      false,
+		FailureReason:   "missing expected context",
+		ExpectedContext: "knowledge explorer listbox pattern",
+		IrrelevantRefs: []domain.RecallFeedbackJudgedResultRef{{
+			Type: domain.RecallFeedbackResultTypeFragment,
+			ID:   "fragment-1",
+			Rank: 1,
+		}},
 	})
 	require.NoError(t, err)
 	require.Len(t, repo.feedbacks, 1)
@@ -78,6 +85,13 @@ func TestRecallFeedbackEventServiceRecordsFeedbackOnlyAndPrunesRetention(t *test
 	assert.Equal(t, "low", got.Quality)
 	assert.NotNil(t, got.MissingContext)
 	assert.True(t, *got.MissingContext)
+	assert.Equal(t, "missing expected context", got.FailureReason)
+	assert.Equal(t, "knowledge explorer listbox pattern", got.ExpectedContext)
+	assert.Equal(t, []domain.RecallFeedbackJudgedResultRef{{
+		Type: domain.RecallFeedbackResultTypeFragment,
+		ID:   "fragment-1",
+		Rank: 1,
+	}}, got.IrrelevantRefs)
 
 	require.NoError(t, svc.Prune(ctx))
 	require.Len(t, repo.pruneCutoffs, 1)

--- a/internal/service/recallquality/metrics.go
+++ b/internal/service/recallquality/metrics.go
@@ -77,8 +77,8 @@ func ScoreAtK(ranked []ResultRef, relevant []Judgment, irrelevant []ResultRef, k
 			if firstRelevantRank == 0 {
 				firstRelevantRank = i + 1
 			}
+			dcg += discountedGain(grade, i+1)
 		}
-		dcg += discountedGain(grade, i+1)
 	}
 	if metrics.RelevantTotal > 0 {
 		metrics.RecallAtK = float64(metrics.RelevantAtK) / float64(metrics.RelevantTotal)

--- a/internal/service/recallquality/metrics.go
+++ b/internal/service/recallquality/metrics.go
@@ -1,0 +1,129 @@
+package recallquality
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+// ResultRef identifies one ranked recall result without content.
+type ResultRef struct {
+	Type string
+	ID   string
+}
+
+// Judgment grades an expected relevant result. Grades must be positive.
+type Judgment struct {
+	Type  string
+	ID    string
+	Grade float64
+}
+
+// Metrics captures one query's offline ranking quality at K.
+type Metrics struct {
+	K             int
+	RelevantAtK   int
+	RelevantTotal int
+	BadAtK        int
+	RecallAtK     float64
+	MRR           float64
+	NDCGAtK       float64
+}
+
+// ScoreAtK scores ranked results against relevant and judged-irrelevant refs.
+func ScoreAtK(ranked []ResultRef, relevant []Judgment, irrelevant []ResultRef, k int) Metrics {
+	if k < 0 {
+		k = 0
+	}
+	if k > len(ranked) {
+		k = len(ranked)
+	}
+	relevantGrades := make(map[string]float64, len(relevant))
+	for _, judgment := range relevant {
+		key := resultKey(judgment.Type, judgment.ID)
+		if key == "" || judgment.Grade <= 0 {
+			continue
+		}
+		if judgment.Grade > relevantGrades[key] {
+			relevantGrades[key] = judgment.Grade
+		}
+	}
+	badRefs := make(map[string]struct{}, len(irrelevant))
+	for _, ref := range irrelevant {
+		if key := resultKey(ref.Type, ref.ID); key != "" {
+			badRefs[key] = struct{}{}
+		}
+	}
+
+	metrics := Metrics{K: k, RelevantTotal: len(relevantGrades)}
+	seenRelevant := map[string]struct{}{}
+	firstRelevantRank := 0
+	dcg := 0.0
+	for i := 0; i < k; i++ {
+		key := resultKey(ranked[i].Type, ranked[i].ID)
+		if key == "" {
+			continue
+		}
+		if _, bad := badRefs[key]; bad {
+			metrics.BadAtK++
+		}
+		grade := relevantGrades[key]
+		if grade <= 0 {
+			continue
+		}
+		if _, seen := seenRelevant[key]; !seen {
+			seenRelevant[key] = struct{}{}
+			metrics.RelevantAtK++
+			if firstRelevantRank == 0 {
+				firstRelevantRank = i + 1
+			}
+		}
+		dcg += discountedGain(grade, i+1)
+	}
+	if metrics.RelevantTotal > 0 {
+		metrics.RecallAtK = float64(metrics.RelevantAtK) / float64(metrics.RelevantTotal)
+	}
+	if firstRelevantRank > 0 {
+		metrics.MRR = 1 / float64(firstRelevantRank)
+	}
+	ideal := idealDCG(relevantGrades, k)
+	if ideal > 0 {
+		metrics.NDCGAtK = dcg / ideal
+	}
+	return metrics
+}
+
+func resultKey(resultType string, id string) string {
+	resultType = strings.TrimSpace(resultType)
+	id = strings.TrimSpace(id)
+	if resultType == "" || id == "" {
+		return ""
+	}
+	return resultType + ":" + id
+}
+
+func discountedGain(grade float64, rank int) float64 {
+	if rank <= 0 {
+		return 0
+	}
+	return (math.Pow(2, grade) - 1) / math.Log2(float64(rank+1))
+}
+
+func idealDCG(relevantGrades map[string]float64, k int) float64 {
+	if k <= 0 || len(relevantGrades) == 0 {
+		return 0
+	}
+	grades := make([]float64, 0, len(relevantGrades))
+	for _, grade := range relevantGrades {
+		grades = append(grades, grade)
+	}
+	sort.Slice(grades, func(i, j int) bool { return grades[i] > grades[j] })
+	if k > len(grades) {
+		k = len(grades)
+	}
+	score := 0.0
+	for i := 0; i < k; i++ {
+		score += discountedGain(grades[i], i+1)
+	}
+	return score
+}

--- a/internal/service/recallquality/metrics_test.go
+++ b/internal/service/recallquality/metrics_test.go
@@ -1,0 +1,48 @@
+package recallquality
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScoreAtKMeasuresRelevantAndJudgedBadResults(t *testing.T) {
+	got := ScoreAtK(
+		[]ResultRef{
+			{Type: "fragment", ID: "stale"},
+			{Type: "fragment", ID: "expected"},
+			{Type: "fact", ID: "decision"},
+		},
+		[]Judgment{
+			{Type: "fragment", ID: "expected", Grade: 3},
+			{Type: "fact", ID: "decision", Grade: 2},
+		},
+		[]ResultRef{{Type: "fragment", ID: "stale"}},
+		3,
+	)
+
+	require.Equal(t, 3, got.K)
+	require.Equal(t, 2, got.RelevantAtK)
+	require.Equal(t, 2, got.RelevantTotal)
+	require.Equal(t, 1, got.BadAtK)
+	require.Equal(t, 1.0, got.RecallAtK)
+	require.Equal(t, 0.5, got.MRR)
+	require.InDelta(t, 0.665, got.NDCGAtK, 0.001)
+}
+
+func TestScoreAtKHandlesNoRelevantJudgments(t *testing.T) {
+	got := ScoreAtK(
+		[]ResultRef{{Type: "fragment", ID: "one"}},
+		nil,
+		[]ResultRef{{Type: "fragment", ID: "one"}},
+		10,
+	)
+
+	require.Equal(t, 1, got.K)
+	require.Equal(t, 1, got.BadAtK)
+	require.Zero(t, got.RelevantAtK)
+	require.Zero(t, got.RelevantTotal)
+	require.Zero(t, got.RecallAtK)
+	require.Zero(t, got.MRR)
+	require.Zero(t, got.NDCGAtK)
+}

--- a/internal/service/recallquality/metrics_test.go
+++ b/internal/service/recallquality/metrics_test.go
@@ -46,3 +46,20 @@ func TestScoreAtKHandlesNoRelevantJudgments(t *testing.T) {
 	require.Zero(t, got.MRR)
 	require.Zero(t, got.NDCGAtK)
 }
+
+func TestScoreAtKDeduplicatesRelevantGainForNDCG(t *testing.T) {
+	got := ScoreAtK(
+		[]ResultRef{
+			{Type: "fragment", ID: "expected"},
+			{Type: "fragment", ID: "expected"},
+		},
+		[]Judgment{{Type: "fragment", ID: "expected", Grade: 3}},
+		nil,
+		2,
+	)
+
+	require.Equal(t, 1, got.RelevantAtK)
+	require.Equal(t, 1.0, got.RecallAtK)
+	require.Equal(t, 1.0, got.MRR)
+	require.Equal(t, 1.0, got.NDCGAtK)
+}

--- a/internal/tools/registry/recall_feedback_test.go
+++ b/internal/tools/registry/recall_feedback_test.go
@@ -56,6 +56,28 @@ func TestSubmitRecallSessionFeedbackRejectsInvalidQuality(t *testing.T) {
 	}
 }
 
+func TestSubmitRecallSessionFeedbackRequiresFailureReasonForNegativeFeedback(t *testing.T) {
+	reg, _ := BuildDefault(Dependencies{
+		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: true},
+		Metrics:              observability.NewInMemoryDiscoverabilityMetrics(),
+	})
+	tool, _ := reg.Get("submit_recall_session_feedback")
+
+	_, err := tool.Invoke(context.Background(), "profile-feedback", map[string]any{
+		"recalls": []any{map[string]any{
+			"recall_id":        "rec-1",
+			"used":             true,
+			"answer_supported": false,
+			"quality":          "medium",
+			"missing_context":  false,
+			"irrelevant":       false,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "recalls[0].failure_reason is required for negative feedback") {
+		t.Fatalf("err = %v; want missing failure reason", err)
+	}
+}
+
 func TestSubmitRecallSessionFeedbackDisabledByRuntimeConfig(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{
 		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: false},
@@ -96,6 +118,54 @@ func TestToolVisibleGatesRecallFeedbackTool(t *testing.T) {
 	}
 	if ToolVisible(ctx, feedbackTool, stubRecallFeedbackConfig{enabled: true, err: errors.New("config unavailable")}) {
 		t.Fatal("feedback tool should be hidden when runtime config is unavailable")
+	}
+}
+
+func TestSubmitRecallSessionFeedbackRecordsFailureDetails(t *testing.T) {
+	recorder := &stubRecallFeedbackRecorder{}
+	metrics := observability.NewInMemoryDiscoverabilityMetrics()
+	reg, _ := BuildDefault(Dependencies{
+		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: true},
+		RecallFeedbackEvents: recorder,
+		Metrics:              metrics,
+	})
+	tool, _ := reg.Get("submit_recall_session_feedback")
+
+	_, err := tool.Invoke(context.Background(), "profile-feedback", map[string]any{
+		"recalls": []any{map[string]any{
+			"recall_id":        " rec-1 ",
+			"used":             true,
+			"answer_supported": false,
+			"quality":          "low",
+			"missing_context":  true,
+			"irrelevant":       true,
+			"failure_reason":   " Returned stale UI redesign notes instead of the button disabled-state pattern. ",
+			"expected_context": " Existing SearchPanel button handling pattern. ",
+			"irrelevant_result_refs": []any{map[string]any{
+				"type": "fragment",
+				"id":   " fragment-1 ",
+				"rank": 1,
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("submit_recall_session_feedback Invoke: %v", err)
+	}
+	if len(recorder.feedback) != 1 {
+		t.Fatalf("recorded feedback = %d; want 1", len(recorder.feedback))
+	}
+	got := recorder.feedback[0]
+	if got.RecallID != "rec-1" || got.FailureReason != "Returned stale UI redesign notes instead of the button disabled-state pattern." {
+		t.Fatalf("recorded feedback = %+v", got)
+	}
+	if got.ExpectedContext != "Existing SearchPanel button handling pattern." {
+		t.Fatalf("expected_context = %q", got.ExpectedContext)
+	}
+	if len(got.IrrelevantRefs) != 1 || got.IrrelevantRefs[0].ID != "fragment-1" || got.IrrelevantRefs[0].Rank != 1 {
+		t.Fatalf("irrelevant refs = %+v", got.IrrelevantRefs)
+	}
+	if len(metrics.RecallFeedbackSamples()) != 1 {
+		t.Fatalf("recall feedback samples = %d; want 1", len(metrics.RecallFeedbackSamples()))
 	}
 }
 
@@ -229,6 +299,7 @@ func TestRecallFeedbackRecorderErrorsSuppressRecallEventAndFailFeedbackSubmit(t 
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       false,
+			"failure_reason":   "snapshot was not recorded",
 		}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "failed to record recalls[0]") {

--- a/internal/tools/registry/recall_feedback_test.go
+++ b/internal/tools/registry/recall_feedback_test.go
@@ -78,6 +78,29 @@ func TestSubmitRecallSessionFeedbackRequiresFailureReasonForNegativeFeedback(t *
 	}
 }
 
+func TestSubmitRecallSessionFeedbackRejectsInvalidFailureReason(t *testing.T) {
+	reg, _ := BuildDefault(Dependencies{
+		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: true},
+		Metrics:              observability.NewInMemoryDiscoverabilityMetrics(),
+	})
+	tool, _ := reg.Get("submit_recall_session_feedback")
+
+	_, err := tool.Invoke(context.Background(), "profile-feedback", map[string]any{
+		"recalls": []any{map[string]any{
+			"recall_id":        "rec-1",
+			"used":             true,
+			"answer_supported": false,
+			"quality":          "low",
+			"missing_context":  true,
+			"irrelevant":       false,
+			"failure_reason":   "returned stale UI redesign notes",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "recalls[0].failure_reason must be one of") {
+		t.Fatalf("err = %v; want invalid failure reason", err)
+	}
+}
+
 func TestSubmitRecallSessionFeedbackDisabledByRuntimeConfig(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{
 		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: false},
@@ -139,8 +162,8 @@ func TestSubmitRecallSessionFeedbackRecordsFailureDetails(t *testing.T) {
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       true,
-			"failure_reason":   " Returned stale UI redesign notes instead of the button disabled-state pattern. ",
-			"expected_context": " Existing SearchPanel button handling pattern. ",
+			"failure_reason":   " STALE_OR_RETRACTED_RESULTS ",
+			"expected_context": " Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern. ",
 			"irrelevant_result_refs": []any{map[string]any{
 				"type": "fragment",
 				"id":   " fragment-1 ",
@@ -155,10 +178,10 @@ func TestSubmitRecallSessionFeedbackRecordsFailureDetails(t *testing.T) {
 		t.Fatalf("recorded feedback = %d; want 1", len(recorder.feedback))
 	}
 	got := recorder.feedback[0]
-	if got.RecallID != "rec-1" || got.FailureReason != "Returned stale UI redesign notes instead of the button disabled-state pattern." {
+	if got.RecallID != "rec-1" || got.FailureReason != "stale_or_retracted_results" {
 		t.Fatalf("recorded feedback = %+v", got)
 	}
-	if got.ExpectedContext != "Existing SearchPanel button handling pattern." {
+	if got.ExpectedContext != "Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern." {
 		t.Fatalf("expected_context = %q", got.ExpectedContext)
 	}
 	if len(got.IrrelevantRefs) != 1 || got.IrrelevantRefs[0].ID != "fragment-1" || got.IrrelevantRefs[0].Rank != 1 {
@@ -299,7 +322,7 @@ func TestRecallFeedbackRecorderErrorsSuppressRecallEventAndFailFeedbackSubmit(t 
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       false,
-			"failure_reason":   "snapshot was not recorded",
+			"failure_reason":   "other",
 		}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "failed to record recalls[0]") {

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -303,6 +303,16 @@ const (
 	recallFeedbackJudgedRefMaxRank     = 50
 )
 
+var recallFeedbackFailureReasonValues = []string{
+	"missing_context",
+	"irrelevant_results",
+	"stale_or_retracted_results",
+	"unsupported_answer",
+	"wrong_scope",
+	"ambiguous_query",
+	"other",
+}
+
 type recallFeedbackJudgedResultRefInput struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
@@ -338,8 +348,12 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 							"quality":          schemaEnum([]string{"high", "medium", "low"}),
 							"missing_context":  map[string]any{"type": "boolean", "description": "Whether important memory context still appeared missing after investigation."},
 							"irrelevant":       map[string]any{"type": "boolean", "description": "Whether this recall's returned context was irrelevant."},
-							"failure_reason":   schemaString("Required when quality is low, answer_supported is false, missing_context is true, or irrelevant is true. Describe the recall failure without user content.", recallFeedbackExplanationMaxLength),
-							"expected_context": schemaString("Optional memory context that would have made the recall useful. Do not include user content.", recallFeedbackExplanationMaxLength),
+							"failure_reason": map[string]any{
+								"type":        "string",
+								"enum":        recallFeedbackFailureReasonValues,
+								"description": "Required when quality is low, answer_supported is false, missing_context is true, or irrelevant is true. Use expected_context for bounded prose details.",
+							},
+							"expected_context": schemaString("Optional detail about the memory context that would have made the recall useful. Do not include user content.", recallFeedbackExplanationMaxLength),
 							"irrelevant_result_refs": map[string]any{
 								"type":        "array",
 								"description": "Optional references to returned results judged irrelevant.",
@@ -417,8 +431,11 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 				if recallFeedbackNeedsFailureReason(quality, recall.AnswerSupported, recall.MissingContext, recall.Irrelevant) && failureReason == "" {
 					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason is required for negative feedback", i)
 				}
-				if runeLen(failureReason) > recallFeedbackExplanationMaxLength {
-					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason must be at most %d characters", i, recallFeedbackExplanationMaxLength)
+				if failureReason != "" {
+					failureReason = strings.ToLower(failureReason)
+					if !recallFeedbackFailureReasonAllowed(failureReason) {
+						return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason must be one of %s", i, strings.Join(recallFeedbackFailureReasonValues, ", "))
+					}
 				}
 				if runeLen(expectedContext) > recallFeedbackExplanationMaxLength {
 					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].expected_context must be at most %d characters", i, recallFeedbackExplanationMaxLength)
@@ -463,6 +480,15 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 
 func recallFeedbackNeedsFailureReason(quality string, answerSupported bool, missingContext bool, irrelevant bool) bool {
 	return quality == "low" || !answerSupported || missingContext || irrelevant
+}
+
+func recallFeedbackFailureReasonAllowed(reason string) bool {
+	for _, allowed := range recallFeedbackFailureReasonValues {
+		if reason == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeRecallFeedbackJudgedRefs(recallIndex int, refs []recallFeedbackJudgedResultRefInput) ([]domain.RecallFeedbackJudgedResultRef, error) {

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -296,10 +296,23 @@ func recallMemoryTool(deps Dependencies) Tool {
 	}
 }
 
+const (
+	recallFeedbackExplanationMaxLength = 1000
+	recallFeedbackIrrelevantRefsMax    = 20
+	recallFeedbackJudgedRefIDMaxLength = 128
+	recallFeedbackJudgedRefMaxRank     = 50
+)
+
+type recallFeedbackJudgedResultRefInput struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Rank *int   `json:"rank,omitempty"`
+}
+
 func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        SubmitRecallSessionFeedbackToolName,
-		Description: "Submit recall feedback, session feedback, or a recall quality evaluation after finishing all context gathering and before the final answer. Use this when recall_memory returns recall_event.feedback_tool=submit_recall_session_feedback; pass recall_event.recall_id once you know which recalls informed the answer. Do not call immediately after exploratory context-building recall. Do not include user content.",
+		Description: "Submit recall feedback, session feedback, or a recall quality evaluation after finishing all context gathering and before the final answer. Use this when recall_memory returns recall_event.feedback_tool=submit_recall_session_feedback; pass recall_event.recall_id once you know which recalls informed the answer. Do not call immediately after exploratory context-building recall. For negative feedback, include failure_reason and optionally expected_context and irrelevant_result_refs. Do not include user content.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"recalls"},
@@ -325,6 +338,27 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 							"quality":          schemaEnum([]string{"high", "medium", "low"}),
 							"missing_context":  map[string]any{"type": "boolean", "description": "Whether important memory context still appeared missing after investigation."},
 							"irrelevant":       map[string]any{"type": "boolean", "description": "Whether this recall's returned context was irrelevant."},
+							"failure_reason":   schemaString("Required when quality is low, answer_supported is false, missing_context is true, or irrelevant is true. Describe the recall failure without user content.", recallFeedbackExplanationMaxLength),
+							"expected_context": schemaString("Optional memory context that would have made the recall useful. Do not include user content.", recallFeedbackExplanationMaxLength),
+							"irrelevant_result_refs": map[string]any{
+								"type":        "array",
+								"description": "Optional references to returned results judged irrelevant.",
+								"maxItems":    recallFeedbackIrrelevantRefsMax,
+								"items": map[string]any{
+									"type":     "object",
+									"required": []string{"type", "id"},
+									"properties": map[string]any{
+										"type": schemaEnum([]string{
+											domain.RecallFeedbackResultTypeFragment,
+											domain.RecallFeedbackResultTypeClaim,
+											domain.RecallFeedbackResultTypeFact,
+										}),
+										"id":   schemaString("Result id from recall feedback result_refs.", recallFeedbackJudgedRefIDMaxLength),
+										"rank": map[string]any{"type": "integer", "minimum": 1, "maximum": recallFeedbackJudgedRefMaxRank},
+									},
+									"additionalProperties": false,
+								},
+							},
 						},
 						"additionalProperties": false,
 					},
@@ -349,12 +383,15 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 			}
 			var req struct {
 				Recalls []struct {
-					RecallID        string `json:"recall_id"`
-					Used            bool   `json:"used"`
-					AnswerSupported bool   `json:"answer_supported"`
-					Quality         string `json:"quality"`
-					MissingContext  bool   `json:"missing_context"`
-					Irrelevant      bool   `json:"irrelevant"`
+					RecallID        string                               `json:"recall_id"`
+					Used            bool                                 `json:"used"`
+					AnswerSupported bool                                 `json:"answer_supported"`
+					Quality         string                               `json:"quality"`
+					MissingContext  bool                                 `json:"missing_context"`
+					Irrelevant      bool                                 `json:"irrelevant"`
+					FailureReason   string                               `json:"failure_reason"`
+					ExpectedContext string                               `json:"expected_context"`
+					IrrelevantRefs  []recallFeedbackJudgedResultRefInput `json:"irrelevant_result_refs"`
 				} `json:"recalls"`
 			}
 			if err := remapInput(input, &req); err != nil {
@@ -375,6 +412,21 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 				default:
 					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].quality must be one of high, medium, low", i)
 				}
+				failureReason := strings.TrimSpace(recall.FailureReason)
+				expectedContext := strings.TrimSpace(recall.ExpectedContext)
+				if recallFeedbackNeedsFailureReason(quality, recall.AnswerSupported, recall.MissingContext, recall.Irrelevant) && failureReason == "" {
+					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason is required for negative feedback", i)
+				}
+				if runeLen(failureReason) > recallFeedbackExplanationMaxLength {
+					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason must be at most %d characters", i, recallFeedbackExplanationMaxLength)
+				}
+				if runeLen(expectedContext) > recallFeedbackExplanationMaxLength {
+					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].expected_context must be at most %d characters", i, recallFeedbackExplanationMaxLength)
+				}
+				irrelevantRefs, err := normalizeRecallFeedbackJudgedRefs(i, recall.IrrelevantRefs)
+				if err != nil {
+					return nil, err
+				}
 				submissions = append(submissions, domain.RecallFeedbackSubmission{
 					RecallID:        strings.TrimSpace(recall.RecallID),
 					Used:            recall.Used,
@@ -382,6 +434,9 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 					Quality:         quality,
 					MissingContext:  recall.MissingContext,
 					Irrelevant:      recall.Irrelevant,
+					FailureReason:   failureReason,
+					ExpectedContext: expectedContext,
+					IrrelevantRefs:  irrelevantRefs,
 				})
 				feedbacks = append(feedbacks, observability.RecallFeedback{
 					Used:            recall.Used,
@@ -404,6 +459,48 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 			return map[string]any{"recorded": true, "recorded_count": len(submissions)}, nil
 		},
 	}
+}
+
+func recallFeedbackNeedsFailureReason(quality string, answerSupported bool, missingContext bool, irrelevant bool) bool {
+	return quality == "low" || !answerSupported || missingContext || irrelevant
+}
+
+func normalizeRecallFeedbackJudgedRefs(recallIndex int, refs []recallFeedbackJudgedResultRefInput) ([]domain.RecallFeedbackJudgedResultRef, error) {
+	if len(refs) > recallFeedbackIrrelevantRefsMax {
+		return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].irrelevant_result_refs must contain at most %d items", recallIndex, recallFeedbackIrrelevantRefsMax)
+	}
+	out := make([]domain.RecallFeedbackJudgedResultRef, 0, len(refs))
+	for i, ref := range refs {
+		refType := strings.TrimSpace(ref.Type)
+		switch refType {
+		case domain.RecallFeedbackResultTypeFragment, domain.RecallFeedbackResultTypeClaim, domain.RecallFeedbackResultTypeFact:
+		default:
+			return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].irrelevant_result_refs[%d].type must be one of fragment, claim, fact", recallIndex, i)
+		}
+		id := strings.TrimSpace(ref.ID)
+		if id == "" {
+			return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].irrelevant_result_refs[%d].id is required", recallIndex, i)
+		}
+		if runeLen(id) > recallFeedbackJudgedRefIDMaxLength {
+			return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].irrelevant_result_refs[%d].id must be at most %d characters", recallIndex, i, recallFeedbackJudgedRefIDMaxLength)
+		}
+		judged := domain.RecallFeedbackJudgedResultRef{Type: refType, ID: id}
+		if ref.Rank != nil {
+			if *ref.Rank < 1 || *ref.Rank > recallFeedbackJudgedRefMaxRank {
+				return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].irrelevant_result_refs[%d].rank must be between 1 and %d", recallIndex, i, recallFeedbackJudgedRefMaxRank)
+			}
+			judged.Rank = *ref.Rank
+		}
+		out = append(out, judged)
+	}
+	if out == nil {
+		return []domain.RecallFeedbackJudgedResultRef{}, nil
+	}
+	return out, nil
+}
+
+func runeLen(value string) int {
+	return len([]rune(value))
 }
 
 func recallFeedbackToolArgs(input map[string]any, req recallservice.RecallRequest) map[string]any {

--- a/migrations/postgres/2026062501_recall_feedback_explanations.sql
+++ b/migrations/postgres/2026062501_recall_feedback_explanations.sql
@@ -9,8 +9,18 @@ ALTER TABLE recall_feedback_events
     ADD COLUMN failure_reason TEXT NOT NULL DEFAULT '',
     ADD COLUMN expected_context TEXT NOT NULL DEFAULT '',
     ADD COLUMN irrelevant_result_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD CONSTRAINT recall_feedback_events_failure_reason_length_check
+        CHECK (char_length(failure_reason) <= 1000),
+    ADD CONSTRAINT recall_feedback_events_expected_context_length_check
+        CHECK (char_length(expected_context) <= 1000),
     ADD CONSTRAINT recall_feedback_events_irrelevant_result_refs_array_check
-        CHECK (jsonb_typeof(irrelevant_result_refs) = 'array');
+        CHECK (
+            CASE
+                WHEN jsonb_typeof(irrelevant_result_refs) = 'array'
+                THEN jsonb_array_length(irrelevant_result_refs) <= 20
+                ELSE false
+            END
+        );
 
 -- +goose StatementEnd
 
@@ -23,6 +33,8 @@ SELECT set_config('app.current_profile_id', '', true);
 
 ALTER TABLE recall_feedback_events
     DROP CONSTRAINT IF EXISTS recall_feedback_events_irrelevant_result_refs_array_check,
+    DROP CONSTRAINT IF EXISTS recall_feedback_events_expected_context_length_check,
+    DROP CONSTRAINT IF EXISTS recall_feedback_events_failure_reason_length_check,
     DROP COLUMN IF EXISTS irrelevant_result_refs,
     DROP COLUMN IF EXISTS expected_context,
     DROP COLUMN IF EXISTS failure_reason;

--- a/migrations/postgres/2026062501_recall_feedback_explanations.sql
+++ b/migrations/postgres/2026062501_recall_feedback_explanations.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+ALTER TABLE recall_feedback_events
+    ADD COLUMN failure_reason TEXT NOT NULL DEFAULT '',
+    ADD COLUMN expected_context TEXT NOT NULL DEFAULT '',
+    ADD COLUMN irrelevant_result_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD CONSTRAINT recall_feedback_events_irrelevant_result_refs_array_check
+        CHECK (jsonb_typeof(irrelevant_result_refs) = 'array');
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+ALTER TABLE recall_feedback_events
+    DROP CONSTRAINT IF EXISTS recall_feedback_events_irrelevant_result_refs_array_check,
+    DROP COLUMN IF EXISTS irrelevant_result_refs,
+    DROP COLUMN IF EXISTS expected_context,
+    DROP COLUMN IF EXISTS failure_reason;
+
+-- +goose StatementEnd

--- a/web/src/App.recall-feedback.test.tsx
+++ b/web/src/App.recall-feedback.test.tsx
@@ -82,6 +82,9 @@ const recallFeedbackEvents: RecallFeedbackEvent[] = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
+    failure_reason: "Returned stale UI notes instead of the requested button pattern.",
+    expected_context: "SearchPanel disabled-state and listbox accessibility pattern.",
+    irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
         type: "fragment",
@@ -147,8 +150,12 @@ it("shows recall feedback query, params, result ids, and resolved state", async 
 
   await userEvent.click(screen.getByRole("button", { name: /view recall feedback rec_1234567890/i }));
   expect(await screen.findByText("fragment-1")).toBeInTheDocument();
+  const failureDetails = screen.getByRole("table", { name: /Recall feedback failure details/i });
+  expect(within(failureDetails).getByText("Returned stale UI notes instead of the requested button pattern.")).toBeInTheDocument();
+  expect(within(failureDetails).getByText("SearchPanel disabled-state and listbox accessibility pattern.")).toBeInTheDocument();
+  expect(within(failureDetails).getByText("#1 fragment:fragment-1")).toBeInTheDocument();
   expect(screen.getByText("The old fragment has been retracted.")).toBeInTheDocument();
-  expect(screen.getByLabelText(/Raw recall feedback rec_1234567890/i)).toHaveTextContent('"tool_args"');
+  expect(screen.getByLabelText(/Raw recall feedback rec_1234567890/i)).toHaveTextContent('"failure_reason"');
 
   await userEvent.selectOptions(screen.getByLabelText("Quality"), "low");
   await waitFor(() => {

--- a/web/src/App.recall-feedback.test.tsx
+++ b/web/src/App.recall-feedback.test.tsx
@@ -82,8 +82,8 @@ const recallFeedbackEvents: RecallFeedbackEvent[] = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
-    failure_reason: "Returned stale UI notes instead of the requested button pattern.",
-    expected_context: "SearchPanel disabled-state and listbox accessibility pattern.",
+    failure_reason: "stale_or_retracted_results",
+    expected_context: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
     irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
@@ -151,8 +151,8 @@ it("shows recall feedback query, params, result ids, and resolved state", async 
   await userEvent.click(screen.getByRole("button", { name: /view recall feedback rec_1234567890/i }));
   expect(await screen.findByText("fragment-1")).toBeInTheDocument();
   const failureDetails = screen.getByRole("table", { name: /Recall feedback failure details/i });
-  expect(within(failureDetails).getByText("Returned stale UI notes instead of the requested button pattern.")).toBeInTheDocument();
-  expect(within(failureDetails).getByText("SearchPanel disabled-state and listbox accessibility pattern.")).toBeInTheDocument();
+  expect(within(failureDetails).getByText("stale_or_retracted_results")).toBeInTheDocument();
+  expect(within(failureDetails).getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeInTheDocument();
   expect(within(failureDetails).getByText("#1 fragment:fragment-1")).toBeInTheDocument();
   expect(screen.getByText("The old fragment has been retracted.")).toBeInTheDocument();
   expect(screen.getByLabelText(/Raw recall feedback rec_1234567890/i)).toHaveTextContent('"failure_reason"');

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -366,6 +366,12 @@ export type RecallFeedbackResultRef = {
   retracted_at?: string;
 };
 
+export type RecallFeedbackJudgedResultRef = {
+  type: "fragment" | "claim" | "fact" | string;
+  id: string;
+  rank?: number;
+};
+
 export type RecallFeedbackResolvedResult = {
   type: string;
   id: string;
@@ -396,6 +402,9 @@ export type RecallFeedbackEvent = {
   quality?: "high" | "medium" | "low" | string;
   missing_context?: boolean | null;
   irrelevant?: boolean | null;
+  failure_reason?: string;
+  expected_context?: string;
+  irrelevant_result_refs?: RecallFeedbackJudgedResultRef[] | null;
   resolved_results?: RecallFeedbackResolvedResult[] | null;
 };
 

--- a/web/src/control/RecallFeedbackPanel.tsx
+++ b/web/src/control/RecallFeedbackPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import { Braces, RefreshCw } from "lucide-react";
-import { ControlApi, RecallFeedbackEvent, RecallFeedbackEventQuery, RecallFeedbackResolvedResult, RecallFeedbackResultRef, Team } from "../api";
+import { ControlApi, RecallFeedbackEvent, RecallFeedbackEventQuery, RecallFeedbackJudgedResultRef, RecallFeedbackResolvedResult, RecallFeedbackResultRef, Team } from "../api";
 import { LoadingState, SectionHeading } from "../ui/components";
 import { formatDate, readError, shortId } from "./utils";
 
@@ -310,10 +310,46 @@ function RecallFeedbackDetail({ event }: { event: RecallFeedbackEvent }) {
         <span className="log-detail-chip">profile={event.profile_id ? shortId(event.profile_id) : "unknown"}</span>
         <span className="log-detail-chip">key={event.key_id ? shortId(event.key_id) : "unknown"}</span>
       </div>
+      <FeedbackFailureDetails event={event} />
       <ResultRefTable refs={refs} resolved={resolved} />
       <pre aria-label={`Raw recall feedback ${event.recall_id}`}>{JSON.stringify(rawEvent(event), null, 2)}</pre>
     </div>
   );
+}
+
+function FeedbackFailureDetails({ event }: { event: RecallFeedbackEvent }) {
+  const irrelevantRefs = event.irrelevant_result_refs ?? [];
+  const rows = [
+    event.failure_reason ? ["Failure reason", event.failure_reason] : null,
+    event.expected_context ? ["Expected context", event.expected_context] : null,
+    irrelevantRefs.length > 0 ? ["Irrelevant refs", irrelevantRefs.map(judgedRefLabel).join(", ")] : null,
+  ].filter((row): row is string[] => row !== null);
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <table className="data-table" aria-label="Recall feedback failure details">
+      <thead>
+        <tr>
+          <th>Signal</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(([label, value]) => (
+          <tr key={label}>
+            <td>{label}</td>
+            <td>{value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function judgedRefLabel(ref: RecallFeedbackJudgedResultRef): string {
+  const rank = ref.rank ? `#${ref.rank} ` : "";
+  return `${rank}${ref.type}:${ref.id}`;
 }
 
 function ResultRefTable({ refs, resolved }: { refs: RecallFeedbackResultRef[]; resolved: RecallFeedbackResolvedResult[] }) {
@@ -413,6 +449,9 @@ function rawEvent(event: RecallFeedbackEvent): Record<string, unknown> {
       quality: event.quality,
       missing_context: event.missing_context,
       irrelevant: event.irrelevant,
+      failure_reason: event.failure_reason,
+      expected_context: event.expected_context,
+      irrelevant_result_refs: event.irrelevant_result_refs ?? [],
     },
     result_refs: event.result_refs ?? [],
     resolved_results: event.resolved_results ?? [],

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -229,8 +229,8 @@ const recallFeedbackEvents = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
-    failure_reason: "Returned stale UI notes instead of the requested button pattern.",
-    expected_context: "SearchPanel disabled-state and listbox accessibility pattern.",
+    failure_reason: "stale_or_retracted_results",
+    expected_context: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
     irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
@@ -459,8 +459,8 @@ test("recall feedback tab renders query, params, result ids, and resolved state"
   const resultRefs = page.getByRole("table", { name: "Recall feedback result refs" });
   await expect(resultRefs.getByRole("row", { name: /fragment-1/ })).toBeVisible();
   const failureDetails = page.getByRole("table", { name: "Recall feedback failure details" });
-  await expect(failureDetails.getByText("Returned stale UI notes instead of the requested button pattern.")).toBeVisible();
-  await expect(failureDetails.getByText("SearchPanel disabled-state and listbox accessibility pattern.")).toBeVisible();
+  await expect(failureDetails.getByText("stale_or_retracted_results")).toBeVisible();
+  await expect(failureDetails.getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeVisible();
   await expect(failureDetails.getByText("#1 fragment:fragment-1")).toBeVisible();
   await expect(resultRefs.getByText("The old fragment has been retracted.")).toBeVisible();
   await expect(page.getByLabel(/Raw recall feedback rec_1234567890/)).toContainText('"failure_reason"');

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -229,6 +229,9 @@ const recallFeedbackEvents = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
+    failure_reason: "Returned stale UI notes instead of the requested button pattern.",
+    expected_context: "SearchPanel disabled-state and listbox accessibility pattern.",
+    irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
         type: "fragment",
@@ -455,8 +458,12 @@ test("recall feedback tab renders query, params, result ids, and resolved state"
   await page.getByRole("button", { name: /View recall feedback rec_1234567890/ }).click();
   const resultRefs = page.getByRole("table", { name: "Recall feedback result refs" });
   await expect(resultRefs.getByRole("row", { name: /fragment-1/ })).toBeVisible();
+  const failureDetails = page.getByRole("table", { name: "Recall feedback failure details" });
+  await expect(failureDetails.getByText("Returned stale UI notes instead of the requested button pattern.")).toBeVisible();
+  await expect(failureDetails.getByText("SearchPanel disabled-state and listbox accessibility pattern.")).toBeVisible();
+  await expect(failureDetails.getByText("#1 fragment:fragment-1")).toBeVisible();
   await expect(resultRefs.getByText("The old fragment has been retracted.")).toBeVisible();
-  await expect(page.getByLabel(/Raw recall feedback rec_1234567890/)).toContainText('"tool_args"');
+  await expect(page.getByLabel(/Raw recall feedback rec_1234567890/)).toContainText('"failure_reason"');
   await expectNoShellOverlap(page);
 
   await page.getByLabel("Quality").selectOption("low");


### PR DESCRIPTION
## Summary
- require bounded `failure_reason` for negative `submit_recall_session_feedback` judgments and persist optional `expected_context` plus `irrelevant_result_refs`
- surface failure details in the control portal recall feedback view while keeping Prometheus recall feedback labels bounded
- add a pure `recallquality` scoring helper for Recall@K, MRR, nDCG@K, and judged-bad-at-K, plus docs and migration updates

## Verification
- `go test ./...`
- `npm test`
- `npm run build`
- `npm run playwright:mock:control`
- `git diff --check && git -C ../dense-mem.wiki diff --check`
- branch push pre-push checks: textlint, Go tests, and 90% coverage gate

Wiki was updated and pushed separately in `dense-mem.wiki` commit `cd6f3a2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer recall feedback details: bounded `failure_reason`, `expected_context`, and optional `irrelevant_result_refs`.
  * Enhanced the recall feedback UI with a dedicated “Failure details” section and updated raw payload rendering.
  * Introduced offline recall ranking-quality metrics (e.g., Recall@K, MRR, NDCG@K).

* **Bug Fixes**
  * Negative recall feedback now requires and validates `failure_reason` (including length/format rules).
  * Persisting, retrieving, and displaying the new fields is now consistent; malformed irrelevant refs are rejected.

* **Documentation**
  * Updated English and Chinese documentation to clarify bounded telemetry labels vs stored investigation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->