### PR TITLE
[codex] Avoid constraint-owned Neo4j index drops

### DIFF
--- a/internal/storage/neo4j/schema.go
+++ b/internal/storage/neo4j/schema.go
@@ -112,6 +112,45 @@ func isConstraintOwnedIndexDropError(err error) bool {
 		strings.Contains(msg, "constraint-backed index")
 }
 
+type legacyUniqueConstraintIndex struct {
+	name string
+	drop string
+}
+
+type legacyIndexStatus struct {
+	exists            bool
+	ownedByConstraint bool
+}
+
+func (s *SchemaBootstrapper) legacyUniqueConstraintIndexStatus(ctx context.Context, name string) (legacyIndexStatus, error) {
+	result, err := s.client.ExecuteRead(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+		res, err := tx.Run(ctx,
+			"SHOW INDEXES YIELD name, owningConstraint WHERE name = $name RETURN owningConstraint",
+			map[string]any{"name": name},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return res.Collect(ctx)
+	})
+	if err != nil {
+		return legacyIndexStatus{}, err
+	}
+
+	records, ok := result.([]*neo4j.Record)
+	if !ok || len(records) == 0 {
+		return legacyIndexStatus{}, nil
+	}
+	for _, record := range records {
+		if raw, ok := record.Get("owningConstraint"); ok {
+			if constraintName, ok := raw.(string); ok && strings.TrimSpace(constraintName) != "" {
+				return legacyIndexStatus{exists: true, ownedByConstraint: true}, nil
+			}
+		}
+	}
+	return legacyIndexStatus{exists: true}, nil
+}
+
 // EnsureSchema creates all required constraints and indexes if they don't exist.
 // All CREATE statements use IF NOT EXISTS for idempotency.
 func (s *SchemaBootstrapper) EnsureSchema(ctx context.Context) error {
@@ -134,26 +173,42 @@ func (s *SchemaBootstrapper) EnsureSchema(ctx context.Context) error {
 	// Older deployments may have created plain indexes with names that are now
 	// used by unique constraints. Neo4j does not treat that as "exists" for
 	// CREATE CONSTRAINT IF NOT EXISTS, so remove only those blocking indexes.
-	uniqueConstraintIndexDrops := []string{
-		"DROP INDEX sourcefragment_fragment_id_unique IF EXISTS",
-		"DROP INDEX claim_claim_id_unique IF EXISTS",
-		"DROP INDEX fact_fact_id_unique IF EXISTS",
-		"DROP INDEX dream_dream_id_unique IF EXISTS",
+	uniqueConstraintIndexes := []legacyUniqueConstraintIndex{
+		{name: "sourcefragment_fragment_id_unique", drop: "DROP INDEX sourcefragment_fragment_id_unique IF EXISTS"},
+		{name: "claim_claim_id_unique", drop: "DROP INDEX claim_claim_id_unique IF EXISTS"},
+		{name: "fact_fact_id_unique", drop: "DROP INDEX fact_fact_id_unique IF EXISTS"},
+		{name: "dream_dream_id_unique", drop: "DROP INDEX dream_dream_id_unique IF EXISTS"},
 	}
 
-	for _, cypher := range uniqueConstraintIndexDrops {
-		_, err := s.client.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
-			_, err := tx.Run(ctx, cypher, nil)
+	for _, idx := range uniqueConstraintIndexes {
+		status, err := s.legacyUniqueConstraintIndexStatus(ctx, idx.name)
+		if err == nil {
+			if !status.exists {
+				continue
+			}
+			if status.ownedByConstraint {
+				s.logger.Debug("constraint-owned index already present", observability.String("name", idx.name))
+				continue
+			}
+		} else {
+			s.logger.Debug("could not inspect legacy unique-constraint index; falling back to drop attempt",
+				observability.String("name", idx.name),
+				observability.String("error", err.Error()),
+			)
+		}
+
+		_, err = s.client.ExecuteWrite(ctx, func(tx neo4j.ManagedTransaction) (interface{}, error) {
+			_, err := tx.Run(ctx, idx.drop, nil)
 			return nil, err
 		})
 		if err != nil {
 			if isConstraintOwnedIndexDropError(err) {
-				s.logger.Debug("constraint-owned index already present", observability.String("query", cypher))
+				s.logger.Debug("constraint-owned index already present", observability.String("name", idx.name))
 				continue
 			}
 			return fmt.Errorf("failed to drop legacy unique-constraint index: %w", err)
 		}
-		s.logger.Debug("Dropped legacy unique-constraint index", observability.String("query", cypher))
+		s.logger.Debug("Dropped legacy unique-constraint index", observability.String("name", idx.name))
 	}
 
 	// Create unique constraints

--- a/internal/storage/neo4j/schema_test.go
+++ b/internal/storage/neo4j/schema_test.go
@@ -238,6 +238,15 @@ func TestEnsureSchema_DropsPlainIndexBeforeSameNamedUniqueConstraint(t *testing.
 	ctx := context.Background()
 	dreamIndexDropped := false
 	client := &recordingClient{
+		resultRecordsFor: func(cypher string) []*neo4j.Record {
+			if strings.Contains(cypher, "SHOW INDEXES") {
+				return []*neo4j.Record{{
+					Keys:   []string{"owningConstraint"},
+					Values: []any{nil},
+				}}
+			}
+			return nil
+		},
 		runErrFor: func(cypher string) error {
 			if strings.Contains(cypher, "DROP INDEX dream_dream_id_unique") {
 				dreamIndexDropped = true
@@ -263,7 +272,31 @@ func TestEnsureSchema_DropsPlainIndexBeforeSameNamedUniqueConstraint(t *testing.
 func TestEnsureSchema_IgnoresConstraintOwnedUniqueIndexDrop(t *testing.T) {
 	ctx := context.Background()
 	client := &recordingClient{
+		resultRecordsFor: func(cypher string) []*neo4j.Record {
+			if strings.Contains(cypher, "SHOW INDEXES") {
+				return []*neo4j.Record{{
+					Keys:   []string{"owningConstraint"},
+					Values: []any{"dream_dream_id_unique"},
+				}}
+			}
+			return nil
+		},
+	}
+	bs := NewSchemaBootstrapper(client, 1536, unitLogger())
+
+	err := bs.EnsureSchema(ctx)
+	require.NoError(t, err)
+	assert.False(t, hasQuery(client.queries, "DROP INDEX dream_dream_id_unique"),
+		"EnsureSchema must not attempt to drop constraint-owned index names")
+}
+
+func TestEnsureSchema_FallsBackWhenLegacyUniqueIndexInspectionFails(t *testing.T) {
+	ctx := context.Background()
+	client := &recordingClient{
 		runErrFor: func(cypher string) error {
+			if strings.Contains(cypher, "SHOW INDEXES") {
+				return fmt.Errorf("Neo4jError: unsupported SHOW INDEXES column")
+			}
 			if strings.Contains(cypher, "DROP INDEX dream_dream_id_unique") {
 				return fmt.Errorf("Neo4jError: Neo.ClientError.Schema.IndexBelongsToConstraint (Index belongs to constraint 'dream_dream_id_unique'.)")
 			}
@@ -274,6 +307,8 @@ func TestEnsureSchema_IgnoresConstraintOwnedUniqueIndexDrop(t *testing.T) {
 
 	err := bs.EnsureSchema(ctx)
 	require.NoError(t, err)
+	assert.True(t, hasQuery(client.queries, "DROP INDEX dream_dream_id_unique"),
+		"EnsureSchema must keep legacy drop fallback when index metadata inspection is unavailable")
 }
 
 // TestEnsureSchema_ClaimCompositeIndexes verifies that EnsureSchema issues


### PR DESCRIPTION
## Summary
- Inspect legacy unique-index names with `SHOW INDEXES` before attempting `DROP INDEX`.
- Skip drops for indexes owned by existing uniqueness constraints, avoiding Neo4j server-side ERROR logs during schema bootstrap.
- Preserve the old drop fallback when index metadata inspection is unavailable.
- Add schema bootstrap tests for standalone legacy indexes, constraint-owned indexes, and fallback behavior.

## Root Cause
`EnsureSchema` attempted `DROP INDEX ... IF EXISTS` for names that can now be backing indexes for uniqueness constraints. Neo4j rejects those drops and logs `Neo.DatabaseError.Schema.IndexDropFailed` even when the client treats the error as benign.

## Validation
- `go test ./internal/storage/neo4j -run '^TestEnsureSchema_(DropsPlainIndexBeforeSameNamedUniqueConstraint|IgnoresConstraintOwnedUniqueIndexDrop|FallsBackWhenLegacyUniqueIndexInspectionFails)$' -count=1 -v`
- `go test ./internal/storage/neo4j -run '^TestEnsureSchema_(DropsPlainIndexBeforeSameNamedUniqueConstraint|IgnoresConstraintOwnedUniqueIndexDrop|FallsBackWhenLegacyUniqueIndexInspectionFails|ClaimCompositeIndexes|FactCompositeIndexes|SourceFragmentStatusIndex|CrossProfileIsolation|LegacyDropIncludesFactPredicateIdx|BackfillsLegacyProfileIDBeforeTeamConstraints|RelationshipConstraintsUnsupportedDoesNotFail|CommunityEditionSkipsRelationshipConstraints|RelationshipConstraintUnexpectedFailureReturnsError)$' -count=1`
- `git diff --check`
- Pre-push hook: full tests and coverage passed; total coverage 90.0% met required 90.0%.