### PR TITLE
[codex] Route confirmed dreams through memory placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,11 @@ or flagged feedback includes a bounded comment and can include irrelevant result
 refs for offline analysis. Prometheus still receives only bounded labels; the
 free-text comment stays in the recall feedback investigation records. When
 related dreams are returned, feedback can also include bounded `dream_feedback`
-judgments without promoting or rejecting the dream automatically. Normal
-production recall traffic still contributes request volume, result count, and
-latency.
+judgments without promoting or rejecting the dream automatically. Confirmed true
+or false dreams should be resolved through `resolve_dream_feedback`, which
+records dream-specific telemetry and routes the confirmation evidence through
+normal memory placement. Normal production recall traffic still contributes
+request volume, result count, and latency.
 
 For the disposable demo image, keep the control portal disabled and use the
 demo telemetry overlay instead:
@@ -242,6 +244,7 @@ memory, applies explicit gates, and returns structured outcomes.
 | `dispute_memory_placement` | Starts or continues a bounded placement dispute with additional evidence; the verifier decides whether to promote or keep the placement rejected. |
 | `import_memories` | Trusted migration path for summarized historical conversations. It may carry explicit claims and can request auto-promotion. |
 | `recall_memory` | Retrieves facts, validated claims, fragments, `clarifications[]`, and hypothesis-only `related_dreams` for the authenticated team. |
+| `resolve_dream_feedback` | Records dream-specific decisions. `ignore` leaves the dream for future recall, while confirmed true or false dreams enter normal memory placement and are removed from future dream recall. |
 | `trace_memory` | Expands one fact or claim into bounded evidence, promotion lineage, contradictions, and supersession links. |
 | `assemble_context` | Builds a bounded prompt-ready context block plus structured facts, claims, fragments, and clarifications. |
 | `reflect_memories` | Reviews active facts, candidate or disputed claims, contradictions, stale memories, and clarification needs. |

--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -438,15 +438,14 @@ func main() {
 	defer placementWorkerCancel()
 	memorySvc.StartPlacementWorker(placementWorkerCtx, time.Minute)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{
-		Graph:          profileScopeEnforcer,
-		Memory:         memorySvc,
-		FragmentCreate: fragmentCreateRegistrySvc,
-		AppConfig:      appConfigService,
-		Profiles:       profileService,
-		Locker:         dreamservice.NewPostgresCycleLocker(),
-		Postgres:       pgDB.GetDB(),
-		Generator:      dreamservice.NewHeuristicGenerator(cfg.GetAIVerifierModel()),
-		Metrics:        discoverabilityMetrics,
+		Graph:     profileScopeEnforcer,
+		Memory:    memorySvc,
+		AppConfig: appConfigService,
+		Profiles:  profileService,
+		Locker:    dreamservice.NewPostgresCycleLocker(),
+		Postgres:  pgDB.GetDB(),
+		Generator: dreamservice.NewHeuristicGenerator(cfg.GetAIVerifierModel()),
+		Metrics:   discoverabilityMetrics,
 	})
 	contextSvc := contextservice.New(contextservice.Dependencies{
 		Reader:      profileScopeEnforcer,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -373,15 +373,14 @@ func main() {
 	defer placementWorkerCancel()
 	memorySvc.StartPlacementWorker(placementWorkerCtx, time.Minute)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{
-		Graph:          profileScopeEnforcer,
-		Memory:         memorySvc,
-		FragmentCreate: fragmentCreateRegistrySvc,
-		AppConfig:      appConfigService,
-		Profiles:       profileService,
-		Locker:         dreamservice.NewPostgresCycleLocker(),
-		Postgres:       pgDB.GetDB(),
-		Generator:      dreamservice.NewHeuristicGenerator(cfg.GetAIVerifierModel()),
-		Metrics:        discoverabilityMetrics,
+		Graph:     profileScopeEnforcer,
+		Memory:    memorySvc,
+		AppConfig: appConfigService,
+		Profiles:  profileService,
+		Locker:    dreamservice.NewPostgresCycleLocker(),
+		Postgres:  pgDB.GetDB(),
+		Generator: dreamservice.NewHeuristicGenerator(cfg.GetAIVerifierModel()),
+		Metrics:   discoverabilityMetrics,
 	})
 	contextSvc := contextservice.New(contextservice.Dependencies{
 		Reader:      profileScopeEnforcer,

--- a/internal/observability/metrics_discoverability_test.go
+++ b/internal/observability/metrics_discoverability_test.go
@@ -107,20 +107,28 @@ func TestInMemoryDiscoverabilityMetrics_RecordsDreamFeedback(t *testing.T) {
 		FromStatus: "reinforced",
 	})
 	m.ObserveDreamFeedback(DreamFeedback{
+		Decision:   "confirm_false",
+		Outcome:    "ok",
+		FromStatus: "proposed",
+	})
+	m.ObserveDreamFeedback(DreamFeedback{
 		Decision:   "sounds_good",
 		Outcome:    "maybe",
 		FromStatus: "draft",
 	})
 
 	samples := m.DreamFeedbackSamples()
-	if len(samples) != 2 {
-		t.Fatalf("dream feedback samples = %d; want 2", len(samples))
+	if len(samples) != 3 {
+		t.Fatalf("dream feedback samples = %d; want 3", len(samples))
 	}
 	if samples[0].Decision != "promote_candidate" || samples[0].Outcome != "ok" || samples[0].FromStatus != "reinforced" {
 		t.Errorf("sample[0] = %+v", samples[0])
 	}
-	if samples[1].Decision != "unknown" || samples[1].Outcome != "unknown" || samples[1].FromStatus != "unknown" {
+	if samples[1].Decision != "confirm_false" || samples[1].Outcome != "ok" || samples[1].FromStatus != "proposed" {
 		t.Errorf("sample[1] = %+v", samples[1])
+	}
+	if samples[2].Decision != "unknown" || samples[2].Outcome != "unknown" || samples[2].FromStatus != "unknown" {
+		t.Errorf("sample[2] = %+v", samples[2])
 	}
 }
 

--- a/internal/observability/prometheus_metrics.go
+++ b/internal/observability/prometheus_metrics.go
@@ -471,7 +471,7 @@ func recallFeedbackQualityScore(quality string) float64 {
 
 func normalizeDreamFeedbackDecision(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "reinforce", "stale", "reject", "promote_candidate":
+	case "ignore", "reinforce", "stale", "reject", "confirm_true", "confirm_false", "promote_candidate":
 		return strings.ToLower(strings.TrimSpace(value))
 	default:
 		return unknownMetricLabel

--- a/internal/observability/prometheus_metrics_test.go
+++ b/internal/observability/prometheus_metrics_test.go
@@ -38,6 +38,7 @@ func TestPrometheusMetrics_RecordsScopedMetrics(t *testing.T) {
 	metrics.ObserveRecallFor(ctx, 42, 3, "ok")
 	metrics.ObserveRecallFeedbackFor(ctx, RecallFeedback{Used: true, AnswerSupported: true, Quality: "high", MissingContext: false, Irrelevant: false})
 	metrics.ObserveDreamFeedbackFor(ctx, DreamFeedback{Decision: "promote_candidate", Outcome: "ok", FromStatus: "reinforced"})
+	metrics.ObserveDreamFeedbackFor(ctx, DreamFeedback{Decision: "confirm_true", Outcome: "ok", FromStatus: "proposed"})
 	metrics.ObserveMemoryFunnelLatencyFor(ctx, "claim_to_verify", 2.5, "verified")
 	metrics.IncFragmentCreateFor(ctx, "created")
 	metrics.IncClaimCreateFor(ctx, "duplicate", "content_hash")
@@ -74,6 +75,7 @@ func TestPrometheusMetrics_RecordsScopedMetrics(t *testing.T) {
 		`irrelevant="false"`,
 		`densemem_recall_feedback_quality_score_bucket{`,
 		`densemem_dream_feedback_total{`,
+		`decision="confirm_true"`,
 		`densemem_memory_funnel_latency_seconds_bucket{`,
 		`stage="claim_to_verify"`,
 		`densemem_claim_create_total{`,

--- a/internal/openapi/routes.go
+++ b/internal/openapi/routes.go
@@ -68,7 +68,7 @@ func DefaultRoutes() []RouteDescriptor {
 		{Method: "POST", Path: "/api/v1/tools/confirm_memory", OperationID: "confirmMemoryTool", ToolName: "confirm_memory", AISafe: true, Description: "Apply an explicit memory clarification decision."},
 		{Method: "POST", Path: "/api/v1/tools/list_dreams", OperationID: "listDreamsTool", ToolName: "list_dreams", AISafe: true, Description: "List reviewable dream hypotheses."},
 		{Method: "POST", Path: "/api/v1/tools/get_dream", OperationID: "getDreamTool", ToolName: "get_dream", AISafe: true, Description: "Fetch one dream hypothesis and its source references."},
-		{Method: "POST", Path: "/api/v1/tools/resolve_dream_feedback", OperationID: "resolveDreamFeedbackTool", ToolName: "resolve_dream_feedback", AISafe: true, Description: "Apply evidence-driven user feedback to a dream hypothesis without directly promoting facts."},
+		{Method: "POST", Path: "/api/v1/tools/resolve_dream_feedback", OperationID: "resolveDreamFeedbackTool", ToolName: "resolve_dream_feedback", AISafe: true, Description: "Apply evidence-driven feedback to a dream hypothesis and route confirmed true or false resolutions through memory placement."},
 
 		// --- MCP Streamable HTTP (full runtime variant) ---
 		{Method: "POST", Path: "/mcp", OperationID: "mcpPost", Description: "MCP Streamable HTTP JSON-RPC endpoint."},
@@ -86,6 +86,5 @@ func DefaultRoutes() []RouteDescriptor {
 
 		// --- Audit log (full variant) ---
 		{Method: "GET", Path: "/api/v1/teams/{teamId}/audit-log", OperationID: "getAuditLog", Description: "Fetch the team's audit log."},
-
 	}
 }

--- a/internal/service/dreamservice/feedback.go
+++ b/internal/service/dreamservice/feedback.go
@@ -1,0 +1,58 @@
+package dreamservice
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+)
+
+func dreamResolutionEvidence(d *domain.Dream, decision, feedback string) (memoryservice.EvidenceInput, error) {
+	content := dreamResolutionContent(d, decision, feedback)
+	if strings.TrimSpace(feedback) == "" {
+		return memoryservice.EvidenceInput{}, fmt.Errorf("resolve dream feedback: feedback is required for %s", decision)
+	}
+	labels := []string{"dream_feedback", "dream_resolution"}
+	if decision == "confirm_false" {
+		labels = append(labels, "dream_rejected")
+	} else {
+		labels = append(labels, "dream_confirmed")
+	}
+	return memoryservice.EvidenceInput{
+		Content:        content,
+		Source:         "dream_feedback:" + d.DreamID,
+		IdempotencyKey: "dream-feedback:" + d.DreamID + ":" + decision,
+		Labels:         labels,
+		Metadata: map[string]any{
+			"dream_id":         d.DreamID,
+			"dream_status":     string(d.Status),
+			"dream_likelihood": d.Likelihood,
+			"dream_confidence": d.Confidence,
+			"dream_decision":   decision,
+		},
+	}, nil
+}
+
+func dreamResolutionContent(d *domain.Dream, decision, feedback string) string {
+	trimmedFeedback := strings.TrimSpace(feedback)
+	parts := []string{}
+	if decision == "confirm_false" {
+		parts = append(parts, "Incorrect dream hypothesis: "+trimmedFeedback)
+	} else if trimmedFeedback != "" {
+		parts = append(parts, trimmedFeedback)
+	}
+	parts = append(parts, "Dense-Mem dream hypothesis: "+d.Hypothesis)
+	if d.WhatIf != "" {
+		parts = append(parts, "What-if: "+d.WhatIf)
+	}
+	if d.PossibleOutcome != "" {
+		parts = append(parts, "Possible outcome: "+d.PossibleOutcome)
+	}
+	if decision == "confirm_true" {
+		parts = append(parts, "Dream decision: confirmed accurate")
+	} else if decision == "confirm_false" {
+		parts = append(parts, "Dream decision: confirmed false")
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/service/dreamservice/service.go
+++ b/internal/service/dreamservice/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/fulltextquery"
-	"github.com/markhuangai/dense-mem/internal/http/dto"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	neo4jstorage "github.com/markhuangai/dense-mem/internal/storage/neo4j"
@@ -406,46 +405,63 @@ func (s *service) ResolveFeedback(ctx context.Context, profileID string, req Res
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, err
 		}
-	case "promote_candidate":
-		if s.deps.FragmentCreate == nil {
+	case "ignore":
+		s.recordDreamFeedback(ctx, decision, dream, "ok")
+		return &ResolveFeedbackResult{Dream: dream}, nil
+	case "confirm_true", "promote_candidate":
+		if s.deps.Memory == nil {
 			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, fmt.Errorf("resolve dream feedback: fragment create service is required")
+			return nil, fmt.Errorf("resolve dream feedback: memory service is required")
 		}
-		content := dreamPromotionContent(dream, req.Feedback)
-		fragment, err := s.deps.FragmentCreate.Create(ctx, profileID, &dto.CreateFragmentRequest{
-			Content:        content,
-			SourceType:     "conversation",
-			Source:         "dream_feedback:" + dream.DreamID,
-			Authority:      "primary",
-			IdempotencyKey: "dream-feedback:" + dream.DreamID,
-			Labels:         []string{"dream_feedback"},
-			Metadata: map[string]any{
-				"dream_id":         dream.DreamID,
-				"dream_status":     string(dream.Status),
-				"dream_likelihood": dream.Likelihood,
-				"dream_confidence": dream.Confidence,
-			},
-			SourceQuality: 0.75,
+		evidence, err := dreamResolutionEvidence(dream, "confirm_true", req.Feedback)
+		if err != nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, err
+		}
+		memory, err := s.deps.Memory.Remember(ctx, profileID, memoryservice.RememberRequest{
+			Evidence: []memoryservice.EvidenceInput{evidence},
 		})
 		if err != nil {
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, err
 		}
-		if err := s.linkDreamPromotion(ctx, profileID, dream.DreamID, fragment.Fragment.FragmentID); err != nil {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, err
-		}
-		if err := s.updateDreamStatus(ctx, profileID, dreamID, domain.DreamStatusPromoted, strings.TrimSpace(req.Feedback)); err != nil {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, err
-		}
-		updated, err := s.Get(ctx, profileID, dreamID)
-		if err != nil {
+		if err := s.deleteDream(ctx, profileID, dreamID); err != nil {
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, err
 		}
 		s.recordDreamFeedback(ctx, decision, dream, "ok")
-		return &ResolveFeedbackResult{Dream: updated, Fragment: fragment}, nil
+		dream.Status = domain.DreamStatusPromoted
+		dream.InvalidatedReason = strings.TrimSpace(req.Feedback)
+		now := s.now().UTC()
+		dream.UpdatedAt = now
+		return &ResolveFeedbackResult{Dream: dream, Memory: memory, Deleted: true}, nil
+	case "confirm_false":
+		if s.deps.Memory == nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, fmt.Errorf("resolve dream feedback: memory service is required")
+		}
+		evidence, err := dreamResolutionEvidence(dream, "confirm_false", req.Feedback)
+		if err != nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, err
+		}
+		memory, err := s.deps.Memory.Remember(ctx, profileID, memoryservice.RememberRequest{
+			Evidence: []memoryservice.EvidenceInput{evidence},
+		})
+		if err != nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, err
+		}
+		if err := s.deleteDream(ctx, profileID, dreamID); err != nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, err
+		}
+		s.recordDreamFeedback(ctx, decision, dream, "ok")
+		dream.Status = domain.DreamStatusRejected
+		dream.InvalidatedReason = strings.TrimSpace(req.Feedback)
+		now := s.now().UTC()
+		dream.UpdatedAt = now
+		return &ResolveFeedbackResult{Dream: dream, Memory: memory, Deleted: true}, nil
 	default:
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return nil, fmt.Errorf("%w: %s", ErrInvalidDreamStatus, decision)
@@ -704,17 +720,11 @@ SET d.status = $status,
 	})
 }
 
-func (s *service) linkDreamPromotion(ctx context.Context, profileID, dreamID, fragmentID string) error {
+func (s *service) deleteDream(ctx context.Context, profileID, dreamID string) error {
 	return s.deps.Graph.ScopedWriteTx(ctx, profileID, func(tx neo4j.ManagedTransaction) error {
 		res, err := neo4jstorage.RunScoped(ctx, tx, profileID, `
 MATCH (d:Dream {team_id: $profileId, dream_id: $dreamId})
-MATCH (sf:SourceFragment {team_id: $profileId, fragment_id: $fragmentId})
-MERGE (d)-[r:PROMOTED_TO {team_id: $profileId, target_type: 'fragment', target_id: $fragmentId}]->(sf)
-ON CREATE SET r.created_at = $createdAt`, map[string]any{
-			"dreamId":    dreamID,
-			"fragmentId": fragmentID,
-			"createdAt":  s.now().UTC(),
-		})
+DETACH DELETE d`, map[string]any{"dreamId": dreamID})
 		if err != nil {
 			return err
 		}
@@ -885,23 +895,6 @@ func dreamContentHash(d *domain.Dream) string {
 		string(data),
 	}, "\x00")))
 	return hex.EncodeToString(h[:])
-}
-
-func dreamPromotionContent(d *domain.Dream, feedback string) string {
-	parts := []string{
-		"Human confirmed a Dense-Mem dream hypothesis.",
-		"Hypothesis: " + d.Hypothesis,
-	}
-	if d.WhatIf != "" {
-		parts = append(parts, "What-if: "+d.WhatIf)
-	}
-	if d.PossibleOutcome != "" {
-		parts = append(parts, "Possible outcome: "+d.PossibleOutcome)
-	}
-	if strings.TrimSpace(feedback) != "" {
-		parts = append(parts, "Human feedback: "+strings.TrimSpace(feedback))
-	}
-	return strings.Join(parts, "\n")
 }
 
 func localRunDate(now time.Time, cfg EffectiveConfig) string {

--- a/internal/service/dreamservice/service_test.go
+++ b/internal/service/dreamservice/service_test.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/http/dto"
 	"github.com/markhuangai/dense-mem/internal/observability"
-	"github.com/markhuangai/dense-mem/internal/service/fragmentservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/stretchr/testify/require"
@@ -318,6 +316,15 @@ func TestDreamServiceResolveFeedback(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, graph.writes)
 
+	ignoreRes, err := svc.ResolveFeedback(context.Background(), "profile-1", ResolveFeedbackRequest{
+		DreamID:  "dream-1",
+		Decision: "ignore",
+		Feedback: "not enough context to decide",
+	})
+	require.NoError(t, err)
+	require.False(t, ignoreRes.Deleted)
+	require.Equal(t, 3, graph.writes)
+
 	_, err = svc.ResolveFeedback(context.Background(), "profile-1", ResolveFeedbackRequest{
 		DreamID:  "dream-1",
 		Decision: "unknown",
@@ -327,6 +334,7 @@ func TestDreamServiceResolveFeedback(t *testing.T) {
 		{Decision: "reject", Outcome: "ok", FromStatus: "proposed"},
 		{Decision: "stale", Outcome: "ok", FromStatus: "proposed"},
 		{Decision: "reinforce", Outcome: "ok", FromStatus: "proposed"},
+		{Decision: "ignore", Outcome: "ok", FromStatus: "proposed"},
 		{Decision: "unknown", Outcome: "error", FromStatus: "proposed"},
 	}, metrics.DreamFeedbackSamples())
 
@@ -334,33 +342,37 @@ func TestDreamServiceResolveFeedback(t *testing.T) {
 	require.ErrorContains(t, err, "dream_id is required")
 }
 
-func TestDreamServiceResolveFeedbackPromotesCandidate(t *testing.T) {
+func TestDreamServiceResolveFeedbackPromotesCandidateThroughRemember(t *testing.T) {
 	now := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
 	graph := &cycleRunGraphStub{executeWrites: true, dreamRows: []map[string]any{{"d": dreamTestNode("dream-1", "profile-1", now)}}}
-	create := &dreamFragmentCreateStub{}
+	memory := &dreamMemoryStub{rememberResult: &memoryservice.RememberResult{IngestID: "ingest-1", Status: "processing"}}
 	metrics := observability.NewInMemoryDiscoverabilityMetrics()
 	svc := New(Dependencies{
-		Graph:          graph,
-		FragmentCreate: create,
-		Metrics:        metrics,
-		Now:            func() time.Time { return now },
+		Graph:   graph,
+		Memory:  memory,
+		Metrics: metrics,
+		Now:     func() time.Time { return now },
 	})
 
 	res, err := svc.ResolveFeedback(context.Background(), "profile-1", ResolveFeedbackRequest{
 		DreamID:  "dream-1",
 		Decision: "promote_candidate",
-		Feedback: "confirmed by user",
+		Feedback: "User works at SAP from 2020 to 2024.",
 	})
 
 	require.NoError(t, err)
-	require.NotNil(t, res.Fragment)
-	require.Equal(t, "dream-fragment", res.Fragment.Fragment.FragmentID)
-	require.Equal(t, "profile-1", create.lastProfile)
-	require.Equal(t, "dream_feedback:dream-1", create.lastReq.Source)
-	require.Equal(t, "dream-1", create.lastReq.Metadata["dream_id"])
-	require.Equal(t, 2, graph.writes)
-	require.True(t, hasDreamWriteQuery(graph.writeQueries, "PROMOTED_TO"))
-	require.True(t, hasDreamWriteQuery(graph.writeQueries, "SET d.status = $status"))
+	require.True(t, res.Deleted)
+	require.Equal(t, domain.DreamStatusPromoted, res.Dream.Status)
+	require.Equal(t, "ingest-1", res.Memory.IngestID)
+	require.Equal(t, 1, memory.remembers)
+	require.Equal(t, "dream_feedback:dream-1", memory.lastRememberReq.Evidence[0].Source)
+	require.Equal(t, "dream-feedback:dream-1:confirm_true", memory.lastRememberReq.Evidence[0].IdempotencyKey)
+	require.Contains(t, memory.lastRememberReq.Evidence[0].Labels, "dream_confirmed")
+	require.Equal(t, "dream-1", memory.lastRememberReq.Evidence[0].Metadata["dream_id"])
+	require.Equal(t, "confirm_true", memory.lastRememberReq.Evidence[0].Metadata["dream_decision"])
+	require.True(t, strings.HasPrefix(memory.lastRememberReq.Evidence[0].Content, "User works at SAP"))
+	require.Equal(t, 1, graph.writes)
+	require.True(t, hasDreamWriteQuery(graph.writeQueries, "DETACH DELETE d"))
 	require.Equal(t, []observability.DreamFeedbackSample{
 		{Decision: "promote_candidate", Outcome: "ok", FromStatus: "proposed"},
 	}, metrics.DreamFeedbackSamples())
@@ -369,40 +381,42 @@ func TestDreamServiceResolveFeedbackPromotesCandidate(t *testing.T) {
 	_, err = New(Dependencies{Graph: graph, Metrics: errorMetrics}).ResolveFeedback(context.Background(), "profile-1", ResolveFeedbackRequest{
 		DreamID:  "dream-1",
 		Decision: "promote_candidate",
+		Feedback: "confirmed by user",
 	})
-	require.ErrorContains(t, err, "fragment create service is required")
+	require.ErrorContains(t, err, "memory service is required")
 	require.Equal(t, []observability.DreamFeedbackSample{
 		{Decision: "promote_candidate", Outcome: "error", FromStatus: "proposed"},
 	}, errorMetrics.DreamFeedbackSamples())
 }
 
-func TestDreamServiceResolveFeedbackPromoteCandidateRefetchError(t *testing.T) {
+func TestDreamServiceResolveFeedbackConfirmFalseThroughRemember(t *testing.T) {
 	now := time.Date(2026, 6, 11, 3, 0, 0, 0, time.UTC)
-	graph := &cycleRunGraphStub{
-		executeWrites: true,
-		readErr:       errors.New("read failed"),
-		readErrAfter:  3,
-		dreamRows:     []map[string]any{{"d": dreamTestNode("dream-1", "profile-1", now)}},
-	}
+	graph := &cycleRunGraphStub{executeWrites: true, dreamRows: []map[string]any{{"d": dreamTestNode("dream-1", "profile-1", now)}}}
+	memory := &dreamMemoryStub{rememberResult: &memoryservice.RememberResult{IngestID: "ingest-false", Status: "processing"}}
 	metrics := observability.NewInMemoryDiscoverabilityMetrics()
 	svc := New(Dependencies{
-		Graph:          graph,
-		FragmentCreate: &dreamFragmentCreateStub{},
-		Metrics:        metrics,
-		Now:            func() time.Time { return now },
+		Graph:   graph,
+		Memory:  memory,
+		Metrics: metrics,
+		Now:     func() time.Time { return now },
 	})
 
 	res, err := svc.ResolveFeedback(context.Background(), "profile-1", ResolveFeedbackRequest{
 		DreamID:  "dream-1",
-		Decision: "promote_candidate",
-		Feedback: "confirmed by user",
+		Decision: "confirm_false",
+		Feedback: "The user said this is not true.",
 	})
 
-	require.ErrorContains(t, err, "read failed")
-	require.Nil(t, res)
-	require.Equal(t, 2, graph.writes)
+	require.NoError(t, err)
+	require.True(t, res.Deleted)
+	require.Equal(t, domain.DreamStatusRejected, res.Dream.Status)
+	require.Equal(t, "ingest-false", res.Memory.IngestID)
+	require.Contains(t, memory.lastRememberReq.Evidence[0].Labels, "dream_rejected")
+	require.Equal(t, "confirm_false", memory.lastRememberReq.Evidence[0].Metadata["dream_decision"])
+	require.Contains(t, memory.lastRememberReq.Evidence[0].Content, "Incorrect dream hypothesis")
+	require.Contains(t, memory.lastRememberReq.Evidence[0].Content, "not true")
 	require.Equal(t, []observability.DreamFeedbackSample{
-		{Decision: "promote_candidate", Outcome: "error", FromStatus: "proposed"},
+		{Decision: "confirm_false", Outcome: "ok", FromStatus: "proposed"},
 	}, metrics.DreamFeedbackSamples())
 }
 
@@ -562,7 +576,12 @@ func TestDreamServiceInputRowsAndHelpers(t *testing.T) {
 		SourceRefs:      []domain.DreamSourceRef{{Type: "fact", ID: "fact-1"}},
 	}
 	require.NotEmpty(t, dreamContentHash(dream))
-	require.Contains(t, dreamPromotionContent(dream, "confirmed"), "Human feedback: confirmed")
+	evidence, err := dreamResolutionEvidence(dream, "confirm_true", "User works on Dense-Mem.")
+	require.NoError(t, err)
+	require.Contains(t, evidence.Content, "Dream decision: confirmed accurate")
+	require.Equal(t, "dream-feedback:dream-1:confirm_true", evidence.IdempotencyKey)
+	_, err = dreamResolutionEvidence(dream, "confirm_true", "")
+	require.ErrorContains(t, err, "feedback is required")
 	require.Equal(t, "2026-06-11", localRunDate(now, EffectiveConfig{DreamingRuntimeConfig: domain.DreamingRuntimeConfig{Timezone: "Nope/Zone"}}))
 	require.Equal(t, "stringer-value", stringFromMap(map[string]any{"x": testStringer("stringer-value")}, "x"))
 	require.True(t, boolFromMap(map[string]any{"x": true}, "x"))
@@ -886,12 +905,24 @@ func (s *dreamGeneratorStub) Model() string {
 }
 
 type dreamMemoryStub struct {
-	result   *memoryservice.ReflectResult
-	err      error
-	reflects int
+	result          *memoryservice.ReflectResult
+	err             error
+	reflects        int
+	remembers       int
+	rememberResult  *memoryservice.RememberResult
+	rememberErr     error
+	lastRememberReq memoryservice.RememberRequest
 }
 
-func (s *dreamMemoryStub) Remember(context.Context, string, memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
+func (s *dreamMemoryStub) Remember(_ context.Context, _ string, req memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
+	s.remembers++
+	s.lastRememberReq = req
+	if s.rememberErr != nil {
+		return nil, s.rememberErr
+	}
+	if s.rememberResult != nil {
+		return s.rememberResult, nil
+	}
 	return &memoryservice.RememberResult{}, nil
 }
 
@@ -920,19 +951,6 @@ func (s *dreamMemoryStub) Reflect(context.Context, string, memoryservice.Reflect
 
 func (s *dreamMemoryStub) ConfirmMemory(context.Context, string, memoryservice.ConfirmRequest) (*memoryservice.ConfirmResult, error) {
 	return &memoryservice.ConfirmResult{}, nil
-}
-
-type dreamFragmentCreateStub struct {
-	lastProfile string
-	lastReq     *dto.CreateFragmentRequest
-}
-
-func (s *dreamFragmentCreateStub) Create(_ context.Context, profileID string, req *dto.CreateFragmentRequest) (*fragmentservice.CreateResult, error) {
-	s.lastProfile = profileID
-	s.lastReq = req
-	return &fragmentservice.CreateResult{
-		Fragment: &domain.Fragment{FragmentID: "dream-fragment", ProfileID: profileID, Content: req.Content},
-	}, nil
 }
 
 func dreamTestNode(dreamID, profileID string, now time.Time) neo4j.Node {

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -55,16 +55,15 @@ type Generator interface {
 }
 
 type Dependencies struct {
-	Graph          ScopedGraph
-	Memory         memoryservice.Service
-	FragmentCreate fragmentservice.CreateFragmentService
-	AppConfig      AppConfig
-	Profiles       ProfileService
-	Locker         CycleLocker
-	Postgres       *gorm.DB
-	Generator      Generator
-	Metrics        observability.DiscoverabilityMetrics
-	Now            func() time.Time
+	Graph     ScopedGraph
+	Memory    memoryservice.Service
+	AppConfig AppConfig
+	Profiles  ProfileService
+	Locker    CycleLocker
+	Postgres  *gorm.DB
+	Generator Generator
+	Metrics   observability.DiscoverabilityMetrics
+	Now       func() time.Time
 }
 
 type Service interface {
@@ -121,8 +120,11 @@ type ResolveFeedbackRequest struct {
 }
 
 type ResolveFeedbackResult struct {
-	Dream    *domain.Dream                 `json:"dream"`
+	Dream *domain.Dream `json:"dream"`
+	// Deprecated: confirmed dream feedback now returns Memory placement.
 	Fragment *fragmentservice.CreateResult `json:"fragment,omitempty"`
+	Memory   *memoryservice.RememberResult `json:"memory,omitempty"`
+	Deleted  bool                          `json:"deleted,omitempty"`
 }
 
 type StatusResult struct {

--- a/internal/tools/registry/dream_tools.go
+++ b/internal/tools/registry/dream_tools.go
@@ -74,14 +74,14 @@ func getDreamTool(deps Dependencies) Tool {
 func resolveDreamFeedbackTool(deps Dependencies) Tool {
 	return Tool{
 		Name:        "resolve_dream_feedback",
-		Description: "Apply evidence-driven feedback to a dream hypothesis. Use reject when the user contradicts it, stale when it is no longer relevant, reinforce when the conversation supports keeping it as a hypothesis, and promote_candidate only after explicit user evidence or confirmation that it should enter normal memory review. Do not promote based only on model confidence.",
+		Description: "Apply evidence-driven feedback to a dream hypothesis. Dreams are uncertain recall hints. Use ignore when no decision was made, reinforce when it remains useful but unconfirmed, reject or stale for manual lifecycle cleanup, confirm_true when prior conversation or user feedback confirms it should enter normal memory placement, and confirm_false when evidence confirms it is not true and correction evidence should enter normal memory placement. promote_candidate is accepted as a backward-compatible alias for confirm_true. Do not confirm based only on model confidence.",
 		InputSchema: map[string]any{
 			"type":     "object",
 			"required": []string{"dream_id", "decision"},
 			"properties": map[string]any{
 				"dream_id": schemaString("Dream id.", 128),
-				"decision": schemaEnum([]string{"reinforce", "stale", "reject", "promote_candidate"}),
-				"feedback": schemaString("User feedback or confirmation text.", 1024),
+				"decision": schemaEnum([]string{"ignore", "reinforce", "stale", "reject", "confirm_true", "confirm_false", "promote_candidate"}),
+				"feedback": schemaString("User feedback, prior-conversation evidence, or correction text. Required for confirm_true, confirm_false, and promote_candidate.", 1024),
 			},
 			"additionalProperties": false,
 		},

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -39,17 +39,33 @@ func TestBuildDefault_DreamInvokers(t *testing.T) {
 	}
 
 	resolveTool, _ := reg.Get("resolve_dream_feedback")
+	decisionSchema := resolveTool.InputSchema["properties"].(map[string]any)["decision"].(map[string]any)
+	decisionEnums := decisionSchema["enum"].([]string)
+	for _, decision := range []string{"ignore", "confirm_true", "confirm_false", "promote_candidate"} {
+		if !containsString(decisionEnums, decision) {
+			t.Fatalf("resolve_dream_feedback decision enum missing %q: %v", decision, decisionEnums)
+		}
+	}
 	resolveOut, err := resolveTool.Invoke(context.Background(), "profile-dream", map[string]any{
 		"dream_id": "dream-1",
-		"decision": "reinforce",
-		"feedback": "still plausible",
+		"decision": "confirm_true",
+		"feedback": "prior conversation confirms it",
 	})
 	if err != nil {
 		t.Fatalf("resolve_dream_feedback Invoke: %v", err)
 	}
-	if resolveOut["dream"] == nil || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "still plausible" {
+	if resolveOut["dream"] == nil || dreams.lastResolveReq.Decision != "confirm_true" || dreams.lastResolveReq.Feedback != "prior conversation confirms it" {
 		t.Fatalf("resolve_dream_feedback output = %v request = %+v", resolveOut, dreams.lastResolveReq)
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 type stubDreamService struct {

--- a/tests/uat/dream-feedback.spec.ts
+++ b/tests/uat/dream-feedback.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import {
+  BASE_URL,
+  PROFILE_ID,
+  headers,
+  neo4jQuery,
+} from './helpers';
+
+test('dream confirmation enters remember flow and removes processed dream', async ({
+  request,
+}) => {
+  const unique = Date.now();
+  const dreamId = `uat-dream-confirm-${unique}`;
+  const feedback = `User works on dense-mem dream resolution UAT ${unique}.`;
+
+  await neo4jQuery(
+    `
+    CREATE (d:Dream {
+      team_id: $profileId,
+      dream_id: $dreamId,
+      hypothesis: $hypothesis,
+      what_if: 'What if this confirmed dream can become normal memory evidence?',
+      possible_outcome: 'The memory verifier can place the evidence as fragment, claim, or fact.',
+      rationale: 'Seeded by UAT to verify dream feedback resolution.',
+      likelihood: 0.72,
+      confidence: 0.81,
+      status: 'proposed',
+      cycle: 'dream',
+      cycle_run_id: 'uat-dream-feedback',
+      generator_model: 'uat',
+      content_hash: $dreamId,
+      source_refs_json: '[]',
+      invalidated_reason: '',
+      created_at: datetime(),
+      updated_at: datetime(),
+      last_evaluated_at: datetime()
+    })
+    `,
+    {
+      profileId: PROFILE_ID,
+      dreamId,
+      hypothesis: `User may work on dense-mem dream resolution UAT ${unique}.`,
+    },
+  );
+
+  const res = await request.post(`${BASE_URL}/api/v1/tools/resolve_dream_feedback`, {
+    headers: headers(PROFILE_ID),
+    data: {
+      dream_id: dreamId,
+      decision: 'confirm_true',
+      feedback,
+    },
+  });
+
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({
+    deleted: true,
+    dream: {
+      dream_id: dreamId,
+      status: 'promoted',
+    },
+    memory: {
+      ingest_id: expect.any(String),
+      status: 'queued',
+    },
+  });
+  expect(body.memory.evidence[0].id).toEqual(expect.any(String));
+
+  const remainingDreams = await neo4jQuery(
+    `
+    MATCH (d:Dream {team_id: $profileId, dream_id: $dreamId})
+    RETURN d.dream_id AS id
+    `,
+    { profileId: PROFILE_ID, dreamId },
+  );
+  expect(remainingDreams).toHaveLength(0);
+
+  const fragments = await neo4jQuery(
+    `
+    MATCH (sf:SourceFragment {team_id: $profileId, source: $source})
+    RETURN sf.fragment_id AS id,
+           sf.content AS content,
+           sf.labels AS labels,
+           sf.metadata_json AS metadata_json
+    `,
+    {
+      profileId: PROFILE_ID,
+      source: `dream_feedback:${dreamId}`,
+    },
+  );
+  expect(fragments).toHaveLength(1);
+  expect(fragments[0].content).toContain(feedback);
+  expect(fragments[0].labels).toEqual(
+    expect.arrayContaining(['dream_feedback', 'dream_confirmed']),
+  );
+  const metadata = JSON.parse(fragments[0].metadata_json as string);
+  expect(metadata).toMatchObject({
+    dream_id: dreamId,
+    dream_decision: 'confirm_true',
+  });
+});


### PR DESCRIPTION
## Summary
- Route confirmed dream feedback through `Memory.Remember` instead of creating dream fragments directly.
- Add `ignore`, `confirm_true`, and `confirm_false` dream feedback decisions while keeping `promote_candidate` as a backward-compatible true-confirmation alias.
- Remove processed true/false dreams from future dream recall after memory placement is created, and keep ignored dreams available.
- Extend bounded dream feedback telemetry labels, docs, and UAT coverage.

## Validation
- `go test ./...`
- `set -a; source .env; set +a; bash tests/uat/scripts/provisioned-e2e.sh dream-feedback.spec.ts`
- `set -a; source .env; set +a; bash tests/uat/scripts/provisioned-e2e.sh phase8-mcp.spec.ts`
- pre-push hook: line lint, Go tests, coverage gate

## Notes
- Wiki docs were updated and pushed separately in `dense-mem.wiki` commit `cb9d144`.