### PR TITLE
[codex] Accept legacy remember content

### DIFF
--- a/internal/http/handler/tool_execute_handler.go
+++ b/internal/http/handler/tool_execute_handler.go
@@ -91,6 +91,7 @@ func (h *ToolExecuteHandler) Handle(c echo.Context) error {
 		return httperr.New(httperr.VALIDATION_ERROR, "evaluation tools do not accept team_id or profile_id")
 	}
 	registry.StripTenantOverrideArgs(args)
+	args = registry.NormalizeInput(tool, args)
 	if err := registry.ValidateInput(tool, args); err != nil {
 		return httperr.New(httperr.VALIDATION_ERROR, err.Error())
 	}

--- a/internal/http/handler/tool_execute_handler_test.go
+++ b/internal/http/handler/tool_execute_handler_test.go
@@ -176,6 +176,60 @@ func TestToolExecuteHandler_StripsTenantFieldsBeforeStrictValidation(t *testing.
 	require.Equal(t, map[string]any{"id": "frag-1"}, gotInput)
 }
 
+func TestToolExecuteHandler_NormalizesInputBeforeStrictValidation(t *testing.T) {
+	reg := registry.New()
+	var gotInput map[string]any
+	err := reg.Register(registry.Tool{
+		Name: "remember",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"required":             []string{"evidence"},
+			"properties":           map[string]any{"evidence": map[string]any{"type": "array"}},
+			"additionalProperties": false,
+		},
+		RequiredScopes: []string{"write"},
+		NormalizeInput: func(input map[string]any) map[string]any {
+			return map[string]any{
+				"evidence": []any{map[string]any{"content": input["content"]}},
+			}
+		},
+		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
+			gotInput = input
+			return map[string]any{"ok": true}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	h := NewToolExecuteHandler(reg)
+	e := newTestEcho()
+	profileID := uuid.New()
+
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := middleware.SetResolvedProfileIDForTest(c.Request().Context(), profileID)
+			ctx = middleware.SetPrincipalForTest(ctx, &middleware.Principal{
+				KeyID:  uuid.New(),
+				Role:   "user",
+				Scopes: []string{"write"},
+			})
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+
+	e.POST("/api/v1/tools/:name", h.Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/remember", strings.NewReader(`{"content":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Profile-ID", profileID.String())
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []any{map[string]any{"content": "hello"}}, gotInput["evidence"])
+}
+
 func TestToolExecuteHandler_RejectsTenantFieldsForEvaluationTools(t *testing.T) {
 	reg := registry.New()
 	called := false

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -341,6 +341,7 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 	// team. The HTTP API derives scope from the bearer key; local registries
 	// may still receive a construction-time team for tests.
 	registry.StripTenantOverrideArgs(args)
+	args = registry.NormalizeInput(tool, args)
 	if err := registry.ValidateInput(tool, args); err != nil {
 		return nil, &rpcError{Code: errCodeInvalidParams, Message: err.Error()}
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -590,12 +590,42 @@ func TestMCP_MemoryToolsScopeProfileAndClarifications(t *testing.T) {
 	}
 }
 
+func TestMCP_RememberAcceptsLegacyContentCallAsEvidence(t *testing.T) {
+	logger, _ := testLogger(t)
+	mem := &mcpMemoryStub{}
+	reg, err := registry.BuildDefault(registry.Dependencies{Memory: mem})
+	if err != nil {
+		t.Fatalf("BuildDefault: %v", err)
+	}
+	server := NewServerWithScopes(reg, "profileA", []string{"read", "write"}, logger)
+
+	out := runRPC(t, server, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remember","arguments":{"content":"legacy client content","labels":["decision","security"],"source":"chat: compatibility","idempotency_key":"legacy-content-call","auto_promote":true,"claims":[{"subject":"client","predicate":"uses","object":"old remember shape","extract_conf":0.99,"resolution_conf":0.99}]}}}`)
+	if strings.Contains(out, `"error"`) {
+		t.Fatalf("legacy remember call failed: %s", out)
+	}
+	if len(mem.lastRemember.Evidence) != 1 {
+		t.Fatalf("remember evidence count = %d; want 1", len(mem.lastRemember.Evidence))
+	}
+	evidence := mem.lastRemember.Evidence[0]
+	if evidence.Content != "legacy client content" {
+		t.Fatalf("remember evidence content = %q", evidence.Content)
+	}
+	if evidence.Source != "chat: compatibility" || evidence.IdempotencyKey != "legacy-content-call" {
+		t.Fatalf("remember evidence provenance = %#v", evidence)
+	}
+	if len(evidence.Labels) != 2 || evidence.Labels[0] != "decision" || evidence.Labels[1] != "security" {
+		t.Fatalf("remember evidence labels = %#v", evidence.Labels)
+	}
+}
+
 type mcpMemoryStub struct {
-	lastProfile string
+	lastProfile  string
+	lastRemember memoryservice.RememberRequest
 }
 
 func (s *mcpMemoryStub) Remember(ctx context.Context, profileID string, req memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
 	s.lastProfile = profileID
+	s.lastRemember = req
 	return &memoryservice.RememberResult{
 		IngestID: "ingest-1",
 		Status:   "queued",

--- a/internal/tools/registry/memory_tools.go
+++ b/internal/tools/registry/memory_tools.go
@@ -23,10 +23,12 @@ func rememberTool(deps Dependencies) Tool {
 		},
 		OutputSchema:   rememberPlacementResultSchema(),
 		RequiredScopes: []string{"write"},
+		NormalizeInput: normalizeRememberInput,
 		Invoke: func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error) {
 			if deps.Memory == nil {
 				return nil, ErrToolUnavailable
 			}
+			input = normalizeRememberInput(input)
 			var req memoryservice.RememberRequest
 			if err := remapInput(input, &req); err != nil {
 				return nil, fmt.Errorf("remember: invalid input: %w", err)
@@ -38,6 +40,37 @@ func rememberTool(deps Dependencies) Tool {
 			return structToMap(res)
 		},
 	}
+}
+
+func normalizeRememberInput(input map[string]any) map[string]any {
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	delete(out, "claims")
+	delete(out, "auto_promote")
+	if _, ok := out["evidence"]; ok {
+		delete(out, "content")
+		delete(out, "source")
+		delete(out, "idempotency_key")
+		delete(out, "labels")
+		delete(out, "metadata")
+		return out
+	}
+	content, ok := out["content"]
+	if !ok {
+		return out
+	}
+	evidence := map[string]any{"content": content}
+	for _, key := range []string{"source", "idempotency_key", "labels", "metadata"} {
+		if value, ok := out[key]; ok {
+			evidence[key] = value
+			delete(out, key)
+		}
+	}
+	delete(out, "content")
+	out["evidence"] = []any{evidence}
+	return out
 }
 
 func getMemoryPlacementTool(deps Dependencies) Tool {

--- a/internal/tools/registry/registry.go
+++ b/internal/tools/registry/registry.go
@@ -23,6 +23,10 @@ var toolNamePattern = regexp.MustCompile(toolNamePatternText)
 // has to parse headers or context keys — the registry stays transport-agnostic.
 type ToolInvoker func(ctx context.Context, profileID string, input map[string]any) (map[string]any, error)
 
+// ToolInputNormalizer rewrites backward-compatible call shapes into the
+// canonical input shape before schema validation and invocation.
+type ToolInputNormalizer func(input map[string]any) map[string]any
+
 // Tool is the metadata + executor bundle for a single registered tool.
 type Tool struct {
 	Name           string
@@ -31,6 +35,7 @@ type Tool struct {
 	OutputSchema   map[string]any
 	RequiredScopes []string
 	Invoke         ToolInvoker
+	NormalizeInput ToolInputNormalizer
 	Aliases        []string
 }
 
@@ -132,4 +137,17 @@ func (r *inMemoryRegistry) List() []Tool {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+// NormalizeInput applies a tool-specific backward-compatibility rewrite, when
+// one is registered. The returned map is the input that should be validated and
+// passed to Invoke.
+func NormalizeInput(tool Tool, args map[string]any) map[string]any {
+	if args == nil {
+		args = map[string]any{}
+	}
+	if tool.NormalizeInput == nil {
+		return args
+	}
+	return tool.NormalizeInput(args)
 }

--- a/internal/tools/registry/toolset_knowledge_test.go
+++ b/internal/tools/registry/toolset_knowledge_test.go
@@ -96,6 +96,60 @@ func TestBuildDefaultMemoryTools_InvokeAndScope(t *testing.T) {
 	}
 }
 
+func TestRememberNormalizesLegacyContentWithoutPromotionHints(t *testing.T) {
+	mem := &stubMemory{}
+	reg, _ := BuildDefault(Dependencies{Memory: mem})
+	tool, ok := reg.Get("remember")
+	if !ok {
+		t.Fatal("remember not registered")
+	}
+	legacy := map[string]any{
+		"content":         "legacy content should be stored as evidence",
+		"source":          "chat: compatibility",
+		"idempotency_key": "legacy-remember-content",
+		"labels":          []any{"decision", "security"},
+		"metadata":        map[string]any{"origin": "legacy-client"},
+		"auto_promote":    true,
+		"claims": []any{map[string]any{
+			"subject":         "client",
+			"predicate":       "uses",
+			"object":          "old remember shape",
+			"extract_conf":    0.99,
+			"resolution_conf": 0.99,
+		}},
+	}
+
+	normalized := NormalizeInput(tool, legacy)
+	if _, ok := normalized["claims"]; ok {
+		t.Fatal("legacy claims must not survive remember normalization")
+	}
+	if _, ok := normalized["auto_promote"]; ok {
+		t.Fatal("legacy auto_promote must not survive remember normalization")
+	}
+	if err := ValidateInput(tool, normalized); err != nil {
+		t.Fatalf("ValidateInput normalized legacy remember: %v", err)
+	}
+	if _, err := tool.Invoke(context.Background(), "profile-memory", legacy); err != nil {
+		t.Fatalf("legacy remember Invoke: %v", err)
+	}
+	if len(mem.lastRemember.Evidence) != 1 {
+		t.Fatalf("remember evidence count = %d; want 1", len(mem.lastRemember.Evidence))
+	}
+	evidence := mem.lastRemember.Evidence[0]
+	if evidence.Content != "legacy content should be stored as evidence" {
+		t.Fatalf("remember evidence content = %q", evidence.Content)
+	}
+	if evidence.Source != "chat: compatibility" || evidence.IdempotencyKey != "legacy-remember-content" {
+		t.Fatalf("remember evidence provenance = %#v", evidence)
+	}
+	if len(evidence.Labels) != 2 || evidence.Labels[0] != "decision" || evidence.Labels[1] != "security" {
+		t.Fatalf("remember evidence labels = %#v", evidence.Labels)
+	}
+	if evidence.Metadata["origin"] != "legacy-client" {
+		t.Fatalf("remember evidence metadata = %#v", evidence.Metadata)
+	}
+}
+
 func TestBuildDefaultMemoryTools_InvalidInputBranches(t *testing.T) {
 	reg, _ := BuildDefault(Dependencies{Memory: &stubMemory{}})
 

--- a/internal/tools/registry/toolset_test.go
+++ b/internal/tools/registry/toolset_test.go
@@ -473,11 +473,13 @@ func (s *stubListCapture) List(ctx context.Context, profileID string, opts fragm
 }
 
 type stubMemory struct {
-	lastProfile string
+	lastProfile  string
+	lastRemember memoryservice.RememberRequest
 }
 
 func (s *stubMemory) Remember(ctx context.Context, profileID string, req memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
 	s.lastProfile = profileID
+	s.lastRemember = req
 	return &memoryservice.RememberResult{
 		IngestID: "ingest-1",
 		Status:   "queued",


### PR DESCRIPTION
## Summary

- add a registry-level input normalizer that runs before HTTP and MCP tool validation
- allow stale `remember` calls with top-level `content` to be converted into one evidence item
- drop legacy `claims` and `auto_promote` hints before validation/invocation so placement remains server/verifier-owned
- add HTTP, MCP, and registry regressions for the legacy payload shape

## Root Cause

PR #57 narrowed `remember` to canonical `evidence` input, but stale clients were still sending top-level `content`. Those calls decoded into an empty `RememberRequest.Evidence` slice and failed with `evidence is required`.

## Validation

- `go test ./internal/tools/registry ./internal/mcp ./internal/http/handler`
- `go test ./...`
- pre-push hook: textlint, Go tests, coverage check at 90.0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool calls now accept both legacy and normalized input shapes, with automatic conversion before validation.
  * Remember actions can now map older `content`-based requests into the expected evidence format.

* **Bug Fixes**
  * Improved handling of tool execution requests so valid legacy payloads no longer fail strict validation.
  * MCP tool calls now process normalized arguments consistently, reducing request errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->