### PR TITLE
[codex] show current version in web portals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ FROM node:22-alpine AS web-builder
 
 WORKDIR /web
 
+ARG IMAGE_VERSION=dev
+
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 
 COPY web/ ./
-RUN npm run build
+RUN DENSE_MEM_VERSION="${IMAGE_VERSION}" npm run build
 
 # ============================================================================
 # Build stage

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -5,11 +5,13 @@ FROM node:22-alpine AS web-builder
 
 WORKDIR /web
 
+ARG IMAGE_VERSION=demo
+
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 
 COPY web/ ./
-RUN npm run build
+RUN DENSE_MEM_VERSION="${IMAGE_VERSION}" npm run build
 
 # ============================================================================
 # Build stage

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 import { CommunityDetectionConfig, ControlMetrics, Dream, DreamRun, DreamStatus, DreamingConfig, GeneralConfig, OperationLog, OperationLogConfig, SecurityBan, SecuritySettings, SSOConfig, Team, TeamProfile } from "./api";
+import { APP_VERSION } from "./version";
 
 const profileA: Team = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -281,6 +282,16 @@ beforeEach(() => {
 });
 
 describe("App", () => {
+  it("shows the current version in the control shell", async () => {
+    mockPortalFetch({ teams: [profileA], keys: [] });
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    await screen.findByRole("button", { name: /Default/ });
+
+    expect(screen.getByLabelText(`Current version ${APP_VERSION}`)).toBeInTheDocument();
+  });
+
   it("validates the token before opening the portal", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({ message: "invalid token" }, 401));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import type { TeamWorkspaceTab } from "./control/TeamWorkspace";
 import { TeamDreamingConfigForm } from "./teamDreamingConfig";
 import { displayKeySuffix, formatDate, profilePermissionLabel, profileRoleLabel, readError, shortId } from "./control/utils";
 import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading } from "./ui/components";
+import { APP_VERSION } from "./version";
 
 const MetricsPanel = lazy(() => import("./control/MetricsPanel").then((module) => ({ default: module.MetricsPanel })));
 const SecurityPanel = lazy(() => import("./control/SecurityPanel").then((module) => ({ default: module.SecurityPanel })));
@@ -92,6 +93,7 @@ export function App() {
         theme={theme}
         title="Dense-Mem Control"
         icon={<span className="brand-initials" aria-hidden="true">DM</span>}
+        version={APP_VERSION}
         onSubmit={submitToken}
         actions={(
           <button
@@ -180,6 +182,7 @@ function Portal({
       theme={theme}
       title="Dense-Mem Control"
       icon={<span className="brand-initials" aria-hidden="true">DM</span>}
+      version={APP_VERSION}
       topbarActions={(
         <>
           <button

--- a/web/src/admin-dashboard-components.css
+++ b/web/src/admin-dashboard-components.css
@@ -535,7 +535,7 @@
   }
 
   .config-tabs .tab-button {
-    flex: 1 1 calc(33.333% - 5px);
+    flex: 1 1 calc(25% - 5px);
     min-width: 0;
   }
 

--- a/web/src/admin-system.css
+++ b/web/src/admin-system.css
@@ -201,6 +201,10 @@ body {
   letter-spacing: 0;
 }
 
+.rail-brand .version-badge {
+  color: var(--rail-muted);
+}
+
 .brand-mark {
   width: 38px;
   height: 38px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -132,12 +132,32 @@ button {
   min-width: 0;
 }
 
+.brand-copy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
 .brand-row h1 {
   margin: 0;
   color: var(--text);
   font-size: 16px;
   line-height: 1.15;
   font-weight: 780;
+}
+
+.version-badge {
+  min-width: 0;
+  max-width: 100%;
+  justify-self: start;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 780;
+  line-height: 1.25;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .brand-mark {

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -85,7 +85,7 @@ export function Brand({ title, icon, version }: BrandProps) {
       <div className="brand-copy">
         <h1>{title}</h1>
         {version && (
-          <span className="version-badge" aria-label={`Current version ${version}`}>
+          <span className="version-badge" aria-label={`Current version ${version}`} title={version}>
             {version}
           </span>
         )}
@@ -103,7 +103,7 @@ export function AuthShell({ theme, title, icon, version, actions, children, onSu
           <div className="brand-copy">
             <h1>{title}</h1>
             {version && (
-              <span className="version-badge" aria-label={`Current version ${version}`}>
+              <span className="version-badge" aria-label={`Current version ${version}`} title={version}>
                 {version}
               </span>
             )}

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -6,6 +6,7 @@ export type ThemeName = "light" | "dark";
 type BrandProps = {
   title: string;
   icon: ReactNode;
+  version?: string;
 };
 
 export type PortalNavItem = {
@@ -77,22 +78,36 @@ type LoadingStateProps = {
   compact?: boolean;
 };
 
-export function Brand({ title, icon }: BrandProps) {
+export function Brand({ title, icon, version }: BrandProps) {
   return (
     <div className="brand-row">
       <span className="brand-mark">{icon}</span>
-      <h1>{title}</h1>
+      <div className="brand-copy">
+        <h1>{title}</h1>
+        {version && (
+          <span className="version-badge" aria-label={`Current version ${version}`}>
+            {version}
+          </span>
+        )}
+      </div>
     </div>
   );
 }
 
-export function AuthShell({ theme, title, icon, actions, children, onSubmit }: AuthShellProps) {
+export function AuthShell({ theme, title, icon, version, actions, children, onSubmit }: AuthShellProps) {
   return (
     <main className="auth-shell" data-theme={theme}>
       <form className="auth-panel" onSubmit={onSubmit}>
         <div className="brand-row">
           <span className="brand-mark">{icon}</span>
-          <h1>{title}</h1>
+          <div className="brand-copy">
+            <h1>{title}</h1>
+            {version && (
+              <span className="version-badge" aria-label={`Current version ${version}`}>
+                {version}
+              </span>
+            )}
+          </div>
           {actions}
         </div>
         {children}
@@ -105,6 +120,7 @@ export function PortalShell({
   theme,
   title,
   icon,
+  version,
   topbarActions,
   navLabel,
   navItemsLabel,
@@ -128,7 +144,7 @@ export function PortalShell({
     resourceRail ? "has-resource-rail" : "",
     topNav ? "has-top-nav" : "",
   ].filter(Boolean).join(" ");
-  const brand = <Brand title={title} icon={icon} />;
+  const brand = <Brand title={title} icon={icon} version={version} />;
 
   return (
     <main className="app-shell" data-theme={theme}>

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserPortalApp } from "./App";
 import { Community, RecallHit, UserKey, UserSession } from "./api";
+import { APP_VERSION } from "../version";
 
 const baseSession: UserSession = {
   team: {
@@ -122,6 +123,16 @@ beforeEach(() => {
 });
 
 describe("UserPortalApp", () => {
+  it("shows the current version in the user shell", async () => {
+    mockUserFetch(baseSession);
+    sessionStorage.setItem("denseMem.userApiKey", "dm_read");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+
+    expect(screen.getByLabelText(`Current version ${APP_VERSION}`)).toBeInTheDocument();
+  });
+
   it("logs in with an API key and does not call team profile list APIs", async () => {
     const fetchMock = mockUserFetch(baseSession);
     render(<UserPortalApp />);

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -26,6 +26,7 @@ import {
   UserSession,
 } from "./api";
 import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading } from "../ui/components";
+import { APP_VERSION } from "../version";
 import { SearchPanel } from "./SearchPanel";
 
 const TelemetryDashboard = lazy(() => import("../telemetry/TelemetryDashboard").then((module) => ({ default: module.TelemetryDashboard })));
@@ -153,6 +154,7 @@ export function UserPortalApp() {
         theme={theme}
         title="Dense-Mem Knowledge"
         icon={<span className="brand-initials" aria-hidden="true">DM</span>}
+        version={APP_VERSION}
         onSubmit={submitToken}
         actions={(
           <button
@@ -322,6 +324,7 @@ function UserPortal({
       theme={theme}
       title="Knowledge"
       icon={<span className="brand-initials" aria-hidden="true">DM</span>}
+      version={APP_VERSION}
       topbarActions={(
         <>
           <button

--- a/web/src/version.ts
+++ b/web/src/version.ts
@@ -1,0 +1,11 @@
+declare const __DENSE_MEM_VERSION__: string;
+
+function formatVersion(version: string) {
+  const trimmed = version.trim();
+  if (!trimmed) {
+    return "dev";
+  }
+  return /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(trimmed) ? `v${trimmed}` : trimmed;
+}
+
+export const APP_VERSION = formatVersion(__DENSE_MEM_VERSION__);

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -302,8 +302,8 @@ test("responsive user portal layout", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Recall" })).toBeVisible();
   const shellMinHeight = await page.locator(".app-shell").evaluate((element) => Number.parseFloat(getComputedStyle(element).minHeight));
   expect(shellMinHeight).toBeGreaterThanOrEqual((page.viewportSize()?.height ?? 0) - 1);
-  await expect(page.locator(".primary-rail")).toBeVisible();
-  await expect(page.locator(".top-nav-bar")).toHaveCount(0);
+  await expect(page.locator(".top-nav-bar")).toBeVisible();
+  await expect(page.locator(".primary-rail")).toHaveCount(0);
   await expect(page.locator(".resource-rail")).toHaveCount(0);
   await expect(page.locator(".knowledge-results-panel")).toHaveCSS("border-radius", "0px");
   await expectNoShellOverlap(page);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+
+function denseMemVersion() {
+  const configuredVersion = process.env.DENSE_MEM_VERSION ?? process.env.VITE_DENSE_MEM_VERSION ?? process.env.IMAGE_VERSION;
+  if (configuredVersion?.trim()) {
+    return configuredVersion.trim();
+  }
+
+  try {
+    const version = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
+      cwd: resolve(__dirname, ".."),
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return version || "dev";
+  } catch {
+    return "dev";
+  }
+}
 
 function manualVendorChunks(id: string) {
   if (!id.includes("node_modules")) {
@@ -19,6 +38,9 @@ function manualVendorChunks(id: string) {
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __DENSE_MEM_VERSION__: JSON.stringify(denseMemVersion()),
+  },
   build: {
     rollupOptions: {
       output: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,24 +1,6 @@
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-
-function denseMemVersion() {
-  const configuredVersion = process.env.DENSE_MEM_VERSION ?? process.env.VITE_DENSE_MEM_VERSION ?? process.env.IMAGE_VERSION;
-  if (configuredVersion?.trim()) {
-    return configuredVersion.trim();
-  }
-
-  try {
-    const version = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
-      cwd: resolve(__dirname, ".."),
-      stdio: ["ignore", "pipe", "ignore"],
-    }).toString().trim();
-    return version || "dev";
-  } catch {
-    return "dev";
-  }
-}
+import { denseMemVersion } from "./vite.version";
 
 function manualVendorChunks(id: string) {
   if (!id.includes("node_modules")) {

--- a/web/vite.user.config.ts
+++ b/web/vite.user.config.ts
@@ -1,8 +1,26 @@
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import type { Plugin } from "vite";
+
+function denseMemVersion() {
+  const configuredVersion = process.env.DENSE_MEM_VERSION ?? process.env.VITE_DENSE_MEM_VERSION ?? process.env.IMAGE_VERSION;
+  if (configuredVersion?.trim()) {
+    return configuredVersion.trim();
+  }
+
+  try {
+    const version = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
+      cwd: resolve(__dirname, ".."),
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return version || "dev";
+  } catch {
+    return "dev";
+  }
+}
 
 function serveUserPortalAtUi(): Plugin {
   return {
@@ -48,6 +66,9 @@ function manualVendorChunks(id: string) {
 export default defineConfig({
   base: "/ui/",
   plugins: [serveUserPortalAtUi(), react()],
+  define: {
+    __DENSE_MEM_VERSION__: JSON.stringify(denseMemVersion()),
+  },
   build: {
     outDir: "user-dist",
     emptyOutDir: true,

--- a/web/vite.user.config.ts
+++ b/web/vite.user.config.ts
@@ -1,26 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import type { Plugin } from "vite";
-
-function denseMemVersion() {
-  const configuredVersion = process.env.DENSE_MEM_VERSION ?? process.env.VITE_DENSE_MEM_VERSION ?? process.env.IMAGE_VERSION;
-  if (configuredVersion?.trim()) {
-    return configuredVersion.trim();
-  }
-
-  try {
-    const version = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
-      cwd: resolve(__dirname, ".."),
-      stdio: ["ignore", "pipe", "ignore"],
-    }).toString().trim();
-    return version || "dev";
-  } catch {
-    return "dev";
-  }
-}
+import { denseMemVersion } from "./vite.version";
 
 function serveUserPortalAtUi(): Plugin {
   return {

--- a/web/vite.version.ts
+++ b/web/vite.version.ts
@@ -1,0 +1,19 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+export function denseMemVersion() {
+  const configuredVersion = process.env.DENSE_MEM_VERSION ?? process.env.VITE_DENSE_MEM_VERSION ?? process.env.IMAGE_VERSION;
+  if (configuredVersion?.trim()) {
+    return configuredVersion.trim();
+  }
+
+  try {
+    const version = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
+      cwd: resolve(__dirname, ".."),
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return version || "dev";
+  } catch {
+    return "dev";
+  }
+}


### PR DESCRIPTION
## Summary
- show the resolved build version in the shared control and `/ui` auth/portal shells
- inject the version into Vite from explicit env/build args, falling back to `git describe`
- pass Docker `IMAGE_VERSION` into web builds and keep mobile shell layout checks current

## Validation
- `npm test`
- `npm run build`
- `go test ./...`
- `npm run playwright:mock`
- push hook lint/tests/coverage passed with coverage at 90.0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible version label to the app’s sign-in and main portal screens.
  * Version values now appear in a cleaner, user-friendly format, with a fallback shown when no version is available.

* **Bug Fixes**
  * Improved the responsive layout on smaller screens so the top navigation displays more appropriately.
  * Adjusted tab sizing and version badge styling for better readability on narrow viewports.

* **Tests**
  * Added coverage for version display and updated responsive layout expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->