### PR TITLE
Document fully local provider setup and first-memory placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,64 @@ Verifier calls send `temperature: 0` by default. Set
 `AI_VERIFIER_DISABLE_TEMPERATURE=true` to omit the field for providers or models
 that reject temperature.
 
+### Fully Local Setup (Ollama)
+
+Dense-Mem also runs with no hosted AI provider at all. Any OpenAI-compatible
+endpoint can serve embeddings and verification; with [Ollama](https://ollama.com)
+on the Docker host, pull the two models once and point `.env` at them:
+
+```bash
+ollama pull nomic-embed-text
+ollama pull llama3.1:8b
+```
+
+```text
+AI_API_URL=http://host.docker.internal:11434/v1
+AI_API_KEY=ollama
+AI_API_EMBEDDING_MODEL=nomic-embed-text
+AI_API_EMBEDDING_DIMENSIONS=768
+AI_VERIFIER_MODEL=llama3.1:8b
+AI_VERIFIER_TIMEOUT_SECONDS=300
+```
+
+Three details matter on this path:
+
+- Use `host.docker.internal`, not `127.0.0.1`; the server calls the provider
+  from inside the compose network. The base compose example maps that name to
+  the Docker host so it also works on Linux, where Docker does not define it
+  by default.
+- `AI_API_KEY` must be non-empty even though Ollama ignores it; startup
+  validation requires a complete embedding configuration.
+- Change `AI_VERIFIER_MODEL` together with the embedding settings. The default
+  is `gpt-4o-mini`, which does not exist on Ollama. Startup still succeeds;
+  the failure only appears later, at claim-verification time. Pick a model
+  that answers within the verifier timeout on your hardware. A 7B-8B class
+  model verifies comfortably on a laptop; larger models can exceed the
+  default 60-second timeout while they load, leaving claims parked as
+  `candidate_claim` with the error recorded in the placement item.
+
+### Your First Memory
+
+`remember` stores evidence and returns an `ingest_id` immediately; placement
+happens asynchronously. Poll `get_memory_placement` with that `ingest_id` to
+see where the memory landed:
+
+| Category | Meaning |
+|----------|---------|
+| `promoted_fact` | A claim was extracted, verified, and promoted to an active fact. |
+| `validated_claim` | The claim verified but did not create a fact. |
+| `candidate_claim` | The claim is parked pending stronger support; check the item's `error` field for verifier failures. |
+| `fragment_only` | The text was stored as searchable evidence without a typed claim. |
+| `needs_more_evidence` | Placement wants more evidence before deciding. |
+| `rejected_false` | The evidence looked like a contradiction or false-memory correction. |
+
+Server-side claim extraction is deliberately conservative: simple first-person
+statements such as "I prefer ...", "I like ...", or "I use ..." are the
+reliable way to see the full evidence-to-fact path on a first run. Other
+phrasings, including third-person forms like "Josh prefers ...", are kept as
+`fragment_only` evidence, which recall still returns and ranks below facts.
+`fragment_only` is a normal outcome, not an error.
+
 ### Telemetry Overlay
 
 Prometheus telemetry is optional and off by default. To collect usage,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,6 +126,59 @@ URL、model 和 dimensions 提供 OpenAI 默认值：`https://api.openai.com/v1`
 Verifier 调用默认发送 `temperature: 0`。如果 provider 或 model 拒绝
 temperature 字段，设置 `AI_VERIFIER_DISABLE_TEMPERATURE=true` 可以省略该字段。
 
+### 完全本地部署（Ollama）
+
+Dense-Mem 也可以完全不依赖托管 AI provider 运行。任何 OpenAI 兼容端点都能提供
+embedding 和 verification；如果 Docker 宿主机上运行着
+[Ollama](https://ollama.com)，先拉取两个模型，再把 `.env` 指向它们：
+
+```bash
+ollama pull nomic-embed-text
+ollama pull llama3.1:8b
+```
+
+```text
+AI_API_URL=http://host.docker.internal:11434/v1
+AI_API_KEY=ollama
+AI_API_EMBEDDING_MODEL=nomic-embed-text
+AI_API_EMBEDDING_DIMENSIONS=768
+AI_VERIFIER_MODEL=llama3.1:8b
+AI_VERIFIER_TIMEOUT_SECONDS=300
+```
+
+这条路径上有三个关键细节：
+
+- 使用 `host.docker.internal` 而不是 `127.0.0.1`；server 是从 compose 网络内部
+  调用 provider 的。基础 compose 示例已经把该域名映射到 Docker 宿主机，因此在
+  Linux（Docker 默认不定义该域名）上同样可用。
+- `AI_API_KEY` 必须非空，即使 Ollama 会忽略它；启动校验要求完整的 embedding
+  配置。
+- `AI_VERIFIER_MODEL` 要和 embedding 配置一起改。默认值是 `gpt-4o-mini`，在
+  Ollama 上并不存在。启动仍会成功，失败要到 claim 验证阶段才暴露。选择一个在
+  你的硬件上能在 verifier 超时之内响应的模型：7B-8B 级别的模型在笔记本上
+  验证起来很轻松，而更大的模型在加载期间可能超过默认的 60 秒超时，导致 claim
+  停在 `candidate_claim`，错误记录在 placement item 里。
+
+### 你的第一条记忆
+
+`remember` 存储 evidence 后立即返回 `ingest_id`；placement 是异步完成的。用该
+`ingest_id` 轮询 `get_memory_placement`，查看这条记忆的去向：
+
+| Category | 含义 |
+|----------|------|
+| `promoted_fact` | claim 被提取、验证并晋升为 active fact。 |
+| `validated_claim` | claim 通过了验证，但没有生成 fact。 |
+| `candidate_claim` | claim 被搁置，等待更强的支持；verifier 失败时错误在 item 的 `error` 字段里。 |
+| `fragment_only` | evidence 以可检索的形式存储，没有生成 typed claim。 |
+| `needs_more_evidence` | placement 需要更多 evidence 才能决定。 |
+| `rejected_false` | evidence 看起来是一条矛盾或 false-memory 更正。 |
+
+服务端的 claim 提取刻意保持保守：像 "I prefer ..."、"I like ..."、"I use ..."
+这样简单的第一人称陈述，是首次运行时看到 evidence 到 fact 完整路径的可靠方式。
+其他表述——包括 "Josh prefers ..." 这类第三人称形式——会作为 `fragment_only`
+的 evidence 保留，recall 仍会返回它们，只是排序低于 facts。`fragment_only`
+是正常结果，不是错误。
+
 ### Telemetry Overlay
 
 Prometheus telemetry 默认关闭，是可选功能。要为 `/ui` 应用和 control portal

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,6 +1,19 @@
 # Dense Memory API Server Configuration
 
 # =============================================================================
+# Quick Start — Required Values
+# =============================================================================
+
+# The base compose example refuses to start until these four values are set.
+# Find each one in its section below; everything else has a working local
+# default.
+#
+#   POSTGRES_PASSWORD      Database Configuration (PostgreSQL)
+#   NEO4J_PASSWORD         Graph Database Configuration (Neo4j)
+#   CONTROL_PORTAL_TOKEN   Local Control Portal Configuration
+#   AI_API_KEY             Embedding Configuration
+
+# =============================================================================
 # Logging Configuration
 # =============================================================================
 
@@ -177,6 +190,15 @@ AI_API_EMBEDDING_MODEL=text-embedding-3-small
 
 # Embedding dimensions must match the provider/model output (required for server startup)
 AI_API_EMBEDDING_DIMENSIONS=1536
+
+# Fully local alternative (Ollama running on the Docker host):
+#   AI_API_URL=http://host.docker.internal:11434/v1
+#   AI_API_KEY=ollama            # any non-empty value; Ollama ignores it
+#   AI_API_EMBEDDING_MODEL=nomic-embed-text
+#   AI_API_EMBEDDING_DIMENSIONS=768
+# Also set AI_VERIFIER_MODEL below to a model that exists on your provider
+# (the gpt-4o-mini default does not exist on Ollama), and raise
+# AI_VERIFIER_TIMEOUT_SECONDS if the model needs time to load.
 
 # Embedding request timeout in seconds (default: 30)
 AI_API_EMBEDDING_TIMEOUT_SECONDS=30

--- a/examples/docker-compose.base.yml
+++ b/examples/docker-compose.base.yml
@@ -101,6 +101,12 @@ services:
     ports:
       - "127.0.0.1:${DENSE_MEM_PORT:-8080}:8080"
       - "127.0.0.1:${CONTROL_PORTAL_PORT:-8090}:8090"
+    # Lets AI_API_URL reach an OpenAI-compatible provider running on the
+    # Docker host (for example Ollama at http://host.docker.internal:11434/v1).
+    # Docker Desktop defines host.docker.internal already; this mapping makes
+    # the same URL work on Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
I went through the 60-second quickstart as a fresh user on a machine with no OpenAI key, which is the exact user the README's "Self-hosted providers keep that traffic inside your boundary" line speaks to. Steps 1 through 4 worked as documented. Getting from there to a promoted fact on a fully local provider took four undocumented details, so this PR documents that path and the first-memory experience around it.

## What changed

- **README.md / README.zh-CN.md**: a "Fully Local Setup (Ollama)" subsection in the quickstart with a verified `.env` block, and a "Your First Memory" subsection that lists the `get_memory_placement` outcome categories and explains why natural phrasings often land as `fragment_only`.
- **examples/docker-compose.base.yml**: `extra_hosts: host.docker.internal:host-gateway` on the server service so the documented provider URL also works on Linux. Docker Desktop already defines the name, so the mapping changes nothing there.
- **examples/.env.example**: a "Quick Start - Required Values" block at the top naming the four values the compose file refuses to start without, and a commented Ollama alternative in the embedding section.

## Verified on a real run (macOS, Docker Desktop, Ollama on the host)

- The exact documented block (`nomic-embed-text`/768 + `llama3.1:8b`, timeout 300) goes from `remember` to `promoted_fact`, and `recall_memory` returns the fact as a tier-1 result.
- With everything else configured for Ollama but `AI_VERIFIER_MODEL` left alone, startup succeeds and the failure only surfaces at claim verification: `verifier provider error: openai: model 'gpt-4o-mini' not found`, with the claim parked as `candidate_claim`. That is why the README bullet calls it out explicitly.
- With a 27B verifier model, verification exceeds the default 60s timeout (`context deadline exceeded`, headers never arrive while the model loads), same `candidate_claim` outcome. Hence the timeout guidance.
- `npm run --prefix .lint lint:lines` passes.

## Notes

The "Josh prefers ..." vs "I prefer ..." `fragment_only` split comes from the prefix list in `extractServerClaim` (`internal/service/memoryservice/placement.go`). Documenting it felt like the right first step. A follow-up that could help more: teach the `remember` tool description the supported phrasings so host LLMs phrase claims extractably on their own. Happy to open that as an issue or a PR.

The wiki Quick-Start and Configuration pages carry the same OpenAI-only assumption; the wiki does not take PRs, so I can send you the equivalent text for those pages if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for fully local setup with Ollama, including required settings, model examples, and Docker-host access notes.
  * Expanded the “first memory” walkthrough with how to submit a memory, check placement status, and interpret the result categories.
  * Updated example environment and Docker Compose docs to show local AI service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->