### PR TITLE
[codex] Keep graph bridge claims visible

### DIFF
--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -362,7 +362,6 @@ CALL {
   MATCH (c:Claim {team_id: $profileId})
   WHERE $includeClaim
     AND coalesce(c.status, 'candidate') <> 'rejected'
-    AND ($includeSuperseded OR coalesce(c.status, 'candidate') <> 'superseded')
     AND ($query = '' OR toLower(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')) CONTAINS $query)
   WITH c
   ORDER BY c.recorded_at DESC, c.claim_id ASC
@@ -448,7 +447,7 @@ MATCH (anchor)
 	      coalesce(anchor.status, '') IN ['active', 'needs_revalidation'] OR
 	      ($includeSuperseded AND coalesce(anchor.status, '') = 'superseded')
 	    )) OR
-	    ($anchorType = 'claim' AND anchor:Claim AND anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(anchor.status, 'candidate') <> 'superseded')) OR
+	    ($anchorType = 'claim' AND anchor:Claim AND anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected') OR
 	    ($anchorType = 'fragment' AND anchor:SourceFragment AND anchor.fragment_id = $anchorID AND coalesce(anchor.status, 'active') <> 'retracted') OR
 	    ($anchorType = 'dream' AND anchor:Dream AND anchor.dream_id = $anchorID AND coalesce(anchor.status, '') IN ['proposed', 'reinforced'])
 	  )
@@ -469,7 +468,7 @@ WITH anchor, n
 	    coalesce(n.status, '') IN ['active', 'needs_revalidation'] OR
 	    ($includeSuperseded AND coalesce(n.status, '') = 'superseded')
 	  )) OR
-	  ($includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(n.status, 'candidate') <> 'superseded')) OR
+	  ($includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected') OR
 	  ($includeFragment AND n:SourceFragment AND coalesce(n.status, 'active') <> 'retracted') OR
 	  ($includeDream AND n:Dream AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
 	)

--- a/internal/service/graphview/graphview_test.go
+++ b/internal/service/graphview/graphview_test.go
@@ -83,6 +83,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	if strings.Count(nodeCall.query, "LIMIT $limit") < 4 {
 		t.Fatalf("node query should apply the limit per graph node type:\n%s", nodeCall.query)
 	}
+	if strings.Contains(nodeCall.query, "coalesce(c.status, 'candidate') <> 'superseded'") {
+		t.Fatalf("overview query must keep superseded claims as provenance bridge nodes:\n%s", nodeCall.query)
+	}
 	if nodeCall.params["limit"] != int64(MaxLimit) {
 		t.Fatalf("limit param = %#v; want %d", nodeCall.params["limit"], MaxLimit)
 	}
@@ -225,8 +228,12 @@ func TestGraphLocalClampsDepthAndRejectsDynamicTraversalInput(t *testing.T) {
 	if !strings.Contains(nodeCall.query, "*1..2") {
 		t.Fatalf("local query missing clamped depth:\n%s", nodeCall.query)
 	}
-	if !strings.Contains(nodeCall.query, "anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected' AND ($includeSuperseded OR coalesce(anchor.status, 'candidate') <> 'superseded')") {
+	if !strings.Contains(nodeCall.query, "anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected'") {
 		t.Fatalf("local query must filter rejected claim anchors:\n%s", nodeCall.query)
+	}
+	if strings.Contains(nodeCall.query, "coalesce(anchor.status, 'candidate') <> 'superseded") ||
+		strings.Contains(nodeCall.query, "coalesce(n.status, 'candidate') <> 'superseded") {
+		t.Fatalf("local query must keep superseded claims as provenance bridge nodes:\n%s", nodeCall.query)
 	}
 	if nodeCall.params["anchorType"] != "claim" || nodeCall.params["anchorID"] != "claim-1" {
 		t.Fatalf("anchor params = %#v", nodeCall.params)

--- a/internal/service/graphview/graphview_test.go
+++ b/internal/service/graphview/graphview_test.go
@@ -83,6 +83,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	if strings.Count(nodeCall.query, "LIMIT $limit") < 4 {
 		t.Fatalf("node query should apply the limit per graph node type:\n%s", nodeCall.query)
 	}
+	if !strings.Contains(nodeCall.query, "coalesce(c.status, 'candidate') <> 'rejected'") {
+		t.Fatalf("overview query must filter rejected claims:\n%s", nodeCall.query)
+	}
 	if strings.Contains(nodeCall.query, "coalesce(c.status, 'candidate') <> 'superseded'") {
 		t.Fatalf("overview query must keep superseded claims as provenance bridge nodes:\n%s", nodeCall.query)
 	}
@@ -230,6 +233,9 @@ func TestGraphLocalClampsDepthAndRejectsDynamicTraversalInput(t *testing.T) {
 	}
 	if !strings.Contains(nodeCall.query, "anchor.claim_id = $anchorID AND coalesce(anchor.status, 'candidate') <> 'rejected'") {
 		t.Fatalf("local query must filter rejected claim anchors:\n%s", nodeCall.query)
+	}
+	if !strings.Contains(nodeCall.query, "$includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected'") {
+		t.Fatalf("local query must filter rejected claim nodes:\n%s", nodeCall.query)
 	}
 	if strings.Contains(nodeCall.query, "coalesce(anchor.status, 'candidate') <> 'superseded") ||
 		strings.Contains(nodeCall.query, "coalesce(n.status, 'candidate') <> 'superseded") {


### PR DESCRIPTION
## What

Keep non-rejected claims visible in graph views even when their status is `superseded`.

## Why

Promoted claims are normal provenance bridge nodes in Dense-Mem: they connect facts to supporting fragments through `PROMOTES_TO` and `SUPPORTED_BY` edges. Hiding superseded claims by default removed the connective tissue from the graph and caused graph views to show nodes without their expected edges.

## Impact

The graph view now favors connected-memory visualization by default while still excluding rejected claims. The existing `Superseded` toggle continues to gate superseded facts, which are more likely to clutter the view than provenance bridge claims.

## Validation

- `go test ./internal/service/graphview`
- `go test ./internal/http ./internal/service/graphview`
- `go test ./cmd/... ./internal/...`

`go test ./...` is blocked locally by a pre-existing root-owned generated runtime directory at `tests/eval/runtime/postgres/18/docker`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Superseded claims are now preserved in graph views instead of being hidden in certain cases.
  * Improved claim-node selection so graph results stay consistent across overview and local views.
  * Rejected claims continue to be excluded as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->