### PR TITLE
Simplify migration backup confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ exposes only local host ports:
 
 When a legacy Neo4j source is configured and no compatible V2 marker exists,
 the main MCP data plane returns HTTP 503 and the private control portal shows
-only the guided migration page. The operator must attest that a PostgreSQL
-backup and Neo4j snapshot were created, then click Start migration. After
-cutover, the server restarts into PostgreSQL V2; if any `NEO4J_*` setting is
-still present, the control portal stays in cleanup mode until those legacy env
-vars and services are removed and the deployment is recreated.
+only the guided migration page. The operator must confirm that recoverable
+PostgreSQL and Neo4j backups already exist, then start migration. Dense-Mem does
+not create, inspect, verify, or restore those backups. After cutover, the server
+restarts into PostgreSQL V2; if any `NEO4J_*` setting is still present, the
+control portal stays in cleanup mode until those legacy env vars and services
+are removed and the deployment is recreated.
 
 ```text
 MCP/API:        http://127.0.0.1:8080/mcp

--- a/docs/v2/migration-2026071909-v2-migration-control-plane.md
+++ b/docs/v2/migration-2026071909-v2-migration-control-plane.md
@@ -7,7 +7,7 @@ Adds PostgreSQL state for the V2 legacy-corpus migration protocol:
 - migration runs, corpus items, source maps, checkpoints, errors, exclusions,
   gate results, and operator actions
 - compatibility and cutover markers
-- a private control-portal API for status, preflight approval, start, pause,
+- a private control-portal API for status, backup confirmation, start, pause,
   and resume commands
 - guided migration and cleanup control-portal modes
 
@@ -51,42 +51,39 @@ POST /control/api/v2/migration/resume
 `POST /control/api/v2/migration/cutover` are intentionally not registered.
 The supervisor owns bounded page execution and cutover.
 
-Preflight approval requires creation-only attestations for both recovery
-artifacts:
+Backup confirmation requires one operator confirmation that recoverable
+artifacts exist for both databases:
 
 ```json
 {
-  "postgres_backup_reference": "pg-backup-20260722",
-  "postgres_backup_created": true,
-  "neo4j_snapshot_reference": "neo4j-snapshot-20260722",
-  "neo4j_snapshot_created": true
+  "backups_confirmed": true,
+  "reason": "operator confirmed external database backups"
 }
 ```
 
-The raw references are bounded to 200 characters, rejected if they contain
-control characters, and never stored raw. The run stores only opaque hashes and
-safe booleans:
+Dense-Mem does not create, inspect, verify, restore, or record references to
+these backups. The run stores only safe confirmation metadata:
 
-- `backup_snapshots_created`
-- `postgres_backup_created`
-- `postgres_backup_reference_hash`
-- `neo4j_snapshot_created`
-- `neo4j_snapshot_reference_hash`
-- `attestation_scope=creation_only`
-- `rollback_assurance=backup_and_snapshot_creation_attested_restore_not_verified`
+- `operator_backup_confirmation=true`
+- `postgres_backup_confirmed=true`
+- `neo4j_backup_confirmed=true`
+- `confirmation_scope=operator`
+- `backup_verification=not_performed`
 
-Existing `dense-mem.v2.1.migration-control.v1` runs are not auto-executed by
-the supervisor. The operator must renew preflight through the guided UI, which
-upgrades the run to `dense-mem.v2.1.migration-control.v2` and returns it to
-`ready` before migration can resume.
+The active contract is `dense-mem.v2.1.migration-control.v3`. Existing
+`dense-mem.v2.1.migration-control.v1` and
+`dense-mem.v2.1.migration-control.v2` runs are not auto-executed by the
+supervisor. The operator must renew backup confirmation through the guided UI,
+which upgrades the run to v3 and returns it to `ready` before migration can
+resume.
 
 ## Operator Sequence
 
 ```text
 Deploy rc.12 with complete Neo4j source config
   -> /mcp returns 503 and private portal shows only migration mode
-  -> operator enters backup/snapshot references and checks both creation boxes
-  -> operator clicks Start migration
+  -> operator confirms PostgreSQL and Neo4j backups already exist
+  -> operator clicks Confirm and start migration
   -> supervisor runs pages with bounded retries
   -> supervisor evaluates hard gates
   -> supervisor commits compatible marker
@@ -114,9 +111,10 @@ actions, and markers.
 
 ## Rollback Boundary
 
-Preflight attests that a PostgreSQL backup and Neo4j snapshot were created. It
-does not assert that either artifact was restore-tested. Gate output and portal
-copy must keep that weaker rollback assurance visible.
+Backup confirmation records that an operator confirmed PostgreSQL and Neo4j
+backups already exist outside Dense-Mem. It does not prove the backups exist,
+that Dense-Mem created them, or that either artifact was restore-tested. Gate
+output and portal copy must keep that weaker rollback assurance visible.
 
 The down migration drops migration-control tables and markers. After production
 migration progress exists, rollback is an operator decision because checkpoint,

--- a/internal/http/control_portal_migration_test.go
+++ b/internal/http/control_portal_migration_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestControlPortalV2MigrationStatusAndActions(t *testing.T) {
 	migration := &controlMigrationSvc{
+		validatePreflight: true,
 		status: &domain.V2MigrationControlStatus{
 			State:            domain.V2MigrationStateRequired,
 			Required:         true,
@@ -44,15 +45,20 @@ func TestControlPortalV2MigrationStatusAndActions(t *testing.T) {
 	rec = controlMigrationRequest(server, http.MethodPost, "/control/api/v2/migration/preflight", `{
 		"actor": "operator",
 		"remote_ip": "198.51.100.99",
+		"backups_confirmed": true
+	}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "control_portal:authorization-bearer", migration.lastReq.Actor)
+	require.True(t, migration.lastReq.BackupsConfirmed)
+	require.Equal(t, "192.0.2.1", migration.lastReq.RemoteIP)
+
+	rec = controlMigrationRequest(server, http.MethodPost, "/control/api/v2/migration/preflight", `{
 		"postgres_backup_reference": "pg-backup-20260717",
 		"postgres_backup_created": true,
 		"neo4j_snapshot_reference": "neo4j-snapshot-20260717",
 		"neo4j_snapshot_created": true
 	}`)
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, "control_portal:authorization-bearer", migration.lastReq.Actor)
-	require.Equal(t, "pg-backup-20260717", migration.lastReq.PostgresBackupReference)
-	require.Equal(t, "192.0.2.1", migration.lastReq.RemoteIP)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 
 	rec = controlMigrationRequest(server, http.MethodPost, "/control/api/v2/migration/start", `{"reason":"begin"}`)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -151,10 +157,11 @@ func controlMigrationRequest(server http.Handler, method, path, body string) *ht
 }
 
 type controlMigrationSvc struct {
-	status      *domain.V2MigrationControlStatus
-	lastReq     migrationcontrol.OperatorRequest
-	lastCutover migrationcontrol.CutoverRequest
-	err         error
+	status            *domain.V2MigrationControlStatus
+	lastReq           migrationcontrol.OperatorRequest
+	lastCutover       migrationcontrol.CutoverRequest
+	err               error
+	validatePreflight bool
 }
 
 func (s *controlMigrationSvc) Status(context.Context) (*domain.V2MigrationControlStatus, error) {
@@ -168,6 +175,9 @@ func (s *controlMigrationSvc) Status(context.Context) (*domain.V2MigrationContro
 }
 
 func (s *controlMigrationSvc) ApprovePreflight(_ context.Context, req migrationcontrol.OperatorRequest) (*domain.V2MigrationControlStatus, error) {
+	if s.validatePreflight && !req.BackupsConfirmed {
+		return nil, migrationcontrol.ErrPreflightRequired
+	}
 	return s.action(req)
 }
 

--- a/internal/repository/v2_migration_control_repository.go
+++ b/internal/repository/v2_migration_control_repository.go
@@ -52,6 +52,7 @@ type V2UpdateMigrationRunStateInput struct {
 	CorpusVersion            string
 	PreflightApproved        bool
 	BackupReference          string
+	ClearBackupReference     bool
 	PreflightChecks          map[string]any
 	LastError                string
 	Retryable                bool
@@ -241,17 +242,17 @@ func (r *V2MigrationControlRepositoryImpl) UpdateRunState(ctx context.Context, i
 	var out *domain.V2MigrationRun
 	err = r.withSystemTx(ctx, func(tx *gorm.DB) error {
 		row := tx.Raw(`
-			UPDATE v2_migration_runs
-			SET state = ?,
-			    phase = ?,
-			    migration_contract_version = COALESCE(NULLIF(?, ''), migration_contract_version),
-			    corpus_version = COALESCE(NULLIF(?, ''), corpus_version),
-			    preflight_approved = preflight_approved OR ?,
-			    backup_reference = COALESCE(NULLIF(?, ''), backup_reference),
-			    preflight_checks = CASE WHEN ?::jsonb = '{}'::jsonb THEN preflight_checks ELSE ?::jsonb END,
-			    last_error = ?,
-			    retryable = ?,
-			    started_at = CASE WHEN ? = 'running' AND started_at IS NULL THEN ? ELSE started_at END,
+				UPDATE v2_migration_runs
+				SET state = ?,
+				    phase = ?,
+				    migration_contract_version = COALESCE(NULLIF(?, ''), migration_contract_version),
+				    corpus_version = COALESCE(NULLIF(?, ''), corpus_version),
+				    preflight_approved = preflight_approved OR ?,
+				    backup_reference = CASE WHEN ? THEN '' ELSE COALESCE(NULLIF(?, ''), backup_reference) END,
+				    preflight_checks = CASE WHEN ?::jsonb = '{}'::jsonb THEN preflight_checks ELSE ?::jsonb END,
+				    last_error = ?,
+				    retryable = ?,
+				    started_at = CASE WHEN ? = 'running' AND started_at IS NULL THEN ? ELSE started_at END,
 			    completed_at = CASE WHEN ? IN ('failed', 'cut_over', 'incompatible') THEN ? ELSE completed_at END,
 			    cutover_at = CASE WHEN ? = 'cut_over' THEN ? ELSE cutover_at END,
 			    updated_at = ?
@@ -264,8 +265,8 @@ func (r *V2MigrationControlRepositoryImpl) UpdateRunState(ctx context.Context, i
 			          last_error, retryable, lease_owner, checkpoint_key,
 			          checkpoint_value::text, started_at, completed_at, cutover_at,
 			          created_at, updated_at
-		`, input.ToState, input.Phase, input.MigrationContractVersion, input.CorpusVersion,
-			input.PreflightApproved, input.BackupReference,
+			`, input.ToState, input.Phase, input.MigrationContractVersion, input.CorpusVersion,
+			input.PreflightApproved, input.ClearBackupReference, input.BackupReference,
 			string(checks), string(checks), input.LastError, input.Retryable,
 			input.ToState, now, input.ToState, now, input.ToState, now, now,
 			input.RunID, input.FromState).Row()

--- a/internal/repository/v2_migration_control_repository_integration_test.go
+++ b/internal/repository/v2_migration_control_repository_integration_test.go
@@ -57,13 +57,11 @@ func TestV2MigrationControlRepositoryPersistsStateAndRLS(t *testing.T) {
 		PreflightApproved:        true,
 		BackupReference:          "backup-20260717",
 		PreflightChecks: map[string]any{
-			"backup_snapshots_created":       true,
-			"postgres_backup_created":        true,
-			"postgres_backup_reference_hash": "sha256:pg",
-			"neo4j_snapshot_created":         true,
-			"neo4j_snapshot_reference_hash":  "sha256:neo4j",
-			"attestation_scope":              "creation_only",
-			"rollback_assurance":             "backup_and_snapshot_creation_attested_restore_not_verified",
+			"operator_backup_confirmation": true,
+			"postgres_backup_confirmed":    true,
+			"neo4j_backup_confirmed":       true,
+			"confirmation_scope":           "operator",
+			"backup_verification":          "not_performed",
 		},
 		Now: now,
 	})
@@ -78,6 +76,7 @@ func TestV2MigrationControlRepositoryPersistsStateAndRLS(t *testing.T) {
 		Phase:                    "migration",
 		MigrationContractVersion: "migration-contract-v2",
 		CorpusVersion:            "corpus-v2",
+		ClearBackupReference:     true,
 		Retryable:                true,
 		Now:                      now.Add(time.Minute),
 	})
@@ -85,6 +84,7 @@ func TestV2MigrationControlRepositoryPersistsStateAndRLS(t *testing.T) {
 	require.Equal(t, domain.V2MigrationStateRunning, started.State)
 	require.Equal(t, "migration-contract-v2", started.MigrationContractVersion)
 	require.Equal(t, "corpus-v2", started.CorpusVersion)
+	require.Empty(t, started.BackupReference)
 	require.NotNil(t, started.StartedAt)
 
 	require.NoError(t, repo.RecordOperatorAction(ctx, domain.V2MigrationOperatorAction{
@@ -134,13 +134,11 @@ func TestV2MigrationControlRepositoryCommitsCutoverAtomically(t *testing.T) {
 		PreflightApproved:        true,
 		BackupReference:          "backup-20260721",
 		PreflightChecks: map[string]any{
-			"backup_snapshots_created":       true,
-			"postgres_backup_created":        true,
-			"postgres_backup_reference_hash": "sha256:pg",
-			"neo4j_snapshot_created":         true,
-			"neo4j_snapshot_reference_hash":  "sha256:neo4j",
-			"attestation_scope":              "creation_only",
-			"rollback_assurance":             "backup_and_snapshot_creation_attested_restore_not_verified",
+			"operator_backup_confirmation": true,
+			"postgres_backup_confirmed":    true,
+			"neo4j_backup_confirmed":       true,
+			"confirmation_scope":           "operator",
+			"backup_verification":          "not_performed",
 		},
 		Now: now,
 	})
@@ -153,11 +151,11 @@ func TestV2MigrationControlRepositoryCommitsCutoverAtomically(t *testing.T) {
 		CorpusHash:     "sha256:corpus",
 		GateReportHash: "sha256:gates",
 		GateResults: []domain.V2MigrationGateResult{{
-			GateName:     "backup_snapshots_created",
+			GateName:     "operator_backup_confirmation",
 			Outcome:      domain.V2MigrationGateOutcomePass,
 			EvidenceRef:  "local://backup",
 			EvidenceHash: "sha256:backup",
-			Message:      "backup and snapshot creation attested",
+			Message:      "operator confirmed PostgreSQL and Neo4j backups",
 			Metadata:     map[string]any{"version": "test-v1"},
 		}},
 		Metadata: map[string]any{"release": "v2.1.1"},
@@ -451,13 +449,11 @@ func TestV2MigrationExecutorRepositoryPersistsProgressAndStats(t *testing.T) {
 		PreflightApproved:        true,
 		BackupReference:          "backup-20260717",
 		PreflightChecks: map[string]any{
-			"backup_snapshots_created":       true,
-			"postgres_backup_created":        true,
-			"postgres_backup_reference_hash": "sha256:pg",
-			"neo4j_snapshot_created":         true,
-			"neo4j_snapshot_reference_hash":  "sha256:neo4j",
-			"attestation_scope":              "creation_only",
-			"rollback_assurance":             "backup_and_snapshot_creation_attested_restore_not_verified",
+			"operator_backup_confirmation": true,
+			"postgres_backup_confirmed":    true,
+			"neo4j_backup_confirmed":       true,
+			"confirmation_scope":           "operator",
+			"backup_verification":          "not_performed",
 		},
 		Now: now,
 	})

--- a/internal/service/migrationcontrol/backup_confirmation_test.go
+++ b/internal/service/migrationcontrol/backup_confirmation_test.go
@@ -1,0 +1,152 @@
+package migrationcontrol
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestStartResumeAndCutoverRequireCurrentBackupConfirmation(t *testing.T) {
+	ctx := context.Background()
+	store := newStoreStub()
+	store.run = &domain.V2MigrationRun{
+		RunID:                    "run-1",
+		MigrationContractVersion: "dense-mem.v2.1.migration-control.v2",
+		State:                    domain.V2MigrationStateReady,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
+	}
+	svc := New(store, Config{Required: true})
+	_, err := svc.Start(ctx, OperatorRequest{})
+	if !errors.Is(err, ErrPreflightRequired) {
+		t.Fatalf("Start stale contract err = %v", err)
+	}
+
+	store.run.MigrationContractVersion = DefaultMigrationContractVersion
+	store.run.PreflightChecks = map[string]any{"operator_backup_confirmation": true}
+	_, err = svc.Start(ctx, OperatorRequest{})
+	if !errors.Is(err, ErrPreflightRequired) {
+		t.Fatalf("Start incomplete confirmation err = %v", err)
+	}
+
+	store.run.State = domain.V2MigrationStatePaused
+	store.run.PreflightChecks = createdPreflightChecks()
+	status, err := svc.Resume(ctx, OperatorRequest{})
+	if err != nil {
+		t.Fatalf("Resume current confirmation: %v", err)
+	}
+	if status.State != domain.V2MigrationStateRunning {
+		t.Fatalf("resume status = %#v", status)
+	}
+
+	store.run.State = domain.V2MigrationStateReadyCutover
+	store.run.CorpusHash = "sha256:run-corpus"
+	store.run.MigrationContractVersion = "dense-mem.v2.1.migration-control.v2"
+	_, err = svc.Cutover(ctx, CutoverRequest{
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
+	})
+	if !errors.Is(err, ErrPreflightRequired) {
+		t.Fatalf("Cutover stale contract err = %v", err)
+	}
+}
+
+func TestStatusReportsRenewalWhenBackupConfirmationIsStale(t *testing.T) {
+	ctx := context.Background()
+	store := newStoreStub()
+	store.run = &domain.V2MigrationRun{
+		RunID:                    "run-1",
+		MigrationContractVersion: "dense-mem.v2.1.migration-control.v2",
+		State:                    domain.V2MigrationStateReady,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
+	}
+	svc := New(store, Config{Required: true})
+
+	status, err := svc.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status stale contract: %v", err)
+	}
+	if status.ReadinessMessage != "backup confirmation must be renewed before migration can continue" {
+		t.Fatalf("stale contract message = %q", status.ReadinessMessage)
+	}
+
+	store.run.MigrationContractVersion = DefaultMigrationContractVersion
+	store.run.PreflightChecks = map[string]any{"operator_backup_confirmation": true}
+	status, err = svc.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status incomplete confirmation: %v", err)
+	}
+	if status.ReadinessMessage != "backup confirmation must be renewed before migration can continue" {
+		t.Fatalf("incomplete confirmation message = %q", status.ReadinessMessage)
+	}
+
+	store.run.PreflightChecks = createdPreflightChecks()
+	status, err = svc.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status current confirmation: %v", err)
+	}
+	if status.ReadinessMessage != "backup confirmation recorded; start is allowed" {
+		t.Fatalf("current confirmation message = %q", status.ReadinessMessage)
+	}
+}
+
+func TestPreflightRenewalKeepsNonRetryableFailedRunTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := newStoreStub()
+	store.run = &domain.V2MigrationRun{
+		RunID:                    "run-1",
+		MigrationContractVersion: "dense-mem.v2.1.migration-control.v2",
+		State:                    domain.V2MigrationStateFailed,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
+		Retryable:                false,
+	}
+	svc := New(store, Config{Required: true})
+
+	status, err := svc.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status non-retryable failed run: %v", err)
+	}
+	if status.ReadinessMessage != "migration failed; inspect errors and resume only if retryable" {
+		t.Fatalf("non-retryable failed message = %q", status.ReadinessMessage)
+	}
+
+	_, err = svc.ApprovePreflight(ctx, OperatorRequest{
+		BackupsConfirmed: true,
+	})
+	if !errors.Is(err, ErrIllegalTransition) {
+		t.Fatalf("ApprovePreflight non-retryable failed err = %v", err)
+	}
+	if store.run.State != domain.V2MigrationStateFailed || store.run.Retryable {
+		t.Fatalf("run should remain non-retryable failed: %#v", store.run)
+	}
+
+	store.run.Retryable = true
+	status, err = svc.ApprovePreflight(ctx, OperatorRequest{
+		BackupsConfirmed: true,
+	})
+	if err != nil {
+		t.Fatalf("ApprovePreflight retryable failed run: %v", err)
+	}
+	if status.State != domain.V2MigrationStateReady {
+		t.Fatalf("retryable failed renewal status = %#v", status)
+	}
+}
+
+func assertBackupConfirmationChecks(t *testing.T, checks map[string]any) {
+	t.Helper()
+	want := createdPreflightChecks()
+	if len(checks) != len(want) {
+		t.Fatalf("preflight checks = %#v", checks)
+	}
+	for key, value := range want {
+		if checks[key] != value {
+			t.Fatalf("preflight checks[%s] = %#v, want %#v; all checks = %#v", key, checks[key], value, checks)
+		}
+	}
+}

--- a/internal/service/migrationcontrol/backup_confirmation_test.go
+++ b/internal/service/migrationcontrol/backup_confirmation_test.go
@@ -94,6 +94,34 @@ func TestStatusReportsRenewalWhenBackupConfirmationIsStale(t *testing.T) {
 	}
 }
 
+func TestPreflightRenewalAllowsReadyRunWithStaleConfirmation(t *testing.T) {
+	ctx := context.Background()
+	store := newStoreStub()
+	store.run = &domain.V2MigrationRun{
+		RunID:                    "run-1",
+		MigrationContractVersion: "dense-mem.v2.1.migration-control.v2",
+		State:                    domain.V2MigrationStateReady,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
+	}
+	svc := New(store, Config{Required: true})
+
+	status, err := svc.ApprovePreflight(ctx, OperatorRequest{
+		BackupsConfirmed: true,
+	})
+	if err != nil {
+		t.Fatalf("ApprovePreflight ready stale run: %v", err)
+	}
+	if status.State != domain.V2MigrationStateReady {
+		t.Fatalf("ready renewal status = %#v", status)
+	}
+	if store.run.MigrationContractVersion != DefaultMigrationContractVersion {
+		t.Fatalf("renewed contract = %q", store.run.MigrationContractVersion)
+	}
+	assertBackupConfirmationChecks(t, store.run.PreflightChecks)
+}
+
 func TestPreflightRenewalKeepsNonRetryableFailedRunTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreStub()

--- a/internal/service/migrationcontrol/service.go
+++ b/internal/service/migrationcontrol/service.go
@@ -545,7 +545,8 @@ func canRenewPreflight(run *domain.V2MigrationRun, currentContract string) bool 
 		return false
 	}
 	switch run.State {
-	case domain.V2MigrationStateRunning,
+	case domain.V2MigrationStateReady,
+		domain.V2MigrationStateRunning,
 		domain.V2MigrationStatePaused,
 		domain.V2MigrationStateVerifying,
 		domain.V2MigrationStateReadyCutover:
@@ -598,7 +599,7 @@ func (s *service) requireCurrentBackupConfirmation(run *domain.V2MigrationRun) e
 		return ErrPreflightRequired
 	}
 	if strings.TrimSpace(run.MigrationContractVersion) != strings.TrimSpace(s.cfg.MigrationContractVersion) {
-		return fmt.Errorf("%w: renew backup confirmation for migration contract %s", ErrPreflightRequired, run.MigrationContractVersion)
+		return fmt.Errorf("%w: backup confirmation recorded for contract %s is stale; renew for contract %s", ErrPreflightRequired, run.MigrationContractVersion, s.cfg.MigrationContractVersion)
 	}
 	if !BackupConfirmationRecorded(run.PreflightChecks) {
 		return fmt.Errorf("%w: operator confirmation for PostgreSQL and Neo4j backups is required", ErrPreflightRequired)

--- a/internal/service/migrationcontrol/service.go
+++ b/internal/service/migrationcontrol/service.go
@@ -16,16 +16,15 @@ import (
 )
 
 const (
-	DefaultMigrationContractVersion = "dense-mem.v2.1.migration-control.v2"
+	DefaultMigrationContractVersion = "dense-mem.v2.1.migration-control.v3"
 	DefaultCorpusVersion            = "dense-mem.v2.1.legacy-corpus.v1"
 	DefaultCutoverMarkerVersion     = "dense-mem.v2.1.cutover.v1"
 	defaultSourceKind               = "neo4j"
-	maxPreflightReferenceLen        = 200
 )
 
 var (
 	ErrIllegalTransition = errors.New("v2 migration control: illegal transition")
-	ErrPreflightRequired = errors.New("v2 migration control: preflight approval is required")
+	ErrPreflightRequired = errors.New("v2 migration control: backup confirmation is required")
 	ErrAlreadyCutOver    = errors.New("v2 migration control: already cut over")
 	ErrIncompatible      = errors.New("v2 migration control: incompatible marker")
 	ErrCutoverBlocked    = errors.New("v2 migration control: cutover blocked")
@@ -33,7 +32,7 @@ var (
 )
 
 var defaultCutoverRequiredGates = []string{
-	"backup_snapshots_created",
+	"operator_backup_confirmation",
 	"postgres_schema_topology",
 	"tenant_integrity",
 	"team_owner_reconciliation",
@@ -95,15 +94,10 @@ type Config struct {
 }
 
 type OperatorRequest struct {
-	Actor                   string         `json:"-"`
-	RemoteIP                string         `json:"-"`
-	Reason                  string         `json:"reason,omitempty"`
-	BackupReference         string         `json:"backup_reference,omitempty"`
-	PostgresBackupReference string         `json:"postgres_backup_reference,omitempty"`
-	PostgresBackupCreated   bool           `json:"postgres_backup_created,omitempty"`
-	Neo4jSnapshotReference  string         `json:"neo4j_snapshot_reference,omitempty"`
-	Neo4jSnapshotCreated    bool           `json:"neo4j_snapshot_created,omitempty"`
-	PreflightChecks         map[string]any `json:"preflight_checks,omitempty"`
+	Actor            string `json:"-"`
+	RemoteIP         string `json:"-"`
+	Reason           string `json:"reason,omitempty"`
+	BackupsConfirmed bool   `json:"backups_confirmed,omitempty"`
 }
 
 type CutoverRequest struct {
@@ -143,7 +137,7 @@ func New(store Store, cfg Config) Service {
 
 func (s *service) Status(ctx context.Context) (*domain.V2MigrationControlStatus, error) {
 	if s.store == nil {
-		return statusFromRunMarker(s.cfg.Required, nil, nil, nil), nil
+		return statusFromRunMarker(s.cfg.Required, s.cfg.MigrationContractVersion, nil, nil, nil), nil
 	}
 	marker, err := s.store.GetLatestMarker(ctx)
 	if err != nil {
@@ -157,7 +151,7 @@ func (s *service) Status(ctx context.Context) (*domain.V2MigrationControlStatus,
 	if err != nil {
 		return nil, err
 	}
-	return statusFromRunMarker(s.cfg.Required, run, marker, actions), nil
+	return statusFromRunMarker(s.cfg.Required, s.cfg.MigrationContractVersion, run, marker, actions), nil
 }
 
 func (s *service) ApprovePreflight(ctx context.Context, req OperatorRequest) (*domain.V2MigrationControlStatus, error) {
@@ -181,7 +175,6 @@ func (s *service) ApprovePreflight(ctx context.Context, req OperatorRequest) (*d
 			Phase:                    "preflight",
 			Required:                 true,
 			PreflightApproved:        true,
-			BackupReference:          preflightAttestationHash(req),
 			PreflightChecks:          safePreflightChecks(req),
 			Now:                      now,
 		})
@@ -199,7 +192,7 @@ func (s *service) ApprovePreflight(ctx context.Context, req OperatorRequest) (*d
 			MigrationContractVersion: s.cfg.MigrationContractVersion,
 			CorpusVersion:            s.cfg.CorpusVersion,
 			PreflightApproved:        true,
-			BackupReference:          preflightAttestationHash(req),
+			ClearBackupReference:     true,
 			PreflightChecks:          safePreflightChecks(req),
 			Retryable:                true,
 			Now:                      now,
@@ -257,8 +250,8 @@ func (s *service) Cutover(ctx context.Context, req CutoverRequest) (*domain.V2Mi
 	if run.State != domain.V2MigrationStateReadyCutover {
 		return nil, fmt.Errorf("%w: run state %s", ErrCutoverBlocked, run.State)
 	}
-	if !run.PreflightApproved || !preflightAttestationsCreated(run.PreflightChecks) || strings.TrimSpace(run.BackupReference) == "" {
-		return nil, fmt.Errorf("%w: approved backup and snapshot creation attestations are required", ErrPreflightRequired)
+	if err := s.requireCurrentBackupConfirmation(run); err != nil {
+		return nil, err
 	}
 	corpusHash := strings.TrimSpace(run.CorpusHash)
 	if corpusHash == "" {
@@ -326,7 +319,11 @@ func (s *service) transition(
 	if run.State != from || !canTransition(run.State, to) {
 		return nil, fmt.Errorf("%w: %s -> %s", ErrIllegalTransition, run.State, to)
 	}
-	if !run.PreflightApproved {
+	if to == domain.V2MigrationStateRunning {
+		if err := s.requireCurrentBackupConfirmation(run); err != nil {
+			return nil, err
+		}
+	} else if !run.PreflightApproved {
 		return nil, ErrPreflightRequired
 	}
 	now := s.now().UTC()
@@ -383,6 +380,7 @@ func (s *service) recordAction(ctx context.Context, runID, action string, req Op
 
 func statusFromRunMarker(
 	required bool,
+	migrationContractVersion string,
 	run *domain.V2MigrationRun,
 	marker *domain.V2CompatibilityMarker,
 	actions []domain.V2MigrationOperatorAction,
@@ -420,7 +418,7 @@ func statusFromRunMarker(
 			State:            run.State,
 			Required:         run.Required,
 			DataPlaneAllowed: run.State == domain.V2MigrationStateNotRequired || run.State == domain.V2MigrationStateCutOver,
-			ReadinessMessage: readinessMessage(run.State),
+			ReadinessMessage: readinessMessage(run, migrationContractVersion),
 			Run:              run,
 			Actions:          actions,
 		}
@@ -439,10 +437,13 @@ func statusFromRunMarker(
 	}
 }
 
-func readinessMessage(state string) string {
-	switch state {
+func readinessMessage(run *domain.V2MigrationRun, migrationContractVersion string) string {
+	if requiresCurrentBackupConfirmation(run) && !runHasCurrentBackupConfirmation(run, migrationContractVersion) {
+		return "backup confirmation must be renewed before migration can continue"
+	}
+	switch run.State {
 	case domain.V2MigrationStateReady:
-		return "migration preflight approved; start is allowed"
+		return "backup confirmation recorded; start is allowed"
 	case domain.V2MigrationStateRunning:
 		return "migration is running"
 	case domain.V2MigrationStatePaused:
@@ -458,6 +459,34 @@ func readinessMessage(state string) string {
 	default:
 		return "legacy migration is required; use the private control portal"
 	}
+}
+
+func requiresCurrentBackupConfirmation(run *domain.V2MigrationRun) bool {
+	if run == nil {
+		return false
+	}
+	switch run.State {
+	case domain.V2MigrationStateReady,
+		domain.V2MigrationStateRunning,
+		domain.V2MigrationStatePaused,
+		domain.V2MigrationStateVerifying,
+		domain.V2MigrationStateReadyCutover:
+		return true
+	case domain.V2MigrationStateFailed:
+		return run.Retryable
+	default:
+		return false
+	}
+}
+
+func runHasCurrentBackupConfirmation(run *domain.V2MigrationRun, migrationContractVersion string) bool {
+	if run == nil || !run.PreflightApproved {
+		return false
+	}
+	if strings.TrimSpace(run.MigrationContractVersion) != strings.TrimSpace(migrationContractVersion) {
+		return false
+	}
+	return BackupConfirmationRecorded(run.PreflightChecks)
 }
 
 func v2FreshInstallMarker(marker *domain.V2CompatibilityMarker) bool {
@@ -512,53 +541,25 @@ func canTransition(from, to string) bool {
 }
 
 func canRenewPreflight(run *domain.V2MigrationRun, currentContract string) bool {
-	if run == nil || strings.TrimSpace(run.MigrationContractVersion) == strings.TrimSpace(currentContract) {
+	if run == nil || runHasCurrentBackupConfirmation(run, currentContract) {
 		return false
 	}
 	switch run.State {
 	case domain.V2MigrationStateRunning,
 		domain.V2MigrationStatePaused,
-		domain.V2MigrationStateFailed,
 		domain.V2MigrationStateVerifying,
 		domain.V2MigrationStateReadyCutover:
 		return true
+	case domain.V2MigrationStateFailed:
+		return run.Retryable
 	default:
 		return false
 	}
 }
 
 func validatePreflight(req OperatorRequest) error {
-	postgresRef := strings.TrimSpace(req.PostgresBackupReference)
-	neo4jRef := strings.TrimSpace(req.Neo4jSnapshotReference)
-	if postgresRef == "" {
-		return fmt.Errorf("%w: postgres_backup_reference is required", ErrPreflightRequired)
-	}
-	if neo4jRef == "" {
-		return fmt.Errorf("%w: neo4j_snapshot_reference is required", ErrPreflightRequired)
-	}
-	if err := validatePreflightReference("postgres_backup_reference", postgresRef); err != nil {
-		return err
-	}
-	if err := validatePreflightReference("neo4j_snapshot_reference", neo4jRef); err != nil {
-		return err
-	}
-	if !req.PostgresBackupCreated {
-		return fmt.Errorf("%w: postgres_backup_created must be true", ErrPreflightRequired)
-	}
-	if !req.Neo4jSnapshotCreated {
-		return fmt.Errorf("%w: neo4j_snapshot_created must be true", ErrPreflightRequired)
-	}
-	return nil
-}
-
-func validatePreflightReference(field string, value string) error {
-	if len(value) > maxPreflightReferenceLen {
-		return fmt.Errorf("%w: %s must be at most %d characters", ErrPreflightRequired, field, maxPreflightReferenceLen)
-	}
-	for _, ch := range value {
-		if ch < 0x20 || ch == 0x7f {
-			return fmt.Errorf("%w: %s contains a control character", ErrPreflightRequired, field)
-		}
+	if !req.BackupsConfirmed {
+		return fmt.Errorf("%w: backups_confirmed must be true", ErrPreflightRequired)
 	}
 	return nil
 }
@@ -575,48 +576,34 @@ func truthy(value any) bool {
 }
 
 func safePreflightChecks(req OperatorRequest) map[string]any {
-	postgresRef := strings.TrimSpace(req.PostgresBackupReference)
-	neo4jRef := strings.TrimSpace(req.Neo4jSnapshotReference)
 	return map[string]any{
-		"attestation_scope":              "creation_only",
-		"rollback_assurance":             "backup_and_snapshot_creation_attested_restore_not_verified",
-		"backup_snapshots_created":       req.PostgresBackupCreated && req.Neo4jSnapshotCreated,
-		"postgres_backup_created":        req.PostgresBackupCreated,
-		"postgres_backup_reference_hash": hashString(postgresRef),
-		"neo4j_snapshot_created":         req.Neo4jSnapshotCreated,
-		"neo4j_snapshot_reference_hash":  hashString(neo4jRef),
+		"operator_backup_confirmation": req.BackupsConfirmed,
+		"postgres_backup_confirmed":    req.BackupsConfirmed,
+		"neo4j_backup_confirmed":       req.BackupsConfirmed,
+		"confirmation_scope":           "operator",
+		"backup_verification":          "not_performed",
 	}
 }
 
-func PreflightAttestationsCreated(checks map[string]any) bool {
-	return truthy(checks["backup_snapshots_created"]) &&
-		truthy(checks["postgres_backup_created"]) &&
-		truthy(checks["neo4j_snapshot_created"]) &&
-		strings.TrimSpace(fmt.Sprint(checks["postgres_backup_reference_hash"])) != "" &&
-		strings.TrimSpace(fmt.Sprint(checks["neo4j_snapshot_reference_hash"])) != ""
+func BackupConfirmationRecorded(checks map[string]any) bool {
+	return truthy(checks["operator_backup_confirmation"]) &&
+		truthy(checks["postgres_backup_confirmed"]) &&
+		truthy(checks["neo4j_backup_confirmed"]) &&
+		strings.EqualFold(strings.TrimSpace(fmt.Sprint(checks["confirmation_scope"])), "operator") &&
+		strings.EqualFold(strings.TrimSpace(fmt.Sprint(checks["backup_verification"])), "not_performed")
 }
 
-func preflightAttestationsCreated(checks map[string]any) bool {
-	return PreflightAttestationsCreated(checks)
-}
-
-func preflightAttestationHash(req OperatorRequest) string {
-	checks := safePreflightChecks(req)
-	payload := map[string]any{
-		"schema": "dense-mem.v2.1.migration-preflight-attestation.v1",
-		"checks": checks,
+func (s *service) requireCurrentBackupConfirmation(run *domain.V2MigrationRun) error {
+	if !run.PreflightApproved {
+		return ErrPreflightRequired
 	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return ""
+	if strings.TrimSpace(run.MigrationContractVersion) != strings.TrimSpace(s.cfg.MigrationContractVersion) {
+		return fmt.Errorf("%w: renew backup confirmation for migration contract %s", ErrPreflightRequired, run.MigrationContractVersion)
 	}
-	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:])
-}
-
-func hashString(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return "sha256:" + hex.EncodeToString(sum[:])
+	if !BackupConfirmationRecorded(run.PreflightChecks) {
+		return fmt.Errorf("%w: operator confirmation for PostgreSQL and Neo4j backups is required", ErrPreflightRequired)
+	}
+	return nil
 }
 
 func operatorActor(value string) string {
@@ -629,11 +616,10 @@ func operatorActor(value string) string {
 
 func operatorMetadata(req OperatorRequest) map[string]any {
 	out := map[string]any{}
-	if strings.TrimSpace(req.PostgresBackupReference) != "" || strings.TrimSpace(req.Neo4jSnapshotReference) != "" {
-		out["preflight_attestation_hash"] = preflightAttestationHash(req)
+	if req.BackupsConfirmed {
 		out["preflight_checks"] = safePreflightChecks(req)
-	} else if req.BackupReference != "" {
-		out["backup_reference_hash"] = hashString(strings.TrimSpace(req.BackupReference))
+		out["backup_confirmation"] = true
+		out["backup_verification"] = "not_performed"
 	}
 	return out
 }

--- a/internal/service/migrationcontrol/service_test.go
+++ b/internal/service/migrationcontrol/service_test.go
@@ -41,11 +41,8 @@ func TestPreflightStartPauseResumeStateMachine(t *testing.T) {
 	}
 
 	_, err = svc.ApprovePreflight(ctx, OperatorRequest{
-		Actor:                   "operator",
-		PostgresBackupReference: "pg-backup-20260717",
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot-20260717",
-		Neo4jSnapshotCreated:    true,
+		Actor:            "operator",
+		BackupsConfirmed: true,
 	})
 	if err != nil {
 		t.Fatalf("ApprovePreflight: %v", err)
@@ -53,6 +50,10 @@ func TestPreflightStartPauseResumeStateMachine(t *testing.T) {
 	if store.run.State != domain.V2MigrationStateReady || !store.run.PreflightApproved {
 		t.Fatalf("run after preflight = %#v", store.run)
 	}
+	if store.run.BackupReference != "" {
+		t.Fatalf("backup reference should not be written, got %q", store.run.BackupReference)
+	}
+	assertBackupConfirmationChecks(t, store.run.PreflightChecks)
 
 	started, err := svc.Start(ctx, OperatorRequest{Actor: "operator", Reason: "begin rehearsal"})
 	if err != nil {
@@ -83,33 +84,16 @@ func TestPreflightStartPauseResumeStateMachine(t *testing.T) {
 	}
 }
 
-func TestPreflightRequiresCreatedBackupAndSnapshotAttestations(t *testing.T) {
+func TestPreflightRequiresOperatorBackupConfirmation(t *testing.T) {
 	svc := New(newStoreStub(), Config{Required: true})
-	_, err := svc.ApprovePreflight(context.Background(), OperatorRequest{
-		PostgresBackupReference: "pg-backup",
-		PostgresBackupCreated:   true,
-	})
+	_, err := svc.ApprovePreflight(context.Background(), OperatorRequest{})
 	if !errors.Is(err, ErrPreflightRequired) {
-		t.Fatalf("ApprovePreflight err = %v", err)
+		t.Fatalf("ApprovePreflight missing confirmation err = %v", err)
 	}
 
-	_, err = svc.ApprovePreflight(context.Background(), OperatorRequest{
-		PostgresBackupReference: "pg-backup",
-		Neo4jSnapshotReference:  "neo4j-snapshot",
-		Neo4jSnapshotCreated:    true,
-	})
+	_, err = svc.ApprovePreflight(context.Background(), OperatorRequest{BackupsConfirmed: false})
 	if !errors.Is(err, ErrPreflightRequired) {
-		t.Fatalf("ApprovePreflight missing postgres check err = %v", err)
-	}
-
-	_, err = svc.ApprovePreflight(context.Background(), OperatorRequest{
-		PostgresBackupReference: strings.Repeat("x", maxPreflightReferenceLen+1),
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot",
-		Neo4jSnapshotCreated:    true,
-	})
-	if !errors.Is(err, ErrPreflightRequired) {
-		t.Fatalf("ApprovePreflight long reference err = %v", err)
+		t.Fatalf("ApprovePreflight false confirmation err = %v", err)
 	}
 }
 
@@ -124,10 +108,7 @@ func TestPreflightUpdatesExistingRequiredRun(t *testing.T) {
 	svc := New(store, Config{Required: true})
 
 	status, err := svc.ApprovePreflight(ctx, OperatorRequest{
-		PostgresBackupReference: "pg-backup-20260717",
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot-20260717",
-		Neo4jSnapshotCreated:    true,
+		BackupsConfirmed: true,
 	})
 	if err != nil {
 		t.Fatalf("ApprovePreflight existing run: %v", err)
@@ -138,11 +119,17 @@ func TestPreflightUpdatesExistingRequiredRun(t *testing.T) {
 	if len(store.actions) != 1 || store.actions[0].Actor != "control" {
 		t.Fatalf("actions = %#v", store.actions)
 	}
-	if got := store.actions[0].Metadata["preflight_attestation_hash"]; got == "" {
+	if got := store.actions[0].Metadata["backup_confirmation"]; got != true {
 		t.Fatalf("preflight metadata = %#v", store.actions[0].Metadata)
 	}
-	if checks, ok := store.run.PreflightChecks["backup_snapshots_created"].(bool); !ok || !checks {
-		t.Fatalf("preflight checks = %#v", store.run.PreflightChecks)
+	checks, ok := store.actions[0].Metadata["preflight_checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("preflight metadata = %#v", store.actions[0].Metadata)
+	}
+	assertBackupConfirmationChecks(t, checks)
+	assertBackupConfirmationChecks(t, store.run.PreflightChecks)
+	if store.run.BackupReference != "" {
+		t.Fatalf("backup reference should not be written, got %q", store.run.BackupReference)
 	}
 	if store.run.MigrationContractVersion != DefaultMigrationContractVersion {
 		t.Fatalf("migration contract = %q", store.run.MigrationContractVersion)
@@ -159,14 +146,12 @@ func TestPreflightRenewsLegacyContractRun(t *testing.T) {
 		State:                    domain.V2MigrationStateRunning,
 		Required:                 true,
 		PreflightApproved:        true,
+		BackupReference:          "legacy-backup-reference",
 	}
 	svc := New(store, Config{Required: true})
 
 	status, err := svc.ApprovePreflight(ctx, OperatorRequest{
-		PostgresBackupReference: "pg-backup-20260722",
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot-20260722",
-		Neo4jSnapshotCreated:    true,
+		BackupsConfirmed: true,
 	})
 	if err != nil {
 		t.Fatalf("ApprovePreflight legacy run: %v", err)
@@ -180,17 +165,28 @@ func TestPreflightRenewsLegacyContractRun(t *testing.T) {
 	if store.run.State != domain.V2MigrationStateReady {
 		t.Fatalf("run state = %q", store.run.State)
 	}
+	if store.run.BackupReference != "" {
+		t.Fatalf("legacy backup reference should be cleared, got %q", store.run.BackupReference)
+	}
 
 	store.run.State = domain.V2MigrationStateRunning
 	store.run.MigrationContractVersion = DefaultMigrationContractVersion
 	_, err = svc.ApprovePreflight(ctx, OperatorRequest{
-		PostgresBackupReference: "pg-backup-20260722",
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot-20260722",
-		Neo4jSnapshotCreated:    true,
+		BackupsConfirmed: true,
 	})
 	if !errors.Is(err, ErrIllegalTransition) {
 		t.Fatalf("current running preflight err = %v", err)
+	}
+
+	store.run.PreflightChecks = map[string]any{"operator_backup_confirmation": true}
+	status, err = svc.ApprovePreflight(ctx, OperatorRequest{
+		BackupsConfirmed: true,
+	})
+	if err != nil {
+		t.Fatalf("ApprovePreflight incomplete current run: %v", err)
+	}
+	if status.State != domain.V2MigrationStateReady {
+		t.Fatalf("status after incomplete current renewal = %#v", status)
 	}
 }
 
@@ -214,10 +210,12 @@ func TestTransitionPropagatesUpdateAndRecordErrors(t *testing.T) {
 
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReady,
-		Required:          true,
-		PreflightApproved: true,
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReady,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	store.updateErr = want
 	_, err := New(store, Config{Required: true}).Start(ctx, OperatorRequest{})
@@ -227,10 +225,12 @@ func TestTransitionPropagatesUpdateAndRecordErrors(t *testing.T) {
 
 	store = newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReady,
-		Required:          true,
-		PreflightApproved: true,
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReady,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	store.recordErr = want
 	_, err = New(store, Config{Required: true}).Start(ctx, OperatorRequest{})
@@ -239,24 +239,24 @@ func TestTransitionPropagatesUpdateAndRecordErrors(t *testing.T) {
 	}
 }
 
-func TestCutoverRequiresReadyRunBackupCorpusAndPassingGates(t *testing.T) {
+func TestCutoverRequiresReadyRunConfirmationCorpusAndPassingGates(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	svc := New(store, Config{
 		Required:             true,
-		CutoverRequiredGates: []string{"backup_snapshots_created", "no_neo4j_fallback"},
+		CutoverRequiredGates: []string{"operator_backup_confirmation", "no_neo4j_fallback"},
 	})
 
 	_, err := svc.Cutover(ctx, CutoverRequest{
-		GateResults: passingCutoverGates("backup_snapshots_created", "no_neo4j_fallback"),
+		GateResults: passingCutoverGates("operator_backup_confirmation", "no_neo4j_fallback"),
 	})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("Cutover missing corpus hash err = %v", err)
@@ -265,7 +265,7 @@ func TestCutoverRequiresReadyRunBackupCorpusAndPassingGates(t *testing.T) {
 	store.run.CorpusHash = "sha256:corpus"
 	_, err = svc.Cutover(ctx, CutoverRequest{
 		CorpusHash:  "sha256:corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 	})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("Cutover missing gate err = %v", err)
@@ -274,7 +274,7 @@ func TestCutoverRequiresReadyRunBackupCorpusAndPassingGates(t *testing.T) {
 	store.commitErr = repository.ErrV2MigrationCutoverBlocked
 	_, err = svc.Cutover(ctx, CutoverRequest{
 		CorpusHash:  "sha256:corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created", "no_neo4j_fallback"),
+		GateResults: passingCutoverGates("operator_backup_confirmation", "no_neo4j_fallback"),
 	})
 	if !errors.Is(err, ErrCutoverBlocked) {
 		t.Fatalf("Cutover repository blocked err = %v", err)
@@ -285,27 +285,27 @@ func TestCutoverRejectsUnknownGateAndInvalidEvidenceHash(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		CorpusHash:        "sha256:run-corpus",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		CorpusHash:               "sha256:run-corpus",
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	svc := New(store, Config{
 		Required:             true,
-		CutoverRequiredGates: []string{"backup_snapshots_created"},
+		CutoverRequiredGates: []string{"operator_backup_confirmation"},
 	})
 
 	_, err := svc.Cutover(ctx, CutoverRequest{
-		GateResults: passingCutoverGates("backup_snapshots_created", "unexpected_gate"),
+		GateResults: passingCutoverGates("operator_backup_confirmation", "unexpected_gate"),
 	})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("unknown gate err = %v", err)
 	}
 
-	gates := passingCutoverGates("backup_snapshots_created")
+	gates := passingCutoverGates("operator_backup_confirmation")
 	gates[0].EvidenceHash = "sha256:not-a-digest"
 	_, err = svc.Cutover(ctx, CutoverRequest{GateResults: gates})
 	if !errors.Is(err, ErrCutoverGate) {
@@ -315,7 +315,7 @@ func TestCutoverRejectsUnknownGateAndInvalidEvidenceHash(t *testing.T) {
 
 func TestCutoverRejectsBlockedStateAndMissingPreflight(t *testing.T) {
 	ctx := context.Background()
-	gates := passingCutoverGates("backup_snapshots_created")
+	gates := passingCutoverGates("operator_backup_confirmation")
 
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
@@ -323,11 +323,10 @@ func TestCutoverRejectsBlockedStateAndMissingPreflight(t *testing.T) {
 		State:             domain.V2MigrationStateRunning,
 		Required:          true,
 		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
 		CorpusHash:        "sha256:run-corpus",
 		PreflightChecks:   createdPreflightChecks(),
 	}
-	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"backup_snapshots_created"}})
+	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"operator_backup_confirmation"}})
 	_, err := svc.Cutover(ctx, CutoverRequest{GateResults: gates})
 	if !errors.Is(err, ErrCutoverBlocked) {
 		t.Fatalf("blocked state err = %v", err)
@@ -341,10 +340,10 @@ func TestCutoverRejectsBlockedStateAndMissingPreflight(t *testing.T) {
 	}
 
 	store.run.PreflightApproved = true
-	store.run.BackupReference = ""
+	store.run.PreflightChecks = map[string]any{"operator_backup_confirmation": false}
 	_, err = svc.Cutover(ctx, CutoverRequest{GateResults: gates})
 	if !errors.Is(err, ErrPreflightRequired) {
-		t.Fatalf("missing backup err = %v", err)
+		t.Fatalf("missing backup confirmation err = %v", err)
 	}
 }
 
@@ -352,15 +351,15 @@ func TestCutoverGateValidationRejectsIncompleteGateEvidence(t *testing.T) {
 	ctx := context.Background()
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		CorpusHash:        "sha256:run-corpus",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		CorpusHash:               "sha256:run-corpus",
+		PreflightChecks:          createdPreflightChecks(),
 	}
-	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"backup_snapshots_created"}})
+	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"operator_backup_confirmation"}})
 
 	cases := map[string]func([]domain.V2MigrationGateResult) []domain.V2MigrationGateResult{
 		"empty name": func(gates []domain.V2MigrationGateResult) []domain.V2MigrationGateResult {
@@ -392,7 +391,7 @@ func TestCutoverGateValidationRejectsIncompleteGateEvidence(t *testing.T) {
 	for name, mutate := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, err := svc.Cutover(ctx, CutoverRequest{
-				GateResults: mutate(passingCutoverGates("backup_snapshots_created")),
+				GateResults: mutate(passingCutoverGates("operator_backup_confirmation")),
 			})
 			if !errors.Is(err, ErrCutoverGate) {
 				t.Fatalf("Cutover err = %v", err)
@@ -400,7 +399,7 @@ func TestCutoverGateValidationRejectsIncompleteGateEvidence(t *testing.T) {
 		})
 	}
 
-	duplicate := append(passingCutoverGates("backup_snapshots_created"), passingCutoverGates("backup_snapshots_created")...)
+	duplicate := append(passingCutoverGates("operator_backup_confirmation"), passingCutoverGates("operator_backup_confirmation")...)
 	_, err := svc.Cutover(ctx, CutoverRequest{GateResults: duplicate})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("duplicate gate err = %v", err)
@@ -433,21 +432,21 @@ func TestCutoverPropagatesStoreAndPreflightLookupErrors(t *testing.T) {
 
 	store = newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		CorpusHash:        "sha256:run-corpus",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		CorpusHash:               "sha256:run-corpus",
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	store.commitErr = want
 	_, err = New(store, Config{
 		Required:             true,
-		CutoverRequiredGates: []string{"backup_snapshots_created"},
+		CutoverRequiredGates: []string{"operator_backup_confirmation"},
 	}).Cutover(ctx, CutoverRequest{
 		CorpusHash:  "sha256:run-corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 	})
 	if !errors.Is(err, want) {
 		t.Fatalf("commit err = %v", err)
@@ -458,17 +457,17 @@ func TestCutoverCommitsMarkerAndOperatorAction(t *testing.T) {
 	now := time.Date(2026, 7, 21, 15, 0, 0, 0, time.UTC)
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		CorpusHash:        "sha256:run-corpus",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		CorpusHash:               "sha256:run-corpus",
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	svc := New(store, Config{
 		Required:             true,
-		CutoverRequiredGates: []string{"backup_snapshots_created"},
+		CutoverRequiredGates: []string{"operator_backup_confirmation"},
 		Now:                  func() time.Time { return now },
 	})
 
@@ -476,7 +475,7 @@ func TestCutoverCommitsMarkerAndOperatorAction(t *testing.T) {
 		Actor:       "operator",
 		RemoteIP:    "192.0.2.55",
 		Reason:      "final cutover",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 		Metadata:    map[string]any{"release": "v2.1.1"},
 	})
 
@@ -506,18 +505,18 @@ func TestCutoverCommitsMarkerAndOperatorAction(t *testing.T) {
 func TestCutoverRequiresFinalizedRunCorpusHashAndRejectsMismatch(t *testing.T) {
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateReadyCutover,
-		Required:          true,
-		PreflightApproved: true,
-		BackupReference:   "backup-20260717",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateReadyCutover,
+		Required:                 true,
+		PreflightApproved:        true,
+		PreflightChecks:          createdPreflightChecks(),
 	}
-	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"backup_snapshots_created"}})
+	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"operator_backup_confirmation"}})
 
 	_, err := svc.Cutover(context.Background(), CutoverRequest{
 		CorpusHash:  "sha256:request-corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 	})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("Cutover missing finalized corpus hash err = %v", err)
@@ -526,7 +525,7 @@ func TestCutoverRequiresFinalizedRunCorpusHashAndRejectsMismatch(t *testing.T) {
 	store.run.CorpusHash = "sha256:run-corpus"
 	_, err = svc.Cutover(context.Background(), CutoverRequest{
 		CorpusHash:  "sha256:request-corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 	})
 	if !errors.Is(err, ErrCutoverGate) {
 		t.Fatalf("Cutover mismatched corpus hash err = %v", err)
@@ -534,7 +533,7 @@ func TestCutoverRequiresFinalizedRunCorpusHashAndRejectsMismatch(t *testing.T) {
 
 	_, err = svc.Cutover(context.Background(), CutoverRequest{
 		CorpusHash:  "sha256:run-corpus",
-		GateResults: passingCutoverGates("backup_snapshots_created"),
+		GateResults: passingCutoverGates("operator_backup_confirmation"),
 	})
 	if err != nil {
 		t.Fatalf("Cutover matching corpus hash: %v", err)
@@ -547,10 +546,7 @@ func TestCutoverRequiresFinalizedRunCorpusHashAndRejectsMismatch(t *testing.T) {
 func TestPreflightPropagatesStoreErrors(t *testing.T) {
 	ctx := context.Background()
 	req := OperatorRequest{
-		PostgresBackupReference: "pg-backup-20260717",
-		PostgresBackupCreated:   true,
-		Neo4jSnapshotReference:  "neo4j-snapshot-20260717",
-		Neo4jSnapshotCreated:    true,
+		BackupsConfirmed: true,
 	}
 	want := errors.New("store failed")
 
@@ -732,7 +728,7 @@ func TestActionRequiresStore(t *testing.T) {
 
 func TestReadinessMessagesForMigrationStates(t *testing.T) {
 	cases := map[string]string{
-		domain.V2MigrationStateReady:        "migration preflight approved; start is allowed",
+		domain.V2MigrationStateReady:        "backup confirmation recorded; start is allowed",
 		domain.V2MigrationStateRunning:      "migration is running",
 		domain.V2MigrationStatePaused:       "migration is paused at a durable checkpoint",
 		domain.V2MigrationStateFailed:       "migration failed; inspect errors and resume only if retryable",
@@ -744,10 +740,13 @@ func TestReadinessMessagesForMigrationStates(t *testing.T) {
 	}
 	for state, want := range cases {
 		t.Run(state, func(t *testing.T) {
-			status := statusFromRunMarker(true, &domain.V2MigrationRun{
-				RunID:    "run-1",
-				State:    state,
-				Required: true,
+			status := statusFromRunMarker(true, DefaultMigrationContractVersion, &domain.V2MigrationRun{
+				RunID:                    "run-1",
+				MigrationContractVersion: DefaultMigrationContractVersion,
+				State:                    state,
+				Required:                 true,
+				PreflightApproved:        true,
+				PreflightChecks:          createdPreflightChecks(),
 			}, nil, nil)
 			if status.ReadinessMessage != want {
 				t.Fatalf("message = %q, want %q", status.ReadinessMessage, want)
@@ -784,7 +783,7 @@ func TestTransitionTableRejectsUnsupportedEdges(t *testing.T) {
 }
 
 func TestCutoverGateHashRejectsUnserializableMetadata(t *testing.T) {
-	gates := passingCutoverGates("backup_snapshots_created")
+	gates := passingCutoverGates("operator_backup_confirmation")
 	gates[0].Metadata["bad"] = make(chan struct{})
 	_, err := cutoverGateReportHash(gates)
 	if !errors.Is(err, ErrCutoverGate) {
@@ -870,6 +869,9 @@ func (s *storeStub) UpdateRunState(_ context.Context, input repository.V2UpdateM
 		s.run.CorpusVersion = input.CorpusVersion
 	}
 	s.run.PreflightApproved = s.run.PreflightApproved || input.PreflightApproved
+	if input.ClearBackupReference {
+		s.run.BackupReference = ""
+	}
 	if input.BackupReference != "" {
 		s.run.BackupReference = input.BackupReference
 	}
@@ -967,10 +969,10 @@ func passingCutoverGates(names ...string) []domain.V2MigrationGateResult {
 
 func createdPreflightChecks() map[string]any {
 	return map[string]any{
-		"backup_snapshots_created":       true,
-		"postgres_backup_created":        true,
-		"postgres_backup_reference_hash": "sha256:" + strings.Repeat("b", 64),
-		"neo4j_snapshot_created":         true,
-		"neo4j_snapshot_reference_hash":  "sha256:" + strings.Repeat("c", 64),
+		"operator_backup_confirmation": true,
+		"postgres_backup_confirmed":    true,
+		"neo4j_backup_confirmed":       true,
+		"confirmation_scope":           "operator",
+		"backup_verification":          "not_performed",
 	}
 }

--- a/internal/service/migrationcontrol/service_test.go
+++ b/internal/service/migrationcontrol/service_test.go
@@ -319,12 +319,13 @@ func TestCutoverRejectsBlockedStateAndMissingPreflight(t *testing.T) {
 
 	store := newStoreStub()
 	store.run = &domain.V2MigrationRun{
-		RunID:             "run-1",
-		State:             domain.V2MigrationStateRunning,
-		Required:          true,
-		PreflightApproved: true,
-		CorpusHash:        "sha256:run-corpus",
-		PreflightChecks:   createdPreflightChecks(),
+		RunID:                    "run-1",
+		MigrationContractVersion: DefaultMigrationContractVersion,
+		State:                    domain.V2MigrationStateRunning,
+		Required:                 true,
+		PreflightApproved:        true,
+		CorpusHash:               "sha256:run-corpus",
+		PreflightChecks:          createdPreflightChecks(),
 	}
 	svc := New(store, Config{Required: true, CutoverRequiredGates: []string{"operator_backup_confirmation"}})
 	_, err := svc.Cutover(ctx, CutoverRequest{GateResults: gates})
@@ -871,8 +872,7 @@ func (s *storeStub) UpdateRunState(_ context.Context, input repository.V2UpdateM
 	s.run.PreflightApproved = s.run.PreflightApproved || input.PreflightApproved
 	if input.ClearBackupReference {
 		s.run.BackupReference = ""
-	}
-	if input.BackupReference != "" {
+	} else if input.BackupReference != "" {
 		s.run.BackupReference = input.BackupReference
 	}
 	if input.PreflightChecks != nil {

--- a/internal/service/migrationsupervisor/release_evidence.go
+++ b/internal/service/migrationsupervisor/release_evidence.go
@@ -173,8 +173,8 @@ var staticReleaseEvidence = map[string]releaseEvidenceEntry{
 		},
 	},
 	"rollback_compatibility": {
-		message:  "Rollback compatibility is bounded by explicit backup and snapshot attestations.",
-		criteria: "Control-plane docs and tests mark backup/snapshot creation as a hard gate.",
+		message:  "Rollback compatibility is bounded by operator backup confirmation.",
+		criteria: "Control-plane docs and tests require the operator to confirm PostgreSQL and Neo4j backups; Dense-Mem does not create or verify them.",
 		sources: []string{
 			"docs/v2/migration-2026071909-v2-migration-control-plane.md",
 			"internal/service/migrationcontrol/service_test.go",

--- a/internal/service/migrationsupervisor/service.go
+++ b/internal/service/migrationsupervisor/service.go
@@ -271,8 +271,8 @@ func (s *Service) tick(ctx context.Context) error {
 		if status == nil {
 			return nil
 		}
-		if status.Run != nil && status.Run.MigrationContractVersion != migrationcontrol.DefaultMigrationContractVersion {
-			s.setLastError("renew preflight before resuming legacy migration contract " + status.Run.MigrationContractVersion)
+		if message := supervisorBackupConfirmationRenewalMessage(status); message != "" {
+			s.setLastError(message)
 			return nil
 		}
 		switch status.State {
@@ -293,6 +293,24 @@ func (s *Service) tick(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func supervisorBackupConfirmationRenewalMessage(status *domain.V2MigrationControlStatus) string {
+	if status == nil || status.Run == nil {
+		return ""
+	}
+	switch status.State {
+	case domain.V2MigrationStateRunning, domain.V2MigrationStateReadyCutover:
+	default:
+		return ""
+	}
+	if strings.TrimSpace(status.Run.MigrationContractVersion) != migrationcontrol.DefaultMigrationContractVersion {
+		return "renew backup confirmation before resuming legacy migration contract " + status.Run.MigrationContractVersion
+	}
+	if !status.Run.PreflightApproved || !migrationcontrol.BackupConfirmationRecorded(status.Run.PreflightChecks) {
+		return "renew backup confirmation before continuing migration"
+	}
+	return ""
 }
 
 func (s *Service) runPages(ctx context.Context) (bool, error) {
@@ -396,13 +414,14 @@ func (s *Service) evaluateGate(
 	}
 	var err error
 	switch name {
-	case "backup_snapshots_created":
-		if !migrationcontrol.PreflightAttestationsCreated(run.PreflightChecks) {
-			err = fmt.Errorf("%w: backup and snapshot creation attestations are missing", ErrGateBlocked)
+	case "operator_backup_confirmation":
+		if !migrationcontrol.BackupConfirmationRecorded(run.PreflightChecks) {
+			err = fmt.Errorf("%w: operator backup confirmation is missing", ErrGateBlocked)
 		}
-		evidence.Ref = "dense-mem://migration/preflight/backup-snapshots-created"
-		evidence.Message = "operator attested PostgreSQL backup and Neo4j snapshot creation; restore was not verified"
-		evidence.Details["attestation_scope"] = "creation_only"
+		evidence.Ref = "dense-mem://migration/preflight/operator-backup-confirmation"
+		evidence.Message = "operator confirmed PostgreSQL and Neo4j backups; Dense-Mem did not create, inspect, verify, or restore backups"
+		evidence.Details["confirmation_scope"] = "operator"
+		evidence.Details["backup_verification"] = "not_performed"
 	case "terminal_official_pipeline_outcomes":
 		if run.TotalItems != run.CompletedItems || run.FailedItems != 0 || run.ExcludedItems != 0 {
 			err = fmt.Errorf("%w: migration outcomes are not terminal and clean", ErrGateBlocked)
@@ -605,7 +624,7 @@ func publicSupervisorError(err error) string {
 	case errors.Is(err, ErrGateBlocked):
 		return safeGateMessage(err)
 	case errors.Is(err, migrationcontrol.ErrPreflightRequired):
-		return "migration preflight is required"
+		return "backup confirmation is required"
 	default:
 		return supervisorInternalErrorMessage
 	}

--- a/internal/service/migrationsupervisor/service_test.go
+++ b/internal/service/migrationsupervisor/service_test.go
@@ -124,7 +124,34 @@ func TestSupervisorRequiresRenewedPreflightForLegacyContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
-	if len(got.RecentErrors) != 1 || !strings.Contains(got.RecentErrors[0], "renew preflight") {
+	if len(got.RecentErrors) != 1 || !strings.Contains(got.RecentErrors[0], "renew backup confirmation") {
+		t.Fatalf("recent errors = %#v", got.RecentErrors)
+	}
+}
+
+func TestSupervisorRequiresCompleteBackupConfirmationBeforeRunningPages(t *testing.T) {
+	ctx := context.Background()
+	status := supervisorStatus(domain.V2MigrationStateRunning)
+	status.Run.PreflightChecks = map[string]any{"operator_backup_confirmation": true}
+	control := &supervisorControlStub{status: status}
+	executor := &supervisorExecutorStub{}
+	service := New(Config{
+		Control:  control,
+		Executor: executor,
+		Lock:     &supervisorLockStub{locked: true},
+	})
+
+	if err := service.tick(ctx); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if executor.calls != 0 {
+		t.Fatalf("incomplete confirmation should not execute pages, calls = %d", executor.calls)
+	}
+	got, err := service.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(got.RecentErrors) != 1 || !strings.Contains(got.RecentErrors[0], "renew backup confirmation") {
 		t.Fatalf("recent errors = %#v", got.RecentErrors)
 	}
 }
@@ -168,6 +195,21 @@ func TestTelemetryGateRequiresPersistedOperatorActions(t *testing.T) {
 	}
 }
 
+func TestOperatorBackupConfirmationGateEvidenceStatesVerificationBoundary(t *testing.T) {
+	ctx := context.Background()
+	service := New(Config{RequiredGates: []string{"operator_backup_confirmation"}})
+	gates, err := service.evaluateGates(ctx, supervisorStatus(domain.V2MigrationStateReadyCutover))
+	if err != nil {
+		t.Fatalf("evaluateGates: %v", err)
+	}
+	if len(gates) != 1 || gates[0].Outcome != domain.V2MigrationGateOutcomePass {
+		t.Fatalf("gate = %#v", gates)
+	}
+	if !strings.Contains(gates[0].Message, "Dense-Mem did not create") || !strings.Contains(gates[0].Message, "verify") {
+		t.Fatalf("gate message = %q", gates[0].Message)
+	}
+}
+
 func supervisorStatus(state string) *domain.V2MigrationControlStatus {
 	now := time.Date(2026, 7, 22, 7, 43, 0, 0, time.UTC)
 	run := &domain.V2MigrationRun{
@@ -178,15 +220,12 @@ func supervisorStatus(state string) *domain.V2MigrationControlStatus {
 		State:                    state,
 		Required:                 true,
 		PreflightApproved:        true,
-		BackupReference:          "sha256:preflight-attestation",
 		PreflightChecks: map[string]any{
-			"backup_snapshots_created":       true,
-			"postgres_backup_created":        true,
-			"postgres_backup_reference_hash": "sha256:pg",
-			"neo4j_snapshot_created":         true,
-			"neo4j_snapshot_reference_hash":  "sha256:neo4j",
-			"attestation_scope":              "creation_only",
-			"rollback_assurance":             "backup_and_snapshot_creation_attested_restore_not_verified",
+			"operator_backup_confirmation": true,
+			"postgres_backup_confirmed":    true,
+			"neo4j_backup_confirmed":       true,
+			"confirmation_scope":           "operator",
+			"backup_verification":          "not_performed",
 		},
 		CorpusHash:     "sha256:corpus",
 		TotalItems:     3,

--- a/web/src/App.migration.test.tsx
+++ b/web/src/App.migration.test.tsx
@@ -28,16 +28,16 @@ describe("App migration portal", () => {
       }
       if (url.endsWith("/v2/migration/preflight") && method === "POST") {
         const body = JSON.parse(String(init?.body));
-        expect(body.postgres_backup_reference).toBe("pg-backup-1");
-        expect(body.postgres_backup_created).toBe(true);
-        expect(body.neo4j_snapshot_reference).toBe("neo4j-snapshot-1");
-        expect(body.neo4j_snapshot_created).toBe(true);
+        expect(body).toEqual({
+          backups_confirmed: true,
+          reason: "operator confirmed external PostgreSQL and Neo4j backups",
+        });
         return jsonResponse({
           data: {
             state: "ready",
             required: true,
             data_plane_allowed: false,
-            readiness_message: "migration preflight approved",
+            readiness_message: "backup confirmation recorded",
             run: migrationRun({ state: "ready" }),
           },
         });
@@ -61,19 +61,22 @@ describe("App migration portal", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Legacy migration is required" })).toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith("/teams"))).toBe(false);
+    expect(screen.queryByLabelText("PostgreSQL backup reference")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Neo4j snapshot reference")).not.toBeInTheDocument();
+    expect(screen.getByText("Dense-Mem does not create, inspect, or restore these backups.")).toBeInTheDocument();
 
-    await userEvent.type(screen.getByLabelText("PostgreSQL backup reference"), "pg-backup-1");
-    await userEvent.click(screen.getByLabelText("PostgreSQL backup created"));
-    await userEvent.type(screen.getByLabelText("Neo4j snapshot reference"), "neo4j-snapshot-1");
-    await userEvent.click(screen.getByLabelText("Neo4j snapshot created"));
-    await userEvent.click(screen.getByRole("button", { name: /start migration/i }));
+    const startButton = screen.getByRole("button", { name: /confirm and start migration/i });
+    expect(startButton).toBeDisabled();
+    await userEvent.click(screen.getByLabelText("I confirm that I have backed up both the PostgreSQL and Neo4j databases."));
+    expect(startButton).toBeEnabled();
+    await userEvent.click(startButton);
 
     await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => (
       String(url).endsWith("/v2/migration/start")
     ))).toBe(true));
   });
 
-  it("renews old migration preflight before resuming an rc11 run", async () => {
+  it("renews old migration backup confirmation before resuming an rc11 run", async () => {
     let preflightCalls = 0;
     const legacyRun = migrationRun({
       run_id: "run-rc11",
@@ -86,7 +89,8 @@ describe("App migration portal", () => {
     const currentRun = {
       ...legacyRun,
       state: "ready",
-      migration_contract_version: "dense-mem.v2.1.migration-control.v2",
+      migration_contract_version: "dense-mem.v2.1.migration-control.v3",
+      preflight_checks: confirmationChecks(),
     };
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -100,7 +104,7 @@ describe("App migration portal", () => {
             state: "running",
             required: true,
             data_plane_allowed: false,
-            readiness_message: "renew preflight before resuming legacy migration contract",
+            readiness_message: "renew backup confirmation before resuming legacy migration contract",
             run: legacyRun,
           },
         });
@@ -112,7 +116,7 @@ describe("App migration portal", () => {
             state: "ready",
             required: true,
             data_plane_allowed: false,
-            readiness_message: "migration preflight approved",
+            readiness_message: "backup confirmation recorded",
             run: currentRun,
           },
         });
@@ -135,14 +139,179 @@ describe("App migration portal", () => {
 
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Legacy migration is required" })).toBeInTheDocument();
-    await userEvent.type(screen.getByLabelText("PostgreSQL backup reference"), "pg-backup-2");
-    await userEvent.click(screen.getByLabelText("PostgreSQL backup created"));
-    await userEvent.type(screen.getByLabelText("Neo4j snapshot reference"), "neo4j-snapshot-2");
-    await userEvent.click(screen.getByLabelText("Neo4j snapshot created"));
-    await userEvent.click(screen.getByRole("button", { name: /start migration/i }));
+    await userEvent.click(screen.getByLabelText("I confirm that I have backed up both the PostgreSQL and Neo4j databases."));
+    await userEvent.click(screen.getByRole("button", { name: /confirm and start migration/i }));
 
     await waitFor(() => expect(preflightCalls).toBe(1));
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith("/v2/migration/start"))).toBe(true);
+  });
+
+  it("renews incomplete current backup confirmation before restarting an active run", async () => {
+    let preflightCalls = 0;
+    const activeRun = migrationRun({
+      state: "running",
+      total_items: 4,
+      completed_items: 2,
+      preflight_checks: { operator_backup_confirmation: true },
+      updated_at: "2026-07-22T00:00:01Z",
+    });
+    const currentRun = {
+      ...activeRun,
+      state: "ready",
+      preflight_checks: confirmationChecks(),
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/session")) {
+        return jsonResponse({ data: { authenticated: true, portal_mode: "migration", legacy_config_present: true } });
+      }
+      if (url.endsWith("/v2/migration") && method === "GET") {
+        return jsonResponse({
+          data: {
+            state: "running",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "backup confirmation must be renewed before migration can continue",
+            run: activeRun,
+          },
+        });
+      }
+      if (url.endsWith("/v2/migration/preflight") && method === "POST") {
+        preflightCalls++;
+        return jsonResponse({
+          data: {
+            state: "ready",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "backup confirmation recorded",
+            run: currentRun,
+          },
+        });
+      }
+      if (url.endsWith("/v2/migration/start") && method === "POST") {
+        return jsonResponse({
+          data: {
+            state: "running",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "migration is running",
+            run: { ...currentRun, state: "running" },
+          },
+        });
+      }
+      return jsonResponse({ message: "not found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Legacy migration is required" })).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("I confirm that I have backed up both the PostgreSQL and Neo4j databases."));
+    await userEvent.click(screen.getByRole("button", { name: /confirm and start migration/i }));
+
+    await waitFor(() => expect(preflightCalls).toBe(1));
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith("/v2/migration/start"))).toBe(true);
+  });
+
+  it("does not offer backup confirmation renewal for a non-retryable failed run", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/session")) {
+        return jsonResponse({ data: { authenticated: true, portal_mode: "migration", legacy_config_present: true } });
+      }
+      if (url.endsWith("/v2/migration") && method === "GET") {
+        return jsonResponse({
+          data: {
+            state: "failed",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "migration failed; inspect errors and resume only if retryable",
+            run: migrationRun({
+              state: "failed",
+              retryable: false,
+              migration_contract_version: "dense-mem.v2.1.migration-control.v2",
+            }),
+          },
+        });
+      }
+      return jsonResponse({ message: "not found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    expect(await screen.findByText("migration failed; inspect errors and resume only if retryable")).toBeInTheDocument();
+    const startButton = screen.getByRole("button", { name: /confirm and start migration/i });
+    expect(startButton).toBeDisabled();
+    await userEvent.click(screen.getByLabelText("I confirm that I have backed up both the PostgreSQL and Neo4j databases."));
+    expect(startButton).toBeDisabled();
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith("/v2/migration/preflight"))).toBe(false);
+  });
+
+  it("retries start without reconfirming when confirmation succeeds but start fails", async () => {
+    let preflightCalls = 0;
+    let startCalls = 0;
+    const readyRun = migrationRun({ state: "ready" });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/session")) {
+        return jsonResponse({ data: { authenticated: true, portal_mode: "migration", legacy_config_present: true } });
+      }
+      if (url.endsWith("/v2/migration") && method === "GET") {
+        return jsonResponse({
+          data: {
+            state: "required",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "legacy migration is required",
+          },
+        });
+      }
+      if (url.endsWith("/v2/migration/preflight") && method === "POST") {
+        preflightCalls++;
+        return jsonResponse({
+          data: {
+            state: "ready",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "backup confirmation recorded",
+            run: readyRun,
+          },
+        });
+      }
+      if (url.endsWith("/v2/migration/start") && method === "POST") {
+        startCalls++;
+        if (startCalls === 1) {
+          return jsonResponse({ message: "start failed" }, 500);
+        }
+        return jsonResponse({
+          data: {
+            state: "running",
+            required: true,
+            data_plane_allowed: false,
+            readiness_message: "migration is running",
+            run: { ...readyRun, state: "running" },
+          },
+        });
+      }
+      return jsonResponse({ message: "not found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Legacy migration is required" })).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("I confirm that I have backed up both the PostgreSQL and Neo4j databases."));
+    await userEvent.click(screen.getByRole("button", { name: /confirm and start migration/i }));
+
+    expect(await screen.findByText("start failed")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /start migration/i }));
+
+    await waitFor(() => expect(startCalls).toBe(2));
+    expect(preflightCalls).toBe(1);
   });
 
   it("shows cleanup mode without normal control routes", async () => {
@@ -185,13 +354,24 @@ function migrationRun(overrides: Record<string, unknown> = {}) {
     failed_items: 0,
     excluded_items: 0,
     retryable: true,
-    migration_contract_version: "dense-mem.v2.1.migration-control.v2",
+    migration_contract_version: "dense-mem.v2.1.migration-control.v3",
+    preflight_checks: confirmationChecks(),
     corpus_version: "dense-mem.v2.1.legacy-corpus.v1",
     source_kind: "neo4j",
     required: true,
     created_at: "2026-07-22T00:00:00Z",
     updated_at: "2026-07-22T00:00:00Z",
     ...overrides,
+  };
+}
+
+function confirmationChecks() {
+  return {
+    operator_backup_confirmation: true,
+    postgres_backup_confirmed: true,
+    neo4j_backup_confirmed: true,
+    confirmation_scope: "operator",
+    backup_verification: "not_performed",
   };
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -491,6 +491,11 @@ function MigrationPortal({
   const progress = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : (status?.state === "cut_over" ? 100 : 0);
   const contractCurrent = run?.migration_contract_version === CURRENT_MIGRATION_CONTRACT;
   const backupConfirmationCurrent = !!run?.preflight_approved && contractCurrent && hasBackupConfirmation(run.preflight_checks);
+  useEffect(() => {
+    if (backupConfirmationCurrent) {
+      setBackupsConfirmed(false);
+    }
+  }, [backupConfirmationCurrent]);
   const confirmationRenewalState = !!run && !backupConfirmationCurrent && (
     status?.state === "running" ||
     status?.state === "paused_retryable" ||

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,7 +48,7 @@ const RecallFeedbackPanel = lazy(() => import("./control/RecallFeedbackPanel").t
 
 const TOKEN_STORAGE_KEY = "denseMem.controlToken";
 const THEME_STORAGE_KEY = "denseMem.controlTheme";
-const CURRENT_MIGRATION_CONTRACT = "dense-mem.v2.1.migration-control.v2";
+const CURRENT_MIGRATION_CONTRACT = "dense-mem.v2.1.migration-control.v3";
 
 type LoadState = "idle" | "loading" | "error";
 type Theme = "light" | "dark";
@@ -406,10 +406,7 @@ function MigrationPortal({
   onSignOut: () => void;
 }) {
   const [status, setStatus] = useState<MigrationStatus | null>(null);
-  const [postgresRef, setPostgresRef] = useState("");
-  const [neo4jRef, setNeo4jRef] = useState("");
-  const [postgresCreated, setPostgresCreated] = useState(false);
-  const [neo4jCreated, setNeo4jCreated] = useState(false);
+  const [backupsConfirmed, setBackupsConfirmed] = useState(false);
   const [busy, setBusy] = useState(false);
   const [connection, setConnection] = useState<"connected" | "reconnecting">("connected");
   const [error, setError] = useState("");
@@ -444,15 +441,14 @@ function MigrationPortal({
         next = await api.getMigrationStatus();
       }
       const currentPreflight = next?.run?.preflight_approved &&
-        next.run.migration_contract_version === CURRENT_MIGRATION_CONTRACT;
+        next.run.migration_contract_version === CURRENT_MIGRATION_CONTRACT &&
+        hasBackupConfirmation(next.run.preflight_checks);
       if (!currentPreflight) {
         next = await api.approveMigrationPreflight({
-          postgres_backup_reference: postgresRef.trim(),
-          postgres_backup_created: postgresCreated,
-          neo4j_snapshot_reference: neo4jRef.trim(),
-          neo4j_snapshot_created: neo4jCreated,
-          reason: "operator confirmed backup and snapshot creation",
+          backups_confirmed: backupsConfirmed,
+          reason: "operator confirmed external PostgreSQL and Neo4j backups",
         });
+        setStatus(next);
       }
       if (next.state === "ready") {
         next = await api.startMigration("operator started guided migration");
@@ -493,21 +489,22 @@ function MigrationPortal({
   const total = run?.total_items ?? 0;
   const completed = run?.completed_items ?? 0;
   const progress = total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : (status?.state === "cut_over" ? 100 : 0);
-  const preflightReady = postgresRef.trim().length > 0 && neo4jRef.trim().length > 0 && postgresCreated && neo4jCreated;
   const contractCurrent = run?.migration_contract_version === CURRENT_MIGRATION_CONTRACT;
-  const preflightCurrent = !!run?.preflight_approved && contractCurrent;
-  const legacyRenewalState = !!run && !contractCurrent && (
+  const backupConfirmationCurrent = !!run?.preflight_approved && contractCurrent && hasBackupConfirmation(run.preflight_checks);
+  const confirmationRenewalState = !!run && !backupConfirmationCurrent && (
     status?.state === "running" ||
     status?.state === "paused_retryable" ||
-    status?.state === "failed" ||
+    (status?.state === "failed" && run.retryable) ||
     status?.state === "verifying" ||
     status?.state === "ready_to_cutover"
   );
   const canStart = session.portal_mode === "migration" &&
-    (status?.state === "required" || status?.state === "ready" || legacyRenewalState) &&
-    (preflightCurrent || preflightReady);
+    (status?.state === "required" || status?.state === "ready" || confirmationRenewalState) &&
+    (backupConfirmationCurrent || backupsConfirmed);
   const canPause = session.portal_mode === "migration" && status?.state === "running";
-  const canResume = session.portal_mode === "migration" && (status?.state === "paused_retryable" || (status?.state === "failed" && run?.retryable));
+  const canResume = session.portal_mode === "migration" &&
+    backupConfirmationCurrent &&
+    (status?.state === "paused_retryable" || (status?.state === "failed" && run?.retryable));
   const cleanup = session.portal_mode === "cleanup";
 
   return (
@@ -564,47 +561,33 @@ function MigrationPortal({
           <section className="maintenance-panel">
             <SectionHeading
               title="Start migration"
-              subtitle="Attest that both recovery artifacts have been created. This does not prove a restore test."
+              subtitle="Confirm that both recovery artifacts exist before the migration starts."
             />
             <form className="migration-preflight" onSubmit={(event) => { event.preventDefault(); void start(); }}>
-              <label htmlFor="postgres-backup-ref">PostgreSQL backup reference</label>
-              <input
-                id="postgres-backup-ref"
-                value={postgresRef}
-                maxLength={200}
-                onChange={(event) => setPostgresRef(event.target.value)}
-                disabled={busy || preflightCurrent}
-              />
+              <div className="backup-confirmation-card" aria-label="Before you migrate">
+                <div>
+                  <h3>Before you migrate</h3>
+                  <p>Confirm that recoverable copies exist for both databases.</p>
+                </div>
+                <div className="backup-confirmation-scope" aria-label="Databases covered by this confirmation">
+                  <span><Database size={15} aria-hidden="true" /> PostgreSQL</span>
+                  <span><Database size={15} aria-hidden="true" /> Neo4j</span>
+                </div>
+              </div>
               <label className="check-row">
                 <input
                   type="checkbox"
-                  checked={postgresCreated}
-                  onChange={(event) => setPostgresCreated(event.target.checked)}
-                  disabled={busy || preflightCurrent}
+                  checked={backupsConfirmed || backupConfirmationCurrent}
+                  onChange={(event) => setBackupsConfirmed(event.target.checked)}
+                  disabled={busy || backupConfirmationCurrent}
                 />
-                PostgreSQL backup created
+                I confirm that I have backed up both the PostgreSQL and Neo4j databases.
               </label>
-              <label htmlFor="neo4j-snapshot-ref">Neo4j snapshot reference</label>
-              <input
-                id="neo4j-snapshot-ref"
-                value={neo4jRef}
-                maxLength={200}
-                onChange={(event) => setNeo4jRef(event.target.value)}
-                disabled={busy || preflightCurrent}
-              />
-              <label className="check-row">
-                <input
-                  type="checkbox"
-                  checked={neo4jCreated}
-                  onChange={(event) => setNeo4jCreated(event.target.checked)}
-                  disabled={busy || preflightCurrent}
-                />
-                Neo4j snapshot created
-              </label>
+              <p className="confirmation-note">Dense-Mem does not create, inspect, or restore these backups.</p>
               <div className="button-row">
                 <button className="primary-button" type="submit" disabled={busy || !canStart}>
                   <Play size={16} aria-hidden="true" />
-                  Start migration
+                  {backupConfirmationCurrent ? "Start migration" : "Confirm and start migration"}
                 </button>
                 <button className="ghost-button" type="button" disabled={busy || !canPause} onClick={() => void pause()}>
                   <PauseCircle size={16} aria-hidden="true" />
@@ -712,7 +695,7 @@ function CleanupPanel() {
 function stateLabel(state: string) {
   switch (state) {
     case "required":
-      return "Ready for preflight";
+      return "Needs backup confirmation";
     case "ready":
       return "Ready to start";
     case "running":
@@ -728,6 +711,17 @@ function stateLabel(state: string) {
     default:
       return state.replaceAll("_", " ");
   }
+}
+
+function hasBackupConfirmation(checks?: Record<string, unknown>) {
+  if (!checks) {
+    return false;
+  }
+  return checks.operator_backup_confirmation === true &&
+    checks.postgres_backup_confirmed === true &&
+    checks.neo4j_backup_confirmed === true &&
+    checks.confirmation_scope === "operator" &&
+    checks.backup_verification === "not_performed";
 }
 
 function LazyPanelFallback() {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -216,7 +216,7 @@ describe("ControlApi", () => {
         state: "ready",
         required: true,
         data_plane_allowed: false,
-        readiness_message: "migration preflight approved",
+        readiness_message: "backup confirmation recorded",
       },
     };
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response(JSON.stringify(migrationStatus), { status: 200 })));
@@ -225,11 +225,8 @@ describe("ControlApi", () => {
     const api = new ControlApi("secret", "/control/api");
     await api.getMigrationStatus();
     await api.approveMigrationPreflight({
-      postgres_backup_reference: "pg-backup-20260722",
-      postgres_backup_created: true,
-      neo4j_snapshot_reference: "neo4j-snapshot-20260722",
-      neo4j_snapshot_created: true,
-      reason: "operator attested backup artifacts",
+      backups_confirmed: true,
+      reason: "operator confirmed external database backups",
     });
     await api.startMigration("start migration");
     await api.pauseMigration("operator pause");
@@ -241,11 +238,8 @@ describe("ControlApi", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(2, "/control/api/v2/migration/preflight", expect.objectContaining({
       method: "POST",
       body: JSON.stringify({
-        postgres_backup_reference: "pg-backup-20260722",
-        postgres_backup_created: true,
-        neo4j_snapshot_reference: "neo4j-snapshot-20260722",
-        neo4j_snapshot_created: true,
-        reason: "operator attested backup artifacts",
+        backups_confirmed: true,
+        reason: "operator confirmed external database backups",
       }),
     }));
     expect(fetchMock).toHaveBeenNthCalledWith(3, "/control/api/v2/migration/start", expect.objectContaining({

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -552,10 +552,7 @@ export type MigrationStatus = {
 };
 
 export type MigrationPreflightInput = {
-  postgres_backup_reference: string;
-  postgres_backup_created: boolean;
-  neo4j_snapshot_reference: string;
-  neo4j_snapshot_created: boolean;
+  backups_confirmed: boolean;
   reason?: string;
 };
 

--- a/web/src/maintenance.css
+++ b/web/src/maintenance.css
@@ -172,6 +172,45 @@
   gap: 10px;
 }
 
+.backup-confirmation-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-muted);
+}
+
+.backup-confirmation-card h3 {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.backup-confirmation-card p,
+.confirmation-note {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.backup-confirmation-scope {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.backup-confirmation-scope span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--text);
+  font-size: 13px;
+}
+
 .cleanup-panel ol {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Summary

- replace backup/snapshot reference attestations with a single operator backup confirmation in the migration portal and control API
- enforce the v3 confirmation contract before start, resume, supervisor execution, and cutover; stale/incomplete runs must renew first
- clear legacy backup references on renewal and keep non-retryable failed runs terminal
- update migration docs, supervisor gate evidence, backend tests, and portal tests

## Validation

- codex review --uncommitted -c sandbox_mode="danger-full-access"
- ./scripts/ci-check.sh
- go test ./internal/service/migrationcontrol ./internal/service/migrationsupervisor ./internal/http -count=1
- go test ./internal/repository -count=1
- npm test --prefix web -- --run App.migration.test.tsx api.test.ts
- npm test --prefix web
- npm run build --prefix web
- git diff --check

## Risk

The migration now relies on operator confirmation instead of recorded backup references. The portal and gate evidence state that Dense-Mem does not create, inspect, verify, or restore backups, and non-retryable failed runs cannot be resurrected by renewing confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified migration setup with a single confirmation that recoverable PostgreSQL and Neo4j backups exist.
  * Added a guided backup-confirmation card and clearer migration readiness messaging.
  * Added contract-aware confirmation renewal before migration can resume or reach cutover.

* **Bug Fixes**
  * Prevented migrations from proceeding when backup confirmation is missing, incomplete, or outdated.
  * Improved legacy migration and cleanup-mode guidance, including required environment and service removal steps.

* **Documentation**
  * Clarified backup responsibilities, rollback boundaries, migration contracts, and post-cutover cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->