### PR TITLE
Address semantic ledger follow-up findings

### DIFF
--- a/internal/repository/v2_semantic_helpers.go
+++ b/internal/repository/v2_semantic_helpers.go
@@ -675,6 +675,7 @@ func upsertV2RelationshipRecord(
 			SET predicate_version = ?,
 			    tier = ?,
 			    status = ?,
+			    recorded_to = CASE WHEN ? = 'active' THEN NULL ELSE recorded_to END,
 			    relationship_kind = ?,
 			    current_cardinality = ?,
 			    semantic_group_key = ?,
@@ -683,7 +684,7 @@ func upsertV2RelationshipRecord(
 			WHERE team_id = ?::uuid
 			  AND relationship_id = ?::uuid
 			  AND owner_profile_id = ?::uuid
-		`, input.PredicateVersion, tier, status, predicate.RelationshipKind, predicate.CurrentCardinality,
+		`, input.PredicateVersion, tier, status, status, predicate.RelationshipKind, predicate.CurrentCardinality,
 			semanticGroupKey, input.TeamID, existing.RelationshipID, input.OwnerProfileID)
 		if result.Error != nil {
 			return nil, result.Error

--- a/internal/repository/v2_semantic_repository_integration_test.go
+++ b/internal/repository/v2_semantic_repository_integration_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"sync"
 	"testing"
@@ -698,6 +699,57 @@ func TestV2SemanticOneCardinalitySupersedesPriorActiveRelationship(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, edges, 1)
 	assert.Equal(t, second.Relationship.RelationshipID, edges[0].RelationshipID)
+
+	thirdIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"primary database postgres again", "Dense-Mem now uses PostgreSQL as its primary database.")
+	third := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        thirdIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    "primary_database",
+		ObjectEntityID:  postgres.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     thirdIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:primary-db-3",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem now uses PostgreSQL as its primary database."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, first.Relationship.RelationshipID, third.Relationship.RelationshipID)
+	assert.Equal(t, "active", third.Relationship.Status)
+
+	var reopenedStatus string
+	var reopenedRecordedTo sql.NullTime
+	var supersededStatus string
+	var supersededRecordedTo sql.NullTime
+	err = rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT status, recorded_to
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, third.Relationship.RelationshipID).Row().Scan(&reopenedStatus, &reopenedRecordedTo); err != nil {
+			return err
+		}
+		return tx.Raw(`
+			SELECT status, recorded_to
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, second.Relationship.RelationshipID).Row().Scan(&supersededStatus, &supersededRecordedTo)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "active", reopenedStatus)
+	assert.False(t, reopenedRecordedTo.Valid)
+	assert.Equal(t, "superseded", supersededStatus)
+	assert.True(t, supersededRecordedTo.Valid)
+
+	edges, err = semanticRepo.ListSemanticEdges(ctx, teamID, 20)
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	assert.Equal(t, third.Relationship.RelationshipID, edges[0].RelationshipID)
 }
 
 func TestV2SemanticAppendOnlyHistoryAndRetraction(t *testing.T) {

--- a/internal/repository/v2_semantic_review_regression_test.go
+++ b/internal/repository/v2_semantic_review_regression_test.go
@@ -178,6 +178,91 @@ func TestV2SemanticOneCardinalityUpgradeSupersedesLegacyManyRows(t *testing.T) {
 	assert.Equal(t, upgraded.Relationship.RelationshipID, edges[0].RelationshipID)
 }
 
+func TestV2SemanticDelayedOlderOneVersionDoesNotSupersedeNewerManyRows(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupV2LedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createV2LedgerTeam(t, adminDB, rls, "one-cardinality-reversal-team")
+	ownerID := createV2LedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledgerRepo := NewV2LedgerRepository(appDB, rls)
+	semanticRepo := NewV2SemanticRepository(appDB, rls)
+
+	denseMem := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "project", "Dense-Mem")
+	postgres := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "PostgreSQL")
+	neo4j := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "Neo4j")
+	redis := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "Redis")
+	predicateKey := "runtime_policy_" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	require.NoError(t, insertV2PolicyReversalPredicate(ctx, adminDB, rls, predicateKey))
+
+	postgresIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"policy reversal postgres", "Dense-Mem uses PostgreSQL as a durable store.")
+	postgresUse := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:           teamID,
+		OwnerProfileID:   ownerID,
+		IngestID:         postgresIngest.IngestID,
+		SubjectEntityID:  denseMem.EntityID,
+		PredicateKey:     predicateKey,
+		PredicateVersion: 2,
+		ObjectEntityID:   postgres.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     postgresIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:policy-reversal-postgres",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem uses PostgreSQL as a durable store."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, "many", postgresUse.Relationship.CurrentCardinality)
+
+	neo4jIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"policy reversal neo4j", "Neo4j remains legacy migration input.")
+	neo4jUse := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:           teamID,
+		OwnerProfileID:   ownerID,
+		IngestID:         neo4jIngest.IngestID,
+		SubjectEntityID:  denseMem.EntityID,
+		PredicateKey:     predicateKey,
+		PredicateVersion: 2,
+		ObjectEntityID:   neo4j.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     neo4jIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:policy-reversal-neo4j",
+			SpanStart:      0,
+			SpanEnd:        len("Neo4j remains legacy migration input."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, "many", neo4jUse.Relationship.CurrentCardinality)
+
+	delayedIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"delayed old redis", "Dense-Mem used Redis as its runtime memory store.")
+	delayed := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        delayedIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    predicateKey,
+		ObjectEntityID:  redis.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     delayedIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:delayed-old-redis",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem used Redis as its runtime memory store."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, "one", delayed.Relationship.CurrentCardinality)
+
+	statuses := loadV2RelationshipStatuses(t, ctx, appDB, rls, teamID, ownerID,
+		postgresUse.Relationship.RelationshipID,
+		neo4jUse.Relationship.RelationshipID,
+		delayed.Relationship.RelationshipID,
+	)
+	assert.Equal(t, "active", statuses[postgresUse.Relationship.RelationshipID])
+	assert.Equal(t, "active", statuses[neo4jUse.Relationship.RelationshipID])
+	assert.Equal(t, "active", statuses[delayed.Relationship.RelationshipID])
+}
+
 func createV2SemanticSourceIngest(
 	t *testing.T,
 	ctx context.Context,
@@ -224,6 +309,38 @@ func v2SemanticSupport(sourceGroupKey string, content string) *V2EvidenceSupport
 	}
 }
 
+func loadV2RelationshipStatuses(
+	t *testing.T,
+	ctx context.Context,
+	db *gorm.DB,
+	rls interface {
+		WithTeamProfileTx(context.Context, *gorm.DB, string, string, func(*gorm.DB) error) error
+	},
+	teamID string,
+	ownerID string,
+	relationshipIDs ...string,
+) map[string]string {
+	t.Helper()
+	statuses := make(map[string]string, len(relationshipIDs))
+	err := rls.WithTeamProfileTx(ctx, db, teamID, ownerID, func(tx *gorm.DB) error {
+		for _, relationshipID := range relationshipIDs {
+			var status string
+			if err := tx.Raw(`
+				SELECT status
+				FROM relationship_records
+				WHERE team_id = ?::uuid
+				  AND relationship_id = ?::uuid
+			`, teamID, relationshipID).Scan(&status).Error; err != nil {
+				return err
+			}
+			statuses[relationshipID] = status
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return statuses
+}
+
 func insertV2CardinalityUpgradePredicate(
 	ctx context.Context,
 	db *gorm.DB,
@@ -249,6 +366,36 @@ func insertV2CardinalityUpgradePredicate(
 			        ARRAY['project','product','organization','other']::text[],
 			        ARRAY['project','product','concept','other']::text[],
 			        'state', 'one'
+			    )
+		`, predicateKey, predicateKey).Error
+	})
+}
+
+func insertV2PolicyReversalPredicate(
+	ctx context.Context,
+	db *gorm.DB,
+	rls interface {
+		WithMigrationTx(context.Context, *gorm.DB, func(*gorm.DB) error) error
+	},
+	predicateKey string,
+) error {
+	return rls.WithMigrationTx(ctx, db, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO predicate_definitions (
+			    predicate_key, version, aliases, allowed_subject_kinds, allowed_object_kinds,
+			    relationship_kind, current_cardinality
+			) VALUES
+			    (
+			        ?, 1, ARRAY[]::text[],
+			        ARRAY['project','product','organization','other']::text[],
+			        ARRAY['project','product','concept','other']::text[],
+			        'state', 'one'
+			    ),
+			    (
+			        ?, 2, ARRAY['runtime_component']::text[],
+			        ARRAY['project','product','organization','other']::text[],
+			        ARRAY['project','product','concept','other']::text[],
+			        'state', 'many'
 			    )
 		`, predicateKey, predicateKey).Error
 	})

--- a/internal/repository/v2_semantic_review_regression_test.go
+++ b/internal/repository/v2_semantic_review_regression_test.go
@@ -1,0 +1,255 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestV2SemanticSupportMustMatchSuppliedIngest(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupV2LedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createV2LedgerTeam(t, adminDB, rls, "semantic-support-ingest-team")
+	ownerID := createV2LedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledgerRepo := NewV2LedgerRepository(appDB, rls)
+	semanticRepo := NewV2SemanticRepository(appDB, rls)
+
+	sourceOne, err := ledgerRepo.AdvanceSourceRevision(ctx, V2AdvanceSourceRevisionInput{
+		TeamID:         teamID,
+		OwnerProfileID: ownerID,
+		SourceKey:      "doc://ingest-one",
+		RevisionToken:  "rev-1",
+		ContentHash:    "sha256:one",
+	})
+	require.NoError(t, err)
+	sourceTwo, err := ledgerRepo.AdvanceSourceRevision(ctx, V2AdvanceSourceRevisionInput{
+		TeamID:         teamID,
+		OwnerProfileID: ownerID,
+		SourceKey:      "doc://ingest-two",
+		RevisionToken:  "rev-1",
+		ContentHash:    "sha256:two",
+	})
+	require.NoError(t, err)
+
+	firstIngest := createV2SemanticSourceIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"Dense-Mem uses PostgreSQL.", sourceOne)
+	secondIngest := createV2SemanticSourceIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"Dense-Mem used Neo4j.", sourceTwo)
+	denseMem := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "project", "Dense-Mem")
+	postgres := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "PostgreSQL")
+
+	_, err = semanticRepo.ApplyRelationshipDecision(ctx, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        firstIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    "uses",
+		ObjectEntityID:  postgres.EntityID,
+		Support: v2SemanticSupportFromSource(
+			secondIngest.Evidence[0].FragmentID, sourceTwo, "doc://ingest-two", "Dense-Mem used Neo4j.",
+		),
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrV2SemanticOwnerMismatch), err)
+
+	_, err = semanticRepo.ApplyRelationshipDecision(ctx, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        firstIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    "uses",
+		ObjectEntityID:  postgres.EntityID,
+		Support: v2SemanticSupportFromSource(
+			firstIngest.Evidence[0].FragmentID, sourceTwo, "doc://ingest-two", "Dense-Mem uses PostgreSQL.",
+		),
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrV2SemanticOwnerMismatch), err)
+
+	matching := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        firstIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    "uses",
+		ObjectEntityID:  postgres.EntityID,
+		Support: v2SemanticSupportFromSource(
+			firstIngest.Evidence[0].FragmentID, sourceOne, "doc://ingest-one", "Dense-Mem uses PostgreSQL.",
+		),
+	})
+	require.NotNil(t, matching.Relationship)
+	assert.NotEmpty(t, matching.SupportID)
+}
+
+func TestV2SemanticOneCardinalityUpgradeSupersedesLegacyManyRows(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupV2LedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createV2LedgerTeam(t, adminDB, rls, "one-cardinality-upgrade-team")
+	ownerID := createV2LedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledgerRepo := NewV2LedgerRepository(appDB, rls)
+	semanticRepo := NewV2SemanticRepository(appDB, rls)
+
+	denseMem := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "project", "Dense-Mem")
+	postgres := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "PostgreSQL")
+	neo4j := createV2SemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "Neo4j")
+	predicateKey := "sole_runtime_" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	require.NoError(t, insertV2CardinalityUpgradePredicate(ctx, adminDB, rls, predicateKey))
+
+	postgresIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID, "uses postgres", "Dense-Mem uses PostgreSQL.")
+	postgresUse := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        postgresIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    predicateKey,
+		ObjectEntityID:  postgres.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     postgresIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:uses-postgres",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem uses PostgreSQL."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, "many", postgresUse.Relationship.CurrentCardinality)
+
+	neo4jIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID, "uses neo4j", "Dense-Mem uses Neo4j.")
+	neo4jUse := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:          teamID,
+		OwnerProfileID:  ownerID,
+		IngestID:        neo4jIngest.IngestID,
+		SubjectEntityID: denseMem.EntityID,
+		PredicateKey:    predicateKey,
+		ObjectEntityID:  neo4j.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     neo4jIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:uses-neo4j",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem uses Neo4j."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, "many", neo4jUse.Relationship.CurrentCardinality)
+
+	upgradeIngest := createV2SemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"uses postgres as sole database", "Dense-Mem uses PostgreSQL as its sole durable database.")
+	upgraded := applyV2SemanticDecision(t, ctx, semanticRepo, V2ApplyRelationshipDecisionInput{
+		TeamID:           teamID,
+		OwnerProfileID:   ownerID,
+		IngestID:         upgradeIngest.IngestID,
+		SubjectEntityID:  denseMem.EntityID,
+		PredicateKey:     predicateKey,
+		PredicateVersion: 2,
+		ObjectEntityID:   postgres.EntityID,
+		Support: &V2EvidenceSupportInput{
+			FragmentID:     upgradeIngest.Evidence[0].FragmentID,
+			SourceGroupKey: "conversation:uses-postgres-sole",
+			SpanStart:      0,
+			SpanEnd:        len("Dense-Mem uses PostgreSQL as its sole durable database."),
+			Authority:      "primary",
+		},
+	})
+	require.Equal(t, postgresUse.Relationship.RelationshipID, upgraded.Relationship.RelationshipID)
+	assert.Equal(t, "one", upgraded.Relationship.CurrentCardinality)
+
+	var legacySiblingStatus string
+	err := rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT status
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, neo4jUse.Relationship.RelationshipID).Scan(&legacySiblingStatus).Error
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "superseded", legacySiblingStatus)
+
+	edges, err := semanticRepo.ListSemanticEdges(ctx, teamID, 20)
+	require.NoError(t, err)
+	require.Len(t, edges, 1)
+	assert.Equal(t, upgraded.Relationship.RelationshipID, edges[0].RelationshipID)
+}
+
+func createV2SemanticSourceIngest(
+	t *testing.T,
+	ctx context.Context,
+	repo *V2LedgerRepositoryImpl,
+	teamID string,
+	ownerID string,
+	content string,
+	source *V2SourceRevisionResult,
+) *V2CreateIngestResult {
+	t.Helper()
+	result, err := repo.CreateIngest(ctx, V2CreateIngestInput{
+		TeamID:         teamID,
+		OwnerProfileID: ownerID,
+		Evidence: []V2EvidenceInput{{
+			Content:          content,
+			SourceID:         source.SourceID,
+			SourceRevisionID: source.SourceRevisionID,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Evidence, 1)
+	return result
+}
+
+func v2SemanticSupportFromSource(
+	fragmentID string,
+	source *V2SourceRevisionResult,
+	sourceGroupKey string,
+	content string,
+) *V2EvidenceSupportInput {
+	support := v2SemanticSupport(sourceGroupKey, content)
+	support.FragmentID = fragmentID
+	support.SourceID = source.SourceID
+	support.SourceRevisionID = source.SourceRevisionID
+	return support
+}
+
+func v2SemanticSupport(sourceGroupKey string, content string) *V2EvidenceSupportInput {
+	return &V2EvidenceSupportInput{
+		SourceGroupKey: sourceGroupKey,
+		SpanStart:      0,
+		SpanEnd:        len(content),
+		Authority:      "primary",
+	}
+}
+
+func insertV2CardinalityUpgradePredicate(
+	ctx context.Context,
+	db *gorm.DB,
+	rls interface {
+		WithMigrationTx(context.Context, *gorm.DB, func(*gorm.DB) error) error
+	},
+	predicateKey string,
+) error {
+	return rls.WithMigrationTx(ctx, db, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO predicate_definitions (
+			    predicate_key, version, aliases, allowed_subject_kinds, allowed_object_kinds,
+			    relationship_kind, current_cardinality
+			) VALUES
+			    (
+			        ?, 1, ARRAY[]::text[],
+			        ARRAY['project','product','organization','other']::text[],
+			        ARRAY['project','product','concept','other']::text[],
+			        'state', 'many'
+			    ),
+			    (
+			        ?, 2, ARRAY['primary_runtime']::text[],
+			        ARRAY['project','product','organization','other']::text[],
+			        ARRAY['project','product','concept','other']::text[],
+			        'state', 'one'
+			    )
+		`, predicateKey, predicateKey).Error
+	})
+}

--- a/internal/repository/v2_semantic_support_helpers.go
+++ b/internal/repository/v2_semantic_support_helpers.go
@@ -29,6 +29,10 @@ func supersedeV2OneCardinalityRelationships(
 			  AND valid_to IS NOT DISTINCT FROM ?
 			  AND scope_key IS NOT DISTINCT FROM NULLIF(?, '')
 			  AND relationship_id <> COALESCE(NULLIF(?, '')::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+			  AND (
+			      predicate_version < ?
+			      OR (predicate_version = ? AND current_cardinality = 'one')
+			  )
 			  AND status = 'active'
 			  AND tier IN ('validated_claim', 'fact')
 			FOR UPDATE
@@ -48,7 +52,7 @@ func supersedeV2OneCardinalityRelationships(
 		FROM updated
 	`, input.TeamID, input.OwnerProfileID, input.SubjectEntityID, input.PredicateKey,
 		input.Polarity, v2TimeArg(input.ValidFrom), v2TimeArg(input.ValidTo), input.ScopeKey,
-		keepRelationshipID, input.TeamID).Rows()
+		keepRelationshipID, input.PredicateVersion, input.PredicateVersion, input.TeamID).Rows()
 	if err != nil {
 		return err
 	}

--- a/internal/repository/v2_semantic_support_helpers.go
+++ b/internal/repository/v2_semantic_support_helpers.go
@@ -29,7 +29,6 @@ func supersedeV2OneCardinalityRelationships(
 			  AND valid_to IS NOT DISTINCT FROM ?
 			  AND scope_key IS NOT DISTINCT FROM NULLIF(?, '')
 			  AND relationship_id <> COALESCE(NULLIF(?, '')::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
-			  AND current_cardinality = 'one'
 			  AND status = 'active'
 			  AND tier IN ('validated_claim', 'fact')
 			FOR UPDATE
@@ -99,37 +98,43 @@ func validateV2SupportOwnership(ctx context.Context, tx *gorm.DB, input V2ApplyR
 	if input.Support == nil {
 		return nil
 	}
-	if ok, err := existsV2OwnerReference(ctx, tx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM evidence_fragments
-			WHERE team_id = ?::uuid
-			  AND fragment_id = ?::uuid
-			  AND owner_profile_id = ?::uuid
-		)
-	`, input.TeamID, input.Support.FragmentID, input.OwnerProfileID); err != nil {
-		return err
-	} else if !ok {
-		return ErrV2SemanticOwnerMismatch
-	}
 	if (input.Support.SourceID == "") != (input.Support.SourceRevisionID == "") {
 		return errors.New("support source and source revision must be provided together")
 	}
+	query := `
+		SELECT EXISTS (
+			SELECT 1
+			FROM evidence_fragments AS fragment
+			WHERE fragment.team_id = ?::uuid
+			  AND fragment.ingest_id = ?::uuid
+			  AND fragment.fragment_id = ?::uuid
+			  AND fragment.owner_profile_id = ?::uuid
+	`
+	args := []any{input.TeamID, input.IngestID, input.Support.FragmentID, input.OwnerProfileID}
 	if input.Support.SourceID != "" {
-		if ok, err := existsV2OwnerReference(ctx, tx, `
-			SELECT EXISTS (
-				SELECT 1
-				FROM evidence_source_revisions
-				WHERE team_id = ?::uuid
-				  AND source_id = ?::uuid
-				  AND source_revision_id = ?::uuid
-				  AND owner_profile_id = ?::uuid
-			)
-		`, input.TeamID, input.Support.SourceID, input.Support.SourceRevisionID, input.OwnerProfileID); err != nil {
-			return err
-		} else if !ok {
-			return ErrV2SemanticOwnerMismatch
-		}
+		query += `
+			  AND fragment.source_id = ?::uuid
+			  AND fragment.source_revision_id = ?::uuid
+			  AND EXISTS (
+			      SELECT 1
+			      FROM evidence_source_revisions AS revision
+			      WHERE revision.team_id = fragment.team_id
+			        AND revision.source_id = fragment.source_id
+			        AND revision.source_revision_id = fragment.source_revision_id
+			        AND revision.owner_profile_id = fragment.owner_profile_id
+			  )
+		`
+		args = append(args, input.Support.SourceID, input.Support.SourceRevisionID)
+	}
+	query += `
+		)
+	`
+	ok, err := existsV2OwnerReference(ctx, tx, query, args...)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrV2SemanticOwnerMismatch
 	}
 	return nil
 }

--- a/internal/storage/postgres/client_test.go
+++ b/internal/storage/postgres/client_test.go
@@ -5,14 +5,16 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
-	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -325,18 +327,31 @@ func createMigrationTestDatabase(t *testing.T, ctx context.Context, dsn string) 
 	dbName := "dense_mem_migration_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	quotedName := quoteMigrationIdentifier(dbName)
 	if _, err := adminSQLDB.ExecContext(ctx, "CREATE DATABASE "+quotedName+" TEMPLATE template0"); err != nil {
-		_ = adminSQLDB.Close()
-		t.Skipf("Postgres migration tests require CREATE DATABASE privilege for DATABASE_URL isolation: %v", err)
+		closeErr := adminSQLDB.Close()
+		if isPostgresInsufficientPrivilege(err) {
+			if closeErr != nil {
+				t.Errorf("close migration admin database after CREATE DATABASE privilege error: %v", closeErr)
+			}
+			t.Skipf("Postgres migration tests require CREATE DATABASE privilege for DATABASE_URL isolation: %v", err)
+		}
+		if closeErr != nil {
+			t.Errorf("close migration admin database after CREATE DATABASE failure: %v", closeErr)
+		}
+		t.Fatalf("create migration test database %q: %v", dbName, err)
 	}
 
 	cleanup := func() {
-		_, _ = adminSQLDB.ExecContext(ctx, `
+		if _, err := adminSQLDB.ExecContext(ctx, `
 			SELECT pg_terminate_backend(pid)
 			FROM pg_stat_activity
 			WHERE datname = $1
 			  AND pid <> pg_backend_pid()
-		`, dbName)
-		_, _ = adminSQLDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quotedName)
+		`, dbName); err != nil {
+			t.Errorf("terminate connections to migration test database %q: %v", dbName, err)
+		}
+		if _, err := adminSQLDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quotedName); err != nil {
+			t.Errorf("drop migration test database %q: %v", dbName, err)
+		}
 		_ = adminSQLDB.Close()
 	}
 	return migrationDatabaseDSN(t, dsn, dbName), cleanup
@@ -344,28 +359,90 @@ func createMigrationTestDatabase(t *testing.T, ctx context.Context, dsn string) 
 
 func migrationDatabaseDSN(t *testing.T, dsn string, dbName string) string {
 	t.Helper()
-	if strings.Contains(dsn, "://") {
-		parsed, err := url.Parse(dsn)
-		require.NoError(t, err, "DATABASE_URL should be parseable")
-		parsed.Path = "/" + dbName
-		return parsed.String()
+	config, err := pgconn.ParseConfig(dsn)
+	require.NoError(t, err, "DATABASE_URL should be parseable")
+	config.Database = dbName
+	return migrationConnInfo(config)
+}
+
+func isPostgresInsufficientPrivilege(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "42501"
+}
+
+func migrationConnInfo(config *pgconn.Config) string {
+	fields := make([]string, 0, 8+len(config.RuntimeParams))
+	if config.Host != "" {
+		fields = append(fields, "host="+quoteConnInfoValue(config.Host))
 	}
-	fields := strings.Fields(dsn)
-	replaced := false
-	for i, field := range fields {
-		if strings.HasPrefix(field, "dbname=") {
-			fields[i] = "dbname=" + dbName
-			replaced = true
-		}
+	if config.Port != 0 {
+		fields = append(fields, fmt.Sprintf("port=%d", config.Port))
 	}
-	if !replaced {
-		fields = append(fields, "dbname="+dbName)
+	fields = append(fields, "dbname="+quoteConnInfoValue(config.Database))
+	if config.User != "" {
+		fields = append(fields, "user="+quoteConnInfoValue(config.User))
+	}
+	if config.Password != "" {
+		fields = append(fields, "password="+quoteConnInfoValue(config.Password))
+	}
+	if config.ConnectTimeout > 0 {
+		fields = append(fields, fmt.Sprintf("connect_timeout=%d", int(config.ConnectTimeout.Seconds())))
+	}
+	if config.TLSConfig == nil {
+		fields = append(fields, "sslmode=disable")
+	}
+	keys := make([]string, 0, len(config.RuntimeParams))
+	for key := range config.RuntimeParams {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fields = append(fields, key+"="+quoteConnInfoValue(config.RuntimeParams[key]))
 	}
 	return strings.Join(fields, " ")
 }
 
+func quoteConnInfoValue(value string) string {
+	return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(value) + "'"
+}
+
 func quoteMigrationIdentifier(value string) string {
 	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func TestMigrationDatabaseDSNUpdatesURL(t *testing.T) {
+	dsn := "postgres://test%20user:pa%20ss@localhost:5433/old%20db?sslmode=disable&application_name=dense+mem"
+	got := migrationDatabaseDSN(t, dsn, "new db")
+
+	config, err := pgconn.ParseConfig(got)
+	require.NoError(t, err)
+	assert.Equal(t, "new db", config.Database)
+	assert.Equal(t, "test user", config.User)
+	assert.Equal(t, "pa ss", config.Password)
+	assert.Equal(t, "localhost", config.Host)
+	assert.Equal(t, uint16(5433), config.Port)
+	assert.Equal(t, "dense mem", config.RuntimeParams["application_name"])
+	assert.Nil(t, config.TLSConfig)
+}
+
+func TestMigrationDatabaseDSNPreservesQuotedConninfoValues(t *testing.T) {
+	dsn := `host='localhost' user='test user' password='pa ss\'word' dbname='old db' sslmode=disable application_name='dense mem tests'`
+	got := migrationDatabaseDSN(t, dsn, "new db")
+
+	config, err := pgconn.ParseConfig(got)
+	require.NoError(t, err)
+	assert.Equal(t, "new db", config.Database)
+	assert.Equal(t, "test user", config.User)
+	assert.Equal(t, "pa ss'word", config.Password)
+	assert.Equal(t, "localhost", config.Host)
+	assert.Equal(t, "dense mem tests", config.RuntimeParams["application_name"])
+	assert.Nil(t, config.TLSConfig)
+}
+
+func TestPostgresInsufficientPrivilegeDetection(t *testing.T) {
+	assert.True(t, isPostgresInsufficientPrivilege(&pgconn.PgError{Code: "42501"}))
+	assert.False(t, isPostgresInsufficientPrivilege(&pgconn.PgError{Code: "42P04"}))
+	assert.False(t, isPostgresInsufficientPrivilege(errors.New("network failure")))
 }
 
 func runGooseUpTo(t *testing.T, ctx context.Context, db *sql.DB, version int64) {

--- a/internal/storage/postgres/client_test.go
+++ b/internal/storage/postgres/client_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -131,25 +132,13 @@ func TestOpenFailsOnEmptyDSN(t *testing.T) {
 func TestMigratorRunUp(t *testing.T) {
 	ctx := context.Background()
 
-	dsn, cleanup := skipIfNoPostgres(t, ctx)
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
 	defer cleanup()
 
-	cfg := &testConfig{dsn: dsn}
-
-	db, err := Open(ctx, cfg)
-	require.NoError(t, err, "Open should succeed")
-	defer func() {
-		sqlDB, _ := db.DB()
-		if sqlDB != nil {
-			sqlDB.Close()
-		}
-	}()
-
-	m, err := NewMigrator(db)
-	require.NoError(t, err, "NewMigrator should succeed")
+	m := NewMigratorWithDB(sqlDB)
 
 	// Run up migrations
-	err = m.RunUp(ctx)
+	err := m.RunUp(ctx)
 	// Should succeed since we have a valid migrations directory
 	assert.NoError(t, err, "RunUp should succeed")
 	err = m.RunUp(ctx)
@@ -160,25 +149,13 @@ func TestMigratorRunUp(t *testing.T) {
 func TestMigratorRunDown(t *testing.T) {
 	ctx := context.Background()
 
-	dsn, cleanup := skipIfNoPostgres(t, ctx)
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
 	defer cleanup()
 
-	cfg := &testConfig{dsn: dsn}
-
-	db, err := Open(ctx, cfg)
-	require.NoError(t, err, "Open should succeed")
-	defer func() {
-		sqlDB, _ := db.DB()
-		if sqlDB != nil {
-			sqlDB.Close()
-		}
-	}()
-
-	m, err := NewMigrator(db)
-	require.NoError(t, err, "NewMigrator should succeed")
+	m := NewMigratorWithDB(sqlDB)
 
 	// First run up
-	err = m.RunUp(ctx)
+	err := m.RunUp(ctx)
 	require.NoError(t, err, "RunUp should succeed")
 
 	// Then run down
@@ -257,25 +234,13 @@ func TestV2SemanticLedgerMigrationGuardedRollbackRejectsCanonicalAuthority(t *te
 func TestMigratorStatus(t *testing.T) {
 	ctx := context.Background()
 
-	dsn, cleanup := skipIfNoPostgres(t, ctx)
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
 	defer cleanup()
 
-	cfg := &testConfig{dsn: dsn}
-
-	db, err := Open(ctx, cfg)
-	require.NoError(t, err, "Open should succeed")
-	defer func() {
-		sqlDB, _ := db.DB()
-		if sqlDB != nil {
-			sqlDB.Close()
-		}
-	}()
-
-	m, err := NewMigrator(db)
-	require.NoError(t, err, "NewMigrator should succeed")
+	m := NewMigratorWithDB(sqlDB)
 
 	// Run status
-	err = m.Status(ctx)
+	err := m.Status(ctx)
 	// Status may write to stdout, but should not error
 	assert.NoError(t, err, "Status should not error")
 }
@@ -330,6 +295,15 @@ func TestDBPingTimeout(t *testing.T) {
 func openMigrationSQLDB(t *testing.T, ctx context.Context) (*sql.DB, func()) {
 	t.Helper()
 	dsn, cleanup := skipIfNoPostgres(t, ctx)
+	if os.Getenv("DATABASE_URL") != "" {
+		isolatedDSN, isolatedCleanup := createMigrationTestDatabase(t, ctx, dsn)
+		dsn = isolatedDSN
+		baseCleanup := cleanup
+		cleanup = func() {
+			isolatedCleanup()
+			baseCleanup()
+		}
+	}
 	cfg := &testConfig{dsn: dsn}
 	db, err := Open(ctx, cfg)
 	require.NoError(t, err, "Open should succeed")
@@ -339,6 +313,59 @@ func openMigrationSQLDB(t *testing.T, ctx context.Context) (*sql.DB, func()) {
 		_ = sqlDB.Close()
 		cleanup()
 	}
+}
+
+func createMigrationTestDatabase(t *testing.T, ctx context.Context, dsn string) (string, func()) {
+	t.Helper()
+	adminDB, err := Open(ctx, &testConfig{dsn: dsn})
+	require.NoError(t, err, "Open should succeed")
+	adminSQLDB, err := adminDB.DB()
+	require.NoError(t, err, "underlying sql.DB should be available")
+
+	dbName := "dense_mem_migration_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	quotedName := quoteMigrationIdentifier(dbName)
+	if _, err := adminSQLDB.ExecContext(ctx, "CREATE DATABASE "+quotedName+" TEMPLATE template0"); err != nil {
+		_ = adminSQLDB.Close()
+		t.Skipf("Postgres migration tests require CREATE DATABASE privilege for DATABASE_URL isolation: %v", err)
+	}
+
+	cleanup := func() {
+		_, _ = adminSQLDB.ExecContext(ctx, `
+			SELECT pg_terminate_backend(pid)
+			FROM pg_stat_activity
+			WHERE datname = $1
+			  AND pid <> pg_backend_pid()
+		`, dbName)
+		_, _ = adminSQLDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quotedName)
+		_ = adminSQLDB.Close()
+	}
+	return migrationDatabaseDSN(t, dsn, dbName), cleanup
+}
+
+func migrationDatabaseDSN(t *testing.T, dsn string, dbName string) string {
+	t.Helper()
+	if strings.Contains(dsn, "://") {
+		parsed, err := url.Parse(dsn)
+		require.NoError(t, err, "DATABASE_URL should be parseable")
+		parsed.Path = "/" + dbName
+		return parsed.String()
+	}
+	fields := strings.Fields(dsn)
+	replaced := false
+	for i, field := range fields {
+		if strings.HasPrefix(field, "dbname=") {
+			fields[i] = "dbname=" + dbName
+			replaced = true
+		}
+	}
+	if !replaced {
+		fields = append(fields, "dbname="+dbName)
+	}
+	return strings.Join(fields, " ")
+}
+
+func quoteMigrationIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func runGooseUpTo(t *testing.T, ctx context.Context, db *sql.DB, version int64) {


### PR DESCRIPTION
## Summary
- Bind relationship support validation to the supplied ingest, fragment, and source revision provenance tuple.
- Supersede legacy many-cardinality siblings when a predicate version upgrades to one-cardinality, and reopen `recorded_to` when a relationship row is reactivated.
- Isolate migration tests that use `DATABASE_URL` by creating a per-test temporary database.

## Validation
- `DATABASE_URL='postgres://testuser:testpass@172.17.0.4:5432/testdb?sslmode=disable' DENSE_MEM_ALLOW_DESTRUCTIVE_POSTGRES_TESTS=1 go test ./internal/repository -run 'TestV2Semantic(SupportMustMatchSuppliedIngest|SupportSourceRevisionMustMatchSource|OneCardinalitySupersedesPriorActiveRelationship|OneCardinalityUpgradeSupersedesLegacyManyRows)$' -count=1 -v`
- `DATABASE_URL='postgres://testuser:testpass@172.17.0.4:5432/testdb?sslmode=disable' DENSE_MEM_ALLOW_DESTRUCTIVE_POSTGRES_TESTS=1 go test ./internal/repository -run 'TestV2(Ledger|Semantic)' -count=1`
- `DATABASE_URL='postgres://testuser:testpass@172.17.0.4:5432/testdb?sslmode=disable' go test -tags=integration ./internal/storage/postgres -run 'TestMigratorRunUp|TestMigratorRunDown|TestMigratorStatus|TestV2SemanticLedgerMigration(UpgradesPopulated1703|RejectsLegacyDerivedAuthority|GuardedRollbackRejectsCanonicalAuthority)$' -count=1`
- `go test ./internal/domain ./internal/repository ./internal/tools/registry -count=1`
- `git diff --check`
- `./scripts/ci-check.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected relationship status transitions so reactivated relationships clear previous end timestamps.
  - Improved one-to-one relationship upgrades by superseding legacy many-valued relationships while preserving the correct active relationship.
  - Added validation to reject relationship evidence that does not belong to the specified source or ingest.
  - Ensured semantic relationship listings return only the final active relationship after successive decisions.

- **Tests**
  - Added regression coverage for relationship ownership, status transitions, and cardinality upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->