### PR TITLE
[codex] fix streamable mcp notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ temp/
 telemetry-scrape-token
 prometheus.yml
 .env.mcp
+.codex

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -49,8 +49,9 @@ func NewMCPHandlerWithLifecycleAndRuntimeConfig(reg registry.Registry, logger ob
 	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle, recallFeedbackConfig: recallFeedbackConfig}
 }
 
-// HandlePost serves POST /mcp. It accepts a single JSON-RPC request and returns
-// either application/json or a one-shot text/event-stream response, depending on Accept.
+// HandlePost serves POST /mcp. It accepts a single JSON-RPC payload and returns
+// either 202 for notifications, application/json, or a one-shot text/event-stream
+// response, depending on the payload and Accept.
 func (h *MCPHandler) HandlePost(c echo.Context) error {
 	ctx := c.Request().Context()
 	profileID, ok := middleware.GetResolvedProfileID(ctx)
@@ -77,13 +78,16 @@ func (h *MCPHandler) HandlePost(c echo.Context) error {
 		team.Description = resolvedTeam.Description
 	}
 	server := mcp.NewServerWithScopesTeamContextAndRuntimeConfig(h.reg, profileID.String(), principal.Scopes, team, h.logger, h.recallFeedbackConfig)
-	responsePayload := server.HandlePayload(ctx, payload)
-
-	if acceptsEventStream(c.Request().Header.Get("Accept")) {
-		return writeMCPSSE(c, responsePayload)
+	response := server.HandlePayloadResult(ctx, payload)
+	if !response.Respond {
+		return c.NoContent(http.StatusAccepted)
 	}
 
-	return c.Blob(http.StatusOK, "application/json", responsePayload)
+	if acceptsEventStream(c.Request().Header.Get("Accept")) {
+		return writeMCPSSE(c, response.Payload)
+	}
+
+	return c.Blob(http.StatusOK, "application/json", response.Payload)
 }
 
 // HandleGet serves GET /mcp as an SSE stream for Streamable HTTP clients.

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -120,6 +120,22 @@ func TestMCPHandlerPostSSE(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "data: {")
 }
 
+func TestMCPHandlerPostNotificationAcceptedWithSSEAccept(t *testing.T) {
+	h := NewMCPHandler(registry.New(), testMCPLogger())
+	e := echo.New()
+	profileID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	req.Header.Set(echo.HeaderAccept, "text/event-stream, application/json")
+	req = req.WithContext(mcpTestContext(req.Context(), profileID, []string{"read"}))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.HandlePost(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Empty(t, rec.Body.String())
+}
+
 func TestMCPHandlerToolsListFiltersByScope(t *testing.T) {
 	reg := registry.New()
 	require.NoError(t, reg.Register(registry.Tool{Name: "read_tool", Description: "read", RequiredScopes: []string{"read"}}))

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -109,14 +109,31 @@ type rpcError struct {
 	Data    any    `json:"data,omitempty"`
 }
 
+// PayloadResult describes whether a JSON-RPC payload produced a response.
+type PayloadResult struct {
+	Payload []byte
+	Respond bool
+}
+
 // HandlePayload handles one JSON-RPC request payload and returns one JSON-RPC response payload.
 func (s *Server) HandlePayload(ctx context.Context, payload []byte) []byte {
+	result := s.HandlePayloadResult(ctx, payload)
+	return result.Payload
+}
+
+// HandlePayloadResult handles one JSON-RPC payload and reports whether the
+// transport should write a response. Valid JSON-RPC notifications have no id and
+// must not receive a JSON-RPC response.
+func (s *Server) HandlePayloadResult(ctx context.Context, payload []byte) PayloadResult {
 	var req rpcRequest
 	if err := json.Unmarshal(payload, &req); err != nil {
 		s.logger.Warn("mcp: parse error", observability.String("error", err.Error()))
-		return mustMarshalResponse(errorResponse(nil, errCodeParseError, "parse error"))
+		return PayloadResult{Payload: mustMarshalResponse(errorResponse(nil, errCodeParseError, "parse error")), Respond: true}
 	}
-	return mustMarshalResponse(s.dispatch(ctx, req))
+	if req.isNotification() {
+		return PayloadResult{Respond: false}
+	}
+	return PayloadResult{Payload: mustMarshalResponse(s.dispatch(ctx, req)), Respond: true}
 }
 
 // dispatch routes a single request to the right handler.
@@ -144,6 +161,10 @@ func (s *Server) dispatch(ctx context.Context, req rpcRequest) rpcResponse {
 		s.logger.Warn("mcp: method not found", observability.String("method", req.Method))
 		return errorResponse(req.ID, errCodeMethodNotFound, fmt.Sprintf("method not found: %s", req.Method))
 	}
+}
+
+func (r rpcRequest) isNotification() bool {
+	return len(r.ID) == 0 && r.JSONRPC == "2.0" && r.Method != ""
 }
 
 // handleInitialize returns the server's capability block.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -692,6 +692,32 @@ func TestMCP_UnknownMethodReturnsError(t *testing.T) {
 	}
 }
 
+func TestMCP_HandlePayloadResultNotifications(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	s := NewServer(reg, "pA", logger)
+
+	notification := s.HandlePayloadResult(context.Background(), []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	if notification.Respond {
+		t.Fatalf("notification Respond = true, payload = %q", string(notification.Payload))
+	}
+	if len(notification.Payload) != 0 {
+		t.Fatalf("notification payload = %q; want empty", string(notification.Payload))
+	}
+
+	invalid := s.HandlePayloadResult(context.Background(), []byte(`{"jsonrpc":"2.0"}`))
+	if !invalid.Respond {
+		t.Fatal("invalid no-id payload Respond = false; want error response")
+	}
+	var resp rpcResp
+	if err := json.Unmarshal(invalid.Payload, &resp); err != nil {
+		t.Fatalf("unmarshal invalid response: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != errCodeMethodNotFound {
+		t.Fatalf("invalid no-id error = %+v; want method not found", resp.Error)
+	}
+}
+
 func TestMCP_HandlePayloadProducesOnlyJSONRPC(t *testing.T) {
 	logger, logBuf := testLogger(t)
 	reg := registry.New()


### PR DESCRIPTION
## Summary

Fix direct Streamable HTTP MCP startup with Codex by returning `202 Accepted` for valid JSON-RPC notifications instead of serializing them as SSE responses.

## Root Cause

Codex sends `notifications/initialized` during MCP startup with `Accept: text/event-stream, application/json`. Dense-Mem previously treated any POST whose `Accept` included `text/event-stream` as a one-shot SSE response, including no-id JSON-RPC notifications. Codex expects notifications to receive no JSON-RPC response, so it closed the transport during startup.

## Changes

- Added `HandlePayloadResult` so the MCP layer can distinguish response-producing requests from valid notifications.
- Updated `POST /mcp` to return `202 Accepted` for valid notifications before content negotiation.
- Added regression coverage for `notifications/initialized` with Codex-style `Accept` headers.
- Ignored project-level `.codex` config to keep local MCP bearer-token config out of git.

## Validation

- `go test ./internal/mcp`
- `go test ./internal/http/handler`
- `go test ./...`
- Rebuilt and ran the local Docker Compose server, then verified direct Codex Streamable HTTP handshake against `http://127.0.0.1:8080/mcp`.
- Pre-push hook passed lint, Go tests, and coverage gate: total coverage 90.1%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved request handling for the MCP endpoint, including support for no-content responses when a request doesn’t require output.
  * Responses now better match the client’s preferred format, including streamed output when requested.

* **Bug Fixes**
  * Improved handling of invalid or incomplete requests so errors are returned more reliably.
  * Added coverage for notification-style requests to prevent unexpected responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->