### PR TITLE
[codex] fix ui graph and stale portal tabs

### DIFF
--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -218,15 +218,20 @@ func (h *userPortalHandler) graphSnapshot(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	includeSuperseded, err := userPortalOptionalBoolQuery(c, "include_superseded")
+	if err != nil {
+		return err
+	}
 
 	snapshot, err := h.graph.Graph(c.Request().Context(), teamID.String(), graphview.Query{
-		Scope:      c.QueryParam("scope"),
-		Query:      c.QueryParam("q"),
-		Types:      userPortalGraphTypes(c.QueryParam("types")),
-		AnchorType: c.QueryParam("anchor_type"),
-		AnchorID:   c.QueryParam("anchor_id"),
-		Depth:      depth,
-		Limit:      limit,
+		Scope:             c.QueryParam("scope"),
+		Query:             c.QueryParam("q"),
+		Types:             userPortalGraphTypes(c.QueryParam("types")),
+		AnchorType:        c.QueryParam("anchor_type"),
+		AnchorID:          c.QueryParam("anchor_id"),
+		Depth:             depth,
+		Limit:             limit,
+		IncludeSuperseded: includeSuperseded,
 	})
 	if err != nil {
 		if errors.Is(err, graphview.ErrMissingAnchor) || errors.Is(err, graphview.ErrInvalidAnchorType) {
@@ -245,6 +250,18 @@ func userPortalOptionalIntQuery(c echo.Context, name string) (int, error) {
 	value, err := strconv.Atoi(raw)
 	if err != nil || value < 0 {
 		return 0, httperr.New(httperr.VALIDATION_ERROR, name+" must be a non-negative integer")
+	}
+	return value, nil
+}
+
+func userPortalOptionalBoolQuery(c echo.Context, name string) (bool, error) {
+	raw := strings.TrimSpace(c.QueryParam(name))
+	if raw == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, httperr.New(httperr.VALIDATION_ERROR, name+" must be a boolean")
 	}
 	return value, nil
 }

--- a/internal/http/user_portal_test.go
+++ b/internal/http/user_portal_test.go
@@ -306,7 +306,7 @@ func TestUserPortalGraphUsesAuthenticatedTeamScope(t *testing.T) {
 	graph := &userPortalGraphSvc{}
 	server := userPortalTestServerWithGraph(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", nil, graph)
 
-	req := httptest.NewRequest(http.MethodGet, "/ui/api/graph?scope=local&anchor_type=fact&anchor_id=fact-1&depth=2&limit=50&types=fact,claim&q=memory", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/graph?scope=local&anchor_type=fact&anchor_id=fact-1&depth=2&limit=50&types=fact,claim&q=memory&include_superseded=true", nil)
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
@@ -320,6 +320,7 @@ func TestUserPortalGraphUsesAuthenticatedTeamScope(t *testing.T) {
 	require.Equal(t, "fact-1", graph.query.AnchorID)
 	require.Equal(t, 2, graph.query.Depth)
 	require.Equal(t, 50, graph.query.Limit)
+	require.True(t, graph.query.IncludeSuperseded)
 	require.Equal(t, []string{"fact", "claim"}, graph.query.Types)
 	require.Equal(t, "memory", graph.query.Query)
 }

--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -37,13 +37,14 @@ type Service interface {
 }
 
 type Query struct {
-	Scope      string
-	Query      string
-	Types      []string
-	AnchorType string
-	AnchorID   string
-	Depth      int
-	Limit      int
+	Scope             string
+	Query             string
+	Types             []string
+	AnchorType        string
+	AnchorID          string
+	Depth             int
+	Limit             int
+	IncludeSuperseded bool
 }
 
 type Snapshot struct {
@@ -95,17 +96,17 @@ func New(reader ScopedReader) Service {
 }
 
 type normalizedQuery struct {
-	scope           string
-	search          string
-	includeFact     bool
-	includeClaim    bool
-	includeFragment bool
-	includeDream    bool
-	anchorType      string
-	anchorID        string
-	depth           int
-	limit           int
-	edgeLimit       int64
+	scope             string
+	search            string
+	includeFact       bool
+	includeClaim      bool
+	includeFragment   bool
+	includeDream      bool
+	anchorType        string
+	anchorID          string
+	depth             int
+	limit             int
+	includeSuperseded bool
 }
 
 func (s *service) Graph(ctx context.Context, profileID string, query Query) (*Snapshot, error) {
@@ -137,7 +138,6 @@ func (s *service) Graph(ctx context.Context, profileID string, query Query) (*Sn
 		_, edgeRows, err := s.reader.ScopedRead(ctx, profileID, graphEdgesCypher, map[string]any{
 			"nodeKeys":          nodeKeys,
 			"relationshipTypes": relationshipTypes,
-			"edgeLimit":         normalized.edgeLimit,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("graph view edges: %w", err)
@@ -175,6 +175,7 @@ func (q normalizedQuery) params() map[string]any {
 		"anchorID":          q.anchorID,
 		"relationshipTypes": relationshipTypes,
 		"limit":             int64(q.limit),
+		"includeSuperseded": q.includeSuperseded,
 	}
 }
 
@@ -189,16 +190,16 @@ func normalizeQuery(query Query) (normalizedQuery, error) {
 
 	types := normalizeTypes(query.Types)
 	normalized := normalizedQuery{
-		scope:           scope,
-		search:          strings.ToLower(strings.TrimSpace(query.Query)),
-		includeFact:     types["fact"],
-		includeClaim:    types["claim"],
-		includeFragment: types["fragment"],
-		includeDream:    types["dream"],
-		limit:           clamp(query.Limit, DefaultLimit, MaxLimit),
-		depth:           clamp(query.Depth, DefaultDepth, MaxDepth),
+		scope:             scope,
+		search:            strings.ToLower(strings.TrimSpace(query.Query)),
+		includeFact:       types["fact"],
+		includeClaim:      types["claim"],
+		includeFragment:   types["fragment"],
+		includeDream:      types["dream"],
+		limit:             clamp(query.Limit, DefaultLimit, MaxLimit),
+		depth:             clamp(query.Depth, DefaultDepth, MaxDepth),
+		includeSuperseded: query.IncludeSuperseded,
 	}
-	normalized.edgeLimit = int64(clampRange(normalized.limit*4, 120, 720))
 
 	if normalized.scope == ScopeLocal {
 		normalized.anchorType = normalizeType(query.AnchorType)
@@ -246,16 +247,6 @@ func normalizeType(raw string) string {
 func clamp(value, defaultValue, maxValue int) int {
 	if value <= 0 {
 		return defaultValue
-	}
-	if value > maxValue {
-		return maxValue
-	}
-	return value
-}
-
-func clampRange(value, minValue, maxValue int) int {
-	if value < minValue {
-		return minValue
 	}
 	if value > maxValue {
 		return maxValue
@@ -345,78 +336,122 @@ const overviewNodesCypher = `
 CALL {
   MATCH (f:Fact {team_id: $profileId})
   WHERE $includeFact
-    AND coalesce(f.status, '') IN ['active', 'needs_revalidation']
+    AND (
+      coalesce(f.status, '') IN ['active', 'needs_revalidation'] OR
+      ($includeSuperseded AND coalesce(f.status, '') = 'superseded')
+    )
     AND ($query = '' OR toLower(coalesce(f.subject, '') + ' ' + coalesce(f.predicate, '') + ' ' + coalesce(f.object, '')) CONTAINS $query)
-  RETURN 'fact' AS type,
-         f.fact_id AS id,
-         'fact:' + f.fact_id AS key,
-         trim(coalesce(f.subject, '') + ' ' + coalesce(f.predicate, '') + ' ' + coalesce(f.object, '')) AS title,
-         coalesce(f.object, '') AS body,
-         coalesce(f.status, '') AS status,
-         toString(f.community_id) AS community_id,
-         '' AS source,
-         coalesce(f.truth_score, 0.0) AS score,
-         f.recorded_at AS recorded_at
-  UNION ALL
+  WITH f
+  ORDER BY f.recorded_at DESC, f.fact_id ASC
+  LIMIT $limit
+  RETURN collect({
+    type: 'fact',
+    id: f.fact_id,
+    key: 'fact:' + f.fact_id,
+    title: trim(coalesce(f.subject, '') + ' ' + coalesce(f.predicate, '') + ' ' + coalesce(f.object, '')),
+    body: coalesce(f.object, ''),
+    status: coalesce(f.status, ''),
+    community_id: toString(f.community_id),
+    source: '',
+    score: coalesce(f.truth_score, 0.0),
+    recorded_at: f.recorded_at
+  }) AS rows
+}
+WITH rows AS factRows
+CALL {
   MATCH (c:Claim {team_id: $profileId})
   WHERE $includeClaim
     AND coalesce(c.status, 'candidate') <> 'rejected'
+    AND ($includeSuperseded OR coalesce(c.status, 'candidate') <> 'superseded')
     AND ($query = '' OR toLower(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')) CONTAINS $query)
-  RETURN 'claim' AS type,
-         c.claim_id AS id,
-         'claim:' + c.claim_id AS key,
-         trim(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')) AS title,
-         coalesce(c.object, '') AS body,
-         coalesce(c.status, '') AS status,
-         toString(c.community_id) AS community_id,
-         '' AS source,
-         coalesce(c.resolution_conf, c.extract_conf, c.source_quality, 0.0) AS score,
-         c.recorded_at AS recorded_at
-  UNION ALL
+  WITH c
+  ORDER BY c.recorded_at DESC, c.claim_id ASC
+  LIMIT $limit
+  RETURN collect({
+    type: 'claim',
+    id: c.claim_id,
+    key: 'claim:' + c.claim_id,
+    title: trim(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')),
+    body: coalesce(c.object, ''),
+    status: coalesce(c.status, ''),
+    community_id: toString(c.community_id),
+    source: '',
+    score: coalesce(c.resolution_conf, c.extract_conf, c.source_quality, 0.0),
+    recorded_at: c.recorded_at
+  }) AS rows
+}
+WITH factRows, rows AS claimRows
+CALL {
   MATCH (sf:SourceFragment {team_id: $profileId})
   WHERE $includeFragment
     AND coalesce(sf.status, 'active') <> 'retracted'
     AND ($query = '' OR toLower(coalesce(sf.content, '') + ' ' + coalesce(sf.source, '')) CONTAINS $query)
-  RETURN 'fragment' AS type,
-         sf.fragment_id AS id,
-         'fragment:' + sf.fragment_id AS key,
-         substring(coalesce(sf.content, ''), 0, 160) AS title,
-         substring(coalesce(sf.content, ''), 0, 600) AS body,
-         coalesce(sf.status, 'active') AS status,
-         toString(sf.community_id) AS community_id,
-         coalesce(sf.source, '') AS source,
-         coalesce(sf.source_quality, 0.0) AS score,
-         sf.created_at AS recorded_at
-  UNION ALL
+  WITH sf
+  ORDER BY sf.created_at DESC, sf.fragment_id ASC
+  LIMIT $limit
+  RETURN collect({
+    type: 'fragment',
+    id: sf.fragment_id,
+    key: 'fragment:' + sf.fragment_id,
+    title: substring(coalesce(sf.content, ''), 0, 160),
+    body: substring(coalesce(sf.content, ''), 0, 600),
+    status: coalesce(sf.status, 'active'),
+    community_id: toString(sf.community_id),
+    source: coalesce(sf.source, ''),
+    score: coalesce(sf.source_quality, 0.0),
+    recorded_at: sf.created_at
+  }) AS rows
+}
+WITH factRows, claimRows, rows AS fragmentRows
+CALL {
   MATCH (d:Dream {team_id: $profileId})
   WHERE $includeDream
     AND coalesce(d.status, '') IN ['proposed', 'reinforced']
     AND ($query = '' OR toLower(coalesce(d.hypothesis, '') + ' ' + coalesce(d.what_if, '') + ' ' + coalesce(d.possible_outcome, '')) CONTAINS $query)
-  RETURN 'dream' AS type,
-         d.dream_id AS id,
-         'dream:' + d.dream_id AS key,
-         coalesce(d.hypothesis, '') AS title,
-         trim(coalesce(d.what_if, '') + ' ' + coalesce(d.possible_outcome, '')) AS body,
-         coalesce(d.status, '') AS status,
-         toString(d.community_id) AS community_id,
-         coalesce(d.generator_model, '') AS source,
-         coalesce(d.confidence, d.likelihood, 0.0) AS score,
-         d.updated_at AS recorded_at
+  WITH d
+  ORDER BY d.updated_at DESC, d.dream_id ASC
+  LIMIT $limit
+  RETURN collect({
+    type: 'dream',
+    id: d.dream_id,
+    key: 'dream:' + d.dream_id,
+    title: coalesce(d.hypothesis, ''),
+    body: trim(coalesce(d.what_if, '') + ' ' + coalesce(d.possible_outcome, '')),
+    status: coalesce(d.status, ''),
+    community_id: toString(d.community_id),
+    source: coalesce(d.generator_model, ''),
+    score: coalesce(d.confidence, d.likelihood, 0.0),
+    recorded_at: d.updated_at
+  }) AS rows
 }
-RETURN type, id, key, title, body, status, community_id, source, score, recorded_at
+WITH factRows + claimRows + fragmentRows + rows AS nodeRows
+UNWIND nodeRows AS row
+RETURN row.type AS type,
+       row.id AS id,
+       row.key AS key,
+       row.title AS title,
+       row.body AS body,
+       row.status AS status,
+       row.community_id AS community_id,
+       row.source AS source,
+       row.score AS score,
+       row.recorded_at AS recorded_at
 ORDER BY recorded_at DESC, key ASC
-LIMIT $limit`
+`
 
 func localNodesCypher(depth int) string {
 	return fmt.Sprintf(`
 MATCH (anchor)
-WHERE anchor.team_id = $profileId
-  AND (
-    ($anchorType = 'fact' AND anchor:Fact AND anchor.fact_id = $anchorID AND coalesce(anchor.status, '') IN ['active', 'needs_revalidation']) OR
-    ($anchorType = 'claim' AND anchor:Claim AND anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected') OR
-    ($anchorType = 'fragment' AND anchor:SourceFragment AND anchor.fragment_id = $anchorID AND coalesce(anchor.status, 'active') <> 'retracted') OR
-    ($anchorType = 'dream' AND anchor:Dream AND anchor.dream_id = $anchorID AND coalesce(anchor.status, '') IN ['proposed', 'reinforced'])
-  )
+	WHERE anchor.team_id = $profileId
+	  AND (
+	    ($anchorType = 'fact' AND anchor:Fact AND anchor.fact_id = $anchorID AND (
+	      coalesce(anchor.status, '') IN ['active', 'needs_revalidation'] OR
+	      ($includeSuperseded AND coalesce(anchor.status, '') = 'superseded')
+	    )) OR
+	    ($anchorType = 'claim' AND anchor:Claim AND anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(anchor.status, 'candidate') <> 'superseded')) OR
+	    ($anchorType = 'fragment' AND anchor:SourceFragment AND anchor.fragment_id = $anchorID AND coalesce(anchor.status, 'active') <> 'retracted') OR
+	    ($anchorType = 'dream' AND anchor:Dream AND anchor.dream_id = $anchorID AND coalesce(anchor.status, '') IN ['proposed', 'reinforced'])
+	  )
 CALL {
   WITH anchor
   RETURN anchor AS n
@@ -429,12 +464,15 @@ CALL {
   RETURN DISTINCT n
 }
 WITH anchor, n
-WHERE elementId(n) = elementId(anchor) OR (
-  ($includeFact AND n:Fact AND coalesce(n.status, '') IN ['active', 'needs_revalidation']) OR
-  ($includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected') OR
-  ($includeFragment AND n:SourceFragment AND coalesce(n.status, 'active') <> 'retracted') OR
-  ($includeDream AND n:Dream AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
-)
+	WHERE elementId(n) = elementId(anchor) OR (
+	  ($includeFact AND n:Fact AND (
+	    coalesce(n.status, '') IN ['active', 'needs_revalidation'] OR
+	    ($includeSuperseded AND coalesce(n.status, '') = 'superseded')
+	  )) OR
+	  ($includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(n.status, 'candidate') <> 'superseded')) OR
+	  ($includeFragment AND n:SourceFragment AND coalesce(n.status, 'active') <> 'retracted') OR
+	  ($includeDream AND n:Dream AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
+	)
 WITH DISTINCT anchor, n
 RETURN
        CASE
@@ -523,4 +561,4 @@ RETURN elementId(r) AS id,
        target_key AS target,
        type(r) AS relationship
 ORDER BY relationship ASC, source ASC, target ASC
-LIMIT $edgeLimit`
+`

--- a/internal/service/graphview/graphview_test.go
+++ b/internal/service/graphview/graphview_test.go
@@ -80,6 +80,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 			t.Fatalf("node query missing %q:\n%s", required, nodeCall.query)
 		}
 	}
+	if strings.Count(nodeCall.query, "LIMIT $limit") < 4 {
+		t.Fatalf("node query should apply the limit per graph node type:\n%s", nodeCall.query)
+	}
 	if nodeCall.params["limit"] != int64(MaxLimit) {
 		t.Fatalf("limit param = %#v; want %d", nodeCall.params["limit"], MaxLimit)
 	}
@@ -91,6 +94,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	}
 	if nodeCall.params["includeClaim"] != false || nodeCall.params["includeFragment"] != false {
 		t.Fatalf("unexpected default type params after explicit filter: %#v", nodeCall.params)
+	}
+	if nodeCall.params["includeSuperseded"] != false {
+		t.Fatalf("includeSuperseded = %#v; want false", nodeCall.params["includeSuperseded"])
 	}
 }
 
@@ -172,8 +178,8 @@ func TestGraphOverviewReturnsNormalizedEdgesAndDedupedNodes(t *testing.T) {
 		t.Fatalf("fallback edge = %#v", got.Edges[1])
 	}
 	edgeCall := reader.calls[1]
-	if edgeCall.params["edgeLimit"] != int64(120) {
-		t.Fatalf("edgeLimit = %#v; want minimum cap", edgeCall.params["edgeLimit"])
+	if _, exists := edgeCall.params["edgeLimit"]; exists || strings.Contains(edgeCall.query, "LIMIT $edgeLimit") {
+		t.Fatalf("edge query should not apply a separate edge cap: params=%#v\n%s", edgeCall.params, edgeCall.query)
 	}
 	if keys, ok := edgeCall.params["nodeKeys"].([]string); !ok || len(keys) != 1 || keys[0] != "fact:fact-1" {
 		t.Fatalf("nodeKeys = %#v; want returned node keys", edgeCall.params["nodeKeys"])
@@ -219,7 +225,7 @@ func TestGraphLocalClampsDepthAndRejectsDynamicTraversalInput(t *testing.T) {
 	if !strings.Contains(nodeCall.query, "*1..2") {
 		t.Fatalf("local query missing clamped depth:\n%s", nodeCall.query)
 	}
-	if !strings.Contains(nodeCall.query, "anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected'") {
+	if !strings.Contains(nodeCall.query, "anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(anchor.status, 'candidate') <> 'superseded')") {
 		t.Fatalf("local query must filter rejected claim anchors:\n%s", nodeCall.query)
 	}
 	if nodeCall.params["anchorType"] != "claim" || nodeCall.params["anchorID"] != "claim-1" {

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -278,11 +278,21 @@ describe("UserPortalApp", () => {
     await userEvent.click(screen.getByRole("button", { name: /graph/i }));
 
     expect(await screen.findByLabelText("Knowledge graph")).toBeInTheDocument();
+    const controls = screen.getByLabelText("Graph controls");
+    expect(within(controls).queryByLabelText("Limit")).not.toBeInTheDocument();
     expect((await screen.findAllByText("Alice works_on project-x")).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByLabelText("Graph totals")).toHaveTextContent("2");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=1&limit=80",
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2",
+        expect.any(Object),
+      );
+    });
+    await userEvent.click(within(controls).getByRole("checkbox", { name: "Superseded" }));
+    await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2&include_superseded=true",
         expect.any(Object),
       );
     });
@@ -298,7 +308,7 @@ describe("UserPortalApp", () => {
     const controls = await screen.findByLabelText("Graph controls");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=1&limit=80",
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2",
         expect.any(Object),
       );
     });
@@ -329,7 +339,7 @@ describe("UserPortalApp", () => {
     expect(await screen.findByTestId("force-graph")).toHaveTextContent("Alice works_on project-x");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=local&types=fact%2Cclaim%2Cfragment%2Cdream&anchor_type=fact&anchor_id=fact-1&depth=1&limit=48",
+        "/ui/api/graph?scope=local&types=fact%2Cclaim%2Cfragment%2Cdream&anchor_type=fact&anchor_id=fact-1&depth=2&limit=48",
         expect.any(Object),
       );
     });

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserPortalApp } from "./App";
-import { Community, GraphSnapshot, RecallHit, UserKey, UserSession } from "./api";
+import { GraphSnapshot, RecallHit, UserKey, UserSession } from "./api";
 
 vi.mock("react-force-graph-2d", async () => {
   const React = await import("react");
@@ -128,18 +128,6 @@ const recallHits: RecallHit[] = [
   },
 ];
 
-const recallCommunities: Community[] = [
-  {
-    community_id: "community-1",
-    level: 0,
-    summary: "Project work around Dense-Mem.",
-    member_count: 3,
-    top_entities: ["Alice", "project-x", "Dense-Mem"],
-    top_predicates: ["works_on", "uses"],
-    last_summarized_at: "2026-05-02T12:00:00Z",
-  },
-];
-
 const overviewGraph: GraphSnapshot = {
   scope: "overview",
   depth: 1,
@@ -201,6 +189,10 @@ describe("UserPortalApp", () => {
     expect(screen.getByLabelText("Knowledge navigation")).toHaveClass("top-nav-bar");
     expect(screen.getByLabelText("Knowledge sections")).toHaveClass("top-nav-tabs");
     expect(screen.getByLabelText("Current workspace")).not.toHaveTextContent("Mine");
+    expect(screen.queryByRole("button", { name: "Facts" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Claims" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fragments" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Communities" })).not.toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/profiles"))).toBe(false);
   });
 
@@ -227,7 +219,7 @@ describe("UserPortalApp", () => {
   });
 
   it("filters recall results and updates the inspector selection", async () => {
-    mockUserFetch(baseSession, [], { recallHits, communities: recallCommunities });
+    mockUserFetch(baseSession, [], { recallHits });
     sessionStorage.setItem("denseMem.userApiKey", "dm_read");
 
     render(<UserPortalApp />);
@@ -326,7 +318,7 @@ describe("UserPortalApp", () => {
   });
 
   it("loads a local graph from the recall inspector", async () => {
-    const fetchMock = mockUserFetch(baseSession, [], { recallHits, communities: recallCommunities, graphSnapshot: localGraph });
+    const fetchMock = mockUserFetch(baseSession, [], { recallHits, graphSnapshot: localGraph });
     sessionStorage.setItem("denseMem.userApiKey", "dm_read");
 
     render(<UserPortalApp />);
@@ -346,7 +338,7 @@ describe("UserPortalApp", () => {
   });
 
   it("resets stale source filters after a new recall search", async () => {
-    mockUserFetch(baseSession, [], { recallHits: [recallHits, [recallHits[0]]], communities: recallCommunities });
+    mockUserFetch(baseSession, [], { recallHits: [recallHits, [recallHits[0]]] });
     sessionStorage.setItem("denseMem.userApiKey", "dm_read");
 
     render(<UserPortalApp />);
@@ -709,7 +701,7 @@ async function expectCurrentWorkspace(teamName: string) {
   expect(workspace).toHaveTextContent(teamName);
 }
 
-function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; communities?: Community[]; graphSnapshot?: GraphSnapshot } = {}) {
+function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot } = {}) {
   let currentTeam = session.team;
   let currentProfiles = profiles;
   let recallCallCount = 0;
@@ -782,9 +774,6 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
     if (url.includes(`/api/v1/teams/${currentTeam.id}/profiles/`) && method === "DELETE") {
       currentProfiles = currentProfiles.filter((profile) => !url.endsWith(`/profiles/${profile.id}`));
       return jsonResponse({ data: { status: "deleted" } });
-    }
-    if (url.startsWith("/api/v1/communities")) {
-      return jsonResponse({ items: options.communities ?? [] });
     }
     if (url.startsWith("/api/v1/recall")) {
       const configuredHits = options.recallHits ?? [];
@@ -904,9 +893,6 @@ function mockSSOUserFetch(initial: UserSession, switched: UserSession, options: 
         return jsonResponse({ message: "logout failed" }, options.logoutStatus);
       }
       return jsonResponse({ data: { status: "signed_out" } });
-    }
-    if (url.startsWith("/api/v1/communities")) {
-      return jsonResponse({ items: [] });
     }
     if (url.startsWith("/api/v1/recall")) {
       return jsonResponse({ data: [] });

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -2,10 +2,7 @@ import { Component, FormEvent, lazy, Suspense, useEffect, useMemo, useRef, useSt
 import type { ReactNode } from "react";
 import {
   BarChart3,
-  FileText,
-  GitBranch,
   KeyRound,
-  Layers3,
   LogOut,
   Moon,
   Network,
@@ -17,10 +14,6 @@ import {
 } from "lucide-react";
 import { TelemetrySnapshot, TelemetryWindowKey } from "../telemetry/types";
 import {
-  Claim,
-  Community,
-  Fact,
-  Fragment,
   RotateResponse,
   SSOProvider,
   UserApi,
@@ -39,7 +32,7 @@ const THEME_STORAGE_KEY = "denseMem.userTheme";
 
 type Theme = "light" | "dark";
 type AuthMode = "none" | "api_key" | "sso";
-type UserTab = "search" | "graph" | "dreams" | "usage" | "facts" | "claims" | "fragments" | "communities" | "team" | "key";
+type UserTab = "search" | "graph" | "dreams" | "usage" | "team" | "key";
 type ProfilePermission = "read" | "read_write";
 
 function sessionAuthMode(session: UserSession): AuthMode {
@@ -307,10 +300,6 @@ function UserPortal({
     ...(canShowUsage(session) ? [
       { id: "usage", label: "Usage", icon: <BarChart3 size={17} aria-hidden="true" />, active: activeTab === "usage", onClick: () => setActiveTab("usage") },
     ] : []),
-    { id: "facts", label: "Facts", icon: <ShieldCheck size={17} aria-hidden="true" />, active: activeTab === "facts", onClick: () => setActiveTab("facts") },
-    { id: "claims", label: "Claims", icon: <GitBranch size={17} aria-hidden="true" />, active: activeTab === "claims", onClick: () => setActiveTab("claims") },
-    { id: "fragments", label: "Fragments", icon: <FileText size={17} aria-hidden="true" />, active: activeTab === "fragments", onClick: () => setActiveTab("fragments") },
-    { id: "communities", label: "Communities", icon: <Layers3 size={17} aria-hidden="true" />, active: activeTab === "communities", onClick: () => setActiveTab("communities") },
     ...(session?.can_manage_team ? [
       { id: "team", label: "Team", icon: <Users size={17} aria-hidden="true" />, active: activeTab === "team", onClick: () => setActiveTab("team") },
     ] : []),
@@ -373,10 +362,6 @@ function UserPortal({
           {activeTab === "usage" && session && canShowUsage(session) && (
             <UserTelemetryPanel key={userTelemetryIdentity(session)} api={api} session={session} />
           )}
-          {activeTab === "facts" && <FactsPanel api={api} />}
-          {activeTab === "claims" && <ClaimsPanel api={api} />}
-          {activeTab === "fragments" && <FragmentsPanel api={api} />}
-          {activeTab === "communities" && <CommunitiesPanel api={api} />}
           {activeTab === "team" && session?.can_manage_team && (
             <TeamManagementPanel
               api={api}
@@ -523,54 +508,6 @@ function UserTelemetryPanel({ api, session }: { api: UserApi; session: UserSessi
   );
 }
 
-function FactsPanel({ api }: { api: UserApi }) {
-  const { data, loading, error, reload } = useKnowledge(() => api.listFacts(20), [api]);
-  return (
-    <section className="surface">
-      <PanelHeading title="Facts" count={data?.items.length ?? 0} onRefresh={reload} />
-      {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <LoadingState label="Loading facts" />}
-      {!loading && <FactList items={data?.items ?? []} />}
-    </section>
-  );
-}
-
-function ClaimsPanel({ api }: { api: UserApi }) {
-  const { data, loading, error, reload } = useKnowledge(() => api.listClaims(20), [api]);
-  return (
-    <section className="surface">
-      <PanelHeading title="Claims" count={data?.items.length ?? 0} onRefresh={reload} />
-      {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <LoadingState label="Loading claims" />}
-      {!loading && <ClaimList items={data?.items ?? []} />}
-    </section>
-  );
-}
-
-function FragmentsPanel({ api }: { api: UserApi }) {
-  const { data, loading, error, reload } = useKnowledge(() => api.listFragments(20), [api]);
-  return (
-    <section className="surface">
-      <PanelHeading title="Fragments" count={data?.items.length ?? 0} onRefresh={reload} />
-      {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <LoadingState label="Loading fragments" />}
-      {!loading && <FragmentList items={data?.items ?? []} />}
-    </section>
-  );
-}
-
-function CommunitiesPanel({ api }: { api: UserApi }) {
-  const { data, loading, error, reload } = useKnowledge(() => api.listCommunities(20), [api]);
-  return (
-    <section className="surface">
-      <PanelHeading title="Communities" count={data?.items.length ?? 0} onRefresh={reload} />
-      {error && <div className="banner error" role="alert">{error}</div>}
-      {loading && <LoadingState label="Loading communities" />}
-      {!loading && <CommunityList items={data?.items ?? []} />}
-    </section>
-  );
-}
-
 function KeyPanel({
   api,
   session,
@@ -696,102 +633,6 @@ function KeyPanel({
   );
 }
 
-function PanelHeading({ title, count, onRefresh }: { title: string; count: number; onRefresh: () => void }) {
-  return (
-    <SectionHeading
-      title={title}
-      actions={(
-        <div className="button-row">
-          <span>{count}</span>
-          <button className="icon-button" type="button" aria-label={`Refresh ${title}`} onClick={onRefresh}>
-            <RefreshCw size={16} aria-hidden="true" />
-          </button>
-        </div>
-      )}
-    />
-  );
-}
-
-function FactList({ items }: { items: Fact[] }) {
-  if (items.length === 0) {
-    return <div className="table-placeholder">No facts</div>;
-  }
-  return (
-    <div className="knowledge-list">
-      {items.map((fact) => (
-        <article className="knowledge-item" key={fact.fact_id}>
-          <div className="knowledge-item-head">
-            <span className="status-pill neutral">{fact.status}</span>
-            <small>{scoreLabel(fact.truth_score)}</small>
-          </div>
-          <h3>{fact.subject}</h3>
-          <p>{fact.predicate}: {fact.object}</p>
-        </article>
-      ))}
-    </div>
-  );
-}
-
-function ClaimList({ items }: { items: Claim[] }) {
-  if (items.length === 0) {
-    return <div className="table-placeholder">No claims</div>;
-  }
-  return (
-    <div className="knowledge-list">
-      {items.map((claim) => (
-        <article className="knowledge-item" key={claim.claim_id}>
-          <div className="knowledge-item-head">
-            <span className="status-pill neutral">{claim.status}</span>
-            <small>{claim.entailment_verdict || claim.modality}</small>
-          </div>
-          <h3>{claim.subject}</h3>
-          <p>{claim.predicate}: {claim.object}</p>
-        </article>
-      ))}
-    </div>
-  );
-}
-
-function FragmentList({ items }: { items: Fragment[] }) {
-  if (items.length === 0) {
-    return <div className="table-placeholder">No fragments</div>;
-  }
-  return (
-    <div className="knowledge-list">
-      {items.map((fragment) => (
-        <article className="knowledge-item" key={fragment.fragment_id || fragment.id}>
-          <div className="knowledge-item-head">
-            <span className="status-pill neutral">{fragment.source_type || "fragment"}</span>
-            <small>{fragment.status || "active"}</small>
-          </div>
-          <h3>{fragment.source || shortId(fragment.fragment_id || fragment.id)}</h3>
-          <p>{fragment.content}</p>
-        </article>
-      ))}
-    </div>
-  );
-}
-
-function CommunityList({ items }: { items: Community[] }) {
-  if (items.length === 0) {
-    return <div className="table-placeholder">No communities</div>;
-  }
-  return (
-    <div className="knowledge-list">
-      {items.map((community) => (
-        <article className="knowledge-item" key={community.community_id}>
-          <div className="knowledge-item-head">
-            <span className="status-pill neutral">Level {community.level}</span>
-            <small>{community.member_count} members</small>
-          </div>
-          <h3>{community.top_entities?.slice(0, 3).join(", ") || shortId(community.community_id)}</h3>
-          <p>{community.summary}</p>
-        </article>
-      ))}
-    </div>
-  );
-}
-
 function CreatedKeyNotice({ apiKey, onDismiss }: { apiKey: string; onDismiss: () => void }) {
   return (
     <SecretBox
@@ -802,37 +643,6 @@ function CreatedKeyNotice({ apiKey, onDismiss }: { apiKey: string; onDismiss: ()
       onDismiss={onDismiss}
     />
   );
-}
-
-function useKnowledge<T>(load: () => Promise<T>, deps: unknown[]) {
-  const [data, setData] = useState<T | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-
-  async function reload() {
-    setLoading(true);
-    setError("");
-    try {
-      setData(await load());
-    } catch (err) {
-      setError(readError(err));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    void reload();
-  }, deps);
-
-  return { data, loading, error, reload };
-}
-
-function scoreLabel(value: number | undefined): string {
-  if (value === undefined || Number.isNaN(value)) {
-    return "";
-  }
-  return value.toFixed(value >= 1 ? 0 : 3);
 }
 
 function readTheme(): Theme {
@@ -849,10 +659,6 @@ function displayKeySuffix(suffix: string | null): string {
 
 function profileRoleLabel(role: UserSession["key"]["role"] | null | undefined): string {
   return role === "manager" ? "Manager" : "Member";
-}
-
-function shortId(id: string): string {
-  return id.length <= 8 ? id : id.slice(0, 8);
 }
 
 function formatDate(value: string): string {

--- a/web/src/user/GraphPanel.tsx
+++ b/web/src/user/GraphPanel.tsx
@@ -38,8 +38,8 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [anchorType, setAnchorType] = useState<GraphNodeType>("fact");
   const [anchorId, setAnchorId] = useState("");
   const [types, setTypes] = useState<TypeFilter>(defaultTypes);
-  const [depth, setDepth] = useState(1);
-  const [limit, setLimit] = useState(80);
+  const [depth, setDepth] = useState(2);
+  const [includeSuperseded, setIncludeSuperseded] = useState(false);
   const [nodeSize, setNodeSize] = useState(5);
   const [linkDistance, setLinkDistance] = useState(92);
   const [showArrows, setShowArrows] = useState(true);
@@ -48,7 +48,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  async function loadGraph(query: GraphQuery = buildQuery({ searchText, scope, anchorType, anchorId, types, depth, limit })) {
+  async function loadGraph(query: GraphQuery = buildQuery({ searchText, scope, anchorType, anchorId, types, depth, includeSuperseded })) {
     if (query.types?.length === 0) {
       setError("Select at least one type.");
       return;
@@ -71,7 +71,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   }
 
   useEffect(() => {
-    void loadGraph(buildQuery({ searchText: "", scope: "overview", anchorType, anchorId: "", types, depth: 1, limit }));
+    void loadGraph(buildQuery({ searchText: "", scope: "overview", anchorType, anchorId: "", types, depth: 2, includeSuperseded }));
   }, [api]);
 
   const selectedNode = snapshot?.nodes.find((node) => node.key === selectedKey) ?? snapshot?.nodes[0] ?? null;
@@ -146,11 +146,6 @@ export function GraphPanel({ api }: { api: UserApi }) {
             <span>{depth}</span>
           </div>
           <div className="graph-slider-row">
-            <label htmlFor="graph-limit">Limit</label>
-            <input id="graph-limit" type="range" min={30} max={180} step={10} value={limit} onChange={(event) => setLimit(Number(event.target.value))} />
-            <span>{limit}</span>
-          </div>
-          <div className="graph-slider-row">
             <label htmlFor="graph-node-size">Node size</label>
             <input id="graph-node-size" type="range" min={3} max={9} step={1} value={nodeSize} onChange={(event) => setNodeSize(Number(event.target.value))} />
             <span>{nodeSize}</span>
@@ -168,6 +163,10 @@ export function GraphPanel({ api }: { api: UserApi }) {
           <label className="toggle-row compact-toggle">
             <span>Labels</span>
             <input type="checkbox" checked={showLabels} onChange={(event) => setShowLabels(event.target.checked)} />
+          </label>
+          <label className="toggle-row compact-toggle">
+            <span>Superseded</span>
+            <input type="checkbox" checked={includeSuperseded} onChange={(event) => setIncludeSuperseded(event.target.checked)} />
           </label>
           <label className="toggle-row compact-toggle">
             <span>Communities</span>
@@ -228,7 +227,7 @@ export function ResultGraphPreview({ api, anchor }: { api: UserApi; anchor: Grap
       scope: "local",
       anchorType: anchor.type,
       anchorId: anchor.id,
-      depth: 1,
+      depth: 2,
       limit: 48,
       types: ["fact", "claim", "fragment", "dream"],
     })
@@ -309,6 +308,7 @@ function GraphCanvas({
 }) {
   const graphRef = useRef<ForceGraphMethods<ForceNode, ForceLink> | undefined>(undefined);
   const { ref, width, height } = useElementSize<HTMLDivElement>(compact ? 220 : 620);
+  const canvasTheme = useCanvasTheme(ref);
   const graphData = useMemo(() => ({
     nodes: snapshot.nodes.map((node) => ({ ...node, id: node.key, val: nodeValue(node, nodeSize) })),
     links: snapshot.edges.map((edge) => ({ ...edge, source: edge.source, target: edge.target })),
@@ -344,6 +344,7 @@ function GraphCanvas({
           nodeSize,
           showLabels,
           compact,
+          theme: canvasTheme,
         })}
         nodePointerAreaPaint={(node, color, canvas) => paintNodeArea(node, color, canvas, nodeSize)}
         linkLabel={(link) => relationshipLabel(link.relationship)}
@@ -386,6 +387,61 @@ function useElementSize<T extends HTMLElement>(fallbackHeight: number) {
   }, [fallbackHeight]);
 
   return { ref, ...size };
+}
+
+type CanvasTheme = {
+  label: string;
+  stroke: string;
+  selectedStroke: string;
+};
+
+const defaultCanvasTheme: CanvasTheme = {
+  label: "rgba(20, 31, 29, 0.92)",
+  stroke: "rgba(255, 255, 255, 0.86)",
+  selectedStroke: "#111827",
+};
+
+function useCanvasTheme<T extends HTMLElement>(ref: { current: T | null }): CanvasTheme {
+  const [theme, setTheme] = useState(defaultCanvasTheme);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+
+    const readTheme = () => {
+      const styles = getComputedStyle(node);
+      const shell = node.closest(".app-shell, .auth-shell");
+      const shellStyles = shell ? getComputedStyle(shell) : styles;
+      const isDark = shellStyles.getPropertyValue("color-scheme").includes("dark");
+      const next = {
+        label: cssVar(shellStyles, "--text", defaultCanvasTheme.label),
+        stroke: isDark ? "rgba(238, 247, 246, 0.82)" : defaultCanvasTheme.stroke,
+        selectedStroke: cssVar(shellStyles, "--accent-strong", defaultCanvasTheme.selectedStroke),
+      };
+      setTheme((current) => sameCanvasTheme(current, next) ? current : next);
+    };
+
+    readTheme();
+    const shell = node.closest(".app-shell, .auth-shell");
+    if (!shell || typeof MutationObserver === "undefined") {
+      return;
+    }
+    const observer = new MutationObserver(readTheme);
+    observer.observe(shell, { attributes: true, attributeFilter: ["data-theme", "class", "style"] });
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return theme;
+}
+
+function cssVar(styles: CSSStyleDeclaration, name: string, fallback: string): string {
+  return styles.getPropertyValue(name).trim() || fallback;
+}
+
+function sameCanvasTheme(left: CanvasTheme, right: CanvasTheme): boolean {
+  return left.label === right.label && left.stroke === right.stroke && left.selectedStroke === right.selectedStroke;
 }
 
 function GraphStats({ snapshot }: { snapshot: GraphSnapshot | null }) {
@@ -449,7 +505,7 @@ function buildQuery({
   anchorId,
   types,
   depth,
-  limit,
+  includeSuperseded,
 }: {
   searchText: string;
   scope: "overview" | "local";
@@ -457,7 +513,7 @@ function buildQuery({
   anchorId: string;
   types: TypeFilter;
   depth: number;
-  limit: number;
+  includeSuperseded: boolean;
 }): GraphQuery {
   const enabledTypes = (Object.keys(types) as GraphNodeType[]).filter((type) => types[type]);
   return {
@@ -467,7 +523,7 @@ function buildQuery({
     anchorType: scope === "local" ? anchorType : undefined,
     anchorId: scope === "local" ? anchorId.trim() : undefined,
     depth,
-    limit,
+    includeSuperseded,
   };
 }
 
@@ -475,7 +531,7 @@ function drawNode(
   node: ForceNode,
   canvas: CanvasRenderingContext2D,
   globalScale: number,
-  opts: { colorMode: ColorMode; selected: boolean; nodeSize: number; showLabels: boolean; compact: boolean },
+  opts: { colorMode: ColorMode; selected: boolean; nodeSize: number; showLabels: boolean; compact: boolean; theme: CanvasTheme },
 ) {
   const radius = nodeValue(node, opts.nodeSize);
   const color = nodeColor(node, opts.colorMode);
@@ -484,7 +540,7 @@ function drawNode(
   canvas.fillStyle = color;
   canvas.fill();
   canvas.lineWidth = opts.selected ? 3 / globalScale : 1.2 / globalScale;
-  canvas.strokeStyle = opts.selected ? "#111827" : "rgba(255, 255, 255, 0.86)";
+  canvas.strokeStyle = opts.selected ? opts.theme.selectedStroke : opts.theme.stroke;
   canvas.stroke();
 
   if (!opts.compact && (opts.showLabels || globalScale > 1.4)) {
@@ -493,7 +549,7 @@ function drawNode(
     canvas.font = `${fontSize}px Inter, ui-sans-serif, system-ui`;
     canvas.textAlign = "center";
     canvas.textBaseline = "top";
-    canvas.fillStyle = "rgba(20, 31, 29, 0.92)";
+    canvas.fillStyle = opts.theme.label;
     canvas.fillText(label, node.x ?? 0, (node.y ?? 0) + radius + 3);
   }
 }

--- a/web/src/user/SearchPanel.tsx
+++ b/web/src/user/SearchPanel.tsx
@@ -9,7 +9,7 @@ import {
   X,
 } from "lucide-react";
 import { LoadingState, SectionHeading } from "../ui/components";
-import { Claim, Community, Fact, Fragment, GraphNodeType, RecallHit, UserApi } from "./api";
+import { Claim, Fact, Fragment, GraphNodeType, RecallHit, UserApi } from "./api";
 
 const ResultGraphPreview = lazy(() => import("./GraphPanel").then((module) => ({ default: module.ResultGraphPreview })));
 
@@ -28,7 +28,6 @@ type IndexedRecallResult = {
 export function SearchPanel({ api }: { api: UserApi }) {
   const [query, setQuery] = useState("");
   const [hits, setHits] = useState<RecallHit[]>([]);
-  const [communities, setCommunities] = useState<Community[]>([]);
   const [selectedKey, setSelectedKey] = useState("");
   const [enabledTypes, setEnabledTypes] = useState<Record<RecallResultKind, boolean>>({
     fact: true,
@@ -62,12 +61,8 @@ export function SearchPanel({ api }: { api: UserApi }) {
     setLoading(true);
     setError("");
     try {
-      const [nextHits, nextCommunities] = await Promise.all([
-        api.recall(trimmed, 10),
-        api.listCommunities(20).catch(() => ({ items: [] as Community[] })),
-      ]);
+      const nextHits = await api.recall(trimmed, 10);
       setHits(nextHits);
-      setCommunities(nextCommunities.items);
       setSourceFilter("all");
       setInspectorOpen(true);
       setInspectorTab("evidence");
@@ -79,7 +74,7 @@ export function SearchPanel({ api }: { api: UserApi }) {
     }
   }
 
-  const entities = useMemo(() => deriveEntities(hits, communities), [hits, communities]);
+  const entities = useMemo(() => deriveEntities(hits), [hits]);
   const indexedHits = useMemo(() => hits.map((hit, index) => ({
     hit,
     key: recallKey(hit, index),
@@ -486,7 +481,7 @@ function recallGraphAnchor(result: IndexedRecallResult): { type: GraphNodeType; 
   return null;
 }
 
-function deriveEntities(hits: RecallHit[], communities: Community[]): string[] {
+function deriveEntities(hits: RecallHit[]): string[] {
   const values = new Set<string>();
   for (const hit of hits) {
     const source = hit.fact ?? hit.claim;
@@ -494,11 +489,6 @@ function deriveEntities(hits: RecallHit[], communities: Community[]): string[] {
       addEntity(values, source.subject);
       addEntity(values, source.object);
       addEntity(values, source.predicate);
-    }
-  }
-  for (const community of communities) {
-    for (const entity of community.top_entities ?? []) {
-      addEntity(values, entity);
     }
   }
   return Array.from(values).slice(0, 20);

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -104,11 +104,12 @@ describe("UserApi", () => {
       anchorId: "fact-1",
       depth: 2,
       limit: 40,
+      includeSuperseded: true,
     });
 
     expect(result.scope).toBe("local");
     expect(fetchMock).toHaveBeenCalledWith(
-      "/ui/api/graph?scope=local&q=project+graph&types=fact%2Cclaim&anchor_type=fact&anchor_id=fact-1&depth=2&limit=40",
+      "/ui/api/graph?scope=local&q=project+graph&types=fact%2Cclaim&anchor_type=fact&anchor_id=fact-1&depth=2&limit=40&include_superseded=true",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
       }),

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -263,6 +263,7 @@ export type GraphQuery = {
   anchorId?: string;
   depth?: number;
   limit?: number;
+  includeSuperseded?: boolean;
 };
 
 type RequestOptions = {
@@ -387,6 +388,9 @@ export class UserApi {
     }
     if (query.limit !== undefined) {
       params.set("limit", String(query.limit));
+    }
+    if (query.includeSuperseded) {
+      params.set("include_superseded", "true");
     }
     const suffix = params.toString() ? `?${params.toString()}` : "";
     const payload = await this.request<Envelope<GraphSnapshot>>(`/ui/api/graph${suffix}`);

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -121,16 +121,6 @@ export type Fact = {
   labels?: string[];
 };
 
-export type Community = {
-  community_id: string;
-  level: number;
-  summary: string;
-  member_count: number;
-  top_entities?: string[];
-  top_predicates?: string[];
-  last_summarized_at: string;
-};
-
 export type ListResponse<T> = {
   items: T[];
   next_cursor?: string;
@@ -395,22 +385,6 @@ export class UserApi {
     const suffix = params.toString() ? `?${params.toString()}` : "";
     const payload = await this.request<Envelope<GraphSnapshot>>(`/ui/api/graph${suffix}`);
     return payload.data;
-  }
-
-  listFacts(limit = 20): Promise<ListResponse<Fact>> {
-    return this.request<ListResponse<Fact>>(`/api/v1/facts?limit=${limit}`);
-  }
-
-  listClaims(limit = 20): Promise<ListResponse<Claim>> {
-    return this.request<ListResponse<Claim>>(`/api/v1/claims?limit=${limit}`);
-  }
-
-  listFragments(limit = 20): Promise<ListResponse<Fragment>> {
-    return this.request<ListResponse<Fragment>>(`/api/v1/fragments?limit=${limit}`);
-  }
-
-  listCommunities(limit = 20): Promise<ListResponse<Community>> {
-    return this.request<ListResponse<Community>>(`/api/v1/communities?limit=${limit}`);
   }
 
   async dreamingStatus(): Promise<DreamStatus> {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -97,18 +97,6 @@ const fragments = [
   },
 ];
 
-const communities = [
-  {
-    community_id: "community-1",
-    level: 0,
-    summary: "Project work around Dense-Mem.",
-    member_count: 3,
-    top_entities: ["Alice", "project-x", "Dense-Mem"],
-    top_predicates: ["works_on", "uses"],
-    last_summarized_at: "2026-05-02T12:00:00Z",
-  },
-];
-
 const graphSnapshot = {
   scope: "overview",
   depth: 1,
@@ -230,7 +218,7 @@ const telemetry = {
   state_series: telemetrySeries.filter((series) => currentTelemetryIds.has(series.id)),
 };
 
-test("API key login, recall, and read-only knowledge tabs", async ({ page }) => {
+test("API key login, recall, and read-only navigation", async ({ page }) => {
   const calls = await mockUserApi(page, { key: readKey, canRotate: false });
   await openUserPortal(page, "dm_read");
 
@@ -257,18 +245,10 @@ test("API key login, recall, and read-only knowledge tabs", async ({ page }) => 
   await expect(page.getByLabel("Inspector")).toContainText("Alice is working on project-x with Dense-Mem.");
 
   await expect(page.getByRole("button", { name: "Usage" })).toHaveCount(0);
-
-  await page.getByRole("button", { name: "Facts" }).click();
-  await expect(page.getByText("works_on: project-x")).toBeVisible();
-
-  await page.getByRole("button", { name: "Claims" }).click();
-  await expect(page.getByText("uses: Dense-Mem")).toBeVisible();
-
-  await page.getByRole("button", { name: "Fragments" }).click();
-  await expect(page.getByText("Alice is working on project-x with Dense-Mem.")).toBeVisible();
-
-  await page.getByRole("button", { name: "Communities" }).click();
-  await expect(page.getByText("Project work around Dense-Mem.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Facts" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Claims" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Fragments" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Communities" })).toHaveCount(0);
   expect(calls.disallowedProfileCalls).toEqual([]);
   expect(calls.telemetryRequests).toEqual([]);
 });
@@ -626,22 +606,6 @@ async function mockUserApi(
         ],
       }),
     });
-  });
-
-  await page.route("**/api/v1/facts**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: facts, has_more: false }) });
-  });
-
-  await page.route("**/api/v1/claims**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: claims, has_more: false }) });
-  });
-
-  await page.route("**/api/v1/fragments**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: fragments, has_more: false }) });
-  });
-
-  await page.route("**/api/v1/communities**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: communities, total: communities.length }) });
   });
 
   return calls;


### PR DESCRIPTION
## What changed

- Removed the visible graph node limit control from the `/ui` graph tab.
- Balanced overview graph node selection per enabled type so fragments cannot starve facts and claims.
- Removed the separate edge cap so all edges among returned nodes are included.
- Defaulted local graph depth to `2` and added an `include_superseded` graph query flag with a Superseded toggle.
- Updated canvas label and stroke rendering to use theme colors so labels remain visible in dark theme.
- Removed `/ui` tabs, panels, API wrappers, and test mocks for direct facts, claims, fragments, and communities list routes that now 404.

## Why

The graph tab could return only fragments when fact, claim, and fragment filters were enabled because the backend applied one global node limit across all types. Canvas labels also used a light-theme text color, making them hard to read in dark theme. The portal also still exposed direct knowledge list tabs backed by routes that are intentionally no longer served.

## Validation

- `go test ./internal/service/graphview ./internal/http`
- `npm --prefix web test -- src/user/api.test.ts src/user/App.test.tsx`
- `npm --prefix web run typecheck`
- `npm --prefix web run playwright:mock:user -- --grep "API key login|graph tab renders"`
- Pre-push hook full lint/test/coverage flow passed; total coverage `90.2%`.
