### PR TITLE
[codex] Require feedback comments for recall feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ scrape job when Prometheus is shared.
 Online recall-quality cards use `densemem_recall_feedback_total` and
 `densemem_recall_feedback_quality_score`. They stay at zero until
 recall feedback is enabled from the control portal config panel and a host LLM
-submits feedback for `recall_memory` results. Negative feedback requires a
-bounded `failure_reason` enum and can include expected context plus irrelevant
-result refs for offline analysis. Prometheus still receives only bounded labels;
-the free-text details stay in the recall feedback investigation records. Normal
+submits feedback for `recall_memory` results. Feedback only omits
+`feedback_comment` when quality is `high` with no negative flags; medium, low,
+or flagged feedback includes a bounded comment and can include irrelevant result
+refs for offline analysis. Prometheus still receives only bounded labels; the
+free-text comment stays in the recall feedback investigation records. Normal
 production recall traffic still contributes request volume, result count, and
 latency.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,9 +151,10 @@ docker compose -f docker-compose.yml -f docker-compose.telemetry.yml up -d
 在线 recall quality 卡片使用 `densemem_recall_feedback_total` 和
 `densemem_recall_feedback_quality_score`。在 control portal config panel
 开启 recall feedback，并且宿主 LLM 为 `recall_memory` 结果提交 feedback
-之前，这些卡片会保持为零。负向 feedback 需要有界的 `failure_reason` enum，
-也可以包含 expected context 和 irrelevant result refs，供离线分析使用。
-Prometheus 仍然只接收有界 labels；自由文本详情保存在 recall feedback
+之前，这些卡片会保持为零。只有质量为 `high` 且没有负向 flags 的 feedback
+可以省略 `feedback_comment`；`medium`、`low` 或带负向 flags 的 feedback
+需要有界 comment，也可以包含 irrelevant result refs，供离线分析使用。
+Prometheus 仍然只接收有界 labels；自由文本 comment 保存在 recall feedback
 investigation records 中。正常生产 recall 流量仍然会贡献请求量、结果数和延迟指标。
 
 对于一次性 demo image，保持 control portal 关闭，改用 demo telemetry

--- a/internal/domain/recall_feedback_event.go
+++ b/internal/domain/recall_feedback_event.go
@@ -37,8 +37,7 @@ type RecallFeedbackEvent struct {
 	Quality         string                          `json:"quality,omitempty"`
 	MissingContext  *bool                           `json:"missing_context,omitempty"`
 	Irrelevant      *bool                           `json:"irrelevant,omitempty"`
-	FailureReason   string                          `json:"failure_reason,omitempty"`
-	ExpectedContext string                          `json:"expected_context,omitempty"`
+	FeedbackComment string                          `json:"feedback_comment,omitempty"`
 	IrrelevantRefs  []RecallFeedbackJudgedResultRef `json:"irrelevant_result_refs,omitempty"`
 	ResolvedResults []RecallFeedbackResolvedResult  `json:"resolved_results,omitempty"`
 }
@@ -71,8 +70,7 @@ type RecallFeedbackSubmission struct {
 	Quality         string
 	MissingContext  bool
 	Irrelevant      bool
-	FailureReason   string
-	ExpectedContext string
+	FeedbackComment string
 	IrrelevantRefs  []RecallFeedbackJudgedResultRef
 }
 

--- a/internal/repository/recall_feedback_event_repository.go
+++ b/internal/repository/recall_feedback_event_repository.go
@@ -103,14 +103,14 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 				recall_id, created_at, updated_at, feedback_at, team_id, profile_id, key_id,
 				auth_method, tool_name, query, tool_args, result_refs,
 				result_count, snapshot_state, used, answer_supported,
-				quality, missing_context, irrelevant, failure_reason,
-				expected_context, irrelevant_result_refs
+				quality, missing_context, irrelevant, feedback_comment,
+				irrelevant_result_refs
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7,
 				$8, $9, $10, $11::jsonb, $12::jsonb,
 				$13, $14, $15, $16,
 				$17, $18, $19, $20,
-				$21, $22::jsonb
+				$21::jsonb
 			)
 			ON CONFLICT (recall_id) DO UPDATE SET
 				updated_at = EXCLUDED.updated_at,
@@ -127,8 +127,7 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 				quality = EXCLUDED.quality,
 				missing_context = EXCLUDED.missing_context,
 				irrelevant = EXCLUDED.irrelevant,
-				failure_reason = EXCLUDED.failure_reason,
-				expected_context = EXCLUDED.expected_context,
+				feedback_comment = EXCLUDED.feedback_comment,
 				irrelevant_result_refs = EXCLUDED.irrelevant_result_refs
 		`,
 			event.RecallID,
@@ -150,8 +149,7 @@ func (r *RecallFeedbackEventRepositoryImpl) RecordFeedback(ctx context.Context, 
 			event.Quality,
 			boolPtrValue(event.MissingContext),
 			boolPtrValue(event.Irrelevant),
-			event.FailureReason,
-			event.ExpectedContext,
+			event.FeedbackComment,
 			string(irrelevantRefs),
 		).Error
 	})
@@ -266,8 +264,7 @@ func normalizeRecallFeedbackEvent(event domain.RecallFeedbackEvent) domain.Recal
 	}
 	event.Query = strings.TrimSpace(event.Query)
 	event.Quality = strings.ToLower(strings.TrimSpace(event.Quality))
-	event.FailureReason = strings.TrimSpace(event.FailureReason)
-	event.ExpectedContext = strings.TrimSpace(event.ExpectedContext)
+	event.FeedbackComment = strings.TrimSpace(event.FeedbackComment)
 	event.SnapshotState = strings.TrimSpace(event.SnapshotState)
 	if event.SnapshotState == "" {
 		event.SnapshotState = domain.RecallFeedbackSnapshotCaptured
@@ -346,8 +343,8 @@ func recallFeedbackEventColumns() string {
 		team_id::text, profile_id::text, key_id::text,
 		auth_method, tool_name, query, tool_args, result_refs,
 		result_count, snapshot_state, used, answer_supported,
-		quality, missing_context, irrelevant, failure_reason,
-		expected_context, irrelevant_result_refs
+		quality, missing_context, irrelevant, feedback_comment,
+		irrelevant_result_refs
 	`
 }
 
@@ -386,8 +383,7 @@ func scanRecallFeedbackEvent(rows *sql.Rows) (domain.RecallFeedbackEvent, error)
 		&event.Quality,
 		&missingContextRaw,
 		&irrelevantRaw,
-		&event.FailureReason,
-		&event.ExpectedContext,
+		&event.FeedbackComment,
 		&irrelevantRefsRaw,
 	); err != nil {
 		return domain.RecallFeedbackEvent{}, err

--- a/internal/repository/recall_feedback_event_repository_test.go
+++ b/internal/repository/recall_feedback_event_repository_test.go
@@ -30,12 +30,11 @@ func TestScanRecallFeedbackEventRejectsMalformedIrrelevantResultRefsJSON(t *test
 	require.ErrorContains(t, err, "invalid recall_feedback_events.irrelevant_result_refs JSON")
 }
 
-func TestScanRecallFeedbackEventReadsFailureDetails(t *testing.T) {
+func TestScanRecallFeedbackEventReadsFeedbackComment(t *testing.T) {
 	rows := recallFeedbackEventRows(t, []byte("{}"), []byte("[]"), []byte(`[{"type":"fragment","id":"fragment-1","rank":1}]`))
 	got, err := scanRecallFeedbackEvent(rows)
 	require.NoError(t, err)
-	require.Equal(t, "missing expected context", got.FailureReason)
-	require.Equal(t, "knowledge explorer listbox pattern", got.ExpectedContext)
+	require.Equal(t, "knowledge explorer listbox pattern was missing", got.FeedbackComment)
 	require.Equal(t, []domain.RecallFeedbackJudgedResultRef{{
 		Type: domain.RecallFeedbackResultTypeFragment,
 		ID:   "fragment-1",
@@ -84,8 +83,7 @@ func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte, i
 		"quality",
 		"missing_context",
 		"irrelevant",
-		"failure_reason",
-		"expected_context",
+		"feedback_comment",
 		"irrelevant_result_refs",
 	}).AddRow(
 		"rec_1",
@@ -107,8 +105,7 @@ func recallFeedbackEventRows(t *testing.T, toolArgs []byte, resultRefs []byte, i
 		"",
 		nil,
 		nil,
-		"missing expected context",
-		"knowledge explorer listbox pattern",
+		"knowledge explorer listbox pattern was missing",
 		irrelevantRefs,
 	)
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)

--- a/internal/service/recall_feedback_event_service.go
+++ b/internal/service/recall_feedback_event_service.go
@@ -103,8 +103,7 @@ func (s *RecallFeedbackEventServiceImpl) RecordRecallFeedback(ctx context.Contex
 		Quality:         strings.ToLower(strings.TrimSpace(feedback.Quality)),
 		MissingContext:  &missingContext,
 		Irrelevant:      &irrelevant,
-		FailureReason:   strings.TrimSpace(feedback.FailureReason),
-		ExpectedContext: strings.TrimSpace(feedback.ExpectedContext),
+		FeedbackComment: strings.TrimSpace(feedback.FeedbackComment),
 		IrrelevantRefs:  feedback.IrrelevantRefs,
 	})
 	if event.RecallID == "" {

--- a/internal/service/recall_feedback_event_service_test.go
+++ b/internal/service/recall_feedback_event_service_test.go
@@ -66,8 +66,7 @@ func TestRecallFeedbackEventServiceRecordsFeedbackOnlyAndPrunesRetention(t *test
 		Quality:         "low",
 		MissingContext:  true,
 		Irrelevant:      false,
-		FailureReason:   "missing expected context",
-		ExpectedContext: "knowledge explorer listbox pattern",
+		FeedbackComment: "knowledge explorer listbox pattern was missing",
 		IrrelevantRefs: []domain.RecallFeedbackJudgedResultRef{{
 			Type: domain.RecallFeedbackResultTypeFragment,
 			ID:   "fragment-1",
@@ -85,8 +84,7 @@ func TestRecallFeedbackEventServiceRecordsFeedbackOnlyAndPrunesRetention(t *test
 	assert.Equal(t, "low", got.Quality)
 	assert.NotNil(t, got.MissingContext)
 	assert.True(t, *got.MissingContext)
-	assert.Equal(t, "missing expected context", got.FailureReason)
-	assert.Equal(t, "knowledge explorer listbox pattern", got.ExpectedContext)
+	assert.Equal(t, "knowledge explorer listbox pattern was missing", got.FeedbackComment)
 	assert.Equal(t, []domain.RecallFeedbackJudgedResultRef{{
 		Type: domain.RecallFeedbackResultTypeFragment,
 		ID:   "fragment-1",

--- a/internal/tools/registry/recall_feedback_test.go
+++ b/internal/tools/registry/recall_feedback_test.go
@@ -56,7 +56,7 @@ func TestSubmitRecallSessionFeedbackRejectsInvalidQuality(t *testing.T) {
 	}
 }
 
-func TestSubmitRecallSessionFeedbackRequiresFailureReasonForNegativeFeedback(t *testing.T) {
+func TestSubmitRecallSessionFeedbackRequiresCommentForNonHighFeedback(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{
 		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: true},
 		Metrics:              observability.NewInMemoryDiscoverabilityMetrics(),
@@ -67,20 +67,22 @@ func TestSubmitRecallSessionFeedbackRequiresFailureReasonForNegativeFeedback(t *
 		"recalls": []any{map[string]any{
 			"recall_id":        "rec-1",
 			"used":             true,
-			"answer_supported": false,
+			"answer_supported": true,
 			"quality":          "medium",
 			"missing_context":  false,
 			"irrelevant":       false,
 		}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "recalls[0].failure_reason is required for negative feedback") {
-		t.Fatalf("err = %v; want missing failure reason", err)
+	if err == nil || !strings.Contains(err.Error(), "recalls[0].feedback_comment is required") {
+		t.Fatalf("err = %v; want missing feedback comment", err)
 	}
 }
 
-func TestSubmitRecallSessionFeedbackRejectsInvalidFailureReason(t *testing.T) {
+func TestSubmitRecallSessionFeedbackAcceptsLegacyCommentFields(t *testing.T) {
+	recorder := &stubRecallFeedbackRecorder{}
 	reg, _ := BuildDefault(Dependencies{
 		RecallFeedbackConfig: stubRecallFeedbackConfig{enabled: true},
+		RecallFeedbackEvents: recorder,
 		Metrics:              observability.NewInMemoryDiscoverabilityMetrics(),
 	})
 	tool, _ := reg.Get("submit_recall_session_feedback")
@@ -93,11 +95,14 @@ func TestSubmitRecallSessionFeedbackRejectsInvalidFailureReason(t *testing.T) {
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       false,
-			"failure_reason":   "returned stale UI redesign notes",
+			"failure_reason":   "legacy fallback comment",
 		}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "recalls[0].failure_reason must be one of") {
-		t.Fatalf("err = %v; want invalid failure reason", err)
+	if err != nil {
+		t.Fatalf("submit_recall_session_feedback Invoke: %v", err)
+	}
+	if len(recorder.feedback) != 1 || recorder.feedback[0].FeedbackComment != "legacy fallback comment" {
+		t.Fatalf("recorded feedback = %+v", recorder.feedback)
 	}
 }
 
@@ -162,8 +167,7 @@ func TestSubmitRecallSessionFeedbackRecordsFailureDetails(t *testing.T) {
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       true,
-			"failure_reason":   " STALE_OR_RETRACTED_RESULTS ",
-			"expected_context": " Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern. ",
+			"feedback_comment": " Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern. ",
 			"irrelevant_result_refs": []any{map[string]any{
 				"type": "fragment",
 				"id":   " fragment-1 ",
@@ -178,11 +182,11 @@ func TestSubmitRecallSessionFeedbackRecordsFailureDetails(t *testing.T) {
 		t.Fatalf("recorded feedback = %d; want 1", len(recorder.feedback))
 	}
 	got := recorder.feedback[0]
-	if got.RecallID != "rec-1" || got.FailureReason != "stale_or_retracted_results" {
+	if got.RecallID != "rec-1" {
 		t.Fatalf("recorded feedback = %+v", got)
 	}
-	if got.ExpectedContext != "Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern." {
-		t.Fatalf("expected_context = %q", got.ExpectedContext)
+	if got.FeedbackComment != "Returned stale UI redesign notes instead of the button disabled-state pattern. Existing SearchPanel button handling pattern." {
+		t.Fatalf("feedback_comment = %q", got.FeedbackComment)
 	}
 	if len(got.IrrelevantRefs) != 1 || got.IrrelevantRefs[0].ID != "fragment-1" || got.IrrelevantRefs[0].Rank != 1 {
 		t.Fatalf("irrelevant refs = %+v", got.IrrelevantRefs)
@@ -322,7 +326,7 @@ func TestRecallFeedbackRecorderErrorsSuppressRecallEventAndFailFeedbackSubmit(t 
 			"quality":          "low",
 			"missing_context":  true,
 			"irrelevant":       false,
-			"failure_reason":   "other",
+			"feedback_comment": "persistence failure should stop metrics recording",
 		}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "failed to record recalls[0]") {

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -297,21 +297,11 @@ func recallMemoryTool(deps Dependencies) Tool {
 }
 
 const (
-	recallFeedbackExplanationMaxLength = 1000
+	recallFeedbackCommentMaxLength     = 1000
 	recallFeedbackIrrelevantRefsMax    = 20
 	recallFeedbackJudgedRefIDMaxLength = 128
 	recallFeedbackJudgedRefMaxRank     = 50
 )
-
-var recallFeedbackFailureReasonValues = []string{
-	"missing_context",
-	"irrelevant_results",
-	"stale_or_retracted_results",
-	"unsupported_answer",
-	"wrong_scope",
-	"ambiguous_query",
-	"other",
-}
 
 type recallFeedbackJudgedResultRefInput struct {
 	Type string `json:"type"`
@@ -322,7 +312,7 @@ type recallFeedbackJudgedResultRefInput struct {
 func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        SubmitRecallSessionFeedbackToolName,
-		Description: "Submit recall feedback, session feedback, or a recall quality evaluation after finishing all context gathering and before the final answer. Use this when recall_memory returns recall_event.feedback_tool=submit_recall_session_feedback; pass recall_event.recall_id once you know which recalls informed the answer. Do not call immediately after exploratory context-building recall. For negative feedback, include failure_reason and optionally expected_context and irrelevant_result_refs. Do not include user content.",
+		Description: "Submit recall feedback, session feedback, or a recall quality evaluation after finishing all context gathering and before the final answer. Use this when recall_memory returns recall_event.feedback_tool=submit_recall_session_feedback; pass recall_event.recall_id once you know which recalls informed the answer. Do not call immediately after exploratory context-building recall. Include feedback_comment unless quality is high with no negative flags. Do not include user content.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"recalls"},
@@ -348,12 +338,14 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 							"quality":          schemaEnum([]string{"high", "medium", "low"}),
 							"missing_context":  map[string]any{"type": "boolean", "description": "Whether important memory context still appeared missing after investigation."},
 							"irrelevant":       map[string]any{"type": "boolean", "description": "Whether this recall's returned context was irrelevant."},
+							"feedback_comment": schemaString("Required unless quality is high, answer_supported is true, missing_context is false, and irrelevant is false. Explain the recall quality without including user content.", recallFeedbackCommentMaxLength),
 							"failure_reason": map[string]any{
 								"type":        "string",
-								"enum":        recallFeedbackFailureReasonValues,
-								"description": "Required when quality is low, answer_supported is false, missing_context is true, or irrelevant is true. Use expected_context for bounded prose details.",
+								"maxLength":   recallFeedbackCommentMaxLength,
+								"deprecated":  true,
+								"description": "Deprecated alias for feedback_comment. Use feedback_comment.",
 							},
-							"expected_context": schemaString("Optional detail about the memory context that would have made the recall useful. Do not include user content.", recallFeedbackExplanationMaxLength),
+							"expected_context": schemaString("Deprecated alias for feedback_comment. Use feedback_comment.", recallFeedbackCommentMaxLength),
 							"irrelevant_result_refs": map[string]any{
 								"type":        "array",
 								"description": "Optional references to returned results judged irrelevant.",
@@ -403,6 +395,7 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 					Quality         string                               `json:"quality"`
 					MissingContext  bool                                 `json:"missing_context"`
 					Irrelevant      bool                                 `json:"irrelevant"`
+					FeedbackComment string                               `json:"feedback_comment"`
 					FailureReason   string                               `json:"failure_reason"`
 					ExpectedContext string                               `json:"expected_context"`
 					IrrelevantRefs  []recallFeedbackJudgedResultRefInput `json:"irrelevant_result_refs"`
@@ -426,19 +419,12 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 				default:
 					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].quality must be one of high, medium, low", i)
 				}
-				failureReason := strings.TrimSpace(recall.FailureReason)
-				expectedContext := strings.TrimSpace(recall.ExpectedContext)
-				if recallFeedbackNeedsFailureReason(quality, recall.AnswerSupported, recall.MissingContext, recall.Irrelevant) && failureReason == "" {
-					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason is required for negative feedback", i)
+				feedbackComment := recallFeedbackComment(recall.FeedbackComment, recall.ExpectedContext, recall.FailureReason)
+				if recallFeedbackNeedsComment(quality, recall.AnswerSupported, recall.MissingContext, recall.Irrelevant) && feedbackComment == "" {
+					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].feedback_comment is required unless quality is high with no negative flags", i)
 				}
-				if failureReason != "" {
-					failureReason = strings.ToLower(failureReason)
-					if !recallFeedbackFailureReasonAllowed(failureReason) {
-						return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].failure_reason must be one of %s", i, strings.Join(recallFeedbackFailureReasonValues, ", "))
-					}
-				}
-				if runeLen(expectedContext) > recallFeedbackExplanationMaxLength {
-					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].expected_context must be at most %d characters", i, recallFeedbackExplanationMaxLength)
+				if runeLen(feedbackComment) > recallFeedbackCommentMaxLength {
+					return nil, fmt.Errorf("submit_recall_session_feedback: recalls[%d].feedback_comment must be at most %d characters", i, recallFeedbackCommentMaxLength)
 				}
 				irrelevantRefs, err := normalizeRecallFeedbackJudgedRefs(i, recall.IrrelevantRefs)
 				if err != nil {
@@ -451,8 +437,7 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 					Quality:         quality,
 					MissingContext:  recall.MissingContext,
 					Irrelevant:      recall.Irrelevant,
-					FailureReason:   failureReason,
-					ExpectedContext: expectedContext,
+					FeedbackComment: feedbackComment,
 					IrrelevantRefs:  irrelevantRefs,
 				})
 				feedbacks = append(feedbacks, observability.RecallFeedback{
@@ -478,17 +463,17 @@ func submitRecallSessionFeedbackTool(deps Dependencies) Tool {
 	}
 }
 
-func recallFeedbackNeedsFailureReason(quality string, answerSupported bool, missingContext bool, irrelevant bool) bool {
-	return quality == "low" || !answerSupported || missingContext || irrelevant
-}
-
-func recallFeedbackFailureReasonAllowed(reason string) bool {
-	for _, allowed := range recallFeedbackFailureReasonValues {
-		if reason == allowed {
-			return true
+func recallFeedbackComment(feedbackComment string, legacyExpectedContext string, legacyFailureReason string) string {
+	for _, candidate := range []string{feedbackComment, legacyExpectedContext, legacyFailureReason} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
 		}
 	}
-	return false
+	return ""
+}
+
+func recallFeedbackNeedsComment(quality string, answerSupported bool, missingContext bool, irrelevant bool) bool {
+	return quality != "high" || !answerSupported || missingContext || irrelevant
 }
 
 func normalizeRecallFeedbackJudgedRefs(recallIndex int, refs []recallFeedbackJudgedResultRefInput) ([]domain.RecallFeedbackJudgedResultRef, error) {

--- a/migrations/postgres/2026062502_recall_feedback_comment.sql
+++ b/migrations/postgres/2026062502_recall_feedback_comment.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+ALTER TABLE recall_feedback_events
+    ADD COLUMN feedback_comment TEXT NOT NULL DEFAULT '',
+    ADD CONSTRAINT recall_feedback_events_feedback_comment_length_check
+        CHECK (char_length(feedback_comment) <= 1000);
+
+UPDATE recall_feedback_events
+SET feedback_comment = CASE
+    WHEN expected_context <> '' THEN expected_context
+    ELSE failure_reason
+END
+WHERE feedback_comment = '';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+ALTER TABLE recall_feedback_events
+    DROP CONSTRAINT IF EXISTS recall_feedback_events_feedback_comment_length_check,
+    DROP COLUMN IF EXISTS feedback_comment;
+
+-- +goose StatementEnd

--- a/web/src/App.recall-feedback.test.tsx
+++ b/web/src/App.recall-feedback.test.tsx
@@ -82,8 +82,7 @@ const recallFeedbackEvents: RecallFeedbackEvent[] = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
-    failure_reason: "stale_or_retracted_results",
-    expected_context: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
+    feedback_comment: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
     irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
@@ -150,12 +149,11 @@ it("shows recall feedback query, params, result ids, and resolved state", async 
 
   await userEvent.click(screen.getByRole("button", { name: /view recall feedback rec_1234567890/i }));
   expect(await screen.findByText("fragment-1")).toBeInTheDocument();
-  const failureDetails = screen.getByRole("table", { name: /Recall feedback failure details/i });
-  expect(within(failureDetails).getByText("stale_or_retracted_results")).toBeInTheDocument();
-  expect(within(failureDetails).getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeInTheDocument();
-  expect(within(failureDetails).getByText("#1 fragment:fragment-1")).toBeInTheDocument();
+  const commentDetails = screen.getByRole("table", { name: /Recall feedback comment details/i });
+  expect(within(commentDetails).getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeInTheDocument();
+  expect(within(commentDetails).getByText("#1 fragment:fragment-1")).toBeInTheDocument();
   expect(screen.getByText("The old fragment has been retracted.")).toBeInTheDocument();
-  expect(screen.getByLabelText(/Raw recall feedback rec_1234567890/i)).toHaveTextContent('"failure_reason"');
+  expect(screen.getByLabelText(/Raw recall feedback rec_1234567890/i)).toHaveTextContent('"feedback_comment"');
 
   await userEvent.selectOptions(screen.getByLabelText("Quality"), "low");
   await waitFor(() => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -402,8 +402,7 @@ export type RecallFeedbackEvent = {
   quality?: "high" | "medium" | "low" | string;
   missing_context?: boolean | null;
   irrelevant?: boolean | null;
-  failure_reason?: string;
-  expected_context?: string;
+  feedback_comment?: string;
   irrelevant_result_refs?: RecallFeedbackJudgedResultRef[] | null;
   resolved_results?: RecallFeedbackResolvedResult[] | null;
 };

--- a/web/src/control/RecallFeedbackPanel.tsx
+++ b/web/src/control/RecallFeedbackPanel.tsx
@@ -310,25 +310,24 @@ function RecallFeedbackDetail({ event }: { event: RecallFeedbackEvent }) {
         <span className="log-detail-chip">profile={event.profile_id ? shortId(event.profile_id) : "unknown"}</span>
         <span className="log-detail-chip">key={event.key_id ? shortId(event.key_id) : "unknown"}</span>
       </div>
-      <FeedbackFailureDetails event={event} />
+      <FeedbackCommentDetails event={event} />
       <ResultRefTable refs={refs} resolved={resolved} />
       <pre aria-label={`Raw recall feedback ${event.recall_id}`}>{JSON.stringify(rawEvent(event), null, 2)}</pre>
     </div>
   );
 }
 
-function FeedbackFailureDetails({ event }: { event: RecallFeedbackEvent }) {
+function FeedbackCommentDetails({ event }: { event: RecallFeedbackEvent }) {
   const irrelevantRefs = event.irrelevant_result_refs ?? [];
   const rows = [
-    event.failure_reason ? ["Failure reason", event.failure_reason] : null,
-    event.expected_context ? ["Expected context", event.expected_context] : null,
+    event.feedback_comment ? ["Feedback comment", event.feedback_comment] : null,
     irrelevantRefs.length > 0 ? ["Irrelevant refs", irrelevantRefs.map(judgedRefLabel).join(", ")] : null,
   ].filter((row): row is string[] => row !== null);
   if (rows.length === 0) {
     return null;
   }
   return (
-    <table className="data-table" aria-label="Recall feedback failure details">
+    <table className="data-table" aria-label="Recall feedback comment details">
       <thead>
         <tr>
           <th>Signal</th>
@@ -449,8 +448,7 @@ function rawEvent(event: RecallFeedbackEvent): Record<string, unknown> {
       quality: event.quality,
       missing_context: event.missing_context,
       irrelevant: event.irrelevant,
-      failure_reason: event.failure_reason,
-      expected_context: event.expected_context,
+      feedback_comment: event.feedback_comment,
       irrelevant_result_refs: event.irrelevant_result_refs ?? [],
     },
     result_refs: event.result_refs ?? [],

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -229,8 +229,7 @@ const recallFeedbackEvents = [
     quality: "low",
     missing_context: true,
     irrelevant: false,
-    failure_reason: "stale_or_retracted_results",
-    expected_context: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
+    feedback_comment: "Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.",
     irrelevant_result_refs: [{ type: "fragment", id: "fragment-1", rank: 1 }],
     resolved_results: [
       {
@@ -458,12 +457,11 @@ test("recall feedback tab renders query, params, result ids, and resolved state"
   await page.getByRole("button", { name: /View recall feedback rec_1234567890/ }).click();
   const resultRefs = page.getByRole("table", { name: "Recall feedback result refs" });
   await expect(resultRefs.getByRole("row", { name: /fragment-1/ })).toBeVisible();
-  const failureDetails = page.getByRole("table", { name: "Recall feedback failure details" });
-  await expect(failureDetails.getByText("stale_or_retracted_results")).toBeVisible();
-  await expect(failureDetails.getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeVisible();
-  await expect(failureDetails.getByText("#1 fragment:fragment-1")).toBeVisible();
+  const commentDetails = page.getByRole("table", { name: "Recall feedback comment details" });
+  await expect(commentDetails.getByText("Returned stale UI notes instead of the requested button pattern. SearchPanel disabled-state and listbox accessibility pattern.")).toBeVisible();
+  await expect(commentDetails.getByText("#1 fragment:fragment-1")).toBeVisible();
   await expect(resultRefs.getByText("The old fragment has been retracted.")).toBeVisible();
-  await expect(page.getByLabel(/Raw recall feedback rec_1234567890/)).toContainText('"failure_reason"');
+  await expect(page.getByLabel(/Raw recall feedback rec_1234567890/)).toContainText('"feedback_comment"');
   await expectNoShellOverlap(page);
 
   await page.getByLabel("Quality").selectOption("low");


### PR DESCRIPTION
## Summary
- Replace the recall feedback explanation contract with `feedback_comment`.
- Require comments for `medium`, `low`, or flagged feedback while allowing clean `high` feedback to omit one.
- Keep `failure_reason` and `expected_context` as deprecated input aliases during compatibility.
- Add a Postgres migration to persist and backfill `feedback_comment`, and update control portal labels/tests/docs.

## Why
`failure_reason` was too narrow for medium-but-useful recall results. Those results need an explanatory comment without implying the recall fully failed.

## Validation
- `go test ./...`
- `cd web && npm run typecheck && npm test`
- `git diff --check`
- Pre-push hook completed, including lint/test coverage at 90.0%.
