### PR TITLE
[codex] Show full UI graph topology

### DIFF
--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -79,6 +79,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 	api.GET("/session", portal.session)
 	api.GET("/telemetry", portal.telemetrySnapshot, httpmw.RequireScopes("write"))
 	api.GET("/graph", portal.graphSnapshot, httpmw.RequireScopes("read"))
+	api.GET("/node-detail", portal.graphNodeDetail, httpmw.RequireScopes("read"))
 	api.POST("/key/rotate", portal.rotateCurrentKey, httpmw.RequireScopes("write"))
 	if deps.SSOService != nil {
 		api.POST("/sso/team", portal.switchSSOTeam, httpmw.RequireScopes("read"))
@@ -240,6 +241,32 @@ func (h *userPortalHandler) graphSnapshot(c echo.Context) error {
 		return err
 	}
 	return c.JSON(nethttp.StatusOK, map[string]any{"data": snapshot})
+}
+
+func (h *userPortalHandler) graphNodeDetail(c echo.Context) error {
+	if h.graph == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "graph view unavailable")
+	}
+	principal := httpmw.GetPrincipal(c.Request().Context())
+	if principal == nil {
+		return httperr.New(httperr.FORBIDDEN, "authentication required")
+	}
+	teamID := principal.GetTeamID()
+	if teamID == uuid.Nil {
+		return httperr.New(httperr.FORBIDDEN, "authenticated key is not team bound")
+	}
+
+	node, err := h.graph.NodeDetail(c.Request().Context(), teamID.String(), c.QueryParam("type"), c.QueryParam("id"))
+	if err != nil {
+		if errors.Is(err, graphview.ErrMissingNode) || errors.Is(err, graphview.ErrInvalidNodeType) {
+			return httperr.New(httperr.VALIDATION_ERROR, err.Error())
+		}
+		if errors.Is(err, graphview.ErrNodeNotFound) {
+			return httperr.New(httperr.NOT_FOUND, err.Error())
+		}
+		return err
+	}
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": node})
 }
 
 func userPortalOptionalIntQuery(c echo.Context, name string) (int, error) {

--- a/internal/http/user_portal_test.go
+++ b/internal/http/user_portal_test.go
@@ -164,10 +164,16 @@ func (s *userPortalRotateErrorKeySvc) RotateForProfile(context.Context, uuid.UUI
 }
 
 type userPortalGraphSvc struct {
-	profileID string
-	query     graphview.Query
-	calls     int
-	err       error
+	profileID        string
+	query            graphview.Query
+	calls            int
+	detailProfileID  string
+	detailType       string
+	detailID         string
+	detailCalls      int
+	err              error
+	nodeDetailErr    error
+	nodeDetailResult *graphview.Node
 }
 
 func (s *userPortalGraphSvc) Graph(_ context.Context, profileID string, query graphview.Query) (*graphview.Snapshot, error) {
@@ -185,6 +191,29 @@ func (s *userPortalGraphSvc) Graph(_ context.Context, profileID string, query gr
 			Type:  "fact",
 			Title: "fact title",
 		}},
+	}, nil
+}
+
+func (s *userPortalGraphSvc) NodeDetail(_ context.Context, profileID string, nodeType string, nodeID string) (*graphview.Node, error) {
+	s.detailProfileID = profileID
+	s.detailType = nodeType
+	s.detailID = nodeID
+	s.detailCalls++
+	if s.nodeDetailErr != nil {
+		return nil, s.nodeDetailErr
+	}
+	if s.nodeDetailResult != nil {
+		return s.nodeDetailResult, nil
+	}
+	return &graphview.Node{
+		Key:         "fact:fact-1",
+		ID:          "fact-1",
+		Type:        "fact",
+		Title:       "fact title",
+		Body:        "fact detail",
+		Status:      "active",
+		CommunityID: "community-1",
+		Score:       0.9,
 	}, nil
 }
 
@@ -338,6 +367,47 @@ func TestUserPortalGraphRequiresReadScope(t *testing.T) {
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
 	require.Equal(t, 0, graph.calls)
+}
+
+func TestUserPortalGraphNodeDetailUsesAuthenticatedTeamScope(t *testing.T) {
+	teamID := uuid.New()
+	authKey, rawKey := userPortalTestKey(t, teamID, uuid.New(), "Reader", []string{"read"})
+	graph := &userPortalGraphSvc{}
+	server := userPortalTestServerWithGraph(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", nil, graph)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/node-detail?type=fact&id=fact-1", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"body":"fact detail"`)
+	require.Equal(t, 1, graph.detailCalls)
+	require.Equal(t, teamID.String(), graph.detailProfileID)
+	require.Equal(t, "fact", graph.detailType)
+	require.Equal(t, "fact-1", graph.detailID)
+}
+
+func TestUserPortalGraphNodeDetailMapsValidationAndNotFound(t *testing.T) {
+	teamID := uuid.New()
+	authKey, rawKey := userPortalTestKey(t, teamID, uuid.New(), "Reader", []string{"read"})
+	graph := &userPortalGraphSvc{nodeDetailErr: graphview.ErrMissingNode}
+	server := userPortalTestServerWithGraph(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", nil, graph)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/node-detail", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+	graph.nodeDetailErr = graphview.ErrNodeNotFound
+	req = httptest.NewRequest(http.MethodGet, "/ui/api/node-detail?type=fact&id=missing", nil)
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestUserPortalTelemetryReadOnlyForbidden(t *testing.T) {

--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -26,6 +26,9 @@ const (
 var (
 	ErrMissingAnchor     = errors.New("graph local view requires anchor_type and anchor_id")
 	ErrInvalidAnchorType = errors.New("unsupported graph anchor_type")
+	ErrMissingNode       = errors.New("graph node detail requires type and id")
+	ErrInvalidNodeType   = errors.New("unsupported graph node type")
+	ErrNodeNotFound      = errors.New("graph node not found")
 )
 
 type ScopedReader interface {
@@ -34,6 +37,7 @@ type ScopedReader interface {
 
 type Service interface {
 	Graph(ctx context.Context, profileID string, query Query) (*Snapshot, error)
+	NodeDetail(ctx context.Context, profileID string, nodeType string, nodeID string) (*Node, error)
 }
 
 type Query struct {
@@ -145,12 +149,16 @@ func (s *service) Graph(ctx context.Context, profileID string, query Query) (*Sn
 		edges = edgesFromRows(edgeRows)
 	}
 
+	truncated := false
+	if normalized.scope == ScopeLocal {
+		truncated = len(nodes) >= normalized.limit
+	}
 	snapshot := &Snapshot{
 		Scope:     normalized.scope,
 		Query:     normalized.search,
 		Depth:     normalized.depth,
 		Limit:     normalized.limit,
-		Truncated: len(nodes) >= normalized.limit,
+		Truncated: truncated,
 		Nodes:     nodes,
 		Edges:     edges,
 	}
@@ -162,6 +170,33 @@ func (s *service) Graph(ctx context.Context, profileID string, query Query) (*Sn
 		}
 	}
 	return snapshot, nil
+}
+
+func (s *service) NodeDetail(ctx context.Context, profileID string, nodeType string, nodeID string) (*Node, error) {
+	if s == nil || s.reader == nil {
+		return nil, errors.New("graph view reader is not configured")
+	}
+	normalizedType := normalizeType(nodeType)
+	normalizedID := strings.TrimSpace(nodeID)
+	if normalizedType == "" && strings.TrimSpace(nodeType) != "" {
+		return nil, ErrInvalidNodeType
+	}
+	if normalizedType == "" || normalizedID == "" {
+		return nil, ErrMissingNode
+	}
+
+	_, rows, err := s.reader.ScopedRead(ctx, profileID, graphNodeDetailCypher, map[string]any{
+		"nodeType": normalizedType,
+		"nodeID":   normalizedID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graph node detail: %w", err)
+	}
+	nodes := nodesFromRows(rows)
+	if len(nodes) == 0 {
+		return nil, ErrNodeNotFound
+	}
+	return &nodes[0], nil
 }
 
 func (q normalizedQuery) params() map[string]any {
@@ -225,6 +260,7 @@ func normalizeTypes(values []string) map[string]bool {
 		out["fact"] = true
 		out["claim"] = true
 		out["fragment"] = true
+		out["dream"] = true
 	}
 	return out
 }
@@ -341,101 +377,110 @@ CALL {
       ($includeSuperseded AND coalesce(f.status, '') = 'superseded')
     )
     AND ($query = '' OR toLower(coalesce(f.subject, '') + ' ' + coalesce(f.predicate, '') + ' ' + coalesce(f.object, '')) CONTAINS $query)
-  WITH f
-  ORDER BY f.recorded_at DESC, f.fact_id ASC
-  LIMIT $limit
-  RETURN collect({
-    type: 'fact',
-    id: f.fact_id,
-    key: 'fact:' + f.fact_id,
-    title: trim(coalesce(f.subject, '') + ' ' + coalesce(f.predicate, '') + ' ' + coalesce(f.object, '')),
-    body: coalesce(f.object, ''),
-    status: coalesce(f.status, ''),
-    community_id: toString(f.community_id),
-    source: '',
-    score: coalesce(f.truth_score, 0.0),
-    recorded_at: f.recorded_at
-  }) AS rows
+  RETURN collect(f) AS seeds
 }
-WITH rows AS factRows
+WITH seeds AS factSeeds
 CALL {
   MATCH (c:Claim {team_id: $profileId})
   WHERE $includeClaim
     AND coalesce(c.status, 'candidate') <> 'rejected'
     AND ($query = '' OR toLower(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')) CONTAINS $query)
-  WITH c
-  ORDER BY c.recorded_at DESC, c.claim_id ASC
-  LIMIT $limit
-  RETURN collect({
-    type: 'claim',
-    id: c.claim_id,
-    key: 'claim:' + c.claim_id,
-    title: trim(coalesce(c.subject, '') + ' ' + coalesce(c.predicate, '') + ' ' + coalesce(c.object, '')),
-    body: coalesce(c.object, ''),
-    status: coalesce(c.status, ''),
-    community_id: toString(c.community_id),
-    source: '',
-    score: coalesce(c.resolution_conf, c.extract_conf, c.source_quality, 0.0),
-    recorded_at: c.recorded_at
-  }) AS rows
+  RETURN collect(c) AS seeds
 }
-WITH factRows, rows AS claimRows
+WITH factSeeds, seeds AS claimSeeds
 CALL {
   MATCH (sf:SourceFragment {team_id: $profileId})
   WHERE $includeFragment
     AND coalesce(sf.status, 'active') <> 'retracted'
     AND ($query = '' OR toLower(coalesce(sf.content, '') + ' ' + coalesce(sf.source, '')) CONTAINS $query)
-  WITH sf
-  ORDER BY sf.created_at DESC, sf.fragment_id ASC
-  LIMIT $limit
-  RETURN collect({
-    type: 'fragment',
-    id: sf.fragment_id,
-    key: 'fragment:' + sf.fragment_id,
-    title: substring(coalesce(sf.content, ''), 0, 160),
-    body: substring(coalesce(sf.content, ''), 0, 600),
-    status: coalesce(sf.status, 'active'),
-    community_id: toString(sf.community_id),
-    source: coalesce(sf.source, ''),
-    score: coalesce(sf.source_quality, 0.0),
-    recorded_at: sf.created_at
-  }) AS rows
+  RETURN collect(sf) AS seeds
 }
-WITH factRows, claimRows, rows AS fragmentRows
+WITH factSeeds, claimSeeds, seeds AS fragmentSeeds
 CALL {
   MATCH (d:Dream {team_id: $profileId})
   WHERE $includeDream
     AND coalesce(d.status, '') IN ['proposed', 'reinforced']
     AND ($query = '' OR toLower(coalesce(d.hypothesis, '') + ' ' + coalesce(d.what_if, '') + ' ' + coalesce(d.possible_outcome, '')) CONTAINS $query)
-  WITH d
-  ORDER BY d.updated_at DESC, d.dream_id ASC
-  LIMIT $limit
-  RETURN collect({
-    type: 'dream',
-    id: d.dream_id,
-    key: 'dream:' + d.dream_id,
-    title: coalesce(d.hypothesis, ''),
-    body: trim(coalesce(d.what_if, '') + ' ' + coalesce(d.possible_outcome, '')),
-    status: coalesce(d.status, ''),
-    community_id: toString(d.community_id),
-    source: coalesce(d.generator_model, ''),
-    score: coalesce(d.confidence, d.likelihood, 0.0),
-    recorded_at: d.updated_at
-  }) AS rows
+  RETURN collect(d) AS seeds
 }
-WITH factRows + claimRows + fragmentRows + rows AS nodeRows
-UNWIND nodeRows AS row
-RETURN row.type AS type,
-       row.id AS id,
-       row.key AS key,
-       row.title AS title,
-       row.body AS body,
-       row.status AS status,
-       row.community_id AS community_id,
-       row.source AS source,
-       row.score AS score,
-       row.recorded_at AS recorded_at
-ORDER BY recorded_at DESC, key ASC
+WITH factSeeds + claimSeeds + fragmentSeeds + seeds AS seedRows
+UNWIND seedRows AS seed
+WITH DISTINCT seed
+WITH seed,
+     CASE
+       WHEN seed:Fact THEN seed.recorded_at
+       WHEN seed:Claim THEN seed.recorded_at
+       WHEN seed:SourceFragment THEN seed.created_at
+       WHEN seed:Dream THEN seed.updated_at
+       ELSE null
+     END AS seed_recorded_at,
+     CASE
+       WHEN seed:Fact THEN 'fact:' + seed.fact_id
+       WHEN seed:Claim THEN 'claim:' + seed.claim_id
+       WHEN seed:SourceFragment THEN 'fragment:' + seed.fragment_id
+       WHEN seed:Dream THEN 'dream:' + seed.dream_id
+       ELSE ''
+     END AS seed_key
+ORDER BY seed_recorded_at DESC, seed_key ASC
+CALL {
+  WITH seed
+  RETURN seed AS n, 1 AS seed_rank
+  UNION
+  WITH seed
+  MATCH (seed)-[r]-(neighbor)
+  WHERE r.team_id = $profileId
+    AND type(r) IN $relationshipTypes
+    AND neighbor.team_id = $profileId
+  RETURN neighbor AS n, 0 AS seed_rank
+}
+WITH n, max(seed_rank) AS seed_rank
+WHERE (
+  ($includeFact AND n:Fact AND (
+    coalesce(n.status, '') IN ['active', 'needs_revalidation'] OR
+    ($includeSuperseded AND coalesce(n.status, '') = 'superseded')
+  )) OR
+  ($includeClaim AND n:Claim AND coalesce(n.status, 'candidate') <> 'rejected') OR
+  ($includeFragment AND n:SourceFragment AND coalesce(n.status, 'active') <> 'retracted') OR
+  ($includeDream AND n:Dream AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
+)
+WITH n, seed_rank,
+     CASE
+       WHEN n:Fact THEN 'fact:' + n.fact_id
+       WHEN n:Claim THEN 'claim:' + n.claim_id
+       WHEN n:SourceFragment THEN 'fragment:' + n.fragment_id
+       WHEN n:Dream THEN 'dream:' + n.dream_id
+       ELSE ''
+     END AS key,
+     CASE
+       WHEN n:Dream THEN n.updated_at
+       WHEN n:SourceFragment THEN n.created_at
+       ELSE n.recorded_at
+     END AS recorded_at
+ORDER BY seed_rank DESC, recorded_at DESC, key ASC
+RETURN
+       CASE
+         WHEN n:Fact THEN 'fact'
+         WHEN n:Claim THEN 'claim'
+         WHEN n:SourceFragment THEN 'fragment'
+         WHEN n:Dream THEN 'dream'
+         ELSE ''
+       END AS type,
+       CASE
+         WHEN n:Fact THEN n.fact_id
+         WHEN n:Claim THEN n.claim_id
+         WHEN n:SourceFragment THEN n.fragment_id
+         WHEN n:Dream THEN n.dream_id
+         ELSE ''
+       END AS id,
+       key AS key,
+       CASE
+         WHEN n:Fact THEN trim(coalesce(n.subject, '') + ' ' + coalesce(n.predicate, '') + ' ' + coalesce(n.object, ''))
+         WHEN n:Claim THEN trim(coalesce(n.subject, '') + ' ' + coalesce(n.predicate, '') + ' ' + coalesce(n.object, ''))
+         WHEN n:SourceFragment THEN substring(coalesce(n.content, ''), 0, 160)
+         WHEN n:Dream THEN coalesce(n.hypothesis, '')
+         ELSE ''
+       END AS title
+ORDER BY seed_rank DESC, recorded_at DESC, key ASC
 `
 
 func localNodesCypher(depth int) string {
@@ -472,7 +517,84 @@ WITH anchor, n
 	  ($includeFragment AND n:SourceFragment AND coalesce(n.status, 'active') <> 'retracted') OR
 	  ($includeDream AND n:Dream AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
 	)
-WITH DISTINCT anchor, n
+WITH DISTINCT anchor, n,
+     CASE
+       WHEN n:Dream THEN n.updated_at
+       WHEN n:SourceFragment THEN n.created_at
+       ELSE n.recorded_at
+     END AS recorded_at
+RETURN
+       CASE
+         WHEN n:Fact THEN 'fact'
+         WHEN n:Claim THEN 'claim'
+         WHEN n:SourceFragment THEN 'fragment'
+         WHEN n:Dream THEN 'dream'
+         ELSE ''
+       END AS type,
+       CASE
+         WHEN n:Fact THEN n.fact_id
+         WHEN n:Claim THEN n.claim_id
+         WHEN n:SourceFragment THEN n.fragment_id
+         WHEN n:Dream THEN n.dream_id
+         ELSE ''
+       END AS id,
+       CASE
+         WHEN n:Fact THEN 'fact:' + n.fact_id
+         WHEN n:Claim THEN 'claim:' + n.claim_id
+         WHEN n:SourceFragment THEN 'fragment:' + n.fragment_id
+         WHEN n:Dream THEN 'dream:' + n.dream_id
+         ELSE ''
+       END AS key,
+	       CASE
+	         WHEN n:Fact THEN trim(coalesce(n.subject, '') + ' ' + coalesce(n.predicate, '') + ' ' + coalesce(n.object, ''))
+	         WHEN n:Claim THEN trim(coalesce(n.subject, '') + ' ' + coalesce(n.predicate, '') + ' ' + coalesce(n.object, ''))
+	         WHEN n:SourceFragment THEN substring(coalesce(n.content, ''), 0, 160)
+	         WHEN n:Dream THEN coalesce(n.hypothesis, '')
+	         ELSE ''
+	       END AS title
+	ORDER BY CASE WHEN elementId(n) = elementId(anchor) THEN 0 ELSE 1 END, recorded_at DESC, key ASC
+	LIMIT $limit`, depth)
+}
+
+const graphEdgesCypher = `
+MATCH (a)-[r]->(b)
+WHERE a.team_id = $profileId
+  AND b.team_id = $profileId
+  AND r.team_id = $profileId
+  AND type(r) IN $relationshipTypes
+WITH a, r, b,
+     CASE
+       WHEN a:Fact THEN 'fact:' + a.fact_id
+       WHEN a:Claim THEN 'claim:' + a.claim_id
+       WHEN a:SourceFragment THEN 'fragment:' + a.fragment_id
+       WHEN a:Dream THEN 'dream:' + a.dream_id
+       ELSE ''
+     END AS source_key,
+     CASE
+       WHEN b:Fact THEN 'fact:' + b.fact_id
+       WHEN b:Claim THEN 'claim:' + b.claim_id
+       WHEN b:SourceFragment THEN 'fragment:' + b.fragment_id
+       WHEN b:Dream THEN 'dream:' + b.dream_id
+       ELSE ''
+     END AS target_key
+WHERE source_key IN $nodeKeys
+  AND target_key IN $nodeKeys
+RETURN elementId(r) AS id,
+       source_key AS source,
+       target_key AS target,
+       type(r) AS relationship
+ORDER BY relationship ASC, source ASC, target ASC
+`
+
+const graphNodeDetailCypher = `
+MATCH (n)
+WHERE n.team_id = $profileId
+  AND (
+    ($nodeType = 'fact' AND n:Fact AND n.fact_id = $nodeID AND coalesce(n.status, '') IN ['active', 'needs_revalidation', 'superseded']) OR
+    ($nodeType = 'claim' AND n:Claim AND n.claim_id = $nodeID AND coalesce(n.status, 'candidate') <> 'rejected') OR
+    ($nodeType = 'fragment' AND n:SourceFragment AND n.fragment_id = $nodeID AND coalesce(n.status, 'active') <> 'retracted') OR
+    ($nodeType = 'dream' AND n:Dream AND n.dream_id = $nodeID AND coalesce(n.status, '') IN ['proposed', 'reinforced'])
+  )
 RETURN
        CASE
          WHEN n:Fact THEN 'fact'
@@ -505,7 +627,7 @@ RETURN
        CASE
          WHEN n:Fact THEN coalesce(n.object, '')
          WHEN n:Claim THEN coalesce(n.object, '')
-         WHEN n:SourceFragment THEN substring(coalesce(n.content, ''), 0, 600)
+         WHEN n:SourceFragment THEN coalesce(n.content, '')
          WHEN n:Dream THEN trim(coalesce(n.what_if, '') + ' ' + coalesce(n.possible_outcome, ''))
          ELSE ''
        END AS body,
@@ -528,36 +650,5 @@ RETURN
          WHEN n:SourceFragment THEN n.created_at
          ELSE n.recorded_at
        END AS recorded_at
-ORDER BY CASE WHEN elementId(n) = elementId(anchor) THEN 0 ELSE 1 END, recorded_at DESC, key ASC
-LIMIT $limit`, depth)
-}
-
-const graphEdgesCypher = `
-MATCH (a)-[r]->(b)
-WHERE a.team_id = $profileId
-  AND b.team_id = $profileId
-  AND r.team_id = $profileId
-  AND type(r) IN $relationshipTypes
-WITH a, r, b,
-     CASE
-       WHEN a:Fact THEN 'fact:' + a.fact_id
-       WHEN a:Claim THEN 'claim:' + a.claim_id
-       WHEN a:SourceFragment THEN 'fragment:' + a.fragment_id
-       WHEN a:Dream THEN 'dream:' + a.dream_id
-       ELSE ''
-     END AS source_key,
-     CASE
-       WHEN b:Fact THEN 'fact:' + b.fact_id
-       WHEN b:Claim THEN 'claim:' + b.claim_id
-       WHEN b:SourceFragment THEN 'fragment:' + b.fragment_id
-       WHEN b:Dream THEN 'dream:' + b.dream_id
-       ELSE ''
-     END AS target_key
-WHERE source_key IN $nodeKeys
-  AND target_key IN $nodeKeys
-RETURN elementId(r) AS id,
-       source_key AS source,
-       target_key AS target,
-       type(r) AS relationship
-ORDER BY relationship ASC, source ASC, target ASC
+LIMIT 1
 `

--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -406,22 +406,6 @@ CALL {
 WITH factSeeds + claimSeeds + fragmentSeeds + seeds AS seedRows
 UNWIND seedRows AS seed
 WITH DISTINCT seed
-WITH seed,
-     CASE
-       WHEN seed:Fact THEN seed.recorded_at
-       WHEN seed:Claim THEN seed.recorded_at
-       WHEN seed:SourceFragment THEN seed.created_at
-       WHEN seed:Dream THEN seed.updated_at
-       ELSE null
-     END AS seed_recorded_at,
-     CASE
-       WHEN seed:Fact THEN 'fact:' + seed.fact_id
-       WHEN seed:Claim THEN 'claim:' + seed.claim_id
-       WHEN seed:SourceFragment THEN 'fragment:' + seed.fragment_id
-       WHEN seed:Dream THEN 'dream:' + seed.dream_id
-       ELSE ''
-     END AS seed_key
-ORDER BY seed_recorded_at DESC, seed_key ASC
 CALL {
   WITH seed
   RETURN seed AS n, 1 AS seed_rank
@@ -456,7 +440,6 @@ WITH n, seed_rank,
        WHEN n:SourceFragment THEN n.created_at
        ELSE n.recorded_at
      END AS recorded_at
-ORDER BY seed_rank DESC, recorded_at DESC, key ASC
 RETURN
        CASE
          WHEN n:Fact THEN 'fact'

--- a/internal/service/graphview/graphview_test.go
+++ b/internal/service/graphview/graphview_test.go
@@ -67,6 +67,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	if len(got.Nodes) != 1 || got.Nodes[0].Key != "fact:fact-1" {
 		t.Fatalf("nodes = %#v; want fact node", got.Nodes)
 	}
+	if got.Truncated {
+		t.Fatal("overview graph must not mark all-topology response truncated")
+	}
 	if len(reader.calls) != 2 {
 		t.Fatalf("read calls = %d; want nodes and edges reads", len(reader.calls))
 	}
@@ -75,13 +78,18 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	if nodeCall.profileID != "team-1" {
 		t.Fatalf("ScopedRead profile = %q; want team-1", nodeCall.profileID)
 	}
-	for _, required := range []string{"$profileId", "MATCH (f:Fact {team_id: $profileId})", "LIMIT $limit"} {
+	for _, required := range []string{
+		"$profileId",
+		"MATCH (f:Fact {team_id: $profileId})",
+		"MATCH (seed)-[r]-(neighbor)",
+		"type(r) IN $relationshipTypes",
+	} {
 		if !strings.Contains(nodeCall.query, required) {
 			t.Fatalf("node query missing %q:\n%s", required, nodeCall.query)
 		}
 	}
-	if strings.Count(nodeCall.query, "LIMIT $limit") < 4 {
-		t.Fatalf("node query should apply the limit per graph node type:\n%s", nodeCall.query)
+	if strings.Contains(nodeCall.query, "LIMIT $limit") || strings.Contains(nodeCall.query, "LIMIT $nodeLimit") {
+		t.Fatalf("overview query must not apply node limits:\n%s", nodeCall.query)
 	}
 	if !strings.Contains(nodeCall.query, "coalesce(c.status, 'candidate') <> 'rejected'") {
 		t.Fatalf("overview query must filter rejected claims:\n%s", nodeCall.query)
@@ -91,6 +99,9 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	}
 	if nodeCall.params["limit"] != int64(MaxLimit) {
 		t.Fatalf("limit param = %#v; want %d", nodeCall.params["limit"], MaxLimit)
+	}
+	if _, exists := nodeCall.params["nodeLimit"]; exists {
+		t.Fatalf("nodeLimit param must not be sent for unbounded overview: %#v", nodeCall.params)
 	}
 	if nodeCall.params["query"] != "graph" {
 		t.Fatalf("query param = %#v; want graph", nodeCall.params["query"])
@@ -106,21 +117,107 @@ func TestGraphOverviewClampsLimitAndUsesScopedQuery(t *testing.T) {
 	}
 }
 
-func TestGraphOverviewReturnsNormalizedEdgesAndDedupedNodes(t *testing.T) {
+func TestGraphOverviewExpandsNeighborsBeforeEdgeRead(t *testing.T) {
 	recordedAt := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
 	reader := &fakeGraphReader{rowsByCall: [][]map[string]any{
 		{
 			{
-				"type":         "fact",
-				"id":           "fact-1",
-				"key":          "fact:fact-1",
-				"title":        strings.Repeat("a", 200),
-				"body":         strings.Repeat("b", 500),
-				"status":       "active",
-				"community_id": "community-1",
-				"source":       "seed",
-				"score":        0.91,
-				"recorded_at":  recordedAt,
+				"type":        "claim",
+				"id":          "claim-1",
+				"key":         "claim:claim-1",
+				"title":       "claim title",
+				"status":      "superseded",
+				"recorded_at": recordedAt,
+			},
+			{
+				"type":        "fact",
+				"id":          "fact-1",
+				"key":         "fact:fact-1",
+				"title":       "fact title",
+				"status":      "active",
+				"recorded_at": recordedAt.Add(-time.Minute),
+			},
+			{
+				"type":        "fragment",
+				"id":          "fragment-1",
+				"key":         "fragment:fragment-1",
+				"title":       "fragment title",
+				"status":      "active",
+				"recorded_at": recordedAt.Add(-2 * time.Minute),
+			},
+		},
+		{
+			{
+				"id":           "edge-promotes",
+				"source":       "claim:claim-1",
+				"target":       "fact:fact-1",
+				"relationship": "PROMOTES_TO",
+			},
+			{
+				"id":           "edge-supports",
+				"source":       "claim:claim-1",
+				"target":       "fragment:fragment-1",
+				"relationship": "SUPPORTED_BY",
+			},
+		},
+	}}
+	svc := New(reader)
+
+	got, err := svc.Graph(context.Background(), "team-1", Query{})
+	if err != nil {
+		t.Fatalf("Graph returned error: %v", err)
+	}
+
+	if len(got.Nodes) != 3 {
+		t.Fatalf("nodes = %#v; want expanded claim/fact/fragment neighborhood", got.Nodes)
+	}
+	if len(got.Edges) != 2 {
+		t.Fatalf("edges = %#v; want claim connected to fact and fragment", got.Edges)
+	}
+	claimDegree := 0
+	for _, edge := range got.Edges {
+		if edge.Source == "claim:claim-1" || edge.Target == "claim:claim-1" {
+			claimDegree++
+		}
+	}
+	if claimDegree != 2 {
+		t.Fatalf("claim degree = %d; want 2 edges", claimDegree)
+	}
+
+	nodeCall := reader.calls[0]
+	if !strings.Contains(nodeCall.query, "MATCH (seed)-[r]-(neighbor)") {
+		t.Fatalf("overview node query must expand one-hop neighbors:\n%s", nodeCall.query)
+	}
+	if nodeCall.params["includeFact"] != true || nodeCall.params["includeClaim"] != true || nodeCall.params["includeFragment"] != true || nodeCall.params["includeDream"] != true {
+		t.Fatalf("default overview types should include all graph node types: %#v", nodeCall.params)
+	}
+	if strings.Contains(nodeCall.query, "LIMIT $limit") || strings.Contains(nodeCall.query, "LIMIT $nodeLimit") {
+		t.Fatalf("overview node query must not cap returned nodes:\n%s", nodeCall.query)
+	}
+	if _, exists := nodeCall.params["nodeLimit"]; exists {
+		t.Fatalf("nodeLimit param must not be sent: %#v", nodeCall.params)
+	}
+
+	edgeCall := reader.calls[1]
+	keys, ok := edgeCall.params["nodeKeys"].([]string)
+	if !ok {
+		t.Fatalf("nodeKeys = %#v; want []string", edgeCall.params["nodeKeys"])
+	}
+	for _, want := range []string{"claim:claim-1", "fact:fact-1", "fragment:fragment-1"} {
+		if !containsString(keys, want) {
+			t.Fatalf("nodeKeys = %#v; missing %q", keys, want)
+		}
+	}
+}
+
+func TestGraphOverviewReturnsNormalizedEdgesAndDedupedNodes(t *testing.T) {
+	reader := &fakeGraphReader{rowsByCall: [][]map[string]any{
+		{
+			{
+				"type":  "fact",
+				"id":    "fact-1",
+				"key":   "fact:fact-1",
+				"title": strings.Repeat("a", 200),
 			},
 			{
 				"type":  "fact",
@@ -170,11 +267,8 @@ func TestGraphOverviewReturnsNormalizedEdgesAndDedupedNodes(t *testing.T) {
 	if len([]rune(node.Title)) != 163 || !strings.HasSuffix(node.Title, "...") {
 		t.Fatalf("title = %q; want truncated title", node.Title)
 	}
-	if len([]rune(node.Body)) != maxNodeBodyRunes+3 || node.Status != "active" || node.CommunityID != "community-1" || node.Source != "seed" || node.Score != 0.91 {
-		t.Fatalf("node = %#v; want normalized metadata", node)
-	}
-	if node.RecordedAt == nil || !node.RecordedAt.Equal(recordedAt) {
-		t.Fatalf("recorded_at = %v; want %v", node.RecordedAt, recordedAt)
+	if node.Body != "" || node.Status != "" || node.CommunityID != "" || node.Source != "" || node.Score != 0 || node.RecordedAt != nil {
+		t.Fatalf("overview node = %#v; want topology summary only", node)
 	}
 
 	if len(got.Edges) != 2 {
@@ -190,6 +284,80 @@ func TestGraphOverviewReturnsNormalizedEdgesAndDedupedNodes(t *testing.T) {
 	if keys, ok := edgeCall.params["nodeKeys"].([]string); !ok || len(keys) != 1 || keys[0] != "fact:fact-1" {
 		t.Fatalf("nodeKeys = %#v; want returned node keys", edgeCall.params["nodeKeys"])
 	}
+}
+
+func TestGraphNodeDetailReturnsFullNode(t *testing.T) {
+	recordedAt := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	reader := &fakeGraphReader{rowsByCall: [][]map[string]any{{
+		{
+			"type":         "fact",
+			"id":           "fact-1",
+			"key":          "fact:fact-1",
+			"title":        "fact title",
+			"body":         strings.Repeat("body ", 120),
+			"status":       "active",
+			"community_id": "community-1",
+			"source":       "seed",
+			"score":        0.91,
+			"recorded_at":  recordedAt,
+		},
+	}}}
+	svc := New(reader)
+
+	got, err := svc.NodeDetail(context.Background(), "team-1", "facts", "fact-1")
+	if err != nil {
+		t.Fatalf("NodeDetail returned error: %v", err)
+	}
+
+	if got.Key != "fact:fact-1" || got.Type != "fact" || got.Title != "fact title" {
+		t.Fatalf("detail identity = %#v", got)
+	}
+	if len([]rune(got.Body)) > maxNodeBodyRunes+3 || !strings.HasSuffix(got.Body, "...") || got.Status != "active" || got.CommunityID != "community-1" || got.Source != "seed" || got.Score != 0.91 {
+		t.Fatalf("detail = %#v; want full normalized metadata", got)
+	}
+	if got.RecordedAt == nil || !got.RecordedAt.Equal(recordedAt) {
+		t.Fatalf("recorded_at = %v; want %v", got.RecordedAt, recordedAt)
+	}
+	call := reader.calls[0]
+	if call.profileID != "team-1" || call.params["nodeType"] != "fact" || call.params["nodeID"] != "fact-1" {
+		t.Fatalf("detail call = %#v", call)
+	}
+	if !strings.Contains(call.query, "$nodeType = 'fact'") || !strings.Contains(call.query, "$nodeType = 'fragment'") {
+		t.Fatalf("detail query missing type branches:\n%s", call.query)
+	}
+}
+
+func TestGraphNodeDetailValidatesInputAndMisses(t *testing.T) {
+	reader := &fakeGraphReader{}
+	svc := New(reader)
+
+	_, err := svc.NodeDetail(context.Background(), "team-1", "bad", "node-1")
+	if !errors.Is(err, ErrInvalidNodeType) {
+		t.Fatalf("err = %v; want invalid type", err)
+	}
+	_, err = svc.NodeDetail(context.Background(), "team-1", "fact", "")
+	if !errors.Is(err, ErrMissingNode) {
+		t.Fatalf("err = %v; want missing node", err)
+	}
+	if len(reader.calls) != 0 {
+		t.Fatalf("ScopedRead calls = %d; want 0", len(reader.calls))
+	}
+
+	reader = &fakeGraphReader{rowsByCall: [][]map[string]any{{}}}
+	svc = New(reader)
+	_, err = svc.NodeDetail(context.Background(), "team-1", "fact", "missing")
+	if !errors.Is(err, ErrNodeNotFound) {
+		t.Fatalf("err = %v; want ErrNodeNotFound", err)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGraphLocalClampsDepthAndRejectsDynamicTraversalInput(t *testing.T) {

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -289,6 +289,13 @@ describe("UserPortalApp", () => {
     expect(within(controls).queryByLabelText("Limit")).not.toBeInTheDocument();
     expect((await screen.findAllByText("Alice works_on project-x")).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByLabelText("Graph totals")).toHaveTextContent("2");
+    expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("Select a node");
+    await userEvent.click(within(screen.getByTestId("force-graph")).getByRole("button", { name: "Alice works_on project-x" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/ui/api/node-detail?type=fact&id=fact-1", expect.any(Object));
+    });
+    expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("community-1");
+    expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("0.940");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment%2Cdream&depth=2",

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserPortalApp } from "./App";
-import { GraphSnapshot, RecallHit, UserKey, UserSession } from "./api";
+import { GraphNode, GraphSnapshot, RecallHit, UserKey, UserSession } from "./api";
 
 vi.mock("react-force-graph-2d", async () => {
   const React = await import("react");
@@ -139,27 +139,42 @@ const overviewGraph: GraphSnapshot = {
       id: "fact-1",
       type: "fact",
       title: "Alice works_on project-x",
-      body: "project-x",
-      status: "active",
-      community_id: "community-1",
-      score: 0.94,
-      recorded_at: "2026-05-02T12:00:00Z",
     },
     {
       key: "claim:claim-1",
       id: "claim-1",
       type: "claim",
       title: "Alice uses Dense-Mem",
-      body: "Dense-Mem",
-      status: "validated",
-      community_id: "community-1",
-      score: 0.88,
-      recorded_at: "2026-05-02T12:00:00Z",
     },
   ],
   edges: [
     { id: "edge-1", source: "claim:claim-1", target: "fact:fact-1", relationship: "PROMOTES_TO", directed: true },
   ],
+};
+
+const graphNodeDetails: Record<string, GraphNode> = {
+  "fact:fact-1": {
+    key: "fact:fact-1",
+    id: "fact-1",
+    type: "fact",
+    title: "Alice works_on project-x",
+    body: "project-x",
+    status: "active",
+    community_id: "community-1",
+    score: 0.94,
+    recorded_at: "2026-05-02T12:00:00Z",
+  },
+  "claim:claim-1": {
+    key: "claim:claim-1",
+    id: "claim-1",
+    type: "claim",
+    title: "Alice uses Dense-Mem",
+    body: "Dense-Mem",
+    status: "validated",
+    community_id: "community-1",
+    score: 0.88,
+    recorded_at: "2026-05-02T12:00:00Z",
+  },
 };
 
 const localGraph: GraphSnapshot = {
@@ -276,7 +291,7 @@ describe("UserPortalApp", () => {
     expect(screen.getByLabelText("Graph totals")).toHaveTextContent("2");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2",
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment%2Cdream&depth=2",
         expect.any(Object),
       );
     });
@@ -284,7 +299,7 @@ describe("UserPortalApp", () => {
     await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2&include_superseded=true",
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment%2Cdream&depth=2&include_superseded=true",
         expect.any(Object),
       );
     });
@@ -300,7 +315,7 @@ describe("UserPortalApp", () => {
     const controls = await screen.findByLabelText("Graph controls");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment&depth=2",
+        "/ui/api/graph?scope=overview&types=fact%2Cclaim%2Cfragment%2Cdream&depth=2",
         expect.any(Object),
       );
     });
@@ -310,6 +325,7 @@ describe("UserPortalApp", () => {
     await userEvent.click(within(controls).getByRole("checkbox", { name: "Fact" }));
     await userEvent.click(within(controls).getByRole("checkbox", { name: "Claim" }));
     await userEvent.click(within(controls).getByRole("checkbox", { name: "Fragment" }));
+    await userEvent.click(within(controls).getByRole("checkbox", { name: "Dream" }));
 
     const refresh = within(controls).getByRole("button", { name: "Refresh" });
     expect(refresh).toBeDisabled();
@@ -701,7 +717,7 @@ async function expectCurrentWorkspace(teamName: string) {
   expect(workspace).toHaveTextContent(teamName);
 }
 
-function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot } = {}) {
+function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot; graphNodeDetails?: Record<string, GraphNode> } = {}) {
   let currentTeam = session.team;
   let currentProfiles = profiles;
   let recallCallCount = 0;
@@ -734,6 +750,11 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
     }
     if (url.startsWith("/ui/api/telemetry") && method === "GET") {
       return jsonResponse({ data: telemetryForSession(session) });
+    }
+    if (url.startsWith("/ui/api/node-detail") && method === "GET") {
+      const params = new URLSearchParams(url.split("?")[1] ?? "");
+      const key = `${params.get("type")}:${params.get("id")}`;
+      return jsonResponse({ data: (options.graphNodeDetails ?? graphNodeDetails)[key] ?? graphNodeDetails["fact:fact-1"] });
     }
     if (url.startsWith("/ui/api/graph") && method === "GET") {
       return jsonResponse({ data: options.graphSnapshot ?? overviewGraph });

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -312,6 +312,38 @@ describe("UserPortalApp", () => {
     });
   });
 
+  it("refreshes selected graph node details when the graph reloads", async () => {
+    const refreshedDetails = {
+      ...graphNodeDetails,
+      "fact:fact-1": {
+        ...graphNodeDetails["fact:fact-1"],
+        body: "project-y",
+        community_id: "community-2",
+        score: 0.67,
+      },
+    };
+    const fetchMock = mockUserFetch(baseSession, [], { graphSnapshot: [overviewGraph, overviewGraph], graphNodeDetails: [graphNodeDetails, refreshedDetails] });
+    sessionStorage.setItem("denseMem.userApiKey", "dm_read");
+
+    render(<UserPortalApp />);
+    await screen.findByText("Research Team");
+    await userEvent.click(screen.getByRole("button", { name: /graph/i }));
+    const controls = await screen.findByLabelText("Graph controls");
+
+    await userEvent.click(within(screen.getByTestId("force-graph")).getByRole("button", { name: "Alice works_on project-x" }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("0.940");
+    });
+
+    await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith("/ui/api/node-detail?type=fact&id=fact-1"))).toHaveLength(2);
+    });
+    expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("community-2");
+    expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("0.670");
+  });
+
   it("blocks graph refresh when every type filter is disabled", async () => {
     const fetchMock = mockUserFetch(baseSession, [], { graphSnapshot: overviewGraph });
     sessionStorage.setItem("denseMem.userApiKey", "dm_read");
@@ -724,10 +756,12 @@ async function expectCurrentWorkspace(teamName: string) {
   expect(workspace).toHaveTextContent(teamName);
 }
 
-function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot; graphNodeDetails?: Record<string, GraphNode> } = {}) {
+function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot | GraphSnapshot[]; graphNodeDetails?: Record<string, GraphNode> | Record<string, GraphNode>[] } = {}) {
   let currentTeam = session.team;
   let currentProfiles = profiles;
   let recallCallCount = 0;
+  let graphCallCount = 0;
+  let graphNodeDetailCallCount = 0;
   const rotatedSession = {
     ...session,
     key: { ...session.key, key_suffix: "new123", last_used_at: null },
@@ -761,10 +795,11 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
     if (url.startsWith("/ui/api/node-detail") && method === "GET") {
       const params = new URLSearchParams(url.split("?")[1] ?? "");
       const key = `${params.get("type")}:${params.get("id")}`;
-      return jsonResponse({ data: (options.graphNodeDetails ?? graphNodeDetails)[key] ?? graphNodeDetails["fact:fact-1"] });
+      const details = optionValue(options.graphNodeDetails ?? graphNodeDetails, graphNodeDetailCallCount++);
+      return jsonResponse({ data: details[key] ?? graphNodeDetails["fact:fact-1"] });
     }
     if (url.startsWith("/ui/api/graph") && method === "GET") {
-      return jsonResponse({ data: options.graphSnapshot ?? overviewGraph });
+      return jsonResponse({ data: optionValue(options.graphSnapshot ?? overviewGraph, graphCallCount++) });
     }
     if (url === `/api/v1/teams/${currentTeam.id}` && method === "PATCH") {
       const body = JSON.parse(String(init?.body));
@@ -815,6 +850,10 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
   });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+function optionValue<T>(value: T | T[], index: number): T {
+  return Array.isArray(value) ? value[Math.min(index, value.length - 1)] : value;
 }
 
 function isRecallSequence(value: RecallHit[] | RecallHit[][]): value is RecallHit[][] {

--- a/web/src/user/GraphPanel.tsx
+++ b/web/src/user/GraphPanel.tsx
@@ -46,6 +46,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [selectedDetail, setSelectedDetail] = useState<GraphNode | null>(null);
+  const [detailKey, setDetailKey] = useState("");
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState("");
 
@@ -77,16 +78,22 @@ export function GraphPanel({ api }: { api: UserApi }) {
 
   const selectedNode = selectedKey ? snapshot?.nodes.find((node) => node.key === selectedKey) ?? null : null;
   const hasSelectedTypes = Object.values(types).some(Boolean);
+  const selectedNodeKey = selectedNode?.key ?? "";
+  const activeDetail = selectedDetail?.key === selectedNodeKey ? selectedDetail : null;
+  const activeDetailLoading = detailKey === selectedNodeKey ? detailLoading : false;
+  const activeDetailError = detailKey === selectedNodeKey ? detailError : "";
 
   useEffect(() => {
     if (!selectedNode) {
       setSelectedDetail(null);
+      setDetailKey("");
       setDetailError("");
       setDetailLoading(false);
       return;
     }
     let active = true;
     setSelectedDetail(null);
+    setDetailKey(selectedNode.key);
     setDetailError("");
     setDetailLoading(true);
     api.nodeDetail(selectedNode.type, selectedNode.id)
@@ -230,7 +237,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
 
       <aside className="graph-inspector" aria-label="Graph inspector">
         <GraphStats snapshot={snapshot} />
-        <NodeInspector summary={selectedNode} detail={selectedDetail} loading={detailLoading} error={detailError} />
+        <NodeInspector summary={selectedNode} detail={activeDetail} loading={activeDetailLoading} error={activeDetailError} />
       </aside>
     </section>
   );

--- a/web/src/user/GraphPanel.tsx
+++ b/web/src/user/GraphPanel.tsx
@@ -14,7 +14,6 @@ import { LoadingState, SectionHeading } from "../ui/components";
 import { GraphEdge, GraphNode, GraphNodeType, GraphQuery, GraphSnapshot, UserApi } from "./api";
 
 type TypeFilter = Record<GraphNodeType, boolean>;
-type ColorMode = "type" | "community";
 type GraphAnchor = {
   type: GraphNodeType;
   id: string;
@@ -27,7 +26,7 @@ const defaultTypes: TypeFilter = {
   fact: true,
   claim: true,
   fragment: true,
-  dream: false,
+  dream: true,
 };
 
 export function GraphPanel({ api }: { api: UserApi }) {
@@ -43,10 +42,12 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [nodeSize, setNodeSize] = useState(5);
   const [linkDistance, setLinkDistance] = useState(92);
   const [showArrows, setShowArrows] = useState(true);
-  const [colorMode, setColorMode] = useState<ColorMode>("community");
   const [showLabels, setShowLabels] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [selectedDetail, setSelectedDetail] = useState<GraphNode | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState("");
 
   async function loadGraph(query: GraphQuery = buildQuery({ searchText, scope, anchorType, anchorId, types, depth, includeSuperseded })) {
     if (query.types?.length === 0) {
@@ -62,7 +63,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
     try {
       const next = await api.graph(query);
       setSnapshot(next);
-      setSelectedKey((current) => next.nodes.some((node) => node.key === current) ? current : next.anchor?.key ?? next.nodes[0]?.key ?? "");
+      setSelectedKey((current) => next.nodes.some((node) => node.key === current) ? current : "");
     } catch (err) {
       setError(readError(err));
     } finally {
@@ -74,8 +75,40 @@ export function GraphPanel({ api }: { api: UserApi }) {
     void loadGraph(buildQuery({ searchText: "", scope: "overview", anchorType, anchorId: "", types, depth: 2, includeSuperseded }));
   }, [api]);
 
-  const selectedNode = snapshot?.nodes.find((node) => node.key === selectedKey) ?? snapshot?.nodes[0] ?? null;
+  const selectedNode = selectedKey ? snapshot?.nodes.find((node) => node.key === selectedKey) ?? null : null;
   const hasSelectedTypes = Object.values(types).some(Boolean);
+
+  useEffect(() => {
+    if (!selectedNode) {
+      setSelectedDetail(null);
+      setDetailError("");
+      setDetailLoading(false);
+      return;
+    }
+    let active = true;
+    setSelectedDetail(null);
+    setDetailError("");
+    setDetailLoading(true);
+    api.nodeDetail(selectedNode.type, selectedNode.id)
+      .then((detail) => {
+        if (active) {
+          setSelectedDetail(detail);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setDetailError(readError(err));
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setDetailLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, selectedNode?.key, selectedNode?.type, selectedNode?.id]);
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -168,10 +201,6 @@ export function GraphPanel({ api }: { api: UserApi }) {
             <span>Superseded</span>
             <input type="checkbox" checked={includeSuperseded} onChange={(event) => setIncludeSuperseded(event.target.checked)} />
           </label>
-          <label className="toggle-row compact-toggle">
-            <span>Communities</span>
-            <input type="checkbox" checked={colorMode === "community"} onChange={(event) => setColorMode(event.target.checked ? "community" : "type")} />
-          </label>
 
           <div className="button-row">
             <button className="primary-button compact" type="submit" disabled={loading || !hasSelectedTypes}>
@@ -190,7 +219,6 @@ export function GraphPanel({ api }: { api: UserApi }) {
             snapshot={snapshot}
             selectedKey={selectedKey}
             onSelect={setSelectedKey}
-            colorMode={colorMode}
             nodeSize={nodeSize}
             linkDistance={linkDistance}
             showArrows={showArrows}
@@ -202,7 +230,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
 
       <aside className="graph-inspector" aria-label="Graph inspector">
         <GraphStats snapshot={snapshot} />
-        <NodeInspector node={selectedNode} />
+        <NodeInspector summary={selectedNode} detail={selectedDetail} loading={detailLoading} error={detailError} />
       </aside>
     </section>
   );
@@ -270,7 +298,6 @@ export function ResultGraphPreview({ api, anchor }: { api: UserApi; anchor: Grap
         snapshot={snapshot}
         selectedKey={selectedKey}
         onSelect={setSelectedKey}
-        colorMode="type"
         nodeSize={4}
         linkDistance={72}
         showArrows
@@ -289,7 +316,6 @@ function GraphCanvas({
   snapshot,
   selectedKey,
   onSelect,
-  colorMode,
   nodeSize,
   linkDistance,
   showArrows,
@@ -299,7 +325,6 @@ function GraphCanvas({
   snapshot: GraphSnapshot;
   selectedKey: string;
   onSelect: (key: string) => void;
-  colorMode: ColorMode;
   nodeSize: number;
   linkDistance: number;
   showArrows: boolean;
@@ -339,7 +364,6 @@ function GraphCanvas({
         nodeVal={(node) => node.val ?? nodeValue(node, nodeSize)}
         nodeLabel={(node) => `${nodeTypeLabel(node.type as GraphNodeType)}: ${node.title}`}
         nodeCanvasObject={(node, canvas, globalScale) => drawNode(node, canvas, globalScale, {
-          colorMode,
           selected: node.key === selectedKey,
           nodeSize,
           showLabels,
@@ -463,23 +487,26 @@ function GraphStats({ snapshot }: { snapshot: GraphSnapshot | null }) {
   );
 }
 
-function NodeInspector({ node }: { node: GraphNode | null }) {
-  if (!node) {
+function NodeInspector({ summary, detail, loading, error }: { summary: GraphNode | null; detail: GraphNode | null; loading: boolean; error: string }) {
+  if (!summary) {
     return <div className="table-placeholder compact">Select a node</div>;
   }
+  const node = detail ?? summary;
   return (
     <article className="graph-node-detail">
       <div className="result-kicker">
-        {nodeIcon(node.type)}
-        <span className="status-pill neutral">{nodeTypeLabel(node.type as GraphNodeType)}</span>
+        {nodeIcon(summary.type)}
+        <span className="status-pill neutral">{nodeTypeLabel(summary.type as GraphNodeType)}</span>
         {node.status && <span className="status-pill success">{node.status}</span>}
       </div>
-      <h3>{node.title || node.id}</h3>
+      <h3>{node.title || summary.title || summary.id}</h3>
+      {loading && <LoadingState label="Loading details" compact />}
+      {error && <div className="banner error" role="alert">{error}</div>}
       {node.body && <p>{node.body}</p>}
       <dl className="evidence-list">
         <div>
           <dt>ID</dt>
-          <dd>{node.id}</dd>
+          <dd>{summary.id}</dd>
         </div>
         <div>
           <dt>Community</dt>
@@ -531,10 +558,10 @@ function drawNode(
   node: ForceNode,
   canvas: CanvasRenderingContext2D,
   globalScale: number,
-  opts: { colorMode: ColorMode; selected: boolean; nodeSize: number; showLabels: boolean; compact: boolean; theme: CanvasTheme },
+  opts: { selected: boolean; nodeSize: number; showLabels: boolean; compact: boolean; theme: CanvasTheme },
 ) {
   const radius = nodeValue(node, opts.nodeSize);
-  const color = nodeColor(node, opts.colorMode);
+  const color = nodeColor(node);
   canvas.beginPath();
   canvas.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false);
   canvas.fillStyle = color;
@@ -561,16 +588,12 @@ function paintNodeArea(node: ForceNode, color: string, canvas: CanvasRenderingCo
   canvas.fill();
 }
 
-function nodeValue(node: Pick<GraphNode, "score" | "type">, nodeSize: number) {
-  const scoreBoost = Math.max(0, Math.min(1, node.score ?? 0)) * 4;
+function nodeValue(node: Pick<GraphNode, "type">, nodeSize: number) {
   const typeBoost = node.type === "fact" ? 1.4 : node.type === "dream" ? 0.6 : 1;
-  return nodeSize + scoreBoost + typeBoost;
+  return nodeSize + typeBoost;
 }
 
-function nodeColor(node: GraphNode, colorMode: ColorMode): string {
-  if (colorMode === "community" && node.community_id) {
-    return communityColor(node.community_id);
-  }
+function nodeColor(node: GraphNode): string {
   switch (node.type) {
     case "fact":
       return "#0f766e";
@@ -583,15 +606,6 @@ function nodeColor(node: GraphNode, colorMode: ColorMode): string {
     default:
       return "#64748b";
   }
-}
-
-function communityColor(communityID: string): string {
-  const palette = ["#0f766e", "#2563eb", "#ca8a04", "#dc2626", "#7c3aed", "#0891b2", "#65a30d", "#db2777"];
-  let hash = 0;
-  for (let index = 0; index < communityID.length; index += 1) {
-    hash = (hash * 31 + communityID.charCodeAt(index)) >>> 0;
-  }
-  return palette[hash % palette.length];
 }
 
 function relationshipColor(type: string): string {

--- a/web/src/user/GraphPanel.tsx
+++ b/web/src/user/GraphPanel.tsx
@@ -49,6 +49,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [detailKey, setDetailKey] = useState("");
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState("");
+  const [graphRevision, setGraphRevision] = useState(0);
 
   async function loadGraph(query: GraphQuery = buildQuery({ searchText, scope, anchorType, anchorId, types, depth, includeSuperseded })) {
     if (query.types?.length === 0) {
@@ -64,6 +65,11 @@ export function GraphPanel({ api }: { api: UserApi }) {
     try {
       const next = await api.graph(query);
       setSnapshot(next);
+      setSelectedDetail(null);
+      setDetailKey("");
+      setDetailError("");
+      setDetailLoading(false);
+      setGraphRevision((current) => current + 1);
       setSelectedKey((current) => next.nodes.some((node) => node.key === current) ? current : "");
     } catch (err) {
       setError(readError(err));
@@ -115,7 +121,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
     return () => {
       active = false;
     };
-  }, [api, selectedNode?.key, selectedNode?.type, selectedNode?.id]);
+  }, [api, selectedNode?.key, selectedNode?.type, selectedNode?.id, graphRevision]);
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -116,6 +116,29 @@ describe("UserApi", () => {
     );
   });
 
+  it("requests graph node details", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        key: "claim:claim-1",
+        id: "claim-1",
+        type: "claim",
+        title: "claim title",
+        body: "claim detail",
+      },
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await new UserApi("dm_key").nodeDetail("claim", "claim-1");
+
+    expect(result.body).toBe("claim detail");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/ui/api/node-detail?type=claim&id=claim-1",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
+      }),
+    );
+  });
+
   it("throws ApiError with server message", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ message: "invalid api key" }), { status: 401 })));
 

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -387,6 +387,12 @@ export class UserApi {
     return payload.data;
   }
 
+  async nodeDetail(type: string, id: string): Promise<GraphNode> {
+    const params = new URLSearchParams({ type, id });
+    const payload = await this.request<Envelope<GraphNode>>(`/ui/api/node-detail?${params.toString()}`);
+    return payload.data;
+  }
+
   async dreamingStatus(): Promise<DreamStatus> {
     const payload = await this.request<Envelope<DreamStatus>>("/api/v1/dreaming/status");
     return payload.data;

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -585,6 +585,17 @@ async function mockUserApi(
     });
   });
 
+  await page.route("**/ui/api/node-detail**", async (route) => {
+    const url = new URL(route.request().url());
+    const key = `${url.searchParams.get("type")}:${url.searchParams.get("id")}`;
+    const node = graphSnapshot.nodes.find((item) => item.key === key) ?? graphSnapshot.nodes[0];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: node }),
+    });
+  });
+
   await page.route("**/ui/api/graph**", async (route) => {
     calls.graphRequests.push(route.request().url());
     await route.fulfill({

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -108,40 +108,61 @@ const graphSnapshot = {
       id: "fact-1",
       type: "fact",
       title: "Alice works_on project-x",
-      body: "project-x",
-      status: "active",
-      community_id: "community-1",
-      score: 0.94,
-      recorded_at: "2026-05-02T12:00:00Z",
     },
     {
       key: "claim:claim-1",
       id: "claim-1",
       type: "claim",
       title: "Alice uses Dense-Mem",
-      body: "Dense-Mem",
-      status: "validated",
-      community_id: "community-1",
-      score: 0.88,
-      recorded_at: "2026-05-02T12:00:00Z",
     },
     {
       key: "fragment:frag-1",
       id: "frag-1",
       type: "fragment",
       title: "Alice is working on project-x with Dense-Mem.",
-      body: "Alice is working on project-x with Dense-Mem.",
-      status: "active",
-      community_id: "community-1",
-      source: "notes",
-      score: 0.75,
-      recorded_at: "2026-05-02T12:00:00Z",
     },
   ],
   edges: [
     { id: "edge-1", source: "claim:claim-1", target: "fact:fact-1", relationship: "PROMOTES_TO", directed: true },
     { id: "edge-2", source: "claim:claim-1", target: "fragment:frag-1", relationship: "SUPPORTED_BY", directed: true },
   ],
+};
+
+const graphNodeDetails = {
+  "fact:fact-1": {
+    key: "fact:fact-1",
+    id: "fact-1",
+    type: "fact",
+    title: "Alice works_on project-x",
+    body: "project-x",
+    status: "active",
+    community_id: "community-1",
+    score: 0.94,
+    recorded_at: "2026-05-02T12:00:00Z",
+  },
+  "claim:claim-1": {
+    key: "claim:claim-1",
+    id: "claim-1",
+    type: "claim",
+    title: "Alice uses Dense-Mem",
+    body: "Dense-Mem",
+    status: "validated",
+    community_id: "community-1",
+    score: 0.88,
+    recorded_at: "2026-05-02T12:00:00Z",
+  },
+  "fragment:frag-1": {
+    key: "fragment:frag-1",
+    id: "frag-1",
+    type: "fragment",
+    title: "Alice is working on project-x with Dense-Mem.",
+    body: "Alice is working on project-x with Dense-Mem.",
+    status: "active",
+    community_id: "community-1",
+    source: "notes",
+    score: 0.75,
+    recorded_at: "2026-05-02T12:00:00Z",
+  },
 };
 
 const telemetryCards = [
@@ -259,7 +280,7 @@ test("graph tab renders a nonblank memory graph", async ({ page }) => {
 
   await page.getByRole("button", { name: "Graph" }).click();
   await expect(page.getByLabel("Knowledge graph")).toBeVisible();
-  await expect(page.getByLabel("Graph inspector")).toContainText("Alice works_on project-x");
+  await expect(page.getByLabel("Graph inspector")).toContainText("Select a node");
   const canvas = page.locator(".graph-canvas canvas").first();
   await expect(canvas).toBeVisible();
   await expect.poll(async () => canvas.evaluate((element) => {
@@ -588,7 +609,7 @@ async function mockUserApi(
   await page.route("**/ui/api/node-detail**", async (route) => {
     const url = new URL(route.request().url());
     const key = `${url.searchParams.get("type")}:${url.searchParams.get("id")}`;
-    const node = graphSnapshot.nodes.find((item) => item.key === key) ?? graphSnapshot.nodes[0];
+    const node = graphNodeDetails[key as keyof typeof graphNodeDetails] ?? graphNodeDetails["fact:fact-1"];
     await route.fulfill({
       status: 200,
       contentType: "application/json",


### PR DESCRIPTION
## What changed

- Return full visible `/ui` graph topology without overview node limits.
- Keep graph snapshot nodes lightweight: `key`, `id`, `type`, and `title`.
- Add lazy `/ui/api/node-detail` for inspector-only node metadata after a user selects a node.
- Include all graph node types by default, including dreams.
- Update user portal graph tests and browser fixtures for the topology/detail split.

## Why

The graph view is meant to show how memories connect. Previously, independently limited node buckets could make the graph look sparse and degree-one even when the underlying graph had richer relationships. Returning full topology while lazy-loading node details keeps the graph connected without shipping inspector payload for every node.

## Validation

- `go test -count=1 ./internal/service/graphview ./internal/http`
- `git ls-files '*.go' | xargs -n1 dirname | sort -u | grep -Ev '^(tests/eval/runtime|tests/uat)($|/)' | sed 's#^#./#' | xargs go test`
- `npm test -- --run src/user/api.test.ts src/user/App.test.tsx` from `web/`
- `npm run typecheck` from `web/`
- `npm run build:user` from `web/`
- `git diff --check`

Note: `go test ./...` remains blocked by the existing local unreadable path `tests/eval/runtime/postgres/18/docker`, so the tracked-package command above was used for the full local Go pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a node detail view in the graph, letting users open a selected node and see more information.
  * Expanded graph support to include additional node types in graph browsing.

* **Bug Fixes**
  * Improved handling for missing or invalid node selections with clearer error responses.
  * Fixed graph overview behavior so non-local views are no longer marked as truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->