### PR TITLE
Resolve overdue relationship conflicts

### DIFF
--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -615,6 +615,17 @@ func processTeamConflictReview(
 		WorkerID:    workerID,
 		Status:      "completed",
 	}
+	if _, err := ledger.ProcessPendingConflictDerivedEvidence(ctx, repository.ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      teamID,
+		ReviewRunID: run.ReviewRunID,
+		WorkerID:    workerID,
+		Limit:       cfg.GetConflictReviewBatchSize(),
+		Lease:       lease,
+	}); err != nil {
+		counts.Status = "failed"
+		counts.LastError = "derived evidence retry failed"
+		outcome = "partial_error"
+	}
 	attempted := map[string]struct{}{}
 	for {
 		excluded := make([]string, 0, len(attempted))
@@ -699,6 +710,7 @@ type conflictReviewLedger interface {
 	ReserveRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error)
 	ClaimRelationshipConflictCases(context.Context, repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error)
 	ReviewRelationshipConflictCase(context.Context, repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error)
+	ProcessPendingConflictDerivedEvidence(context.Context, repository.ClaimConflictDerivedEvidenceTasksInput) (int, error)
 	CompleteRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunCompleteInput) error
 }
 

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/conflictreview"
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/embeddingservice"
@@ -83,10 +84,6 @@ func RunActiveServer(
 	if !VerifierConfigured(&cfg) {
 		log.Fatal("active authority requires configured verifier provider")
 	}
-	if strings.TrimSpace(cfg.GetAIReviewerModel()) != "" {
-		logger.Warn("AI_REVIEWER_MODEL is ignored by the V2.4 integrated assessor")
-	}
-
 	backend, err := buildBackendBundle(startupCtx, cfg)
 	if err != nil {
 		log.Fatalf("failed to build backend: %v", err)
@@ -199,6 +196,10 @@ func RunActiveServer(
 	assessmentLimits := verifier.SemanticAssessmentLimitsForConfig(&cfg)
 	verifierProvider := verifier.NewOpenAIVerifierWithAssessmentLimits(&cfg, nil, assessmentLimits)
 	verifierProvider.SetMetrics(discoverabilityMetrics)
+	conflictReviewRunner, err := conflictreview.NewRunner(ledgerRepo, verifierProvider, cfg.GetAppTimezone(), assessmentLimits)
+	if err != nil {
+		log.Fatalf("failed to build conflict review runner: %v", err)
+	}
 
 	rememberSvc := memoryservice.NewRememberService(memoryservice.RememberDependencies{Ledger: ledgerRepo})
 	recallSvc := memoryservice.NewRecallService(memoryservice.RecallDependencies{
@@ -433,7 +434,7 @@ func RunActiveServer(
 	go dreamservice.NewScheduler(dreamSvc, profileService, slog.Default()).Start(dreamSchedulerCtx)
 	conflictReviewCtx, conflictReviewCancel := context.WithCancel(context.Background())
 	defer conflictReviewCancel()
-	startConflictReviewWorkers(conflictReviewCtx, logger, profileService, ledgerRepo, &cfg, discoverabilityMetrics)
+	startConflictReviewWorkers(conflictReviewCtx, logger, profileService, conflictReviewRunner, &cfg, discoverabilityMetrics)
 
 	httpAddr := os.Getenv("HTTP_ADDR")
 	if httpAddr == "" {

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -575,6 +575,8 @@ func processConflictReviewTick(
 	}
 }
 
+const conflictReviewCompletionTimeout = 15 * time.Second
+
 func processTeamConflictReview(
 	ctx context.Context,
 	logger observability.LogProvider,
@@ -686,7 +688,9 @@ func processTeamConflictReview(
 	} else if counts.ClaimedCases == 0 && counts.Status == "completed" {
 		outcome = "empty"
 	}
-	if err := ledger.CompleteRelationshipConflictReviewRun(ctx, counts); err != nil {
+	completeCtx, completeCancel := context.WithTimeout(context.WithoutCancel(ctx), conflictReviewCompletionTimeout)
+	defer completeCancel()
+	if err := ledger.CompleteRelationshipConflictReviewRun(completeCtx, counts); err != nil {
 		outcome = "error"
 		return err
 	}

--- a/cmd/internal/serverapp/server_test.go
+++ b/cmd/internal/serverapp/server_test.go
@@ -137,6 +137,9 @@ func TestProcessTeamConflictReviewCompletesEmptyRun(t *testing.T) {
 	if len(ledger.completes) != 1 {
 		t.Fatalf("complete calls = %#v", ledger.completes)
 	}
+	if len(ledger.derivedInputs) != 1 || ledger.derivedInputs[0].TeamID != ledger.run.TeamID {
+		t.Fatalf("derived evidence retry inputs = %#v", ledger.derivedInputs)
+	}
 	complete := ledger.completes[0]
 	if complete.Status != "completed" || complete.ClaimedCases != 0 {
 		t.Fatalf("complete input = %#v", complete)
@@ -222,6 +225,8 @@ type conflictReviewLedgerStub struct {
 	reserveErr    error
 	claimBatches  [][]repository.RelationshipConflictCaseRecord
 	claimErr      error
+	derivedErr    error
+	derivedInputs []repository.ClaimConflictDerivedEvidenceTasksInput
 	reviewResults map[string]*repository.ReviewRelationshipConflictCaseResult
 	reviewErrs    map[string]error
 	completes     []repository.ConflictReviewRunCompleteInput
@@ -289,6 +294,11 @@ func (s *conflictReviewLedgerStub) ReviewRelationshipConflictCase(_ context.Cont
 		return result, nil
 	}
 	return &repository.ReviewRelationshipConflictCaseResult{Outcome: repository.ConflictReviewOutcomeNoop}, nil
+}
+
+func (s *conflictReviewLedgerStub) ProcessPendingConflictDerivedEvidence(_ context.Context, input repository.ClaimConflictDerivedEvidenceTasksInput) (int, error) {
+	s.derivedInputs = append(s.derivedInputs, input)
+	return 0, s.derivedErr
 }
 
 func (s *conflictReviewLedgerStub) CompleteRelationshipConflictReviewRun(_ context.Context, input repository.ConflictReviewRunCompleteInput) error {

--- a/cmd/internal/serverapp/server_test.go
+++ b/cmd/internal/serverapp/server_test.go
@@ -137,7 +137,13 @@ func TestProcessTeamConflictReviewCompletesEmptyRun(t *testing.T) {
 	if len(ledger.completes) != 1 {
 		t.Fatalf("complete calls = %#v", ledger.completes)
 	}
-	if len(ledger.derivedInputs) != 1 || ledger.derivedInputs[0].TeamID != ledger.run.TeamID {
+	if len(ledger.derivedInputs) != 1 || ledger.derivedInputs[0] != (repository.ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      ledger.run.TeamID,
+		ReviewRunID: ledger.run.ReviewRunID,
+		WorkerID:    "worker-a",
+		Limit:       cfg.GetConflictReviewBatchSize(),
+		Lease:       time.Duration(cfg.GetConflictReviewLeaseSeconds()) * time.Second,
+	}) {
 		t.Fatalf("derived evidence retry inputs = %#v", ledger.derivedInputs)
 	}
 	complete := ledger.completes[0]
@@ -147,6 +153,61 @@ func TestProcessTeamConflictReviewCompletesEmptyRun(t *testing.T) {
 	samples := metrics.ConflictReviewSamples()
 	if len(samples) != 1 || samples[0].Outcome != "empty" {
 		t.Fatalf("metrics samples = %#v", samples)
+	}
+}
+
+func TestProcessTeamConflictReviewRecordsDerivedEvidenceRetryFailure(t *testing.T) {
+	cfg := testConflictReviewConfig(t, "UTC", "04:00", "0")
+	ledger := &conflictReviewLedgerStub{
+		run: &repository.ConflictReviewRunRecord{
+			TeamID:      "00000000-0000-0000-0000-000000000020",
+			ReviewRunID: "00000000-0000-0000-0000-000000000021",
+			Status:      "running",
+			WorkerID:    "worker-derived-failure",
+		},
+		claimed:    true,
+		derivedErr: errors.New("derived evidence task failed"),
+		claimBatches: [][]repository.RelationshipConflictCaseRecord{{
+			{ConflictID: "00000000-0000-0000-0000-000000000022"},
+		}},
+		reviewResults: map[string]*repository.ReviewRelationshipConflictCaseResult{
+			"00000000-0000-0000-0000-000000000022": {Outcome: repository.ConflictReviewOutcomeNoop},
+		},
+	}
+
+	err := processTeamConflictReview(context.Background(), observability.New(slog.LevelError), ledger, cfg, observability.NoopDiscoverabilityMetrics(), ledger.run.TeamID, ledger.run.WorkerID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("processTeamConflictReview returned error: %v", err)
+	}
+	if len(ledger.completes) != 1 {
+		t.Fatalf("complete calls = %#v", ledger.completes)
+	}
+	complete := ledger.completes[0]
+	if complete.Status != "failed" || complete.LastError != "derived evidence retry failed" || complete.ClaimedCases != 1 || complete.NoOpCases != 1 {
+		t.Fatalf("complete input = %#v", complete)
+	}
+}
+
+func TestProcessTeamConflictReviewCompletesRunAfterParentContextDeadline(t *testing.T) {
+	cfg := testConflictReviewConfig(t, "UTC", "04:00", "0")
+	ledger := &conflictReviewLedgerStub{
+		run: &repository.ConflictReviewRunRecord{
+			TeamID:      "00000000-0000-0000-0000-000000000030",
+			ReviewRunID: "00000000-0000-0000-0000-000000000031",
+			Status:      "running",
+			WorkerID:    "worker-deadline",
+		},
+		claimed: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := processTeamConflictReview(ctx, observability.New(slog.LevelError), ledger, cfg, observability.NoopDiscoverabilityMetrics(), ledger.run.TeamID, ledger.run.WorkerID, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("processTeamConflictReview returned error: %v", err)
+	}
+	if len(ledger.completeContextErrors) != 1 || ledger.completeContextErrors[0] != nil {
+		t.Fatalf("completion context errors = %#v, want [nil]", ledger.completeContextErrors)
 	}
 }
 
@@ -220,17 +281,18 @@ func testConflictReviewConfig(t *testing.T, timezone string, start string, jitte
 }
 
 type conflictReviewLedgerStub struct {
-	run           *repository.ConflictReviewRunRecord
-	claimed       bool
-	reserveErr    error
-	claimBatches  [][]repository.RelationshipConflictCaseRecord
-	claimErr      error
-	derivedErr    error
-	derivedInputs []repository.ClaimConflictDerivedEvidenceTasksInput
-	reviewResults map[string]*repository.ReviewRelationshipConflictCaseResult
-	reviewErrs    map[string]error
-	completes     []repository.ConflictReviewRunCompleteInput
-	completeErr   error
+	run                   *repository.ConflictReviewRunRecord
+	claimed               bool
+	reserveErr            error
+	claimBatches          [][]repository.RelationshipConflictCaseRecord
+	claimErr              error
+	derivedErr            error
+	derivedInputs         []repository.ClaimConflictDerivedEvidenceTasksInput
+	reviewResults         map[string]*repository.ReviewRelationshipConflictCaseResult
+	reviewErrs            map[string]error
+	completes             []repository.ConflictReviewRunCompleteInput
+	completeContextErrors []error
+	completeErr           error
 }
 
 type conflictReviewProfileListStub struct {
@@ -301,7 +363,8 @@ func (s *conflictReviewLedgerStub) ProcessPendingConflictDerivedEvidence(_ conte
 	return 0, s.derivedErr
 }
 
-func (s *conflictReviewLedgerStub) CompleteRelationshipConflictReviewRun(_ context.Context, input repository.ConflictReviewRunCompleteInput) error {
+func (s *conflictReviewLedgerStub) CompleteRelationshipConflictReviewRun(ctx context.Context, input repository.ConflictReviewRunCompleteInput) error {
 	s.completes = append(s.completes, input)
+	s.completeContextErrors = append(s.completeContextErrors, ctx.Err())
 	return s.completeErr
 }

--- a/cmd/review-conflicts/main.go
+++ b/cmd/review-conflicts/main.go
@@ -60,15 +60,16 @@ type postgresConfig struct {
 }
 
 const (
-	reviewConflictMinBatchSize    = 1
-	reviewConflictMaxBatchSize    = 500
-	reviewConflictMinLeaseSeconds = 30
-	reviewConflictMaxLeaseSeconds = 1800
-	reviewConflictMinAttempts     = 1
-	reviewConflictMaxAttempts     = 20
-	reviewConflictMinTimeoutSecs  = 1
-	reviewConflictMaxTimeoutSecs  = 86400
-	reviewConflictDefaultTimeout  = 360
+	reviewConflictMinBatchSize      = 1
+	reviewConflictMaxBatchSize      = 500
+	reviewConflictMinLeaseSeconds   = 30
+	reviewConflictMaxLeaseSeconds   = 1800
+	reviewConflictMinAttempts       = 1
+	reviewConflictMaxAttempts       = 20
+	reviewConflictMinTimeoutSecs    = 1
+	reviewConflictMaxTimeoutSecs    = 86400
+	reviewConflictDefaultTimeout    = 360
+	reviewConflictCompletionTimeout = 15 * time.Second
 )
 
 func (c postgresConfig) GetPostgresDSN() string {
@@ -103,8 +104,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("load verifier configuration: %w", err)
 	}
-	if !conflictVerifierConfigured(&runtimeConfig) {
-		return errors.New("AI_VERIFIER_API_URL, AI_VERIFIER_API_KEY, and AI_VERIFIER_MODEL are required for overdue conflict assessment")
+	if err := conflictVerifierConfigurationError(&runtimeConfig); err != nil {
+		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.timeoutSecs)*time.Second)
 	defer cancel()
@@ -239,15 +240,17 @@ func reviewTeamConflicts(
 		counts.Status = "failed"
 		counts.LastError = "one or more conflict cases failed"
 	}
-	if err := ledger.CompleteRelationshipConflictReviewRun(ctx, counts); err != nil {
-		return reviewOutput{}, err
-	}
 	out.Status = counts.Status
 	out.ClaimedCases = counts.ClaimedCases
 	out.ResolvedCases = counts.ResolvedCases
 	out.OverdueCases = counts.OverdueCases
 	out.NoOpCases = counts.NoOpCases
 	out.FailedCases = counts.FailedCases
+	completeCtx, completeCancel := context.WithTimeout(context.WithoutCancel(ctx), reviewConflictCompletionTimeout)
+	defer completeCancel()
+	if err := ledger.CompleteRelationshipConflictReviewRun(completeCtx, counts); err != nil {
+		return out, err
+	}
 	if counts.Status == "failed" {
 		return out, errReviewConflictsFailed
 	}
@@ -270,6 +273,23 @@ func conflictVerifierConfigured(cfg config.ConfigProvider) bool {
 		strings.TrimSpace(cfg.GetAIVerifierModel()) != ""
 }
 
+func conflictVerifierConfigurationError(cfg config.ConfigProvider) error {
+	if conflictVerifierConfigured(cfg) {
+		return nil
+	}
+	missing := make([]string, 0, 3)
+	if strings.TrimSpace(cfg.GetAIVerifierAPIURL()) == "" {
+		missing = append(missing, "AI_VERIFIER_API_URL or AI_API_URL")
+	}
+	if strings.TrimSpace(cfg.GetAIVerifierAPIKey()) == "" {
+		missing = append(missing, "AI_VERIFIER_API_KEY or AI_API_KEY")
+	}
+	if strings.TrimSpace(cfg.GetAIVerifierModel()) == "" {
+		missing = append(missing, "AI_VERIFIER_MODEL")
+	}
+	return fmt.Errorf("overdue conflict assessment requires configured verifier values: %s", strings.Join(missing, ", "))
+}
+
 func parseCLI(args []string, stderr io.Writer) (cliConfig, error) {
 	var cfg cliConfig
 	fs := flag.NewFlagSet("review-conflicts", flag.ContinueOnError)
@@ -285,7 +305,7 @@ func parseCLI(args []string, stderr io.Writer) (cliConfig, error) {
 	fs.IntVar(&cfg.batchSize, "batch-size", 100, "Maximum cases claimed per batch")
 	fs.IntVar(&cfg.leaseSeconds, "lease-seconds", 300, "Review lease seconds")
 	fs.IntVar(&cfg.maxAttempts, "max-attempts", 5, "Maximum case attempts")
-	fs.IntVar(&cfg.timeoutSecs, "timeout-seconds", reviewConflictDefaultTimeout, "Maximum review command duration in seconds")
+	fs.IntVar(&cfg.timeoutSecs, "timeout-seconds", reviewConflictDefaultTimeout, "Maximum review command duration in seconds; include verifier latency")
 	if err := fs.Parse(args); err != nil {
 		return cliConfig{}, err
 	}

--- a/cmd/review-conflicts/main.go
+++ b/cmd/review-conflicts/main.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/markhuangai/dense-mem/internal/config"
 	"github.com/markhuangai/dense-mem/internal/operatorcli"
 	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service/conflictreview"
 	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+	"github.com/markhuangai/dense-mem/internal/verifier"
 )
 
 type cliConfig struct {
@@ -46,6 +49,10 @@ type reviewCaseResult struct {
 	Stage                string   `json:"stage"`
 	PreferredPositionID  string   `json:"preferred_position_id,omitempty"`
 	UpdatedRelationships []string `json:"updated_relationships,omitempty"`
+	RetractedEvidenceIDs []string `json:"retracted_evidence_ids,omitempty"`
+	AssessmentAttemptID  string   `json:"assessment_attempt_id,omitempty"`
+	ResolutionMethod     string   `json:"resolution_method,omitempty"`
+	ResolutionPending    bool     `json:"resolution_pending,omitempty"`
 }
 
 type postgresConfig struct {
@@ -92,6 +99,13 @@ func run(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	runtimeConfig, err := config.LoadWithPostgresDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("load verifier configuration: %w", err)
+	}
+	if !conflictVerifierConfigured(&runtimeConfig) {
+		return errors.New("AI_VERIFIER_API_URL, AI_VERIFIER_API_KEY, and AI_VERIFIER_MODEL are required for overdue conflict assessment")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.timeoutSecs)*time.Second)
 	defer cancel()
 	pgClient, err := postgres.OpenWithClient(ctx, postgresConfig{dsn: dsn})
@@ -99,7 +113,14 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return fmt.Errorf("connect postgres: %w", err)
 	}
 	defer pgClient.Close()
-	out, reviewErr := reviewTeamConflicts(ctx, repository.NewLedgerRepository(pgClient.GetDB(), postgres.NewRLS()), cfg, now)
+	ledger := repository.NewLedgerRepository(pgClient.GetDB(), postgres.NewRLS())
+	assessmentLimits := verifier.SemanticAssessmentLimitsForConfig(&runtimeConfig)
+	provider := verifier.NewOpenAIVerifierWithAssessmentLimits(&runtimeConfig, nil, assessmentLimits)
+	runner, err := conflictreview.NewRunner(ledger, provider, cfg.timezone, assessmentLimits)
+	if err != nil {
+		return fmt.Errorf("build conflict review runner: %w", err)
+	}
+	out, reviewErr := reviewTeamConflicts(ctx, runner, cfg, now)
 	if reviewErr != nil && out.TeamID == "" {
 		return reviewErr
 	}
@@ -113,7 +134,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 
 func reviewTeamConflicts(
 	ctx context.Context,
-	ledger *repository.LedgerRepositoryImpl,
+	ledger conflictReviewLedger,
 	cfg cliConfig,
 	now time.Time,
 ) (reviewOutput, error) {
@@ -189,6 +210,10 @@ func reviewTeamConflicts(
 				Stage:                result.Stage,
 				PreferredPositionID:  result.PreferredPositionID,
 				UpdatedRelationships: append([]string(nil), result.UpdatedRelationships...),
+				RetractedEvidenceIDs: append([]string(nil), result.RetractedEvidenceIDs...),
+				AssessmentAttemptID:  result.AssessmentAttemptID,
+				ResolutionMethod:     result.ResolutionMethod,
+				ResolutionPending:    result.ResolutionPending,
 			})
 			switch result.Outcome {
 			case repository.ConflictReviewOutcomeResolve:
@@ -220,6 +245,19 @@ func reviewTeamConflicts(
 }
 
 var errReviewConflictsFailed = errors.New("conflict review failed")
+
+type conflictReviewLedger interface {
+	ReserveRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error)
+	ClaimRelationshipConflictCases(context.Context, repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error)
+	ReviewRelationshipConflictCase(context.Context, repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error)
+	CompleteRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunCompleteInput) error
+}
+
+func conflictVerifierConfigured(cfg config.ConfigProvider) bool {
+	return strings.TrimSpace(cfg.GetAIVerifierAPIURL()) != "" &&
+		strings.TrimSpace(cfg.GetAIVerifierAPIKey()) != "" &&
+		strings.TrimSpace(cfg.GetAIVerifierModel()) != ""
+}
 
 func parseCLI(args []string, stderr io.Writer) (cliConfig, error) {
 	var cfg cliConfig

--- a/cmd/review-conflicts/main.go
+++ b/cmd/review-conflicts/main.go
@@ -162,6 +162,16 @@ func reviewTeamConflicts(
 		WorkerID:    cfg.workerID,
 		Status:      "completed",
 	}
+	if _, err := ledger.ProcessPendingConflictDerivedEvidence(ctx, repository.ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      cfg.teamID,
+		ReviewRunID: run.ReviewRunID,
+		WorkerID:    cfg.workerID,
+		Limit:       cfg.batchSize,
+		Lease:       lease,
+	}); err != nil {
+		counts.Status = "failed"
+		counts.LastError = "derived evidence retry failed"
+	}
 	attempted := map[string]struct{}{}
 	for {
 		excluded := make([]string, 0, len(attempted))
@@ -250,6 +260,7 @@ type conflictReviewLedger interface {
 	ReserveRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error)
 	ClaimRelationshipConflictCases(context.Context, repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error)
 	ReviewRelationshipConflictCase(context.Context, repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error)
+	ProcessPendingConflictDerivedEvidence(context.Context, repository.ClaimConflictDerivedEvidenceTasksInput) (int, error)
 	CompleteRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunCompleteInput) error
 }
 

--- a/cmd/review-conflicts/main_test.go
+++ b/cmd/review-conflicts/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/repository"
 )
 
 func TestParseCLIRejectsInvalidTimezone(t *testing.T) {
@@ -132,4 +137,84 @@ func TestParseCLIRejectsOutOfRangeConflictReviewFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConflictVerifierConfigurationErrorUsesResolvedFallbacks(t *testing.T) {
+	configured := config.Config{
+		AIAPIURL:        "https://shared.example.test/v1",
+		AIAPIKey:        "shared-key",
+		AIVerifierModel: "reviewer-model",
+	}
+	if err := conflictVerifierConfigurationError(&configured); err != nil {
+		t.Fatalf("conflictVerifierConfigurationError returned error for shared verifier configuration: %v", err)
+	}
+
+	missing := config.Config{AIVerifierModel: "reviewer-model"}
+	err := conflictVerifierConfigurationError(&missing)
+	if err == nil {
+		t.Fatal("conflictVerifierConfigurationError returned nil for missing endpoint and key")
+	}
+	if !strings.Contains(err.Error(), "AI_VERIFIER_API_URL or AI_API_URL") ||
+		!strings.Contains(err.Error(), "AI_VERIFIER_API_KEY or AI_API_KEY") ||
+		strings.Contains(err.Error(), "AI_VERIFIER_MODEL") {
+		t.Fatalf("conflictVerifierConfigurationError = %q", err)
+	}
+}
+
+func TestReviewTeamConflictsCompletesRunAfterParentContextDeadline(t *testing.T) {
+	ledger := &reviewConflictLedgerStub{
+		run: &repository.ConflictReviewRunRecord{
+			TeamID:      "00000000-0000-0000-0000-000000000001",
+			ReviewRunID: "00000000-0000-0000-0000-000000000002",
+			Status:      "running",
+			WorkerID:    "worker-a",
+		},
+		claimed: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out, err := reviewTeamConflicts(ctx, ledger, cliConfig{
+		teamID:       ledger.run.TeamID,
+		workerID:     "worker-a",
+		batchSize:    1,
+		leaseSeconds: 30,
+		maxAttempts:  1,
+	}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("reviewTeamConflicts returned error: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("review output status = %q, want completed", out.Status)
+	}
+	if len(ledger.completionContextErrors) != 1 || ledger.completionContextErrors[0] != nil {
+		t.Fatalf("completion context errors = %#v, want [nil]", ledger.completionContextErrors)
+	}
+}
+
+type reviewConflictLedgerStub struct {
+	run                     *repository.ConflictReviewRunRecord
+	claimed                 bool
+	completionContextErrors []error
+}
+
+func (s *reviewConflictLedgerStub) ReserveRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error) {
+	return s.run, s.claimed, nil
+}
+
+func (*reviewConflictLedgerStub) ClaimRelationshipConflictCases(context.Context, repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error) {
+	return nil, nil
+}
+
+func (*reviewConflictLedgerStub) ReviewRelationshipConflictCase(context.Context, repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	return nil, nil
+}
+
+func (*reviewConflictLedgerStub) ProcessPendingConflictDerivedEvidence(context.Context, repository.ClaimConflictDerivedEvidenceTasksInput) (int, error) {
+	return 0, nil
+}
+
+func (s *reviewConflictLedgerStub) CompleteRelationshipConflictReviewRun(ctx context.Context, _ repository.ConflictReviewRunCompleteInput) error {
+	s.completionContextErrors = append(s.completionContextErrors, ctx.Err())
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,6 @@ type ConfigProvider interface {
 	// Knowledge-pipeline knobs (AC-X3)
 	GetAIVerifierAPIURL() string
 	GetAIVerifierAPIKey() string
-	GetAIReviewerModel() string
 	GetAIVerifierModel() string
 	GetAIVerifierTimeoutSeconds() int
 	GetAIVerifierMaxConcurrency() int
@@ -148,7 +147,6 @@ type Config struct {
 	// Knowledge-pipeline knobs (AC-X3)
 	AIVerifierAPIURL                      string
 	AIVerifierAPIKey                      string `json:"-"`
-	AIReviewerModel                       string
 	AIVerifierModel                       string
 	AIVerifierDisableTemperature          bool
 	AIVerifierTimeoutSeconds              int
@@ -250,7 +248,6 @@ func (c *Config) GetAIVerifierAPIKey() string {
 	}
 	return c.AIAPIKey
 }
-func (c *Config) GetAIReviewerModel() string { return c.AIReviewerModel }
 func (c *Config) GetAIVerifierModel() string { return c.AIVerifierModel }
 func (c *Config) GetAIVerifierDisableTemperature() bool {
 	return c.AIVerifierDisableTemperature
@@ -453,6 +450,16 @@ func applyIntEnvSpecs(cfg *Config, specs []intEnvSpec) error {
 // Load reads configuration from environment variables and returns a Config.
 // Returns a typed ValidationError for any validation failures.
 func Load() (Config, error) {
+	return loadWithPostgresDSN("")
+}
+
+// LoadWithPostgresDSN validates the normal environment configuration while
+// using a PostgreSQL DSN already resolved by an operator entry point.
+func LoadWithPostgresDSN(postgresDSN string) (Config, error) {
+	return loadWithPostgresDSN(strings.TrimSpace(postgresDSN))
+}
+
+func loadWithPostgresDSN(postgresDSN string) (Config, error) {
 	cfg := Config{}
 	var err error
 	if err := rejectObsoleteAssessorConfig(); err != nil {
@@ -460,7 +467,10 @@ func Load() (Config, error) {
 	}
 
 	// String fields with defaults
-	cfg.PostgresDSN = os.Getenv("POSTGRES_DSN")
+	cfg.PostgresDSN = postgresDSN
+	if cfg.PostgresDSN == "" {
+		cfg.PostgresDSN = os.Getenv("POSTGRES_DSN")
+	}
 	if strings.TrimSpace(os.Getenv("POSTGRES_READ_DSN")) != "" {
 		return cfg, &ValidationError{
 			Field:   "POSTGRES_READ_DSN",
@@ -524,7 +534,6 @@ func Load() (Config, error) {
 	if cfg.AIVerifierAPIKey == "" && !verifierAPIURLSet {
 		cfg.AIVerifierAPIKey = cfg.AIAPIKey
 	}
-	cfg.AIReviewerModel = os.Getenv("AI_REVIEWER_MODEL")
 	cfg.AIVerifierModel = os.Getenv("AI_VERIFIER_MODEL")
 	cfg.AIVerifierDisableTemperature, err = parseBoolOrDefault("AI_VERIFIER_DISABLE_TEMPERATURE", false)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,7 +42,6 @@ func clearEnv() {
 		// Knowledge-pipeline knobs
 		"AI_VERIFIER_API_URL",
 		"AI_VERIFIER_API_KEY",
-		"AI_REVIEWER_MODEL",
 		"AI_VERIFIER_MODEL",
 		"AI_VERIFIER_DISABLE_TEMPERATURE",
 		"AI_VERIFIER_TIMEOUT_SECONDS",
@@ -333,6 +332,20 @@ func TestLoadValidation_MissingPostgresDSN(t *testing.T) {
 	}
 }
 
+func TestLoadWithPostgresDSNUsesOperatorResolvedDSN(t *testing.T) {
+	clearEnv()
+	t.Cleanup(clearEnv)
+
+	const resolvedDSN = "postgres://operator:resolved@localhost:5432/dense_mem?sslmode=disable"
+	cfg, err := LoadWithPostgresDSN(resolvedDSN)
+	if err != nil {
+		t.Fatalf("LoadWithPostgresDSN returned error: %v", err)
+	}
+	if cfg.PostgresDSN != resolvedDSN {
+		t.Fatalf("PostgresDSN = %q, want resolved operator DSN", cfg.PostgresDSN)
+	}
+}
+
 func TestLoadValidation_InvalidInteger(t *testing.T) {
 	clearEnv()
 	setRequiredEnv()
@@ -474,7 +487,6 @@ func TestConfigProviderInterface(t *testing.T) {
 	_ = provider.IsEmbeddingConfigured()
 	_ = provider.GetAIVerifierAPIURL()
 	_ = provider.GetAIVerifierAPIKey()
-	_ = provider.GetAIReviewerModel()
 	_ = provider.GetAIVerifierModel()
 	_ = provider.GetAIVerifierTimeoutSeconds()
 	_ = provider.GetAIVerifierMaxConcurrency()
@@ -489,7 +501,6 @@ func TestConfigGetterFallbacksAndParsers(t *testing.T) {
 		HTTPMaxBodyBytes:         2048,
 		AIAPIURL:                 "https://shared.example/v1",
 		AIAPIKey:                 "shared-key",
-		AIReviewerModel:          "reviewer-model",
 		AIVerifierModel:          "verifier-model",
 		AIVerifierTimeoutSeconds: 0,
 	}
@@ -647,7 +658,6 @@ func TestLoadVerifierConfig_SeparateEndpoint(t *testing.T) {
 	setRequiredEmbeddingEnv()
 	os.Setenv("AI_VERIFIER_API_URL", "https://verifier.example.com/v1")
 	os.Setenv("AI_VERIFIER_API_KEY", "verifier-key")
-	os.Setenv("AI_REVIEWER_MODEL", "local-reviewer")
 	os.Setenv("AI_VERIFIER_MODEL", "local-verifier")
 	os.Setenv("AI_VERIFIER_TIMEOUT_SECONDS", "45")
 
@@ -664,9 +674,6 @@ func TestLoadVerifierConfig_SeparateEndpoint(t *testing.T) {
 	}
 	if got := cfg.GetAIVerifierAPIKey(); got != "verifier-key" {
 		t.Errorf("GetAIVerifierAPIKey() = %q, want %q", got, "verifier-key")
-	}
-	if got := cfg.GetAIReviewerModel(); got != "local-reviewer" {
-		t.Errorf("GetAIReviewerModel() = %q, want %q", got, "local-reviewer")
 	}
 	if got := cfg.GetAIVerifierModel(); got != "local-verifier" {
 		t.Errorf("GetAIVerifierModel() = %q, want %q", got, "local-verifier")
@@ -758,7 +765,7 @@ func TestValidateServerStartup_SucceedsWithEmbeddingConfig(t *testing.T) {
 	}
 }
 
-func TestValidateServerStartup_RequiresVerifierModelAndIgnoresReviewerModel(t *testing.T) {
+func TestValidateServerStartup_RequiresVerifierModel(t *testing.T) {
 	clearEnv()
 	setRequiredEnv()
 	setRequiredEmbeddingEnv()
@@ -774,13 +781,12 @@ func TestValidateServerStartup_RequiresVerifierModelAndIgnoresReviewerModel(t *t
 	}
 
 	os.Setenv("AI_VERIFIER_MODEL", "verifier-model")
-	os.Setenv("AI_REVIEWER_MODEL", "legacy-reviewer-model")
 	cfg, err = Load()
 	if err != nil {
-		t.Fatalf("Load() with tolerated reviewer model returned unexpected error: %v", err)
+		t.Fatalf("Load() with verifier model returned unexpected error: %v", err)
 	}
 	if err := cfg.ValidateServerStartup(); err != nil {
-		t.Fatalf("ValidateServerStartup() with tolerated reviewer model returned unexpected error: %v", err)
+		t.Fatalf("ValidateServerStartup() with verifier model returned unexpected error: %v", err)
 	}
 }
 
@@ -795,9 +801,6 @@ func TestLoadKnowledgeConfigDefaults(t *testing.T) {
 		t.Fatalf("Load() returned unexpected error: %v", err)
 	}
 
-	if got := cfg.GetAIReviewerModel(); got != "" {
-		t.Errorf("GetAIReviewerModel() = %q, want empty", got)
-	}
 	if got := cfg.GetAIVerifierModel(); got != "" {
 		t.Errorf("GetAIVerifierModel() = %q, want empty", got)
 	}

--- a/internal/domain/conflict_overdue_resolution.go
+++ b/internal/domain/conflict_overdue_resolution.go
@@ -1,0 +1,100 @@
+package domain
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ConflictAssessmentDecisionSelect  = "select"
+	ConflictAssessmentDecisionAbstain = "abstain"
+
+	ConflictResolutionReasonAI  = "overdue_ai_assessment"
+	ConflictResolutionReasonLWW = "overdue_last_write_wins"
+)
+
+// ConflictResolutionSupport is the server-owned comparison input for an
+// overdue conflict. AcceptedAt is when Dense-Mem accepted the support, not a
+// model-provided timestamp.
+type ConflictResolutionSupport struct {
+	Authority  string
+	AcceptedAt time.Time
+}
+
+// ConflictResolutionPosition is one mutually incompatible position in an
+// overdue conflict.
+type ConflictResolutionPosition struct {
+	PositionID string
+	Supports   []ConflictResolutionSupport
+}
+
+// ConflictLastWriteWinner is the deterministic fallback selected after an AI
+// abstention or five failed daily assessments for the same case version.
+type ConflictLastWriteWinner struct {
+	PositionID string
+	Authority  string
+	AcceptedAt time.Time
+}
+
+// SelectConflictLastWriteWinner first prefers the strongest source authority,
+// then the latest Dense-Mem accepted support at that authority. Position ID is
+// only a stable tie-breaker.
+func SelectConflictLastWriteWinner(positions []ConflictResolutionPosition) (ConflictLastWriteWinner, bool) {
+	candidates := make([]ConflictLastWriteWinner, 0, len(positions))
+	for _, position := range positions {
+		positionID := strings.TrimSpace(position.PositionID)
+		if positionID == "" {
+			continue
+		}
+		bestRank := 0
+		bestAuthority := ""
+		bestAcceptedAt := time.Time{}
+		for _, support := range position.Supports {
+			rank, authority := conflictAuthorityRank(support.Authority)
+			if bestAuthority == "" || rank < bestRank || (rank == bestRank && support.AcceptedAt.After(bestAcceptedAt)) {
+				bestRank = rank
+				bestAuthority = authority
+				bestAcceptedAt = support.AcceptedAt.UTC()
+			}
+		}
+		if bestAuthority == "" {
+			continue
+		}
+		candidates = append(candidates, ConflictLastWriteWinner{
+			PositionID: positionID,
+			Authority:  bestAuthority,
+			AcceptedAt: bestAcceptedAt,
+		})
+	}
+	if len(candidates) == 0 {
+		return ConflictLastWriteWinner{}, false
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		leftRank, _ := conflictAuthorityRank(candidates[i].Authority)
+		rightRank, _ := conflictAuthorityRank(candidates[j].Authority)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if !candidates[i].AcceptedAt.Equal(candidates[j].AcceptedAt) {
+			return candidates[i].AcceptedAt.After(candidates[j].AcceptedAt)
+		}
+		return candidates[i].PositionID < candidates[j].PositionID
+	})
+	return candidates[0], true
+}
+
+func conflictAuthorityRank(authority string) (int, string) {
+	switch strings.ToLower(strings.TrimSpace(authority)) {
+	case "authoritative":
+		return 0, "authoritative"
+	case "primary":
+		return 1, "primary"
+	case "secondary":
+		return 2, "secondary"
+	case "inferred", "derived":
+		return 3, "inferred"
+	default:
+		return 4, "unknown"
+	}
+}

--- a/internal/domain/conflict_overdue_resolution_test.go
+++ b/internal/domain/conflict_overdue_resolution_test.go
@@ -1,0 +1,91 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSelectConflictLastWriteWinnerPrefersAuthorityThenAcceptanceTime(t *testing.T) {
+	older := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	winner, ok := SelectConflictLastWriteWinner([]ConflictResolutionPosition{
+		{
+			PositionID: "secondary-newer",
+			Supports:   []ConflictResolutionSupport{{Authority: "secondary", AcceptedAt: newer}},
+		},
+		{
+			PositionID: "primary-older",
+			Supports:   []ConflictResolutionSupport{{Authority: "primary", AcceptedAt: older}},
+		},
+	})
+	if !ok {
+		t.Fatal("SelectConflictLastWriteWinner returned no winner")
+	}
+	if winner.PositionID != "primary-older" || winner.Authority != "primary" || !winner.AcceptedAt.Equal(older) {
+		t.Fatalf("winner = %#v", winner)
+	}
+}
+
+func TestSelectConflictLastWriteWinnerUsesLatestSupportAtTheSameAuthority(t *testing.T) {
+	older := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	winner, ok := SelectConflictLastWriteWinner([]ConflictResolutionPosition{
+		{
+			PositionID: "older",
+			Supports:   []ConflictResolutionSupport{{Authority: "primary", AcceptedAt: older}},
+		},
+		{
+			PositionID: "newer",
+			Supports:   []ConflictResolutionSupport{{Authority: "primary", AcceptedAt: newer}},
+		},
+	})
+	if !ok {
+		t.Fatal("SelectConflictLastWriteWinner returned no winner")
+	}
+	if winner.PositionID != "newer" || !winner.AcceptedAt.Equal(newer) {
+		t.Fatalf("winner = %#v", winner)
+	}
+}
+
+func TestSelectConflictLastWriteWinnerHasStableFallbackForUnknownAuthority(t *testing.T) {
+	accepted := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	winner, ok := SelectConflictLastWriteWinner([]ConflictResolutionPosition{
+		{PositionID: "position-b", Supports: []ConflictResolutionSupport{{Authority: "unknown", AcceptedAt: accepted}}},
+		{PositionID: "position-a", Supports: []ConflictResolutionSupport{{Authority: "not-recognized", AcceptedAt: accepted}}},
+	})
+	if !ok {
+		t.Fatal("SelectConflictLastWriteWinner returned no winner")
+	}
+	if winner.PositionID != "position-a" || winner.Authority != "unknown" {
+		t.Fatalf("winner = %#v", winner)
+	}
+}
+
+func TestSelectConflictLastWriteWinnerUsesBestSupportWithinPosition(t *testing.T) {
+	accepted := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	winner, ok := SelectConflictLastWriteWinner([]ConflictResolutionPosition{
+		{
+			PositionID: "mixed-authority",
+			Supports: []ConflictResolutionSupport{
+				{Authority: "secondary", AcceptedAt: accepted.Add(time.Hour)},
+				{Authority: "authoritative", AcceptedAt: accepted},
+			},
+		},
+		{
+			PositionID: "inferred-newer",
+			Supports:   []ConflictResolutionSupport{{Authority: "derived", AcceptedAt: accepted.Add(24 * time.Hour)}},
+		},
+	})
+	if !ok {
+		t.Fatal("SelectConflictLastWriteWinner returned no winner")
+	}
+	if winner.PositionID != "mixed-authority" || winner.Authority != "authoritative" || !winner.AcceptedAt.Equal(accepted) {
+		t.Fatalf("winner = %#v", winner)
+	}
+}
+
+func TestSelectConflictLastWriteWinnerSkipsPositionsWithoutComparableSupport(t *testing.T) {
+	if _, ok := SelectConflictLastWriteWinner([]ConflictResolutionPosition{{PositionID: ""}, {PositionID: "no-support"}}); ok {
+		t.Fatal("SelectConflictLastWriteWinner unexpectedly selected a position")
+	}
+}

--- a/internal/domain/contract.go
+++ b/internal/domain/contract.go
@@ -1,11 +1,12 @@
 package domain
 
 const (
-	ContractVersion        = "dense-mem.v2.4"
-	PredicatePolicyVersion = "open_vocabulary_v1"
-	ConflictPolicyVersion  = "cross_profile_conflict_v1"
-	FeatureGate            = "memory"
-	ToolVisibility         = "dormant"
+	ContractVersion              = "dense-mem.v2.4"
+	PredicatePolicyVersion       = "open_vocabulary_v1"
+	ConflictPolicyVersion        = "cross_profile_conflict_v1"
+	ConflictOverduePolicyVersion = "overdue_conflict_ai_v1"
+	FeatureGate                  = "memory"
+	ToolVisibility               = "dormant"
 )
 
 type IngestID string
@@ -143,14 +144,20 @@ const (
 type RelationshipConflictEventAction string
 
 const (
-	RelationshipConflictEventOpened              RelationshipConflictEventAction = "opened"
-	RelationshipConflictEventPositionAdded       RelationshipConflictEventAction = "position_added"
-	RelationshipConflictEventMemberAdded         RelationshipConflictEventAction = "member_added"
-	RelationshipConflictEventEvaluated           RelationshipConflictEventAction = "evaluated"
-	RelationshipConflictEventMarkedOverdue       RelationshipConflictEventAction = "marked_overdue"
-	RelationshipConflictEventResolved            RelationshipConflictEventAction = "resolved"
-	RelationshipConflictEventRelationshipUpdated RelationshipConflictEventAction = "relationship_updated"
-	RelationshipConflictEventDismissed           RelationshipConflictEventAction = "dismissed"
+	RelationshipConflictEventOpened               RelationshipConflictEventAction = "opened"
+	RelationshipConflictEventPositionAdded        RelationshipConflictEventAction = "position_added"
+	RelationshipConflictEventMemberAdded          RelationshipConflictEventAction = "member_added"
+	RelationshipConflictEventEvaluated            RelationshipConflictEventAction = "evaluated"
+	RelationshipConflictEventMarkedOverdue        RelationshipConflictEventAction = "marked_overdue"
+	RelationshipConflictEventResolved             RelationshipConflictEventAction = "resolved"
+	RelationshipConflictEventRelationshipUpdated  RelationshipConflictEventAction = "relationship_updated"
+	RelationshipConflictEventDismissed            RelationshipConflictEventAction = "dismissed"
+	RelationshipConflictEventAIAssessmentReserved RelationshipConflictEventAction = "ai_assessment_reserved"
+	RelationshipConflictEventAIAssessed           RelationshipConflictEventAction = "ai_assessed"
+	RelationshipConflictEventResolutionPending    RelationshipConflictEventAction = "resolution_pending"
+	RelationshipConflictEventEvidenceRetracted    RelationshipConflictEventAction = "evidence_retracted"
+	RelationshipConflictEventDerivedStaged        RelationshipConflictEventAction = "derived_replacement_staged"
+	RelationshipConflictEventDerivedFailed        RelationshipConflictEventAction = "derived_replacement_failed"
 )
 
 type HypothesisStatus string

--- a/internal/http/middleware/rate_limit_test.go
+++ b/internal/http/middleware/rate_limit_test.go
@@ -62,7 +62,6 @@ func (c *testRateLimitConfig) GetAIEmbeddingTimeoutSeconds() int   { return 30 }
 func (c *testRateLimitConfig) IsEmbeddingConfigured() bool         { return false }
 func (c *testRateLimitConfig) GetAIVerifierAPIURL() string         { return "" }
 func (c *testRateLimitConfig) GetAIVerifierAPIKey() string         { return "" }
-func (c *testRateLimitConfig) GetAIReviewerModel() string          { return "reviewer-model" }
 func (c *testRateLimitConfig) GetAIVerifierModel() string          { return "gpt-4o-mini" }
 func (c *testRateLimitConfig) GetAIVerifierTimeoutSeconds() int    { return 60 }
 func (c *testRateLimitConfig) GetAIVerifierMaxConcurrency() int    { return 5 }
@@ -143,7 +142,6 @@ func (c *redisRateLimitConfig) GetAIEmbeddingTimeoutSeconds() int   { return 30 
 func (c *redisRateLimitConfig) IsEmbeddingConfigured() bool         { return false }
 func (c *redisRateLimitConfig) GetAIVerifierAPIURL() string         { return "" }
 func (c *redisRateLimitConfig) GetAIVerifierAPIKey() string         { return "" }
-func (c *redisRateLimitConfig) GetAIReviewerModel() string          { return "reviewer-model" }
 func (c *redisRateLimitConfig) GetAIVerifierModel() string          { return "gpt-4o-mini" }
 func (c *redisRateLimitConfig) GetAIVerifierTimeoutSeconds() int    { return 60 }
 func (c *redisRateLimitConfig) GetAIVerifierMaxConcurrency() int    { return 5 }

--- a/internal/repository/conflict_derived_evidence_task_repository.go
+++ b/internal/repository/conflict_derived_evidence_task_repository.go
@@ -34,7 +34,7 @@ func (r *LedgerRepositoryImpl) StageConflictDerivedEvidence(
 		OwnerProfileID: target.SystemProfileID,
 		IdempotencyKey: "conflict-derived:" + target.ConflictID + ":" + target.TargetFragmentID,
 		RequestHash:    requestHash,
-		SourceSummary:  "overdue conflict deletion-only derivation",
+		SourceSummary:  conflictResolutionDeletionOnlySourceSummary,
 		Metadata: map[string]any{
 			"conflict_id":                        target.ConflictID,
 			"target_fragment_id":                 target.TargetFragmentID,

--- a/internal/repository/conflict_derived_evidence_task_repository.go
+++ b/internal/repository/conflict_derived_evidence_task_repository.go
@@ -1,0 +1,278 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func (r *LedgerRepositoryImpl) StageConflictDerivedEvidence(
+	ctx context.Context,
+	target ConflictDerivedEvidenceTarget,
+) (*StageConflictDerivedEvidenceResult, error) {
+	target = normalizeConflictDerivedEvidenceTarget(target)
+	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
+		return nil, err
+	}
+	content := "Overdue conflict review retracted prior evidence. This deletion-only derivation cannot establish a semantic relationship."
+	requestHash := sha256Hex(strings.Join([]string{
+		target.ConflictID,
+		target.TargetFragmentID,
+		target.SelectedPositionID,
+		target.SourceGroupKey,
+		fmt.Sprint(target.EvidenceIndex),
+		content,
+	}, "\x00"))
+	ingest, err := r.CreateIngest(ctx, CreateIngestInput{
+		TeamID:         target.TeamID,
+		OwnerProfileID: target.SystemProfileID,
+		IdempotencyKey: "conflict-derived:" + target.ConflictID + ":" + target.TargetFragmentID,
+		RequestHash:    requestHash,
+		SourceSummary:  "overdue conflict deletion-only derivation",
+		Metadata: map[string]any{
+			"conflict_id":                        target.ConflictID,
+			"target_fragment_id":                 target.TargetFragmentID,
+			"target_owner_profile_id":            target.TargetOwnerProfileID,
+			"selected_position_id":               target.SelectedPositionID,
+			"conflict_resolution_deletion_only":  true,
+			"conflict_resolution_policy_version": domain.ConflictOverduePolicyVersion,
+		},
+		Evidence: []EvidenceInput{{
+			Content:    content,
+			SourceType: "observation",
+			Authority:  string(domain.AuthorityInferred),
+			SourceRef:  "conflict:" + target.ConflictID,
+			Metadata: map[string]any{
+				"conflict_id":                       target.ConflictID,
+				"target_fragment_id":                target.TargetFragmentID,
+				"target_owner_profile_id":           target.TargetOwnerProfileID,
+				"selected_position_id":              target.SelectedPositionID,
+				"contract_source_group":             target.SourceGroupKey,
+				"origin_evidence_index":             target.EvidenceIndex,
+				"conflict_resolution_deletion_only": true,
+				"derived_authority":                 string(domain.AuthorityInferred),
+			},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: stage derived evidence: %w", err)
+	}
+	if ingest == nil || ingest.IngestID == "" || len(ingest.Evidence) != 1 || ingest.Evidence[0].FragmentID == "" {
+		return nil, errors.New("conflict review: derived evidence ingest is incomplete")
+	}
+	result := &StageConflictDerivedEvidenceResult{
+		IngestID:            ingest.IngestID,
+		ReplacementFragment: ingest.Evidence[0].FragmentID,
+		Existing:            ingest.Existing,
+	}
+	err = r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		var existingReplacement string
+		err := tx.WithContext(ctx).Raw(`
+			INSERT INTO relationship_conflict_evidence_derivations (
+			    team_id, conflict_id, target_fragment_id, target_owner_profile_id,
+			    selected_position_id, replacement_fragment_id, system_profile_id
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?::uuid,
+			    ?::uuid, ?::uuid, ?::uuid
+		)
+			ON CONFLICT (team_id, conflict_id, target_fragment_id) DO NOTHING
+			RETURNING replacement_fragment_id::text
+		`, target.TeamID, target.ConflictID, target.TargetFragmentID, target.TargetOwnerProfileID,
+			target.SelectedPositionID, result.ReplacementFragment, target.SystemProfileID).Row().Scan(&existingReplacement)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if existingReplacement == "" {
+			if err := tx.WithContext(ctx).Raw(`
+				SELECT replacement_fragment_id::text
+				FROM relationship_conflict_evidence_derivations
+				WHERE team_id = ?::uuid
+				  AND conflict_id = ?::uuid
+				  AND target_fragment_id = ?::uuid
+			`, target.TeamID, target.ConflictID, target.TargetFragmentID).Row().Scan(&existingReplacement); err != nil {
+				return err
+			}
+			result.Existing = true
+		}
+		if existingReplacement != result.ReplacementFragment {
+			return ErrConflictAssessmentStale
+		}
+		updateTask := tx.WithContext(ctx).Exec(`
+			UPDATE relationship_conflict_derived_evidence_tasks
+			SET status = 'completed',
+			    lease_worker_id = NULL,
+			    lease_until = NULL,
+			    last_failure_class = '',
+			    updated_at = now(),
+			    completed_at = COALESCE(completed_at, now())
+			WHERE team_id = ?::uuid
+			  AND derived_evidence_task_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			  AND target_fragment_id = ?::uuid
+			  AND target_owner_profile_id = ?::uuid
+			  AND selected_position_id = ?::uuid
+			  AND system_profile_id = ?::uuid
+			  AND source_group_key = ?
+			  AND origin_evidence_index = ?
+		`, target.TeamID, target.TaskID, target.ConflictID, target.TargetFragmentID,
+			target.TargetOwnerProfileID, target.SelectedPositionID, target.SystemProfileID,
+			target.SourceGroupKey, target.EvidenceIndex)
+		if updateTask.Error != nil {
+			return updateTask.Error
+		}
+		if updateTask.RowsAffected != 1 {
+			return ErrConflictAssessmentStale
+		}
+		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedStaged), "staged", "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_staged", map[string]any{
+			"derived_evidence_task_id": target.TaskID,
+			"target_fragment_id":       target.TargetFragmentID,
+			"replacement_fragment_id":  result.ReplacementFragment,
+			"replacement_ingest_id":    result.IngestID,
+			"source_group_key":         target.SourceGroupKey,
+			"origin_evidence_index":    target.EvidenceIndex,
+			"authority":                string(domain.AuthorityInferred),
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: record derived evidence: %w", err)
+	}
+	return result, nil
+}
+
+func (r *LedgerRepositoryImpl) RecordConflictDerivedEvidenceFailure(
+	ctx context.Context,
+	target ConflictDerivedEvidenceTarget,
+	failureClass string,
+) error {
+	target = normalizeConflictDerivedEvidenceTarget(target)
+	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
+		return err
+	}
+	failureClass = strings.TrimSpace(failureClass)
+	if failureClass == "" || len(failureClass) > 128 {
+		return errors.New("derived evidence failure_class is invalid")
+	}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		updateTask := tx.WithContext(ctx).Exec(`
+			UPDATE relationship_conflict_derived_evidence_tasks
+			SET status = 'pending',
+			    lease_worker_id = NULL,
+			    lease_until = NULL,
+			    last_failure_class = ?,
+			    updated_at = now()
+			WHERE team_id = ?::uuid
+			  AND derived_evidence_task_id = ?::uuid
+			  AND status <> 'completed'
+		`, failureClass, target.TeamID, target.TaskID)
+		if updateTask.Error != nil {
+			return updateTask.Error
+		}
+		if updateTask.RowsAffected == 0 {
+			return nil
+		}
+		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedFailed), failureClass, "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_failed", map[string]any{
+			"derived_evidence_task_id": target.TaskID,
+			"target_fragment_id":       target.TargetFragmentID,
+			"failure_class":            failureClass,
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("conflict review: record derived evidence failure: %w", err)
+	}
+	return nil
+}
+
+func (r *LedgerRepositoryImpl) ClaimConflictDerivedEvidenceTasks(
+	ctx context.Context,
+	input ClaimConflictDerivedEvidenceTasksInput,
+) ([]ConflictDerivedEvidenceTarget, error) {
+	input = normalizeClaimConflictDerivedEvidenceTasksInput(input)
+	if err := validateClaimConflictDerivedEvidenceTasksInput(input); err != nil {
+		return nil, err
+	}
+	targets := []ConflictDerivedEvidenceTarget{}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		rows, err := tx.WithContext(ctx).Raw(`
+			WITH selected AS (
+				SELECT derived_evidence_task_id
+				FROM relationship_conflict_derived_evidence_tasks
+				WHERE team_id = ?::uuid
+				  AND status IN ('pending', 'processing')
+				  AND (status = 'pending' OR lease_until IS NULL OR lease_until < clock_timestamp())
+				ORDER BY created_at, derived_evidence_task_id
+				FOR UPDATE SKIP LOCKED
+				LIMIT ?
+			), claimed AS (
+				UPDATE relationship_conflict_derived_evidence_tasks AS task
+				SET status = 'processing',
+				    attempts = task.attempts + 1,
+				    lease_worker_id = ?,
+				    lease_until = clock_timestamp() + (?::int * interval '1 second'),
+				    last_review_run_id = ?::uuid,
+				    updated_at = now()
+				FROM selected
+				WHERE task.team_id = ?::uuid
+				  AND task.derived_evidence_task_id = selected.derived_evidence_task_id
+				RETURNING task.derived_evidence_task_id::text,
+				          task.conflict_id::text,
+				          task.system_profile_id::text,
+				          task.target_fragment_id::text,
+				          task.target_owner_profile_id::text,
+				          task.selected_position_id::text,
+				          task.source_group_key,
+				          task.origin_evidence_index
+			)
+			SELECT * FROM claimed
+			ORDER BY derived_evidence_task_id
+		`, input.TeamID, input.Limit, input.WorkerID, int(input.Lease.Seconds()), input.ReviewRunID, input.TeamID).Rows()
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			target := ConflictDerivedEvidenceTarget{TeamID: input.TeamID}
+			if err := rows.Scan(
+				&target.TaskID,
+				&target.ConflictID,
+				&target.SystemProfileID,
+				&target.TargetFragmentID,
+				&target.TargetOwnerProfileID,
+				&target.SelectedPositionID,
+				&target.SourceGroupKey,
+				&target.EvidenceIndex,
+			); err != nil {
+				return err
+			}
+			targets = append(targets, target)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: claim derived evidence tasks: %w", err)
+	}
+	return targets, nil
+}

--- a/internal/repository/conflict_overdue_assessment_repository.go
+++ b/internal/repository/conflict_overdue_assessment_repository.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	conflictAssessmentMaxFailedDays = 5
+	ConflictAssessmentMaxFailedDays = 5
 	conflictResolutionMaxFragments  = 200
 )
 
@@ -44,13 +44,12 @@ type OverdueConflictAssessmentReservation struct {
 }
 
 type OverdueConflictAssessmentDossier struct {
-	TeamID          string
-	ConflictID      string
-	CaseVersion     int
-	Question        string
-	Positions       []OverdueConflictAssessmentPosition
-	Evidence        []OverdueConflictAssessmentEvidence
-	SystemProfileID string
+	TeamID      string
+	ConflictID  string
+	CaseVersion int
+	Question    string
+	Positions   []OverdueConflictAssessmentPosition
+	Evidence    []OverdueConflictAssessmentEvidence
 }
 
 type OverdueConflictAssessmentPosition struct {
@@ -207,7 +206,7 @@ func (r *LedgerRepositoryImpl) ReserveOverdueConflictAssessment(
 		if err != nil {
 			return err
 		}
-		if failureCount >= conflictAssessmentMaxFailedDays {
+		if failureCount >= ConflictAssessmentMaxFailedDays {
 			assessmentAttemptID, err := latestFailedOverdueConflictAssessmentID(ctx, tx, input.TeamID, input.ConflictID, version, input.Model, input.PolicyVersion)
 			if err != nil {
 				return err
@@ -522,6 +521,7 @@ func supersedeReservedOverdueConflictAssessments(
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 	type supersededAssessment struct {
 		assessmentAttemptID string
 		caseVersion         int
@@ -530,16 +530,11 @@ func supersedeReservedOverdueConflictAssessments(
 	for rows.Next() {
 		item := supersededAssessment{}
 		if err := rows.Scan(&item.assessmentAttemptID, &item.caseVersion); err != nil {
-			_ = rows.Close()
 			return err
 		}
 		superseded = append(superseded, item)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return err
-	}
-	if err := rows.Close(); err != nil {
 		return err
 	}
 	for _, item := range superseded {

--- a/internal/repository/conflict_overdue_assessment_repository.go
+++ b/internal/repository/conflict_overdue_assessment_repository.go
@@ -1,0 +1,738 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+const (
+	conflictAssessmentMaxFailedDays = 5
+	conflictResolutionMaxFragments  = 200
+)
+
+var (
+	ErrConflictAssessmentUnavailable = errors.New("conflict assessment is unavailable")
+	ErrConflictAssessmentStale       = errors.New("conflict assessment is stale")
+	ErrConflictAssessmentReserved    = errors.New("conflict assessment is not reserved")
+)
+
+type ReserveOverdueConflictAssessmentInput struct {
+	TeamID              string
+	ConflictID          string
+	ReviewRunID         string
+	WorkerID            string
+	LocalAssessmentDate time.Time
+	Model               string
+	PolicyVersion       string
+}
+
+type OverdueConflictAssessmentReservation struct {
+	AssessmentAttemptID string
+	CaseVersion         int
+	Model               string
+	PolicyVersion       string
+	LastWriteWins       bool
+}
+
+type OverdueConflictAssessmentDossier struct {
+	TeamID          string
+	ConflictID      string
+	CaseVersion     int
+	Question        string
+	Positions       []OverdueConflictAssessmentPosition
+	Evidence        []OverdueConflictAssessmentEvidence
+	SystemProfileID string
+}
+
+type OverdueConflictAssessmentPosition struct {
+	PositionID              string
+	PositionKey             string
+	SupportGroupCount       int
+	AuthoritativeGroupCount int
+	OwnerProfileCount       int
+	Supports                []domain.ConflictResolutionSupport
+}
+
+type OverdueConflictAssessmentEvidence struct {
+	FragmentID     string
+	OwnerProfileID string
+	PositionID     string
+	SupportID      string
+	SourceGroupKey string
+	Authority      string
+	AcceptedAt     time.Time
+	EffectiveAt    *time.Time
+	EvidenceIndex  int
+	Content        string
+}
+
+type CompleteOverdueConflictAssessmentInput struct {
+	TeamID              string
+	ConflictID          string
+	AssessmentAttemptID string
+	CaseVersion         int
+	ReviewRunID         string
+	Decision            string
+	SelectedPositionID  string
+	Confidence          *float64
+	ProviderTurns       int
+	ResponseHash        string
+	FailureClass        string
+}
+
+type CompleteOverdueConflictAssessmentResult struct {
+	FailureCount int
+}
+
+type ApplyOverdueConflictResolutionInput struct {
+	TeamID              string
+	ConflictID          string
+	ReviewRunID         string
+	WorkerID            string
+	ExpectedCaseVersion int
+	PreferredPositionID string
+	AssessmentAttemptID string
+	Method              string
+	Now                 time.Time
+}
+
+type ApplyOverdueConflictResolutionResult struct {
+	ConflictID           string
+	PreferredPositionID  string
+	Method               string
+	Resolved             bool
+	Pending              bool
+	Stale                bool
+	UpdatedRelationships []string
+	RetractedEvidenceIDs []string
+	DerivedEvidence      []ConflictDerivedEvidenceTarget
+}
+
+type ResumePendingOverdueConflictResolutionInput struct {
+	TeamID      string
+	ConflictID  string
+	ReviewRunID string
+	WorkerID    string
+	Now         time.Time
+}
+
+type ConflictDerivedEvidenceTarget struct {
+	TeamID               string
+	ConflictID           string
+	SystemProfileID      string
+	TargetFragmentID     string
+	TargetOwnerProfileID string
+	SelectedPositionID   string
+	SourceGroupKey       string
+	EvidenceIndex        int
+}
+
+type StageConflictDerivedEvidenceResult struct {
+	IngestID            string
+	ReplacementFragment string
+	Existing            bool
+}
+
+func (r *LedgerRepositoryImpl) ReserveOverdueConflictAssessment(
+	ctx context.Context,
+	input ReserveOverdueConflictAssessmentInput,
+) (*OverdueConflictAssessmentReservation, *OverdueConflictAssessmentDossier, bool, error) {
+	input = normalizeReserveOverdueConflictAssessmentInput(input)
+	if err := validateReserveOverdueConflictAssessmentInput(input); err != nil {
+		return nil, nil, false, err
+	}
+	var reservation *OverdueConflictAssessmentReservation
+	var dossier *OverdueConflictAssessmentDossier
+	reserved := false
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		var status string
+		var version int
+		if err := tx.WithContext(ctx).Raw(`
+			SELECT status, version
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			FOR UPDATE
+		`, input.TeamID, input.ConflictID).Row().Scan(&status, &version); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		if status != string(domain.RelationshipConflictOverdue) {
+			return nil
+		}
+		var pending int
+		if err := tx.WithContext(ctx).Raw(`
+			SELECT count(*)::int
+			FROM relationship_conflict_resolution_plans
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			  AND expected_case_version = ?
+			  AND status = 'resolution_pending'
+		`, input.TeamID, input.ConflictID, version).Row().Scan(&pending); err != nil {
+			return err
+		}
+		if pending > 0 {
+			return nil
+		}
+		if err := expirePriorOverdueConflictAssessmentReservations(ctx, tx, input, version); err != nil {
+			return err
+		}
+		failureCount, err := countFailedOverdueConflictAssessments(ctx, tx, input.TeamID, input.ConflictID, version, input.Model, input.PolicyVersion)
+		if err != nil {
+			return err
+		}
+		if failureCount >= conflictAssessmentMaxFailedDays {
+			assessmentAttemptID, err := latestFailedOverdueConflictAssessmentID(ctx, tx, input.TeamID, input.ConflictID, version, input.Model, input.PolicyVersion)
+			if err != nil {
+				return err
+			}
+			loaded, err := loadOverdueConflictAssessmentDossier(ctx, tx, input.TeamID, input.ConflictID, version)
+			if err != nil {
+				return err
+			}
+			reservation = &OverdueConflictAssessmentReservation{
+				AssessmentAttemptID: assessmentAttemptID,
+				CaseVersion:         version,
+				Model:               input.Model,
+				PolicyVersion:       input.PolicyVersion,
+				LastWriteWins:       true,
+			}
+			dossier = loaded
+			reserved = true
+			return nil
+		}
+
+		var assessmentAttemptID string
+		err = tx.WithContext(ctx).Raw(`
+			INSERT INTO relationship_conflict_ai_assessment_attempts (
+			    team_id, conflict_id, case_version, local_assessment_date, model, policy_version
+			) VALUES (
+			    ?::uuid, ?::uuid, ?, ?, ?, ?
+			)
+			ON CONFLICT (team_id, conflict_id, case_version, local_assessment_date, model, policy_version)
+			DO NOTHING
+			RETURNING assessment_attempt_id::text
+		`, input.TeamID, input.ConflictID, version, input.LocalAssessmentDate, input.Model, input.PolicyVersion).Row().Scan(&assessmentAttemptID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if assessmentAttemptID == "" {
+			return nil
+		}
+		if err := appendConflictAssessmentEvent(ctx, tx, input.TeamID, assessmentAttemptID, "reserved", "", map[string]any{
+			"case_version": version,
+			"model":        input.Model,
+		}); err != nil {
+			return err
+		}
+		if err := appendRelationshipConflictEvent(ctx, tx, input.TeamID, input.ConflictID, "", "", "", string(domain.RelationshipConflictEventAIAssessmentReserved), "reserved", "case:"+input.ConflictID+":assessment:"+assessmentAttemptID+":reserved", map[string]any{
+			"assessment_attempt_id": assessmentAttemptID,
+			"case_version":          version,
+			"model":                 input.Model,
+		}); err != nil {
+			return err
+		}
+		loaded, err := loadOverdueConflictAssessmentDossier(ctx, tx, input.TeamID, input.ConflictID, version)
+		if err != nil {
+			return err
+		}
+		reservation = &OverdueConflictAssessmentReservation{
+			AssessmentAttemptID: assessmentAttemptID,
+			CaseVersion:         version,
+			Model:               input.Model,
+			PolicyVersion:       input.PolicyVersion,
+		}
+		dossier = loaded
+		reserved = true
+		return nil
+	})
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("conflict review: reserve overdue assessment: %w", err)
+	}
+	return reservation, dossier, reserved, nil
+}
+
+func (r *LedgerRepositoryImpl) CompleteOverdueConflictAssessment(
+	ctx context.Context,
+	input CompleteOverdueConflictAssessmentInput,
+) (*CompleteOverdueConflictAssessmentResult, error) {
+	input = normalizeCompleteOverdueConflictAssessmentInput(input)
+	if err := validateCompleteOverdueConflictAssessmentInput(input); err != nil {
+		return nil, err
+	}
+	result := &CompleteOverdueConflictAssessmentResult{}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if input.Decision == "selected" {
+			if err := validateConflictResolutionPosition(ctx, tx, input.TeamID, input.ConflictID, input.SelectedPositionID); err != nil {
+				return err
+			}
+		}
+		status, outcome, err := conflictAssessmentStoredStatus(input)
+		if err != nil {
+			return err
+		}
+		update := tx.WithContext(ctx).Exec(`
+			UPDATE relationship_conflict_ai_assessment_attempts
+			SET status = ?,
+			    selected_position_id = NULLIF(?, '')::uuid,
+			    confidence = ?,
+			    provider_turns = ?,
+			    response_hash = ?,
+			    failure_class = ?,
+			    completed_at = now()
+			WHERE team_id = ?::uuid
+			  AND assessment_attempt_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			  AND case_version = ?
+			  AND status = 'reserved'
+		`, status, input.SelectedPositionID, input.Confidence, input.ProviderTurns, input.ResponseHash, input.FailureClass,
+			input.TeamID, input.AssessmentAttemptID, input.ConflictID, input.CaseVersion)
+		if update.Error != nil {
+			return update.Error
+		}
+		if update.RowsAffected != 1 {
+			return ErrConflictAssessmentReserved
+		}
+		metadata := map[string]any{
+			"case_version":   input.CaseVersion,
+			"provider_turns": input.ProviderTurns,
+		}
+		if input.SelectedPositionID != "" {
+			metadata["selected_position_id"] = input.SelectedPositionID
+		}
+		if input.Confidence != nil {
+			metadata["confidence"] = *input.Confidence
+		}
+		if input.FailureClass != "" {
+			metadata["failure_class"] = input.FailureClass
+		}
+		if err := appendConflictAssessmentEvent(ctx, tx, input.TeamID, input.AssessmentAttemptID, status, outcome, metadata); err != nil {
+			return err
+		}
+		if err := appendRelationshipConflictEvent(ctx, tx, input.TeamID, input.ConflictID, input.SelectedPositionID, "", "", string(domain.RelationshipConflictEventAIAssessed), outcome, "case:"+input.ConflictID+":assessment:"+input.AssessmentAttemptID+":"+status, metadata); err != nil {
+			return err
+		}
+		if status == "failed" {
+			var model string
+			var policyVersion string
+			if err := tx.WithContext(ctx).Raw(`
+				SELECT model, policy_version
+				FROM relationship_conflict_ai_assessment_attempts
+				WHERE team_id = ?::uuid
+				  AND assessment_attempt_id = ?::uuid
+			`, input.TeamID, input.AssessmentAttemptID).Row().Scan(&model, &policyVersion); err != nil {
+				return err
+			}
+			failureCount, err := countFailedOverdueConflictAssessments(ctx, tx, input.TeamID, input.ConflictID, input.CaseVersion, model, policyVersion)
+			if err != nil {
+				return err
+			}
+			result.FailureCount = failureCount
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: complete overdue assessment: %w", err)
+	}
+	return result, nil
+}
+
+func normalizeReserveOverdueConflictAssessmentInput(input ReserveOverdueConflictAssessmentInput) ReserveOverdueConflictAssessmentInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.ConflictID = strings.TrimSpace(input.ConflictID)
+	input.ReviewRunID = strings.TrimSpace(input.ReviewRunID)
+	input.WorkerID = strings.TrimSpace(input.WorkerID)
+	input.Model = strings.TrimSpace(input.Model)
+	input.PolicyVersion = strings.TrimSpace(input.PolicyVersion)
+	if input.PolicyVersion == "" {
+		input.PolicyVersion = domain.ConflictOverduePolicyVersion
+	}
+	if input.LocalAssessmentDate.IsZero() {
+		input.LocalAssessmentDate = time.Now().UTC()
+	}
+	year, month, day := input.LocalAssessmentDate.Date()
+	input.LocalAssessmentDate = time.Date(
+		year, month, day,
+		0, 0, 0, 0, time.UTC,
+	)
+	return input
+}
+
+func validateReserveOverdueConflictAssessmentInput(input ReserveOverdueConflictAssessmentInput) error {
+	if _, err := uuid.Parse(input.TeamID); err != nil {
+		return fmt.Errorf("team_id is required: %w", err)
+	}
+	if _, err := uuid.Parse(input.ConflictID); err != nil {
+		return fmt.Errorf("conflict_id is required: %w", err)
+	}
+	if _, err := uuid.Parse(input.ReviewRunID); err != nil {
+		return fmt.Errorf("review_run_id is required: %w", err)
+	}
+	if input.WorkerID == "" {
+		return errors.New("worker_id is required")
+	}
+	if input.Model == "" {
+		return errors.New("model is required")
+	}
+	return nil
+}
+
+func normalizeCompleteOverdueConflictAssessmentInput(input CompleteOverdueConflictAssessmentInput) CompleteOverdueConflictAssessmentInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.ConflictID = strings.TrimSpace(input.ConflictID)
+	input.AssessmentAttemptID = strings.TrimSpace(input.AssessmentAttemptID)
+	input.ReviewRunID = strings.TrimSpace(input.ReviewRunID)
+	input.Decision = strings.TrimSpace(input.Decision)
+	input.SelectedPositionID = strings.TrimSpace(input.SelectedPositionID)
+	input.ResponseHash = strings.TrimSpace(input.ResponseHash)
+	input.FailureClass = strings.TrimSpace(input.FailureClass)
+	if input.ProviderTurns < 0 {
+		input.ProviderTurns = 0
+	}
+	return input
+}
+
+func validateCompleteOverdueConflictAssessmentInput(input CompleteOverdueConflictAssessmentInput) error {
+	for _, value := range []struct {
+		name string
+		id   string
+	}{
+		{name: "team_id", id: input.TeamID},
+		{name: "conflict_id", id: input.ConflictID},
+		{name: "assessment_attempt_id", id: input.AssessmentAttemptID},
+	} {
+		if _, err := uuid.Parse(value.id); err != nil {
+			return fmt.Errorf("%s is required: %w", value.name, err)
+		}
+	}
+	if input.CaseVersion < 1 {
+		return errors.New("case_version is required")
+	}
+	if len(input.ResponseHash) > 128 {
+		return errors.New("response_hash exceeds maximum 128")
+	}
+	if len(input.FailureClass) > 128 {
+		return errors.New("failure_class exceeds maximum 128")
+	}
+	switch input.Decision {
+	case "selected":
+		if _, err := uuid.Parse(input.SelectedPositionID); err != nil {
+			return fmt.Errorf("selected_position_id is required: %w", err)
+		}
+		if input.Confidence == nil || *input.Confidence < 0 || *input.Confidence > 1 {
+			return errors.New("selected assessment confidence must be between 0 and 1")
+		}
+	case "abstained":
+		if input.SelectedPositionID != "" || input.Confidence == nil || *input.Confidence != 0 {
+			return errors.New("abstained assessment must not select a position and must use zero confidence")
+		}
+	case "failed":
+		if input.SelectedPositionID != "" || input.Confidence != nil || input.FailureClass == "" {
+			return errors.New("failed assessment requires a failure class and no selected position")
+		}
+	default:
+		return errors.New("assessment decision is unsupported")
+	}
+	return nil
+}
+
+func conflictAssessmentStoredStatus(input CompleteOverdueConflictAssessmentInput) (string, string, error) {
+	switch input.Decision {
+	case "selected":
+		return "selected", "selected", nil
+	case "abstained":
+		return "abstained", "abstained", nil
+	case "failed":
+		return "failed", input.FailureClass, nil
+	default:
+		return "", "", errors.New("assessment decision is unsupported")
+	}
+}
+
+func appendConflictAssessmentEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	assessmentAttemptID string,
+	action string,
+	outcome string,
+	metadata map[string]any,
+) error {
+	encoded, err := marshalJSON(metadata)
+	if err != nil {
+		return err
+	}
+	return tx.WithContext(ctx).Exec(`
+		INSERT INTO relationship_conflict_ai_assessment_events (
+		    team_id, assessment_attempt_id, action, outcome, metadata
+		) VALUES (
+		    ?::uuid, ?::uuid, ?, ?, ?::jsonb
+		)
+	`, teamID, assessmentAttemptID, action, outcome, string(encoded)).Error
+}
+
+func supersedeReservedOverdueConflictAssessments(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+) error {
+	rows, err := tx.WithContext(ctx).Raw(`
+		UPDATE relationship_conflict_ai_assessment_attempts
+		SET status = 'superseded',
+		    failure_class = 'case_version_changed',
+		    completed_at = now()
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND status = 'reserved'
+		RETURNING assessment_attempt_id::text, case_version
+	`, teamID, conflictID).Rows()
+	if err != nil {
+		return err
+	}
+	type supersededAssessment struct {
+		assessmentAttemptID string
+		caseVersion         int
+	}
+	superseded := []supersededAssessment{}
+	for rows.Next() {
+		item := supersededAssessment{}
+		if err := rows.Scan(&item.assessmentAttemptID, &item.caseVersion); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		superseded = append(superseded, item)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, item := range superseded {
+		metadata := map[string]any{
+			"case_version":  item.caseVersion,
+			"failure_class": "case_version_changed",
+		}
+		if err := appendConflictAssessmentEvent(ctx, tx, teamID, item.assessmentAttemptID, "superseded", "case_version_changed", metadata); err != nil {
+			return err
+		}
+		if err := appendRelationshipConflictEvent(ctx, tx, teamID, conflictID, "", "", "", string(domain.RelationshipConflictEventAIAssessed), "superseded", "case:"+conflictID+":assessment:"+item.assessmentAttemptID+":superseded", metadata); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func supersedePendingOverdueConflictResolutions(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+) error {
+	return tx.WithContext(ctx).Exec(`
+		UPDATE relationship_conflict_resolution_plans
+		SET status = 'superseded',
+		    failure_reason = 'case_version_changed'
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND status = 'resolution_pending'
+	`, teamID, conflictID).Error
+}
+
+func loadOverdueConflictAssessmentDossier(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+	caseVersion int,
+) (*OverdueConflictAssessmentDossier, error) {
+	dossier := &OverdueConflictAssessmentDossier{TeamID: teamID, ConflictID: conflictID, CaseVersion: caseVersion}
+	if err := tx.WithContext(ctx).Raw(`
+		SELECT question
+		FROM relationship_conflict_cases
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND version = ?
+		  AND status = 'overdue'
+	`, teamID, conflictID, caseVersion).Row().Scan(&dossier.Question); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrConflictAssessmentStale
+		}
+		return nil, err
+	}
+	positionByID := make(map[string]*OverdueConflictAssessmentPosition)
+	positionRows, err := tx.WithContext(ctx).Raw(`
+		SELECT position.position_id::text,
+		       position.position_key,
+		       position.support_group_count,
+		       position.authoritative_group_count,
+		       (
+		           SELECT count(DISTINCT member.owner_profile_id)::int
+		           FROM relationship_conflict_position_members AS member
+		           WHERE member.team_id = position.team_id
+		             AND member.position_id = position.position_id
+		             AND member.active
+		       ) AS owner_profile_count
+		FROM relationship_conflict_positions AS position
+		WHERE position.team_id = ?::uuid
+		  AND position.conflict_id = ?::uuid
+		  AND position.active
+		ORDER BY position.position_id
+	`, teamID, conflictID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer positionRows.Close()
+	for positionRows.Next() {
+		position := OverdueConflictAssessmentPosition{}
+		if err := positionRows.Scan(&position.PositionID, &position.PositionKey, &position.SupportGroupCount, &position.AuthoritativeGroupCount, &position.OwnerProfileCount); err != nil {
+			return nil, err
+		}
+		dossier.Positions = append(dossier.Positions, position)
+		positionByID[position.PositionID] = &dossier.Positions[len(dossier.Positions)-1]
+	}
+	if err := positionRows.Err(); err != nil {
+		return nil, err
+	}
+	if len(dossier.Positions) < 2 {
+		return nil, ErrConflictAssessmentUnavailable
+	}
+
+	evidenceRows, err := tx.WithContext(ctx).Raw(`
+		WITH member_relationships AS (
+			SELECT DISTINCT member.position_id, member.relationship_id, member.owner_profile_id
+			FROM relationship_conflict_position_members AS member
+			JOIN relationship_conflict_positions AS position
+			  ON position.team_id = member.team_id
+			 AND position.position_id = member.position_id
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.active
+			  AND position.active
+		),
+		latest_support_decision AS (
+			SELECT DISTINCT ON (support.support_id)
+			       support.support_id,
+			       decision.decision
+			FROM relationship_evidence_supports AS support
+			JOIN member_relationships AS member
+			  ON member.relationship_id = support.relationship_id
+			 AND member.owner_profile_id = support.owner_profile_id
+			JOIN relationship_support_decision_events AS decision
+			  ON decision.team_id = support.team_id
+			 AND decision.support_id = support.support_id
+			WHERE support.team_id = ?::uuid
+			ORDER BY support.support_id, decision.created_at DESC, decision.support_decision_id DESC
+		)
+		SELECT member.position_id::text,
+		       fragment.fragment_id::text,
+		       fragment.owner_profile_id::text,
+		       support.support_id::text,
+		       COALESCE(
+		           NULLIF(source.source_key, ''),
+		           NULLIF(fragment.metadata->>'contract_source_group', ''),
+		           NULLIF(fragment.metadata->>'v2_contract_source_group', ''),
+		           NULLIF(support.source_group_key, ''),
+		           support.support_id::text
+		       ) AS source_group_key,
+		       support.authority,
+		       support.created_at,
+		       relationship.valid_from,
+		       fragment.evidence_index,
+		       fragment.content
+		FROM member_relationships AS member
+		JOIN relationship_records AS relationship
+		  ON relationship.team_id = ?::uuid
+		 AND relationship.relationship_id = member.relationship_id
+		 AND relationship.owner_profile_id = member.owner_profile_id
+		JOIN relationship_evidence_supports AS support
+		  ON support.team_id = relationship.team_id
+		 AND support.relationship_id = relationship.relationship_id
+		 AND support.owner_profile_id = relationship.owner_profile_id
+		JOIN latest_support_decision AS latest
+		  ON latest.support_id = support.support_id
+		 AND latest.decision IN ('grant', 'reinstate')
+		JOIN evidence_fragments AS fragment
+		  ON fragment.team_id = support.team_id
+		 AND fragment.fragment_id = support.fragment_id
+		LEFT JOIN evidence_quarantines AS quarantine
+		  ON quarantine.team_id = support.team_id
+		 AND quarantine.fragment_id = support.fragment_id
+		 AND quarantine.status = 'active'
+		LEFT JOIN evidence_sources AS source
+		  ON source.team_id = support.team_id
+		 AND source.source_id = support.source_id
+		LEFT JOIN evidence_lifecycle_events AS lifecycle
+		  ON lifecycle.team_id = support.team_id
+		 AND lifecycle.target_fragment_id = support.fragment_id
+		WHERE quarantine.quarantine_id IS NULL
+		  AND lifecycle.lifecycle_event_id IS NULL
+		  AND COALESCE(fragment.metadata->>'conflict_resolution_deletion_only', '') <> 'true'
+		  AND (support.source_id IS NULL OR source.current_revision_id = support.source_revision_id)
+		ORDER BY member.position_id, support.created_at, support.support_id
+	`, teamID, conflictID, teamID, teamID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer evidenceRows.Close()
+	for evidenceRows.Next() {
+		item := OverdueConflictAssessmentEvidence{}
+		if err := evidenceRows.Scan(
+			&item.PositionID,
+			&item.FragmentID,
+			&item.OwnerProfileID,
+			&item.SupportID,
+			&item.SourceGroupKey,
+			&item.Authority,
+			&item.AcceptedAt,
+			&item.EffectiveAt,
+			&item.EvidenceIndex,
+			&item.Content,
+		); err != nil {
+			return nil, err
+		}
+		position, exists := positionByID[item.PositionID]
+		if !exists {
+			return nil, ErrConflictAssessmentStale
+		}
+		item.AcceptedAt = item.AcceptedAt.UTC()
+		if item.EffectiveAt != nil {
+			value := item.EffectiveAt.UTC()
+			item.EffectiveAt = &value
+		}
+		position.Supports = append(position.Supports, domain.ConflictResolutionSupport{Authority: item.Authority, AcceptedAt: item.AcceptedAt})
+		dossier.Evidence = append(dossier.Evidence, item)
+	}
+	if err := evidenceRows.Err(); err != nil {
+		return nil, err
+	}
+	if len(dossier.Evidence) == 0 {
+		return nil, ErrConflictAssessmentUnavailable
+	}
+	return dossier, nil
+}

--- a/internal/repository/conflict_overdue_assessment_repository.go
+++ b/internal/repository/conflict_overdue_assessment_repository.go
@@ -126,6 +126,7 @@ type ResumePendingOverdueConflictResolutionInput struct {
 }
 
 type ConflictDerivedEvidenceTarget struct {
+	TaskID               string
 	TeamID               string
 	ConflictID           string
 	SystemProfileID      string
@@ -134,6 +135,14 @@ type ConflictDerivedEvidenceTarget struct {
 	SelectedPositionID   string
 	SourceGroupKey       string
 	EvidenceIndex        int
+}
+
+type ClaimConflictDerivedEvidenceTasksInput struct {
+	TeamID      string
+	ReviewRunID string
+	WorkerID    string
+	Limit       int
+	Lease       time.Duration
 }
 
 type StageConflictDerivedEvidenceResult struct {
@@ -585,7 +594,7 @@ func loadOverdueConflictAssessmentDossier(
 		}
 		return nil, err
 	}
-	positionByID := make(map[string]*OverdueConflictAssessmentPosition)
+	positionIndexByID := make(map[string]int)
 	positionRows, err := tx.WithContext(ctx).Raw(`
 		SELECT position.position_id::text,
 		       position.position_key,
@@ -614,7 +623,7 @@ func loadOverdueConflictAssessmentDossier(
 			return nil, err
 		}
 		dossier.Positions = append(dossier.Positions, position)
-		positionByID[position.PositionID] = &dossier.Positions[len(dossier.Positions)-1]
+		positionIndexByID[position.PositionID] = len(dossier.Positions) - 1
 	}
 	if err := positionRows.Err(); err != nil {
 		return nil, err
@@ -716,7 +725,7 @@ func loadOverdueConflictAssessmentDossier(
 		); err != nil {
 			return nil, err
 		}
-		position, exists := positionByID[item.PositionID]
+		positionIndex, exists := positionIndexByID[item.PositionID]
 		if !exists {
 			return nil, ErrConflictAssessmentStale
 		}
@@ -725,7 +734,7 @@ func loadOverdueConflictAssessmentDossier(
 			value := item.EffectiveAt.UTC()
 			item.EffectiveAt = &value
 		}
-		position.Supports = append(position.Supports, domain.ConflictResolutionSupport{Authority: item.Authority, AcceptedAt: item.AcceptedAt})
+		dossier.Positions[positionIndex].Supports = append(dossier.Positions[positionIndex].Supports, domain.ConflictResolutionSupport{Authority: item.Authority, AcceptedAt: item.AcceptedAt})
 		dossier.Evidence = append(dossier.Evidence, item)
 	}
 	if err := evidenceRows.Err(); err != nil {

--- a/internal/repository/conflict_overdue_resolution_repository.go
+++ b/internal/repository/conflict_overdue_resolution_repository.go
@@ -1,0 +1,978 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func (r *LedgerRepositoryImpl) ApplyOverdueConflictResolution(
+	ctx context.Context,
+	input ApplyOverdueConflictResolutionInput,
+) (*ApplyOverdueConflictResolutionResult, error) {
+	input = normalizeApplyOverdueConflictResolutionInput(input)
+	if err := validateApplyOverdueConflictResolutionInput(input); err != nil {
+		return nil, err
+	}
+	result := &ApplyOverdueConflictResolutionResult{
+		ConflictID:          input.ConflictID,
+		PreferredPositionID: input.PreferredPositionID,
+		Method:              input.Method,
+	}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		var status string
+		var version int
+		if err := tx.WithContext(ctx).Raw(`
+			SELECT status, version
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			FOR UPDATE
+		`, input.TeamID, input.ConflictID).Row().Scan(&status, &version); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				result.Stale = true
+				return nil
+			}
+			return err
+		}
+		if status != string(domain.RelationshipConflictOverdue) || version != input.ExpectedCaseVersion {
+			result.Stale = true
+			return markConflictResolutionPlanSuperseded(ctx, tx, input.TeamID, input.ConflictID, input.ExpectedCaseVersion)
+		}
+		records, err := loadRelationshipConflictRecordsByID(ctx, tx, input.TeamID, []string{input.ConflictID}, nil)
+		if err != nil {
+			return err
+		}
+		if len(records) != 1 {
+			return ErrConflictAssessmentStale
+		}
+		current, dismissed, err := refreshRelationshipConflictCaseSnapshotForReview(ctx, tx, ReviewRelationshipConflictCaseInput{
+			TeamID:      input.TeamID,
+			WorkerID:    input.WorkerID,
+			ReviewRunID: input.ReviewRunID,
+			ConflictID:  input.ConflictID,
+			Now:         input.Now,
+		}, &records[0])
+		if err != nil {
+			return err
+		}
+		if dismissed || current.Version != input.ExpectedCaseVersion {
+			result.Stale = true
+			return nil
+		}
+		if err := validateConflictResolutionPosition(ctx, tx, input.TeamID, input.ConflictID, input.PreferredPositionID); err != nil {
+			return err
+		}
+		if err := validateConflictResolutionAssessment(ctx, tx, input); err != nil {
+			return err
+		}
+		records[0] = *current
+		effectiveAt, effectiveTimeBasis := conflictResolutionEffectiveTime(records[0], input.PreferredPositionID, input.Now)
+		planID, planStatus, err := ensureConflictResolutionPlan(ctx, tx, input, effectiveAt, effectiveTimeBasis)
+		if err != nil {
+			return err
+		}
+		if planStatus == "applied" {
+			result.Resolved = true
+			return nil
+		}
+		if planStatus == "superseded" || planStatus == "failed" {
+			result.Stale = true
+			return nil
+		}
+		targets, err := loadConflictLosingEvidenceTargets(ctx, tx, input.TeamID, input.ConflictID, input.PreferredPositionID)
+		if err != nil {
+			return err
+		}
+		if len(targets) > conflictResolutionMaxFragments {
+			if err := appendRelationshipConflictEvent(ctx, tx, input.TeamID, input.ConflictID, input.PreferredPositionID, "", "", string(domain.RelationshipConflictEventResolutionPending), "fanout_bound", "case:"+input.ConflictID+":plan:"+planID+":pending", map[string]any{
+				"resolution_plan_id":    planID,
+				"target_fragment_count": len(targets),
+			}); err != nil {
+				return err
+			}
+			result.Pending = true
+			return nil
+		}
+		evaluation := RelationshipConflictEvaluation{
+			Outcome:             ConflictReviewOutcomeResolve,
+			Stage:               "overdue_" + input.Method,
+			PreferredPositionID: input.PreferredPositionID,
+			Reason:              conflictResolutionReason(input.Method),
+			EffectiveAt:         &effectiveAt,
+			EffectiveTimeBasis:  effectiveTimeBasis,
+		}
+		updated, err := resolveRelationshipConflictCase(ctx, tx, ReviewRelationshipConflictCaseInput{
+			TeamID:      input.TeamID,
+			WorkerID:    input.WorkerID,
+			ReviewRunID: input.ReviewRunID,
+			ConflictID:  input.ConflictID,
+			Now:         input.Now,
+		}, &records[0], evaluation, r.embeddingJobMaxAttempts)
+		if err != nil {
+			return err
+		}
+		systemProfileID, err := ensureConflictSystemProfile(ctx, tx, input.TeamID)
+		if err != nil {
+			return err
+		}
+		retracted, err := retractConflictLosingEvidence(ctx, tx, input, systemProfileID, targets)
+		if err != nil {
+			return err
+		}
+		updatePlan := tx.WithContext(ctx).Exec(`
+			UPDATE relationship_conflict_resolution_plans
+			SET status = 'applied',
+			    applied_at = now(),
+			    failure_reason = ''
+			WHERE team_id = ?::uuid
+			  AND resolution_plan_id = ?::uuid
+			  AND status = 'resolution_pending'
+		`, input.TeamID, planID)
+		if updatePlan.Error != nil {
+			return updatePlan.Error
+		}
+		if updatePlan.RowsAffected != 1 {
+			return ErrConflictAssessmentStale
+		}
+		result.Resolved = true
+		result.UpdatedRelationships = updated
+		result.RetractedEvidenceIDs = retracted
+		result.DerivedEvidence = conflictDerivedEvidenceTargets(input.TeamID, input.ConflictID, systemProfileID, input.PreferredPositionID, targets, retracted)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: apply overdue resolution: %w", err)
+	}
+	return result, nil
+}
+
+func (r *LedgerRepositoryImpl) ResumePendingOverdueConflictResolution(
+	ctx context.Context,
+	input ResumePendingOverdueConflictResolutionInput,
+) (*ApplyOverdueConflictResolutionResult, bool, error) {
+	input = normalizeResumePendingOverdueConflictResolutionInput(input)
+	if err := validateResumePendingOverdueConflictResolutionInput(input); err != nil {
+		return nil, false, err
+	}
+	var resolutionInput ApplyOverdueConflictResolutionInput
+	found := false
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, input.TeamID); err != nil {
+			return err
+		}
+		var expectedCaseVersion int
+		var preferredPositionID string
+		var assessmentAttemptID string
+		var method string
+		err := tx.WithContext(ctx).Raw(`
+			SELECT plan.expected_case_version,
+			       plan.preferred_position_id::text,
+			       COALESCE(plan.assessment_attempt_id::text, ''),
+			       plan.method
+			FROM relationship_conflict_resolution_plans AS plan
+			JOIN relationship_conflict_cases AS conflict
+			  ON conflict.team_id = plan.team_id
+			 AND conflict.conflict_id = plan.conflict_id
+			WHERE plan.team_id = ?::uuid
+			  AND plan.conflict_id = ?::uuid
+			  AND plan.status = 'resolution_pending'
+			  AND conflict.status = 'overdue'
+			  AND conflict.version = plan.expected_case_version
+			FOR UPDATE OF plan, conflict
+		`, input.TeamID, input.ConflictID).Row().Scan(
+			&expectedCaseVersion,
+			&preferredPositionID,
+			&assessmentAttemptID,
+			&method,
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		resolutionInput = ApplyOverdueConflictResolutionInput{
+			TeamID:              input.TeamID,
+			ConflictID:          input.ConflictID,
+			ReviewRunID:         input.ReviewRunID,
+			WorkerID:            input.WorkerID,
+			ExpectedCaseVersion: expectedCaseVersion,
+			PreferredPositionID: preferredPositionID,
+			AssessmentAttemptID: assessmentAttemptID,
+			Method:              method,
+			Now:                 input.Now,
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("conflict review: resume pending overdue resolution: %w", err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+	result, err := r.ApplyOverdueConflictResolution(ctx, resolutionInput)
+	if err != nil {
+		return nil, true, err
+	}
+	return result, true, nil
+}
+
+func (r *LedgerRepositoryImpl) StageConflictDerivedEvidence(
+	ctx context.Context,
+	target ConflictDerivedEvidenceTarget,
+) (*StageConflictDerivedEvidenceResult, error) {
+	target = normalizeConflictDerivedEvidenceTarget(target)
+	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
+		return nil, err
+	}
+	content := "Overdue conflict review retracted prior evidence. This deletion-only derivation cannot establish a semantic relationship."
+	requestHash := sha256Hex(strings.Join([]string{
+		target.ConflictID,
+		target.TargetFragmentID,
+		target.SelectedPositionID,
+		target.SourceGroupKey,
+		fmt.Sprint(target.EvidenceIndex),
+		content,
+	}, "\x00"))
+	ingest, err := r.CreateIngest(ctx, CreateIngestInput{
+		TeamID:         target.TeamID,
+		OwnerProfileID: target.SystemProfileID,
+		IdempotencyKey: "conflict-derived:" + target.ConflictID + ":" + target.TargetFragmentID,
+		RequestHash:    requestHash,
+		SourceSummary:  "overdue conflict deletion-only derivation",
+		Metadata: map[string]any{
+			"conflict_id":                        target.ConflictID,
+			"target_fragment_id":                 target.TargetFragmentID,
+			"target_owner_profile_id":            target.TargetOwnerProfileID,
+			"selected_position_id":               target.SelectedPositionID,
+			"conflict_resolution_deletion_only":  true,
+			"conflict_resolution_policy_version": domain.ConflictOverduePolicyVersion,
+		},
+		Evidence: []EvidenceInput{{
+			Content:    content,
+			SourceType: "observation",
+			Authority:  string(domain.AuthorityInferred),
+			SourceRef:  "conflict:" + target.ConflictID,
+			Metadata: map[string]any{
+				"conflict_id":                       target.ConflictID,
+				"target_fragment_id":                target.TargetFragmentID,
+				"target_owner_profile_id":           target.TargetOwnerProfileID,
+				"selected_position_id":              target.SelectedPositionID,
+				"contract_source_group":             target.SourceGroupKey,
+				"origin_evidence_index":             target.EvidenceIndex,
+				"conflict_resolution_deletion_only": true,
+				"derived_authority":                 string(domain.AuthorityInferred),
+			},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: stage derived evidence: %w", err)
+	}
+	if ingest == nil || ingest.IngestID == "" || len(ingest.Evidence) != 1 || ingest.Evidence[0].FragmentID == "" {
+		return nil, errors.New("conflict review: derived evidence ingest is incomplete")
+	}
+	result := &StageConflictDerivedEvidenceResult{
+		IngestID:            ingest.IngestID,
+		ReplacementFragment: ingest.Evidence[0].FragmentID,
+		Existing:            ingest.Existing,
+	}
+	err = r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		var existingReplacement string
+		err := tx.WithContext(ctx).Raw(`
+			INSERT INTO relationship_conflict_evidence_derivations (
+			    team_id, conflict_id, target_fragment_id, target_owner_profile_id,
+			    selected_position_id, replacement_fragment_id, system_profile_id
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?::uuid,
+			    ?::uuid, ?::uuid, ?::uuid
+			)
+			ON CONFLICT (team_id, conflict_id, target_fragment_id) DO NOTHING
+			RETURNING replacement_fragment_id::text
+		`, target.TeamID, target.ConflictID, target.TargetFragmentID, target.TargetOwnerProfileID,
+			target.SelectedPositionID, result.ReplacementFragment, target.SystemProfileID).Row().Scan(&existingReplacement)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if existingReplacement == "" {
+			if err := tx.WithContext(ctx).Raw(`
+				SELECT replacement_fragment_id::text
+				FROM relationship_conflict_evidence_derivations
+				WHERE team_id = ?::uuid
+				  AND conflict_id = ?::uuid
+				  AND target_fragment_id = ?::uuid
+			`, target.TeamID, target.ConflictID, target.TargetFragmentID).Row().Scan(&existingReplacement); err != nil {
+				return err
+			}
+			result.Existing = true
+		}
+		if existingReplacement != result.ReplacementFragment {
+			return ErrConflictAssessmentStale
+		}
+		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedStaged), "staged", "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_staged", map[string]any{
+			"target_fragment_id":      target.TargetFragmentID,
+			"replacement_fragment_id": result.ReplacementFragment,
+			"replacement_ingest_id":   result.IngestID,
+			"source_group_key":        target.SourceGroupKey,
+			"origin_evidence_index":   target.EvidenceIndex,
+			"authority":               string(domain.AuthorityInferred),
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("conflict review: record derived evidence: %w", err)
+	}
+	return result, nil
+}
+
+func (r *LedgerRepositoryImpl) RecordConflictDerivedEvidenceFailure(
+	ctx context.Context,
+	target ConflictDerivedEvidenceTarget,
+	failureClass string,
+) error {
+	target = normalizeConflictDerivedEvidenceTarget(target)
+	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
+		return err
+	}
+	failureClass = strings.TrimSpace(failureClass)
+	if failureClass == "" || len(failureClass) > 128 {
+		return errors.New("derived evidence failure_class is invalid")
+	}
+	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
+			return err
+		}
+		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedFailed), failureClass, "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_failed", map[string]any{
+			"target_fragment_id": target.TargetFragmentID,
+			"failure_class":      failureClass,
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("conflict review: record derived evidence failure: %w", err)
+	}
+	return nil
+}
+
+func normalizeApplyOverdueConflictResolutionInput(input ApplyOverdueConflictResolutionInput) ApplyOverdueConflictResolutionInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.ConflictID = strings.TrimSpace(input.ConflictID)
+	input.ReviewRunID = strings.TrimSpace(input.ReviewRunID)
+	input.WorkerID = strings.TrimSpace(input.WorkerID)
+	input.PreferredPositionID = strings.TrimSpace(input.PreferredPositionID)
+	input.AssessmentAttemptID = strings.TrimSpace(input.AssessmentAttemptID)
+	input.Method = strings.TrimSpace(input.Method)
+	if input.Now.IsZero() {
+		input.Now = time.Now().UTC()
+	} else {
+		input.Now = input.Now.UTC()
+	}
+	return input
+}
+
+func normalizeResumePendingOverdueConflictResolutionInput(input ResumePendingOverdueConflictResolutionInput) ResumePendingOverdueConflictResolutionInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.ConflictID = strings.TrimSpace(input.ConflictID)
+	input.ReviewRunID = strings.TrimSpace(input.ReviewRunID)
+	input.WorkerID = strings.TrimSpace(input.WorkerID)
+	if input.Now.IsZero() {
+		input.Now = time.Now().UTC()
+	} else {
+		input.Now = input.Now.UTC()
+	}
+	return input
+}
+
+func normalizeConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget) ConflictDerivedEvidenceTarget {
+	target.TeamID = strings.TrimSpace(target.TeamID)
+	target.ConflictID = strings.TrimSpace(target.ConflictID)
+	target.SystemProfileID = strings.TrimSpace(target.SystemProfileID)
+	target.TargetFragmentID = strings.TrimSpace(target.TargetFragmentID)
+	target.TargetOwnerProfileID = strings.TrimSpace(target.TargetOwnerProfileID)
+	target.SelectedPositionID = strings.TrimSpace(target.SelectedPositionID)
+	target.SourceGroupKey = strings.TrimSpace(target.SourceGroupKey)
+	return target
+}
+
+func validateApplyOverdueConflictResolutionInput(input ApplyOverdueConflictResolutionInput) error {
+	for _, value := range []struct {
+		name string
+		id   string
+	}{
+		{name: "team_id", id: input.TeamID},
+		{name: "conflict_id", id: input.ConflictID},
+		{name: "review_run_id", id: input.ReviewRunID},
+		{name: "preferred_position_id", id: input.PreferredPositionID},
+	} {
+		if _, err := uuid.Parse(value.id); err != nil {
+			return fmt.Errorf("%s is required: %w", value.name, err)
+		}
+	}
+	if input.AssessmentAttemptID != "" {
+		if _, err := uuid.Parse(input.AssessmentAttemptID); err != nil {
+			return fmt.Errorf("assessment_attempt_id is invalid: %w", err)
+		}
+	}
+	if input.ExpectedCaseVersion < 1 {
+		return errors.New("expected_case_version is required")
+	}
+	if input.WorkerID == "" {
+		return errors.New("worker_id is required")
+	}
+	if input.Method != "ai" && input.Method != "last_write_wins" {
+		return errors.New("resolution method is unsupported")
+	}
+	return nil
+}
+
+func validateResumePendingOverdueConflictResolutionInput(input ResumePendingOverdueConflictResolutionInput) error {
+	for _, value := range []struct {
+		name string
+		id   string
+	}{
+		{name: "team_id", id: input.TeamID},
+		{name: "conflict_id", id: input.ConflictID},
+		{name: "review_run_id", id: input.ReviewRunID},
+	} {
+		if _, err := uuid.Parse(value.id); err != nil {
+			return fmt.Errorf("%s is required: %w", value.name, err)
+		}
+	}
+	if input.WorkerID == "" {
+		return errors.New("worker_id is required")
+	}
+	return nil
+}
+
+func validateConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget) error {
+	for _, value := range []struct {
+		name string
+		id   string
+	}{
+		{name: "team_id", id: target.TeamID},
+		{name: "conflict_id", id: target.ConflictID},
+		{name: "system_profile_id", id: target.SystemProfileID},
+		{name: "target_fragment_id", id: target.TargetFragmentID},
+		{name: "target_owner_profile_id", id: target.TargetOwnerProfileID},
+		{name: "selected_position_id", id: target.SelectedPositionID},
+	} {
+		if _, err := uuid.Parse(value.id); err != nil {
+			return fmt.Errorf("%s is required: %w", value.name, err)
+		}
+	}
+	if target.SourceGroupKey == "" {
+		return errors.New("source_group_key is required")
+	}
+	if len(target.SourceGroupKey) > 1000 {
+		return errors.New("source_group_key exceeds maximum 1000")
+	}
+	if target.EvidenceIndex < 0 {
+		return errors.New("evidence_index must not be negative")
+	}
+	return nil
+}
+
+func setConflictSystemTeamContext(ctx context.Context, tx *gorm.DB, teamID string) error {
+	return tx.WithContext(ctx).Exec("SELECT set_config('app.current_team_id', ?, true)", teamID).Error
+}
+
+func validateConflictResolutionPosition(ctx context.Context, tx *gorm.DB, teamID, conflictID, positionID string) error {
+	var found string
+	err := tx.WithContext(ctx).Raw(`
+		SELECT position_id::text
+		FROM relationship_conflict_positions
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND position_id = ?::uuid
+		  AND active
+	`, teamID, conflictID, positionID).Row().Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrConflictAssessmentStale
+	}
+	return err
+}
+
+func validateConflictResolutionAssessment(
+	ctx context.Context,
+	tx *gorm.DB,
+	input ApplyOverdueConflictResolutionInput,
+) error {
+	if input.AssessmentAttemptID == "" {
+		return ErrConflictAssessmentStale
+	}
+	var status string
+	var selectedPositionID string
+	var model string
+	var policyVersion string
+	err := tx.WithContext(ctx).Raw(`
+		SELECT status,
+		       COALESCE(selected_position_id::text, ''),
+		       model,
+		       policy_version
+		FROM relationship_conflict_ai_assessment_attempts
+		WHERE team_id = ?::uuid
+		  AND assessment_attempt_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND case_version = ?
+	`, input.TeamID, input.AssessmentAttemptID, input.ConflictID, input.ExpectedCaseVersion).Row().Scan(
+		&status,
+		&selectedPositionID,
+		&model,
+		&policyVersion,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrConflictAssessmentStale
+	}
+	if err != nil {
+		return err
+	}
+	switch input.Method {
+	case "ai":
+		if status != "selected" || selectedPositionID != input.PreferredPositionID {
+			return ErrConflictAssessmentStale
+		}
+	case "last_write_wins":
+		if status == "abstained" {
+			return nil
+		}
+		if status != "failed" {
+			return ErrConflictAssessmentStale
+		}
+		failureCount, err := countFailedOverdueConflictAssessments(
+			ctx,
+			tx,
+			input.TeamID,
+			input.ConflictID,
+			input.ExpectedCaseVersion,
+			model,
+			policyVersion,
+		)
+		if err != nil {
+			return err
+		}
+		if failureCount < conflictAssessmentMaxFailedDays {
+			return ErrConflictAssessmentStale
+		}
+	default:
+		return ErrConflictAssessmentStale
+	}
+	return nil
+}
+
+func expirePriorOverdueConflictAssessmentReservations(
+	ctx context.Context,
+	tx *gorm.DB,
+	input ReserveOverdueConflictAssessmentInput,
+	caseVersion int,
+) error {
+	rows, err := tx.WithContext(ctx).Raw(`
+		UPDATE relationship_conflict_ai_assessment_attempts
+		SET status = 'failed',
+		    failure_class = 'reservation_expired',
+		    completed_at = now()
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND case_version = ?
+		  AND model = ?
+		  AND policy_version = ?
+		  AND status = 'reserved'
+		  AND local_assessment_date < ?
+		RETURNING assessment_attempt_id::text
+	`, input.TeamID, input.ConflictID, caseVersion, input.Model, input.PolicyVersion, input.LocalAssessmentDate).Rows()
+	if err != nil {
+		return err
+	}
+	assessmentAttemptIDs := []string{}
+	for rows.Next() {
+		var assessmentAttemptID string
+		if err := rows.Scan(&assessmentAttemptID); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		assessmentAttemptIDs = append(assessmentAttemptIDs, assessmentAttemptID)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, assessmentAttemptID := range assessmentAttemptIDs {
+		metadata := map[string]any{
+			"case_version":  caseVersion,
+			"failure_class": "reservation_expired",
+		}
+		if err := appendConflictAssessmentEvent(ctx, tx, input.TeamID, assessmentAttemptID, "failed", "reservation_expired", metadata); err != nil {
+			return err
+		}
+		if err := appendRelationshipConflictEvent(ctx, tx, input.TeamID, input.ConflictID, "", "", "", string(domain.RelationshipConflictEventAIAssessed), "reservation_expired", "case:"+input.ConflictID+":assessment:"+assessmentAttemptID+":failed", metadata); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func countFailedOverdueConflictAssessments(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+	caseVersion int,
+	model string,
+	policyVersion string,
+) (int, error) {
+	var count int
+	err := tx.WithContext(ctx).Raw(`
+		SELECT count(*)::int
+		FROM relationship_conflict_ai_assessment_attempts
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND case_version = ?
+		  AND model = ?
+		  AND policy_version = ?
+		  AND status = 'failed'
+	`, teamID, conflictID, caseVersion, model, policyVersion).Row().Scan(&count)
+	return count, err
+}
+
+func latestFailedOverdueConflictAssessmentID(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+	caseVersion int,
+	model string,
+	policyVersion string,
+) (string, error) {
+	var assessmentAttemptID string
+	err := tx.WithContext(ctx).Raw(`
+		SELECT assessment_attempt_id::text
+		FROM relationship_conflict_ai_assessment_attempts
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND case_version = ?
+		  AND model = ?
+		  AND policy_version = ?
+		  AND status = 'failed'
+		ORDER BY completed_at DESC NULLS LAST, created_at DESC, assessment_attempt_id DESC
+		LIMIT 1
+	`, teamID, conflictID, caseVersion, model, policyVersion).Row().Scan(&assessmentAttemptID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrConflictAssessmentStale
+	}
+	return assessmentAttemptID, err
+}
+
+func ensureConflictResolutionPlan(
+	ctx context.Context,
+	tx *gorm.DB,
+	input ApplyOverdueConflictResolutionInput,
+	effectiveAt time.Time,
+	effectiveTimeBasis string,
+) (string, string, error) {
+	var existingID string
+	var existingPositionID string
+	var existingStatus string
+	err := tx.WithContext(ctx).Raw(`
+		SELECT resolution_plan_id::text, preferred_position_id::text, status
+		FROM relationship_conflict_resolution_plans
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND expected_case_version = ?
+		FOR UPDATE
+	`, input.TeamID, input.ConflictID, input.ExpectedCaseVersion).Row().Scan(&existingID, &existingPositionID, &existingStatus)
+	if err == nil {
+		if existingPositionID != input.PreferredPositionID {
+			return "", "", ErrConflictAssessmentStale
+		}
+		return existingID, existingStatus, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", "", err
+	}
+	method := input.Method
+	rows, err := tx.WithContext(ctx).Raw(`
+		INSERT INTO relationship_conflict_resolution_plans (
+		    team_id, conflict_id, expected_case_version, preferred_position_id,
+		    assessment_attempt_id, method, effective_at, effective_time_basis
+		) VALUES (
+		    ?::uuid, ?::uuid, ?, ?::uuid,
+		    NULLIF(?, '')::uuid, ?, ?, ?
+		)
+		RETURNING resolution_plan_id::text, status
+	`, input.TeamID, input.ConflictID, input.ExpectedCaseVersion, input.PreferredPositionID,
+		input.AssessmentAttemptID, method, effectiveAt, effectiveTimeBasis).Rows()
+	if err != nil {
+		return "", "", err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return "", "", sql.ErrNoRows
+	}
+	if err := rows.Scan(&existingID, &existingStatus); err != nil {
+		return "", "", err
+	}
+	return existingID, existingStatus, rows.Err()
+}
+
+func markConflictResolutionPlanSuperseded(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+	expectedCaseVersion int,
+) error {
+	return tx.WithContext(ctx).Exec(`
+		UPDATE relationship_conflict_resolution_plans
+		SET status = 'superseded',
+		    failure_reason = 'case_version_changed'
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND expected_case_version = ?
+		  AND status = 'resolution_pending'
+	`, teamID, conflictID, expectedCaseVersion).Error
+}
+
+func conflictResolutionEffectiveTime(record RelationshipConflictCaseRecord, preferredPositionID string, now time.Time) (time.Time, string) {
+	for _, position := range record.Positions {
+		if position.PositionID != preferredPositionID || position.EffectiveAt == nil {
+			continue
+		}
+		basis := strings.TrimSpace(position.EffectiveTimeBasis)
+		if basis == "" {
+			basis = "recorded_at"
+		}
+		return position.EffectiveAt.UTC(), basis
+	}
+	return now.UTC(), "recorded_at"
+}
+
+func conflictResolutionReason(method string) string {
+	if method == "last_write_wins" {
+		return domain.ConflictResolutionReasonLWW
+	}
+	return domain.ConflictResolutionReasonAI
+}
+
+type conflictLosingEvidenceTarget struct {
+	FragmentID     string
+	OwnerProfileID string
+	SourceGroupKey string
+	EvidenceIndex  int
+}
+
+func loadConflictLosingEvidenceTargets(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictID string,
+	preferredPositionID string,
+) ([]conflictLosingEvidenceTarget, error) {
+	rows, err := tx.WithContext(ctx).Raw(`
+		WITH active_members AS (
+			SELECT member.position_id,
+			       member.relationship_id,
+			       member.fragment_id,
+			       member.owner_profile_id,
+			       member.source_group_key
+			FROM relationship_conflict_position_members AS member
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.active
+			  AND member.fragment_id IS NOT NULL
+		),
+		losing_members AS (
+			SELECT member.fragment_id,
+			       member.owner_profile_id,
+			       MIN(member.source_group_key) AS source_group_key
+			FROM active_members AS member
+			WHERE member.position_id <> ?::uuid
+			GROUP BY member.fragment_id, member.owner_profile_id
+		),
+		targets AS (
+			SELECT loser.fragment_id, loser.owner_profile_id, loser.source_group_key
+			FROM losing_members AS loser
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM active_members AS preferred
+				WHERE preferred.position_id = ?::uuid
+				  AND preferred.fragment_id = loser.fragment_id
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM relationship_evidence_supports AS shared
+				WHERE shared.team_id = ?::uuid
+				  AND shared.fragment_id = loser.fragment_id
+				  AND shared.owner_profile_id = loser.owner_profile_id
+				  AND NOT EXISTS (
+					  SELECT 1
+					  FROM active_members AS case_member
+					  WHERE case_member.relationship_id = shared.relationship_id
+				  )
+			)
+		)
+		SELECT target.fragment_id::text,
+		       target.owner_profile_id::text,
+		       target.source_group_key,
+		       fragment.evidence_index
+		FROM targets AS target
+		JOIN evidence_fragments AS fragment
+		  ON fragment.team_id = ?::uuid
+		 AND fragment.fragment_id = target.fragment_id
+		LEFT JOIN evidence_lifecycle_events AS lifecycle
+		  ON lifecycle.team_id = fragment.team_id
+		 AND lifecycle.target_fragment_id = fragment.fragment_id
+		WHERE lifecycle.lifecycle_event_id IS NULL
+		ORDER BY target.owner_profile_id, target.fragment_id
+	`, teamID, conflictID, preferredPositionID, preferredPositionID, teamID, teamID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	targets := []conflictLosingEvidenceTarget{}
+	for rows.Next() {
+		var target conflictLosingEvidenceTarget
+		if err := rows.Scan(&target.FragmentID, &target.OwnerProfileID, &target.SourceGroupKey, &target.EvidenceIndex); err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+	return targets, rows.Err()
+}
+
+func retractConflictLosingEvidence(
+	ctx context.Context,
+	tx *gorm.DB,
+	input ApplyOverdueConflictResolutionInput,
+	systemProfileID string,
+	targets []conflictLosingEvidenceTarget,
+) ([]string, error) {
+	byOwner := make(map[string]map[string]struct{})
+	for _, target := range targets {
+		if _, ok := byOwner[target.OwnerProfileID]; !ok {
+			byOwner[target.OwnerProfileID] = make(map[string]struct{})
+		}
+		byOwner[target.OwnerProfileID][target.FragmentID] = struct{}{}
+	}
+	ownerIDs := make([]string, 0, len(byOwner))
+	for ownerID := range byOwner {
+		ownerIDs = append(ownerIDs, ownerID)
+	}
+	sort.Strings(ownerIDs)
+	retracted := make([]string, 0, len(targets))
+	for _, ownerID := range ownerIDs {
+		fragmentIDs := make([]string, 0, len(byOwner[ownerID]))
+		for fragmentID := range byOwner[ownerID] {
+			fragmentIDs = append(fragmentIDs, fragmentID)
+		}
+		fragmentIDs = sortedEvidenceIDs(fragmentIDs)
+		for start := 0; start < len(fragmentIDs); start += 50 {
+			end := start + 50
+			if end > len(fragmentIDs) {
+				end = len(fragmentIDs)
+			}
+			chunk := fragmentIDs[start:end]
+			if err := lockEvidenceLifecycleTargetIDs(ctx, tx, input.TeamID, chunk); err != nil {
+				return nil, err
+			}
+			operation := evidenceLifecycleOperationInput{
+				TeamID:         input.TeamID,
+				OwnerProfileID: ownerID,
+				ActorProfileID: systemProfileID,
+				Action:         "retract",
+				EvidenceIDs:    chunk,
+				Reason:         "overdue conflict resolution",
+				IdempotencyKey: "conflict:" + input.ConflictID + ":owner:" + ownerID + ":retract:" + fmt.Sprint(start/50),
+				RequestHash:    sha256Hex(input.ConflictID + "\x00" + input.PreferredPositionID + "\x00" + strings.Join(chunk, ",")),
+			}
+			plan, err := planEvidenceLifecycleInSystem(ctx, tx, operation)
+			if err != nil {
+				return nil, err
+			}
+			operationID, err := insertEvidenceLifecycleOperation(ctx, tx, operation, plan)
+			if err != nil {
+				return nil, err
+			}
+			if err := insertEvidenceLifecycleEvents(ctx, tx, operation, operationID); err != nil {
+				return nil, err
+			}
+			if err := applyEvidenceLifecycleEffectsInSystem(ctx, tx, operation, operationID, plan); err != nil {
+				return nil, err
+			}
+			for _, fragmentID := range chunk {
+				if err := appendRelationshipConflictEvent(ctx, tx, input.TeamID, input.ConflictID, input.PreferredPositionID, "", ownerID, string(domain.RelationshipConflictEventEvidenceRetracted), "retracted", "case:"+input.ConflictID+":evidence:"+fragmentID+":retracted", map[string]any{
+					"fragment_id":            fragmentID,
+					"lifecycle_operation_id": operationID,
+				}); err != nil {
+					return nil, err
+				}
+				retracted = append(retracted, fragmentID)
+			}
+		}
+	}
+	return retracted, nil
+}
+
+func conflictDerivedEvidenceTargets(
+	teamID string,
+	conflictID string,
+	systemProfileID string,
+	selectedPositionID string,
+	targets []conflictLosingEvidenceTarget,
+	retractedIDs []string,
+) []ConflictDerivedEvidenceTarget {
+	retracted := make(map[string]struct{}, len(retractedIDs))
+	for _, fragmentID := range retractedIDs {
+		retracted[fragmentID] = struct{}{}
+	}
+	result := make([]ConflictDerivedEvidenceTarget, 0, len(retractedIDs))
+	seen := make(map[string]struct{}, len(retractedIDs))
+	for _, target := range targets {
+		key := target.OwnerProfileID + "\x00" + target.FragmentID
+		if _, ok := retracted[target.FragmentID]; !ok {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, ConflictDerivedEvidenceTarget{
+			TeamID:               teamID,
+			ConflictID:           conflictID,
+			SystemProfileID:      systemProfileID,
+			TargetFragmentID:     target.FragmentID,
+			TargetOwnerProfileID: target.OwnerProfileID,
+			SelectedPositionID:   selectedPositionID,
+			SourceGroupKey:       target.SourceGroupKey,
+			EvidenceIndex:        target.EvidenceIndex,
+		})
+	}
+	return result
+}

--- a/internal/repository/conflict_overdue_resolution_repository.go
+++ b/internal/repository/conflict_overdue_resolution_repository.go
@@ -393,8 +393,8 @@ func validateClaimConflictDerivedEvidenceTasksInput(input ClaimConflictDerivedEv
 	if input.Limit < 1 || input.Limit > conflictResolutionMaxFragments {
 		return fmt.Errorf("derived evidence task limit must be between 1 and %d", conflictResolutionMaxFragments)
 	}
-	if input.Lease <= 0 {
-		return errors.New("derived evidence task lease is required")
+	if input.Lease < time.Second {
+		return errors.New("derived evidence task lease must be at least 1 second")
 	}
 	return nil
 }
@@ -477,7 +477,7 @@ func validateConflictResolutionAssessment(
 		if err != nil {
 			return err
 		}
-		if failureCount < conflictAssessmentMaxFailedDays {
+		if failureCount < ConflictAssessmentMaxFailedDays {
 			return ErrConflictAssessmentStale
 		}
 	default:
@@ -509,20 +509,16 @@ func expirePriorOverdueConflictAssessmentReservations(
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 	assessmentAttemptIDs := []string{}
 	for rows.Next() {
 		var assessmentAttemptID string
 		if err := rows.Scan(&assessmentAttemptID); err != nil {
-			_ = rows.Close()
 			return err
 		}
 		assessmentAttemptIDs = append(assessmentAttemptIDs, assessmentAttemptID)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return err
-	}
-	if err := rows.Close(); err != nil {
 		return err
 	}
 	for _, assessmentAttemptID := range assessmentAttemptIDs {

--- a/internal/repository/conflict_overdue_resolution_repository.go
+++ b/internal/repository/conflict_overdue_resolution_repository.go
@@ -109,6 +109,10 @@ func (r *LedgerRepositoryImpl) ApplyOverdueConflictResolution(
 			result.Pending = true
 			return nil
 		}
+		systemProfileID, err := ensureConflictSystemProfile(ctx, tx, input.TeamID)
+		if err != nil {
+			return err
+		}
 		evaluation := RelationshipConflictEvaluation{
 			Outcome:             ConflictReviewOutcomeResolve,
 			Stage:               "overdue_" + input.Method,
@@ -127,11 +131,18 @@ func (r *LedgerRepositoryImpl) ApplyOverdueConflictResolution(
 		if err != nil {
 			return err
 		}
-		systemProfileID, err := ensureConflictSystemProfile(ctx, tx, input.TeamID)
+		retracted, err := retractConflictLosingEvidence(ctx, tx, input, systemProfileID, targets)
 		if err != nil {
 			return err
 		}
-		retracted, err := retractConflictLosingEvidence(ctx, tx, input, systemProfileID, targets)
+		derived, err := enqueueConflictDerivedEvidenceTasks(ctx, tx, planID, conflictDerivedEvidenceTargets(
+			input.TeamID,
+			input.ConflictID,
+			systemProfileID,
+			input.PreferredPositionID,
+			targets,
+			retracted,
+		))
 		if err != nil {
 			return err
 		}
@@ -153,7 +164,7 @@ func (r *LedgerRepositoryImpl) ApplyOverdueConflictResolution(
 		result.Resolved = true
 		result.UpdatedRelationships = updated
 		result.RetractedEvidenceIDs = retracted
-		result.DerivedEvidence = conflictDerivedEvidenceTargets(input.TeamID, input.ConflictID, systemProfileID, input.PreferredPositionID, targets, retracted)
+		result.DerivedEvidence = derived
 		return nil
 	})
 	if err != nil {
@@ -237,149 +248,6 @@ func (r *LedgerRepositoryImpl) ResumePendingOverdueConflictResolution(
 	return result, true, nil
 }
 
-func (r *LedgerRepositoryImpl) StageConflictDerivedEvidence(
-	ctx context.Context,
-	target ConflictDerivedEvidenceTarget,
-) (*StageConflictDerivedEvidenceResult, error) {
-	target = normalizeConflictDerivedEvidenceTarget(target)
-	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
-		return nil, err
-	}
-	content := "Overdue conflict review retracted prior evidence. This deletion-only derivation cannot establish a semantic relationship."
-	requestHash := sha256Hex(strings.Join([]string{
-		target.ConflictID,
-		target.TargetFragmentID,
-		target.SelectedPositionID,
-		target.SourceGroupKey,
-		fmt.Sprint(target.EvidenceIndex),
-		content,
-	}, "\x00"))
-	ingest, err := r.CreateIngest(ctx, CreateIngestInput{
-		TeamID:         target.TeamID,
-		OwnerProfileID: target.SystemProfileID,
-		IdempotencyKey: "conflict-derived:" + target.ConflictID + ":" + target.TargetFragmentID,
-		RequestHash:    requestHash,
-		SourceSummary:  "overdue conflict deletion-only derivation",
-		Metadata: map[string]any{
-			"conflict_id":                        target.ConflictID,
-			"target_fragment_id":                 target.TargetFragmentID,
-			"target_owner_profile_id":            target.TargetOwnerProfileID,
-			"selected_position_id":               target.SelectedPositionID,
-			"conflict_resolution_deletion_only":  true,
-			"conflict_resolution_policy_version": domain.ConflictOverduePolicyVersion,
-		},
-		Evidence: []EvidenceInput{{
-			Content:    content,
-			SourceType: "observation",
-			Authority:  string(domain.AuthorityInferred),
-			SourceRef:  "conflict:" + target.ConflictID,
-			Metadata: map[string]any{
-				"conflict_id":                       target.ConflictID,
-				"target_fragment_id":                target.TargetFragmentID,
-				"target_owner_profile_id":           target.TargetOwnerProfileID,
-				"selected_position_id":              target.SelectedPositionID,
-				"contract_source_group":             target.SourceGroupKey,
-				"origin_evidence_index":             target.EvidenceIndex,
-				"conflict_resolution_deletion_only": true,
-				"derived_authority":                 string(domain.AuthorityInferred),
-			},
-		}},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("conflict review: stage derived evidence: %w", err)
-	}
-	if ingest == nil || ingest.IngestID == "" || len(ingest.Evidence) != 1 || ingest.Evidence[0].FragmentID == "" {
-		return nil, errors.New("conflict review: derived evidence ingest is incomplete")
-	}
-	result := &StageConflictDerivedEvidenceResult{
-		IngestID:            ingest.IngestID,
-		ReplacementFragment: ingest.Evidence[0].FragmentID,
-		Existing:            ingest.Existing,
-	}
-	err = r.withSystemTx(ctx, func(tx *gorm.DB) error {
-		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
-			return err
-		}
-		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
-			return err
-		}
-		var existingReplacement string
-		err := tx.WithContext(ctx).Raw(`
-			INSERT INTO relationship_conflict_evidence_derivations (
-			    team_id, conflict_id, target_fragment_id, target_owner_profile_id,
-			    selected_position_id, replacement_fragment_id, system_profile_id
-		) VALUES (
-			    ?::uuid, ?::uuid, ?::uuid, ?::uuid,
-			    ?::uuid, ?::uuid, ?::uuid
-			)
-			ON CONFLICT (team_id, conflict_id, target_fragment_id) DO NOTHING
-			RETURNING replacement_fragment_id::text
-		`, target.TeamID, target.ConflictID, target.TargetFragmentID, target.TargetOwnerProfileID,
-			target.SelectedPositionID, result.ReplacementFragment, target.SystemProfileID).Row().Scan(&existingReplacement)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		if existingReplacement == "" {
-			if err := tx.WithContext(ctx).Raw(`
-				SELECT replacement_fragment_id::text
-				FROM relationship_conflict_evidence_derivations
-				WHERE team_id = ?::uuid
-				  AND conflict_id = ?::uuid
-				  AND target_fragment_id = ?::uuid
-			`, target.TeamID, target.ConflictID, target.TargetFragmentID).Row().Scan(&existingReplacement); err != nil {
-				return err
-			}
-			result.Existing = true
-		}
-		if existingReplacement != result.ReplacementFragment {
-			return ErrConflictAssessmentStale
-		}
-		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedStaged), "staged", "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_staged", map[string]any{
-			"target_fragment_id":      target.TargetFragmentID,
-			"replacement_fragment_id": result.ReplacementFragment,
-			"replacement_ingest_id":   result.IngestID,
-			"source_group_key":        target.SourceGroupKey,
-			"origin_evidence_index":   target.EvidenceIndex,
-			"authority":               string(domain.AuthorityInferred),
-		})
-	})
-	if err != nil {
-		return nil, fmt.Errorf("conflict review: record derived evidence: %w", err)
-	}
-	return result, nil
-}
-
-func (r *LedgerRepositoryImpl) RecordConflictDerivedEvidenceFailure(
-	ctx context.Context,
-	target ConflictDerivedEvidenceTarget,
-	failureClass string,
-) error {
-	target = normalizeConflictDerivedEvidenceTarget(target)
-	if err := validateConflictDerivedEvidenceTarget(target); err != nil {
-		return err
-	}
-	failureClass = strings.TrimSpace(failureClass)
-	if failureClass == "" || len(failureClass) > 128 {
-		return errors.New("derived evidence failure_class is invalid")
-	}
-	err := r.withSystemTx(ctx, func(tx *gorm.DB) error {
-		if err := setConflictSystemTeamContext(ctx, tx, target.TeamID); err != nil {
-			return err
-		}
-		if err := ensureActiveTeamForMutation(ctx, tx, target.TeamID); err != nil {
-			return err
-		}
-		return appendRelationshipConflictEvent(ctx, tx, target.TeamID, target.ConflictID, target.SelectedPositionID, "", "", string(domain.RelationshipConflictEventDerivedFailed), failureClass, "case:"+target.ConflictID+":evidence:"+target.TargetFragmentID+":derived_failed", map[string]any{
-			"target_fragment_id": target.TargetFragmentID,
-			"failure_class":      failureClass,
-		})
-	})
-	if err != nil {
-		return fmt.Errorf("conflict review: record derived evidence failure: %w", err)
-	}
-	return nil
-}
-
 func normalizeApplyOverdueConflictResolutionInput(input ApplyOverdueConflictResolutionInput) ApplyOverdueConflictResolutionInput {
 	input.TeamID = strings.TrimSpace(input.TeamID)
 	input.ConflictID = strings.TrimSpace(input.ConflictID)
@@ -410,6 +278,7 @@ func normalizeResumePendingOverdueConflictResolutionInput(input ResumePendingOve
 }
 
 func normalizeConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget) ConflictDerivedEvidenceTarget {
+	target.TaskID = strings.TrimSpace(target.TaskID)
 	target.TeamID = strings.TrimSpace(target.TeamID)
 	target.ConflictID = strings.TrimSpace(target.ConflictID)
 	target.SystemProfileID = strings.TrimSpace(target.SystemProfileID)
@@ -418,6 +287,13 @@ func normalizeConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget
 	target.SelectedPositionID = strings.TrimSpace(target.SelectedPositionID)
 	target.SourceGroupKey = strings.TrimSpace(target.SourceGroupKey)
 	return target
+}
+
+func normalizeClaimConflictDerivedEvidenceTasksInput(input ClaimConflictDerivedEvidenceTasksInput) ClaimConflictDerivedEvidenceTasksInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.ReviewRunID = strings.TrimSpace(input.ReviewRunID)
+	input.WorkerID = strings.TrimSpace(input.WorkerID)
+	return input
 }
 
 func validateApplyOverdueConflictResolutionInput(input ApplyOverdueConflictResolutionInput) error {
@@ -475,6 +351,7 @@ func validateConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget)
 		name string
 		id   string
 	}{
+		{name: "derived_evidence_task_id", id: target.TaskID},
 		{name: "team_id", id: target.TeamID},
 		{name: "conflict_id", id: target.ConflictID},
 		{name: "system_profile_id", id: target.SystemProfileID},
@@ -494,6 +371,30 @@ func validateConflictDerivedEvidenceTarget(target ConflictDerivedEvidenceTarget)
 	}
 	if target.EvidenceIndex < 0 {
 		return errors.New("evidence_index must not be negative")
+	}
+	return nil
+}
+
+func validateClaimConflictDerivedEvidenceTasksInput(input ClaimConflictDerivedEvidenceTasksInput) error {
+	for _, value := range []struct {
+		name string
+		id   string
+	}{
+		{name: "team_id", id: input.TeamID},
+		{name: "review_run_id", id: input.ReviewRunID},
+	} {
+		if _, err := uuid.Parse(value.id); err != nil {
+			return fmt.Errorf("%s is required: %w", value.name, err)
+		}
+	}
+	if input.WorkerID == "" {
+		return errors.New("worker_id is required")
+	}
+	if input.Limit < 1 || input.Limit > conflictResolutionMaxFragments {
+		return fmt.Errorf("derived evidence task limit must be between 1 and %d", conflictResolutionMaxFragments)
+	}
+	if input.Lease <= 0 {
+		return errors.New("derived evidence task lease is required")
 	}
 	return nil
 }
@@ -975,4 +876,48 @@ func conflictDerivedEvidenceTargets(
 		})
 	}
 	return result
+}
+
+func enqueueConflictDerivedEvidenceTasks(
+	ctx context.Context,
+	tx *gorm.DB,
+	resolutionPlanID string,
+	targets []ConflictDerivedEvidenceTarget,
+) ([]ConflictDerivedEvidenceTarget, error) {
+	result := make([]ConflictDerivedEvidenceTarget, 0, len(targets))
+	for _, target := range targets {
+		var taskID string
+		err := tx.WithContext(ctx).Raw(`
+			INSERT INTO relationship_conflict_derived_evidence_tasks (
+			    team_id, resolution_plan_id, conflict_id,
+			    target_fragment_id, target_owner_profile_id, selected_position_id,
+			    system_profile_id, source_group_key, origin_evidence_index
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid,
+			    ?::uuid, ?::uuid, ?::uuid,
+			    ?::uuid, ?, ?
+		)
+			ON CONFLICT (team_id, conflict_id, target_fragment_id) DO NOTHING
+			RETURNING derived_evidence_task_id::text
+		`, target.TeamID, resolutionPlanID, target.ConflictID,
+			target.TargetFragmentID, target.TargetOwnerProfileID, target.SelectedPositionID,
+			target.SystemProfileID, target.SourceGroupKey, target.EvidenceIndex).Row().Scan(&taskID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		if taskID == "" {
+			if err := tx.WithContext(ctx).Raw(`
+				SELECT derived_evidence_task_id::text
+				FROM relationship_conflict_derived_evidence_tasks
+				WHERE team_id = ?::uuid
+				  AND conflict_id = ?::uuid
+				  AND target_fragment_id = ?::uuid
+			`, target.TeamID, target.ConflictID, target.TargetFragmentID).Row().Scan(&taskID); err != nil {
+				return nil, err
+			}
+		}
+		target.TaskID = taskID
+		result = append(result, target)
+	}
+	return result, nil
 }

--- a/internal/repository/conflict_overdue_review_security_integration_test.go
+++ b/internal/repository/conflict_overdue_review_security_integration_test.go
@@ -1,0 +1,344 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestConflictResolutionDeletionOnlyMarkerRequiresSystemOrigin(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "conflict-deletion-only-origin-team")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "conflict-deletion-only-origin-owner")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	marker := map[string]any{"conflict_resolution_deletion_only": true}
+
+	callerIngest, err := ledgerRepo.CreateIngest(ctx, CreateIngestInput{
+		TeamID:         teamID,
+		OwnerProfileID: ownerID,
+		IdempotencyKey: "caller-deletion-only-marker",
+		RequestHash:    sha256Hex("caller-deletion-only-marker"),
+		SourceSummary:  conflictResolutionDeletionOnlySourceSummary,
+		Metadata:       marker,
+		Evidence: []EvidenceInput{{
+			Content:    "Caller-selected deletion-only marker.",
+			SourceType: "observation",
+			Authority:  string(domain.AuthorityInferred),
+			Metadata:   marker,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, callerIngest.Evidence, 1)
+
+	var callerDeletionOnly bool
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		var err error
+		callerDeletionOnly, err = isConflictResolutionDeletionOnlyFragment(ctx, tx, teamID, callerIngest.Evidence[0].FragmentID)
+		return err
+	}))
+	assert.False(t, callerDeletionOnly)
+
+	var systemProfileID string
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, teamID); err != nil {
+			return err
+		}
+		var err error
+		systemProfileID, err = ensureConflictSystemProfile(ctx, tx, teamID)
+		return err
+	}))
+	systemIngest, err := ledgerRepo.CreateIngest(ctx, CreateIngestInput{
+		TeamID:         teamID,
+		OwnerProfileID: systemProfileID,
+		IdempotencyKey: "system-deletion-only-marker",
+		RequestHash:    sha256Hex("system-deletion-only-marker"),
+		SourceSummary:  conflictResolutionDeletionOnlySourceSummary,
+		Metadata:       marker,
+		Evidence: []EvidenceInput{{
+			Content:    "System-staged deletion-only marker.",
+			SourceType: "observation",
+			Authority:  string(domain.AuthorityInferred),
+			Metadata:   marker,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, systemIngest.Evidence, 1)
+
+	var systemDeletionOnly, missingDeletionOnly bool
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		var err error
+		systemDeletionOnly, err = isConflictResolutionDeletionOnlyFragment(ctx, tx, teamID, systemIngest.Evidence[0].FragmentID)
+		if err != nil {
+			return err
+		}
+		missingDeletionOnly, err = isConflictResolutionDeletionOnlyFragment(ctx, tx, teamID, uuid.NewString())
+		return err
+	}))
+	assert.True(t, systemDeletionOnly)
+	assert.False(t, missingDeletionOnly)
+}
+
+func TestOverdueConflictWorkflowTablesEnforceCrossTeamRLS(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-workflow-rls", 3, "exact", "")
+	teamA := createLedgerTeam(t, adminDB, rls, "overdue-workflow-rls-team-a")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamA, "overdue-workflow-rls-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamA, "overdue-workflow-rls-owner-b")
+	teamB := createLedgerTeam(t, adminDB, rls, "overdue-workflow-rls-team-b")
+	ownerC := createLedgerProfile(t, adminDB, rls, teamB, "overdue-workflow-rls-owner-c")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamA, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamA, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamA, ownerA, "product", "GraphDB")
+	preferred := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamA, ownerA, "worker-overdue-workflow-rls-a",
+		"overdue-workflow-rls-a", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "source-group-overdue-workflow-rls-a",
+	)
+	loser := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamA, ownerB, "worker-overdue-workflow-rls-b",
+		"overdue-workflow-rls-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "source-group-overdue-workflow-rls-b",
+	)
+	conflictID, caseVersion := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamA, ownerA, subject.EntityID)
+
+	var preferredPositionID, targetFragmentID, systemProfileID string
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, teamA); err != nil {
+			return err
+		}
+		var err error
+		systemProfileID, err = ensureConflictSystemProfile(ctx, tx, teamA)
+		if err != nil {
+			return err
+		}
+		if err := tx.Raw(`
+			SELECT member.position_id::text
+			FROM relationship_conflict_position_members AS member
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.relationship_id = ?::uuid
+			  AND member.active
+		`, teamA, conflictID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredPositionID); err != nil {
+			return err
+		}
+		return tx.Raw(`
+			SELECT support.fragment_id::text
+			FROM relationship_evidence_supports AS support
+			WHERE support.team_id = ?::uuid
+			  AND support.relationship_id = ?::uuid
+			  AND support.owner_profile_id = ?::uuid
+		`, teamA, loser.RelationshipResults[0].Relationship.RelationshipID, ownerB).Row().Scan(&targetFragmentID)
+	}))
+
+	assessmentAttemptID := uuid.NewString()
+	resolutionPlanID := uuid.NewString()
+	derivedTaskID := uuid.NewString()
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, teamA); err != nil {
+			return err
+		}
+		if err := tx.Exec(`
+			INSERT INTO relationship_conflict_ai_assessment_attempts (
+			    team_id, assessment_attempt_id, conflict_id, case_version, local_assessment_date,
+			    model, policy_version, status, failure_class, completed_at
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?, CURRENT_DATE,
+			    'test-model', ?, 'failed', 'test_failure', now()
+		)
+		`, teamA, assessmentAttemptID, conflictID, caseVersion, domain.ConflictOverduePolicyVersion).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`
+			INSERT INTO relationship_conflict_ai_assessment_events (
+			    team_id, assessment_attempt_id, action, outcome
+		) VALUES (
+			    ?::uuid, ?::uuid, 'failed', 'test_failure'
+		)
+		`, teamA, assessmentAttemptID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`
+			INSERT INTO relationship_conflict_resolution_plans (
+			    team_id, resolution_plan_id, conflict_id, expected_case_version,
+			    preferred_position_id, assessment_attempt_id, method, effective_at
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?, ?::uuid, ?::uuid, 'ai', now()
+		)
+		`, teamA, resolutionPlanID, conflictID, caseVersion, preferredPositionID, assessmentAttemptID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`
+			INSERT INTO relationship_conflict_evidence_derivations (
+			    team_id, conflict_id, target_fragment_id, target_owner_profile_id,
+			    selected_position_id, system_profile_id
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?::uuid, ?::uuid, ?::uuid
+		)
+		`, teamA, conflictID, targetFragmentID, ownerB, preferredPositionID, systemProfileID).Error; err != nil {
+			return err
+		}
+		return tx.Exec(`
+			INSERT INTO relationship_conflict_derived_evidence_tasks (
+			    team_id, derived_evidence_task_id, resolution_plan_id, conflict_id,
+			    target_fragment_id, target_owner_profile_id, selected_position_id,
+			    system_profile_id, source_group_key, origin_evidence_index
+		) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, ?::uuid,
+			    ?::uuid, ?::uuid, ?::uuid, ?::uuid, 'test-source-group', 0
+		)
+		`, teamA, derivedTaskID, resolutionPlanID, conflictID, targetFragmentID, ownerB, preferredPositionID, systemProfileID).Error
+	}))
+
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamB, ownerC, func(tx *gorm.DB) error {
+		var total int
+		if err := tx.Raw(`
+			SELECT
+			    (SELECT count(*) FROM relationship_conflict_ai_assessment_attempts WHERE team_id = ?::uuid) +
+			    (SELECT count(*) FROM relationship_conflict_ai_assessment_events WHERE team_id = ?::uuid) +
+			    (SELECT count(*) FROM relationship_conflict_resolution_plans WHERE team_id = ?::uuid) +
+			    (SELECT count(*) FROM relationship_conflict_evidence_derivations WHERE team_id = ?::uuid) +
+			    (SELECT count(*) FROM relationship_conflict_derived_evidence_tasks WHERE team_id = ?::uuid)
+		`, teamA, teamA, teamA, teamA, teamA).Row().Scan(&total); err != nil {
+			return err
+		}
+		if total != 0 {
+			return errors.New("cross-team workflow rows were visible")
+		}
+		updated := tx.Exec(`
+			UPDATE relationship_conflict_ai_assessment_attempts
+			SET failure_class = 'cross_team'
+			WHERE team_id = ?::uuid
+		`, teamA)
+		if updated.Error != nil {
+			return updated.Error
+		}
+		if updated.RowsAffected != 0 {
+			return errors.New("cross-team workflow row was updated")
+		}
+		return nil
+	}))
+	err := rls.WithTeamProfileTx(ctx, appDB, teamB, ownerC, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO relationship_conflict_ai_assessment_events (
+			    team_id, assessment_attempt_id, action, outcome
+		) VALUES (
+			    ?::uuid, ?::uuid, 'failed', 'cross_team'
+		)
+		`, teamA, assessmentAttemptID).Error
+	})
+	require.Error(t, err)
+
+	stale, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
+		TeamID:              teamB,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-workflow-rls-cross-team",
+		ExpectedCaseVersion: caseVersion,
+		PreferredPositionID: preferredPositionID,
+		AssessmentAttemptID: assessmentAttemptID,
+		Method:              "ai",
+		Now:                 time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	assert.True(t, stale.Stale)
+}
+
+func TestOverdueConflictDossierKeepsStrongestSupportInSourceGroup(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-authority-dedup", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "overdue-authority-dedup-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "overdue-authority-dedup-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "overdue-authority-dedup-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	preferredContent := "Dense-Mem uses PostgreSQL. Dense-Mem uses PostgreSQL."
+	preferredQuote := "Dense-Mem uses PostgreSQL."
+	preferredSecondStart := strings.LastIndex(preferredContent, preferredQuote)
+	require.Greater(t, preferredSecondStart, 0)
+	preferred := commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-overdue-authority-dedup-a",
+		"overdue-authority-dedup-a", preferredContent, subject.EntityID, postgres.EntityID, "source-group-overdue-authority-dedup-a",
+		conflictTestRelationshipOptions{
+			authority: "primary",
+			additionalSupports: []conflictTestAdditionalSupport{{
+				sourceGroupKey: "source-group-overdue-authority-dedup-a",
+				spanStart:      preferredSecondStart,
+				spanEnd:        preferredSecondStart + len(preferredQuote),
+				quote:          preferredQuote,
+				authority:      "inferred",
+			}},
+		},
+	)
+	commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-overdue-authority-dedup-b",
+		"overdue-authority-dedup-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "source-group-overdue-authority-dedup-b",
+		conflictTestRelationshipOptions{authority: "secondary"},
+	)
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?, next_review_at = ?
+			WHERE team_id = ?::uuid AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+	review := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "worker-overdue-authority-dedup-review", conflictID, reviewNow)
+	require.Equal(t, ConflictReviewOutcomeOverdue, review.Outcome)
+	reservation, dossier, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-authority-dedup-assessment",
+		LocalAssessmentDate: reviewNow,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, reservation)
+	require.NotNil(t, dossier)
+
+	preferredPositionID := ""
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT position_id::text
+			FROM relationship_conflict_position_members
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			  AND relationship_id = ?::uuid
+			  AND active
+		`, teamID, conflictID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredPositionID)
+	}))
+	positions := make([]domain.ConflictResolutionPosition, 0, len(dossier.Positions))
+	for _, position := range dossier.Positions {
+		positions = append(positions, domain.ConflictResolutionPosition{
+			PositionID: position.PositionID,
+			Supports:   position.Supports,
+		})
+	}
+	winner, ok := domain.SelectConflictLastWriteWinner(positions)
+	require.True(t, ok)
+	assert.Equal(t, preferredPositionID, winner.PositionID)
+	assert.Equal(t, "primary", winner.Authority)
+}

--- a/internal/repository/conflict_overdue_shared_evidence_integration_test.go
+++ b/internal/repository/conflict_overdue_shared_evidence_integration_test.go
@@ -1,0 +1,217 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestOverdueConflictResolutionPreservesSharedEvidenceOutsideConflict(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-conflict-shared-evidence", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "overdue-conflict-shared-evidence-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-shared-evidence-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-shared-evidence-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	unrelatedSubject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerB, "project", "Other Project")
+	preferred := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-overdue-shared-preferred",
+		"overdue-shared-preferred", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "source-group-overdue-shared-preferred",
+	)
+
+	sharedContent := "Dense-Mem uses GraphDB. Other Project uses PostgreSQL."
+	losingQuote := "Dense-Mem uses GraphDB."
+	unrelatedQuote := "Other Project uses PostgreSQL."
+	losingStart := strings.Index(sharedContent, losingQuote)
+	unrelatedStart := strings.Index(sharedContent, unrelatedQuote)
+	require.GreaterOrEqual(t, losingStart, 0)
+	require.GreaterOrEqual(t, unrelatedStart, 0)
+	sharedIngest := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerB, "overdue-shared-evidence", sharedContent)
+	claimed, err := ledgerRepo.ClaimNextPlacementRun(ctx, teamID, "worker-overdue-shared-loser", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	committed, err := ledgerRepo.CommitPlacementSemanticResult(ctx, CommitPlacementSemanticInput{
+		TeamID:           teamID,
+		OwnerProfileID:   ownerB,
+		IngestID:         sharedIngest.IngestID,
+		PlacementRunID:   sharedIngest.PlacementRunID,
+		PlacementItemID:  sharedIngest.Items[0].PlacementItemID,
+		WorkerID:         "worker-overdue-shared-loser",
+		ExpectedAttempts: claimed.Attempts,
+		EntityResolutions: []PlacementEntityResolutionInput{
+			{MentionRef: "losing-subject", Action: "reuse", EntityID: subject.EntityID},
+			{MentionRef: "losing-object", Action: "reuse", EntityID: graphdb.EntityID},
+			{MentionRef: "unrelated-subject", Action: "reuse", EntityID: unrelatedSubject.EntityID},
+			{MentionRef: "unrelated-object", Action: "reuse", EntityID: postgres.EntityID},
+		},
+		RelationshipObservations: []PlacementRelationshipDecisionInput{
+			{
+				Ref:          "shared-losing-relationship",
+				SubjectRef:   "losing-subject",
+				PredicateKey: "primary_database",
+				ObjectRef:    "losing-object",
+				Support: &EvidenceSupportInput{
+					FragmentID:     sharedIngest.Evidence[0].FragmentID,
+					SourceGroupKey: "source-group-overdue-shared-loser",
+					SpanStart:      losingStart,
+					SpanEnd:        losingStart + len(losingQuote),
+					Quote:          losingQuote,
+					Authority:      "primary",
+				},
+			},
+			{
+				Ref:          "shared-unrelated-relationship",
+				SubjectRef:   "unrelated-subject",
+				PredicateKey: "primary_database",
+				ObjectRef:    "unrelated-object",
+				Support: &EvidenceSupportInput{
+					FragmentID:     sharedIngest.Evidence[0].FragmentID,
+					SourceGroupKey: "source-group-overdue-shared-unrelated",
+					SpanStart:      unrelatedStart,
+					SpanEnd:        unrelatedStart + len(unrelatedQuote),
+					Quote:          unrelatedQuote,
+					Authority:      "primary",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, committed.RelationshipResults, 2)
+	require.NotNil(t, committed.RelationshipResults[0].Relationship)
+	require.NotNil(t, committed.RelationshipResults[1].Relationship)
+	losingRelationshipID := committed.RelationshipResults[0].Relationship.RelationshipID
+	unrelatedRelationshipID := committed.RelationshipResults[1].Relationship.RelationshipID
+
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?,
+			    next_review_at = ?
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+	review := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "worker-overdue-shared-review", conflictID, reviewNow)
+	require.Equal(t, ConflictReviewOutcomeOverdue, review.Outcome)
+
+	reservation, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-shared-assessment",
+		LocalAssessmentDate: reviewNow,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, reservation)
+
+	preferredPositionID := ""
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT member.position_id::text
+			FROM relationship_conflict_position_members AS member
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.relationship_id = ?::uuid
+			  AND member.active
+		`, teamID, conflictID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredPositionID)
+	}))
+	confidence := 0.92
+	_, err = ledgerRepo.CompleteOverdueConflictAssessment(ctx, CompleteOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		CaseVersion:         reservation.CaseVersion,
+		ReviewRunID:         uuid.NewString(),
+		Decision:            "selected",
+		SelectedPositionID:  preferredPositionID,
+		Confidence:          &confidence,
+		ProviderTurns:       1,
+		ResponseHash:        "sha256:shared-evidence",
+	})
+	require.NoError(t, err)
+	applied, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-shared-apply",
+		ExpectedCaseVersion: reservation.CaseVersion,
+		PreferredPositionID: preferredPositionID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		Method:              "ai",
+		Now:                 reviewNow,
+	})
+	require.NoError(t, err)
+	require.True(t, applied.Resolved)
+	assert.Empty(t, applied.RetractedEvidenceIDs)
+	assert.Empty(t, applied.DerivedEvidence)
+
+	var conflictStatus, losingStatus, unrelatedStatus, evidenceSearchState string
+	var losingSupportCount, unrelatedSupportCount, lifecycleCount, derivationCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT status
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Row().Scan(&conflictStatus))
+		require.NoError(t, tx.Raw(`
+			SELECT status, support_count
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, losingRelationshipID).Row().Scan(&losingStatus, &losingSupportCount))
+		require.NoError(t, tx.Raw(`
+			SELECT status, support_count
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, unrelatedRelationshipID).Row().Scan(&unrelatedStatus, &unrelatedSupportCount))
+		require.NoError(t, tx.Raw(`
+			SELECT search_state
+			FROM search_documents
+			WHERE team_id = ?::uuid
+			  AND source_kind = 'evidence'
+			  AND source_id = ?::uuid
+		`, teamID, sharedIngest.Evidence[0].FragmentID).Row().Scan(&evidenceSearchState))
+		require.NoError(t, tx.Raw(`
+			SELECT count(*)
+			FROM evidence_lifecycle_events
+			WHERE team_id = ?::uuid
+			  AND target_fragment_id = ?::uuid
+		`, teamID, sharedIngest.Evidence[0].FragmentID).Scan(&lifecycleCount).Error)
+		return tx.Raw(`
+			SELECT count(*)
+			FROM relationship_conflict_evidence_derivations
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Scan(&derivationCount).Error
+	}))
+	assert.Equal(t, "resolved", conflictStatus)
+	assert.Equal(t, "superseded", losingStatus)
+	assert.Equal(t, int64(1), losingSupportCount)
+	assert.Equal(t, "active", unrelatedStatus)
+	assert.Equal(t, int64(1), unrelatedSupportCount)
+	assert.NotEqual(t, "not_required", evidenceSearchState)
+	assert.Equal(t, int64(0), lifecycleCount)
+	assert.Equal(t, int64(0), derivationCount)
+}

--- a/internal/repository/conflict_repository.go
+++ b/internal/repository/conflict_repository.go
@@ -78,6 +78,10 @@ type ReviewRelationshipConflictCaseResult struct {
 	Stage                string
 	PreferredPositionID  string
 	UpdatedRelationships []string
+	RetractedEvidenceIDs []string
+	AssessmentAttemptID  string
+	ResolutionMethod     string
+	ResolutionPending    bool
 }
 
 type RelationshipConflictCaseRecord struct {
@@ -143,6 +147,7 @@ type conflictPlacementRow struct {
 	FragmentID              string
 	SourceGroupKey          string
 	Authority               string
+	AcceptedAt              time.Time
 	EffectiveAt             *time.Time
 	EffectiveTimeBasis      string
 	RecordedFallback        bool
@@ -248,6 +253,7 @@ func loadRelationshipConflictPlacement(
 			       support.support_id,
 			       support.verification_event_id,
 			       support.fragment_id,
+			       support.created_at AS accepted_at,
 			       COALESCE(
 			           NULLIF(source.source_key, ''),
 			           NULLIF(fragment.metadata->>'contract_source_group', ''),
@@ -274,7 +280,12 @@ func loadRelationshipConflictPlacement(
 			LEFT JOIN evidence_sources AS source
 			  ON source.team_id = support.team_id
 			 AND source.source_id = support.source_id
+			LEFT JOIN evidence_lifecycle_events AS lifecycle
+			  ON lifecycle.team_id = support.team_id
+			 AND lifecycle.target_fragment_id = support.fragment_id
 			WHERE quarantine.quarantine_id IS NULL
+			  AND lifecycle.lifecycle_event_id IS NULL
+			  AND COALESCE(fragment.metadata->>'conflict_resolution_deletion_only', '') <> 'true'
 			  AND (
 			      support.source_id IS NULL
 			      OR source.current_revision_id = support.source_revision_id
@@ -286,13 +297,15 @@ func loadRelationshipConflictPlacement(
 			       support.support_id,
 			       support.verification_event_id,
 			       support.fragment_id,
+			       support.accepted_at,
 			       support.source_group_key,
 			       support.authority
 			FROM effective_supports AS support
 			ORDER BY support.relationship_id,
-			         support.source_group_key,
-			         CASE WHEN support.authority = 'authoritative' THEN 0 ELSE 1 END,
-			         support.support_id
+				         support.source_group_key,
+				         CASE WHEN support.authority = 'authoritative' THEN 0 ELSE 1 END,
+				         support.accepted_at DESC,
+				         support.support_id
 		),
 		position_counts AS (
 			SELECT active.object_entity_id,
@@ -321,8 +334,9 @@ func loadRelationshipConflictPlacement(
 		       END AS position_key,
 		       support.support_id::text,
 		       support.verification_event_id::text,
-		       support.fragment_id::text,
-		       support.source_group_key,
+			       support.fragment_id::text,
+			       support.accepted_at,
+			       support.source_group_key,
 		       support.authority,
 		       active.valid_from,
 		       CASE WHEN active.valid_from IS NULL THEN 'recorded_at' ELSE 'valid_from' END,
@@ -369,6 +383,7 @@ func loadRelationshipConflictPlacement(
 			&row.SupportID,
 			&row.VerificationEventID,
 			&row.FragmentID,
+			&row.AcceptedAt,
 			&row.SourceGroupKey,
 			&row.Authority,
 			&row.EffectiveAt,
@@ -525,9 +540,19 @@ func loadConflictReviewTTLDays(ctx context.Context, tx *gorm.DB, teamID string, 
 }
 
 func bumpRelationshipConflictCaseVersion(ctx context.Context, tx *gorm.DB, teamID string, conflictID string) error {
+	if err := supersedeReservedOverdueConflictAssessments(ctx, tx, teamID, conflictID); err != nil {
+		return err
+	}
+	if err := supersedePendingOverdueConflictResolutions(ctx, tx, teamID, conflictID); err != nil {
+		return err
+	}
 	result := tx.WithContext(ctx).Exec(`
 		UPDATE relationship_conflict_cases
 		SET version = version + 1,
+		    attempts = 0,
+		    lease_worker_id = '',
+		    lease_until = NULL,
+		    last_error = '',
 		    updated_at = now()
 		WHERE team_id = ?::uuid
 		  AND conflict_id = ?::uuid

--- a/internal/repository/conflict_repository.go
+++ b/internal/repository/conflict_repository.go
@@ -302,9 +302,15 @@ func loadRelationshipConflictPlacement(
 			       support.authority
 			FROM effective_supports AS support
 			ORDER BY support.relationship_id,
-				         support.source_group_key,
-				         CASE WHEN support.authority = 'authoritative' THEN 0 ELSE 1 END,
-				         support.accepted_at DESC,
+			         support.source_group_key,
+			         CASE support.authority
+			             WHEN 'authoritative' THEN 0
+			             WHEN 'primary' THEN 1
+			             WHEN 'secondary' THEN 2
+			             WHEN 'inferred' THEN 3
+			             ELSE 4
+			         END,
+			         support.accepted_at DESC,
 				         support.support_id
 		),
 		position_counts AS (

--- a/internal/repository/conflict_repository_test.go
+++ b/internal/repository/conflict_repository_test.go
@@ -150,3 +150,23 @@ func TestNormalizeConflictReviewRunInputRejectsInvalidTimezone(t *testing.T) {
 
 	assert.ErrorContains(t, err, "timezone is invalid")
 }
+
+func TestValidateClaimConflictDerivedEvidenceTasksRejectsSubsecondLease(t *testing.T) {
+	err := validateClaimConflictDerivedEvidenceTasksInput(ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      "00000000-0000-0000-0000-000000000001",
+		ReviewRunID: "00000000-0000-0000-0000-000000000002",
+		WorkerID:    "worker-a",
+		Limit:       1,
+		Lease:       500 * time.Millisecond,
+	})
+
+	assert.ErrorContains(t, err, "at least 1 second")
+}
+
+func TestConflictTimesEqualAtDatabasePrecision(t *testing.T) {
+	stored := time.Date(2026, 7, 31, 12, 0, 0, 123456000, time.UTC)
+	request := stored.Add(789 * time.Nanosecond)
+
+	assert.True(t, conflictTimesEqualAtDatabasePrecision(stored, request))
+	assert.False(t, conflictTimesEqualAtDatabasePrecision(stored, stored.Add(time.Microsecond)))
+}

--- a/internal/repository/conflict_review_repository.go
+++ b/internal/repository/conflict_review_repository.go
@@ -537,6 +537,7 @@ func markRelationshipConflictCaseOverdue(
 		    lease_worker_id = '',
 		    lease_until = NULL,
 		    next_review_at = ?,
+		    attempts = 0,
 		    last_error = '',
 		    updated_at = now()
 		WHERE team_id = ?::uuid
@@ -559,6 +560,12 @@ func dismissRelationshipConflictCase(
 	input ReviewRelationshipConflictCaseInput,
 	snapshotChanged bool,
 ) error {
+	if err := supersedeReservedOverdueConflictAssessments(ctx, tx, input.TeamID, input.ConflictID); err != nil {
+		return err
+	}
+	if err := supersedePendingOverdueConflictResolutions(ctx, tx, input.TeamID, input.ConflictID); err != nil {
+		return err
+	}
 	result := tx.WithContext(ctx).Exec(`
 		UPDATE relationship_conflict_cases
 		SET status = 'dismissed',

--- a/internal/repository/conflict_review_repository_integration_test.go
+++ b/internal/repository/conflict_review_repository_integration_test.go
@@ -300,6 +300,19 @@ func TestEnsureConflictSystemProfileAvoidsLegacyUserNameCollision(t *testing.T) 
 	assert.Equal(t, "system", authSource)
 	assert.True(t, isSystem)
 	assert.Equal(t, 1, semanticRefCount)
+
+	unscopedTeamID := createLedgerTeam(t, adminDB, rls, "conflict-system-profile-unscoped-team")
+	err := rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO team_profiles (
+			    team_id, key_hash, key_prefix, key_suffix, name, scopes, role, rate_limit,
+			    revoked_at, auth_source, is_system
+		) VALUES (
+			    ?::uuid, NULL, NULL, NULL, ?, ARRAY[]::text[], 'member', 0, now(), 'system', true
+		)
+		`, unscopedTeamID, newConflictSystemProfileName()).Error
+	})
+	require.Error(t, err)
 }
 
 func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDerivation(t *testing.T) {
@@ -795,7 +808,7 @@ func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWin
 	require.Equal(t, ConflictReviewOutcomeOverdue, result.Outcome)
 
 	firstLocalDate := time.Date(2026, time.August, 2, 0, 30, 0, 0, time.FixedZone("UTC+14", 14*60*60))
-	for day := 0; day < conflictAssessmentMaxFailedDays-1; day++ {
+	for day := 0; day < ConflictAssessmentMaxFailedDays-1; day++ {
 		reservation, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
 			TeamID:              teamID,
 			ConflictID:          conflictID,
@@ -826,7 +839,7 @@ func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWin
 		ConflictID:          conflictID,
 		ReviewRunID:         uuid.NewString(),
 		WorkerID:            "worker-overdue-abandoned-assessment",
-		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, conflictAssessmentMaxFailedDays-1),
+		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, ConflictAssessmentMaxFailedDays-1),
 		Model:               "test-model",
 		PolicyVersion:       domain.ConflictOverduePolicyVersion,
 	})
@@ -839,7 +852,7 @@ func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWin
 		ConflictID:          conflictID,
 		ReviewRunID:         uuid.NewString(),
 		WorkerID:            "worker-overdue-abandoned-recovery",
-		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, conflictAssessmentMaxFailedDays),
+		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, ConflictAssessmentMaxFailedDays),
 		Model:               "test-model",
 		PolicyVersion:       domain.ConflictOverduePolicyVersion,
 	})
@@ -859,6 +872,7 @@ func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWin
 	}
 	winner, ok := domain.SelectConflictLastWriteWinner(positions)
 	require.True(t, ok)
+	assert.Equal(t, "authoritative", winner.Authority)
 	applied, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
 		TeamID:              teamID,
 		ConflictID:          conflictID,
@@ -868,7 +882,7 @@ func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWin
 		PreferredPositionID: winner.PositionID,
 		AssessmentAttemptID: fallback.AssessmentAttemptID,
 		Method:              "last_write_wins",
-		Now:                 reviewNow.AddDate(0, 0, conflictAssessmentMaxFailedDays),
+		Now:                 reviewNow.AddDate(0, 0, ConflictAssessmentMaxFailedDays),
 	})
 	require.NoError(t, err)
 	assert.True(t, applied.Resolved)

--- a/internal/repository/conflict_review_repository_integration_test.go
+++ b/internal/repository/conflict_review_repository_integration_test.go
@@ -2,12 +2,16 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
 )
 
 func TestRelationshipConflictReviewerDismissesStaleCaseAfterRetraction(t *testing.T) {
@@ -145,6 +149,696 @@ func TestRelationshipConflictReviewerDoesNotExhaustAttemptsBeforeDueDate(t *test
 	}))
 	assert.Equal(t, "open", status)
 	assert.Equal(t, 0, attempts)
+}
+
+func TestRelationshipConflictReviewerResetsAttemptsAfterOverdueAndSnapshotVersionChange(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "conflict-review-reset-attempts", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "conflict-review-reset-attempts-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "conflict-review-reset-attempts-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "conflict-review-reset-attempts-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-reset-attempts-a",
+		"reset-attempts-conflict-a", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "source-group-reset-attempts-a",
+	)
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-reset-attempts-b",
+		"reset-attempts-conflict-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "source-group-reset-attempts-b",
+	)
+
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?,
+			    next_review_at = ?,
+			    attempts = 4
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+
+	result := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "conflict-reviewer-reset-attempts", conflictID, reviewNow)
+	assert.Equal(t, ConflictReviewOutcomeOverdue, result.Outcome)
+
+	var status string
+	var attempts int
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT status, attempts
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Row().Scan(&status, &attempts)
+	}))
+	assert.Equal(t, "overdue", status)
+	assert.Equal(t, 0, attempts)
+	reservation, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-reset-attempts-assessment",
+		LocalAssessmentDate: reviewNow,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, reservation)
+
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET attempts = 4,
+			    lease_worker_id = 'stale-worker',
+			    lease_until = now() + interval '1 minute',
+			    last_error = 'stale lease'
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Error)
+		return bumpRelationshipConflictCaseVersion(ctx, tx, teamID, conflictID)
+	}))
+
+	var leaseWorkerID string
+	var lastError string
+	var assessmentStatus string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT attempts, lease_worker_id, COALESCE(last_error, '')
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Row().Scan(&attempts, &leaseWorkerID, &lastError)
+	}))
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT status
+			FROM relationship_conflict_ai_assessment_attempts
+			WHERE team_id = ?::uuid
+			  AND assessment_attempt_id = ?::uuid
+		`, teamID, reservation.AssessmentAttemptID).Row().Scan(&assessmentStatus)
+	}))
+	assert.Equal(t, 0, attempts)
+	assert.Empty(t, leaseWorkerID)
+	assert.Empty(t, lastError)
+	assert.Equal(t, "superseded", assessmentStatus)
+}
+
+func TestEnsureConflictSystemProfileAvoidsLegacyUserNameCollision(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "conflict-system-profile-name-collision-team")
+	legacyName := conflictSystemProfileNamePrefix + teamID
+	userProfileID := createLedgerProfile(t, adminDB, rls, teamID, legacyName)
+
+	var systemProfileID string
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, teamID); err != nil {
+			return err
+		}
+		var err error
+		systemProfileID, err = ensureConflictSystemProfile(ctx, tx, teamID)
+		return err
+	}))
+	require.NotEmpty(t, systemProfileID)
+	assert.NotEqual(t, userProfileID, systemProfileID)
+
+	var systemName, authSource string
+	var isSystem bool
+	var semanticRefCount int
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		if err := setConflictSystemTeamContext(ctx, tx, teamID); err != nil {
+			return err
+		}
+		if err := tx.Raw(`
+			SELECT name, auth_source, is_system
+			FROM team_profiles
+			WHERE team_id = ?::uuid
+			  AND id = ?::uuid
+		`, teamID, systemProfileID).Row().Scan(&systemName, &authSource, &isSystem); err != nil {
+			return err
+		}
+		return tx.Raw(`
+			SELECT COUNT(*)
+			FROM semantic_profile_refs
+			WHERE team_id = ?::uuid
+			  AND profile_id = ?::uuid
+		`, teamID, systemProfileID).Row().Scan(&semanticRefCount)
+	}))
+	assert.NotEqual(t, legacyName, systemName)
+	assert.True(t, strings.HasPrefix(systemName, conflictSystemProfileNamePrefix))
+	assert.Equal(t, "system", authSource)
+	assert.True(t, isSystem)
+	assert.Equal(t, 1, semanticRefCount)
+}
+
+func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDerivation(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-conflict-resolution", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "overdue-conflict-resolution-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-resolution-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-resolution-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	preferredContent := "Dense-Mem uses PostgreSQL. Dense-Mem uses PostgreSQL."
+	preferredQuote := "Dense-Mem uses PostgreSQL."
+	preferredSecondStart := strings.LastIndex(preferredContent, preferredQuote)
+	require.Greater(t, preferredSecondStart, 0)
+	preferred := commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-overdue-preferred",
+		"overdue-conflict-preferred", preferredContent, subject.EntityID, postgres.EntityID, "source-group-overdue-preferred",
+		conflictTestRelationshipOptions{
+			authority: "primary",
+			additionalSupports: []conflictTestAdditionalSupport{{
+				sourceGroupKey: "source-group-overdue-preferred-second",
+				spanStart:      preferredSecondStart,
+				spanEnd:        preferredSecondStart + len(preferredQuote),
+				quote:          preferredQuote,
+			}},
+		},
+	)
+	loserContent := "Dense-Mem uses GraphDB. Dense-Mem uses GraphDB."
+	loserQuote := "Dense-Mem uses GraphDB."
+	loserSecondStart := strings.LastIndex(loserContent, loserQuote)
+	require.Greater(t, loserSecondStart, 0)
+	loser := commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-overdue-loser",
+		"overdue-conflict-loser", loserContent, subject.EntityID, graphdb.EntityID, "source-group-overdue-loser",
+		conflictTestRelationshipOptions{
+			authority: "primary",
+			additionalSupports: []conflictTestAdditionalSupport{{
+				sourceGroupKey: "source-group-overdue-loser-second",
+				spanStart:      loserSecondStart,
+				spanEnd:        loserSecondStart + len(loserQuote),
+				quote:          loserQuote,
+			}},
+		},
+	)
+
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?,
+			    next_review_at = ?
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+	result := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "worker-overdue-review", conflictID, reviewNow)
+	require.Equal(t, ConflictReviewOutcomeOverdue, result.Outcome)
+
+	localDate := time.Date(2026, time.August, 2, 0, 30, 0, 0, time.FixedZone("UTC+14", 14*60*60))
+	reservation, dossier, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-assessment",
+		LocalAssessmentDate: localDate,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, reservation)
+	require.NotNil(t, dossier)
+	assert.Len(t, dossier.Positions, 2)
+	assert.Len(t, dossier.Evidence, 4)
+	var storedLocalAssessmentDate string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT local_assessment_date::text
+			FROM relationship_conflict_ai_assessment_attempts
+			WHERE team_id = ?::uuid
+			  AND assessment_attempt_id = ?::uuid
+		`, teamID, reservation.AssessmentAttemptID).Row().Scan(&storedLocalAssessmentDate)
+	}))
+	assert.Equal(t, "2026-08-02", storedLocalAssessmentDate)
+
+	_, _, reservedAgain, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-assessment-retry",
+		LocalAssessmentDate: localDate,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	assert.False(t, reservedAgain)
+
+	preferredPositionID, losingFragmentID := "", ""
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT member.position_id::text
+			FROM relationship_conflict_position_members AS member
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.relationship_id = ?::uuid
+			  AND member.active
+		`, teamID, conflictID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredPositionID))
+		return tx.Raw(`
+			SELECT support.fragment_id::text
+			FROM relationship_evidence_supports AS support
+			WHERE support.team_id = ?::uuid
+			  AND support.relationship_id = ?::uuid
+			  AND support.owner_profile_id = ?::uuid
+		`, teamID, loser.RelationshipResults[0].Relationship.RelationshipID, ownerB).Row().Scan(&losingFragmentID)
+	}))
+	require.NotEmpty(t, preferredPositionID)
+	require.NotEmpty(t, losingFragmentID)
+	confidence := 0.92
+	_, err = ledgerRepo.CompleteOverdueConflictAssessment(ctx, CompleteOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		CaseVersion:         reservation.CaseVersion,
+		ReviewRunID:         uuid.NewString(),
+		Decision:            "selected",
+		SelectedPositionID:  preferredPositionID,
+		Confidence:          &confidence,
+		ProviderTurns:       1,
+		ResponseHash:        "sha256:test",
+	})
+	require.NoError(t, err)
+	applied, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-apply",
+		ExpectedCaseVersion: reservation.CaseVersion,
+		PreferredPositionID: preferredPositionID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		Method:              "ai",
+		Now:                 reviewNow,
+	})
+	require.NoError(t, err)
+	require.True(t, applied.Resolved)
+	assert.Contains(t, applied.RetractedEvidenceIDs, losingFragmentID)
+	require.Len(t, applied.DerivedEvidence, 1)
+
+	derived, err := ledgerRepo.StageConflictDerivedEvidence(ctx, applied.DerivedEvidence[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, derived.IngestID)
+	require.NotEmpty(t, derived.ReplacementFragment)
+
+	var conflictStatus, resolutionReason, loserStatus, searchState, systemProfileID, authSource, replacementAuthority string
+	var loserSupportCount, derivationCount, replacementSearchDocuments, relationshipCountBeforeDerived int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT status, resolution_reason
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Row().Scan(&conflictStatus, &resolutionReason))
+		require.NoError(t, tx.Raw(`
+			SELECT status, support_count
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, loser.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&loserStatus, &loserSupportCount))
+		require.NoError(t, tx.Raw(`
+			SELECT search_state
+			FROM search_documents
+			WHERE team_id = ?::uuid
+			  AND source_kind = 'evidence'
+			  AND source_id = ?::uuid
+		`, teamID, losingFragmentID).Row().Scan(&searchState))
+		require.NoError(t, tx.Raw(`
+			SELECT id::text, auth_source
+			FROM team_profiles
+			WHERE team_id = ?::uuid
+			  AND is_system
+		`, teamID).Row().Scan(&systemProfileID, &authSource))
+		require.NoError(t, tx.Raw(`
+			SELECT fragment.authority
+			FROM relationship_conflict_evidence_derivations AS derivation
+			JOIN evidence_fragments AS fragment
+			  ON fragment.team_id = derivation.team_id
+			 AND fragment.fragment_id = derivation.replacement_fragment_id
+			WHERE derivation.team_id = ?::uuid
+			  AND derivation.conflict_id = ?::uuid
+			  AND derivation.target_fragment_id = ?::uuid
+		`, teamID, conflictID, losingFragmentID).Row().Scan(&replacementAuthority))
+		require.NoError(t, tx.Raw(`
+			SELECT count(*)
+			FROM relationship_conflict_evidence_derivations
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Scan(&derivationCount).Error)
+		require.NoError(t, tx.Raw(`
+			SELECT count(*)
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+		`, teamID).Scan(&relationshipCountBeforeDerived).Error)
+		return tx.Raw(`
+			SELECT count(*)
+			FROM search_documents
+			WHERE team_id = ?::uuid
+			  AND source_kind = 'evidence'
+			  AND source_id = ?::uuid
+		`, teamID, derived.ReplacementFragment).Scan(&replacementSearchDocuments).Error
+	}))
+	assert.Equal(t, "resolved", conflictStatus)
+	assert.Equal(t, domain.ConflictResolutionReasonAI, resolutionReason)
+	assert.Equal(t, "superseded", loserStatus)
+	assert.Equal(t, int64(0), loserSupportCount)
+	assert.Equal(t, "not_required", searchState)
+	assert.NotEmpty(t, systemProfileID)
+	assert.Equal(t, "system", authSource)
+	assert.Equal(t, "inferred", replacementAuthority)
+	assert.Equal(t, int64(1), derivationCount)
+	assert.Equal(t, int64(0), replacementSearchDocuments)
+
+	derivedIngest, err := ledgerRepo.GetPlacementRun(ctx, GetPlacementRunInput{
+		TeamID:         teamID,
+		OwnerProfileID: systemProfileID,
+		IngestID:       derived.IngestID,
+	})
+	require.NoError(t, err)
+	require.Len(t, derivedIngest.Items, 1)
+	claimed, err := ledgerRepo.ClaimNextPlacementRun(ctx, teamID, "worker-overdue-derived", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, derivedIngest.PlacementRunID, claimed.PlacementRunID)
+	derivedCommit, err := ledgerRepo.CommitPlacementSemanticResult(ctx, CommitPlacementSemanticInput{
+		TeamID:           teamID,
+		OwnerProfileID:   systemProfileID,
+		IngestID:         derivedIngest.IngestID,
+		PlacementRunID:   derivedIngest.PlacementRunID,
+		PlacementItemID:  derivedIngest.Items[0].PlacementItemID,
+		WorkerID:         "worker-overdue-derived",
+		ExpectedAttempts: claimed.Attempts,
+		EntityResolutions: []PlacementEntityResolutionInput{
+			{MentionRef: "subject", Action: "reuse", EntityID: subject.EntityID},
+			{MentionRef: "object", Action: "reuse", EntityID: postgres.EntityID},
+		},
+		RelationshipObservations: []PlacementRelationshipDecisionInput{{
+			Ref:          "derived-must-not-project",
+			SubjectRef:   "subject",
+			PredicateKey: "primary_database",
+			ObjectRef:    "object",
+			Support: &EvidenceSupportInput{
+				FragmentID:     derived.ReplacementFragment,
+				SourceGroupKey: "source-group-overdue-loser",
+				SpanStart:      0,
+				SpanEnd:        len(derivedIngest.Evidence[0].Content),
+				Quote:          derivedIngest.Evidence[0].Content,
+				Authority:      "inferred",
+			},
+		}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, derivedCommit.RelationshipResults)
+
+	var relationshipCountAfterDerived, derivedSearchDocuments int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT count(*)
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+		`, teamID).Scan(&relationshipCountAfterDerived).Error)
+		return tx.Raw(`
+			SELECT count(*)
+			FROM search_documents
+			WHERE team_id = ?::uuid
+			  AND source_kind = 'evidence'
+			  AND source_id = ?::uuid
+		`, teamID, derived.ReplacementFragment).Scan(&derivedSearchDocuments).Error
+	}))
+	assert.Equal(t, relationshipCountBeforeDerived, relationshipCountAfterDerived)
+	assert.Equal(t, int64(0), derivedSearchDocuments)
+}
+
+func TestOverdueConflictResolutionRejectsAssessmentAfterEvidenceRetraction(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-conflict-stale-evidence", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "overdue-conflict-stale-evidence-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-stale-evidence-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-stale-evidence-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	preferred := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-overdue-stale-preferred",
+		"overdue-stale-preferred", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "source-group-overdue-stale-preferred",
+	)
+	loser := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-overdue-stale-loser",
+		"overdue-stale-loser", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "source-group-overdue-stale-loser",
+	)
+
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?,
+			    next_review_at = ?
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+	review := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "worker-overdue-stale-review", conflictID, reviewNow)
+	require.Equal(t, ConflictReviewOutcomeOverdue, review.Outcome)
+
+	reservation, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-stale-assessment",
+		LocalAssessmentDate: reviewNow,
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, reservation)
+
+	preferredPositionID, losingFragmentID := "", ""
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT member.position_id::text
+			FROM relationship_conflict_position_members AS member
+			WHERE member.team_id = ?::uuid
+			  AND member.conflict_id = ?::uuid
+			  AND member.relationship_id = ?::uuid
+			  AND member.active
+		`, teamID, conflictID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredPositionID))
+		return tx.Raw(`
+			SELECT support.fragment_id::text
+			FROM relationship_evidence_supports AS support
+			WHERE support.team_id = ?::uuid
+			  AND support.relationship_id = ?::uuid
+			  AND support.owner_profile_id = ?::uuid
+		`, teamID, loser.RelationshipResults[0].Relationship.RelationshipID, ownerB).Row().Scan(&losingFragmentID)
+	}))
+	confidence := 0.92
+	_, err = ledgerRepo.CompleteOverdueConflictAssessment(ctx, CompleteOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		CaseVersion:         reservation.CaseVersion,
+		ReviewRunID:         uuid.NewString(),
+		Decision:            "selected",
+		SelectedPositionID:  preferredPositionID,
+		Confidence:          &confidence,
+		ProviderTurns:       1,
+		ResponseHash:        "sha256:stale-evidence",
+	})
+	require.NoError(t, err)
+
+	_, err = ledgerRepo.RetractEvidence(ctx, RetractEvidenceInput{
+		TeamID:         teamID,
+		OwnerProfileID: ownerB,
+		EvidenceIDs:    []string{losingFragmentID},
+		Reason:         "source was withdrawn while assessment was in flight",
+		IdempotencyKey: "overdue-stale-evidence-retract",
+		RequestHash:    "sha256:overdue-stale-evidence-retract",
+	})
+	require.NoError(t, err)
+
+	applied, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-stale-apply",
+		ExpectedCaseVersion: reservation.CaseVersion,
+		PreferredPositionID: preferredPositionID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		Method:              "ai",
+		Now:                 reviewNow,
+	})
+	require.NoError(t, err)
+	assert.True(t, applied.Stale)
+	assert.False(t, applied.Resolved)
+	assert.Empty(t, applied.RetractedEvidenceIDs)
+
+	var conflictStatus, preferredStatus, loserStatus string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		require.NoError(t, tx.Raw(`
+			SELECT status
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, teamID, conflictID).Row().Scan(&conflictStatus))
+		require.NoError(t, tx.Raw(`
+			SELECT status
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, preferred.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&preferredStatus))
+		return tx.Raw(`
+			SELECT status
+			FROM relationship_records
+			WHERE team_id = ?::uuid
+			  AND relationship_id = ?::uuid
+		`, teamID, loser.RelationshipResults[0].Relationship.RelationshipID).Row().Scan(&loserStatus)
+	}))
+	assert.Equal(t, "dismissed", conflictStatus)
+	assert.Equal(t, "active", preferredStatus)
+	assert.Equal(t, "pending_evidence", loserStatus)
+}
+
+func TestReserveOverdueConflictAssessmentExpiresAbandonedAttemptIntoLastWriteWins(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "overdue-conflict-abandoned", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "overdue-conflict-abandoned-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-abandoned-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "overdue-conflict-abandoned-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-overdue-abandoned-preferred",
+		"overdue-conflict-abandoned-preferred", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "source-group-overdue-abandoned-preferred",
+		conflictTestRelationshipOptions{authority: "authoritative"},
+	)
+	commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-overdue-abandoned-loser",
+		"overdue-conflict-abandoned-loser", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "source-group-overdue-abandoned-loser",
+		conflictTestRelationshipOptions{authority: "primary"},
+	)
+
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	reviewNow := time.Now().UTC()
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE relationship_conflict_cases
+			SET review_due_at = ?,
+			    next_review_at = ?
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+		`, reviewNow.Add(-time.Minute), reviewNow.Add(-time.Minute), teamID, conflictID).Error
+	}))
+	result := reviewConflictCaseForTest(t, ctx, ledgerRepo, teamID, "worker-overdue-abandoned-review", conflictID, reviewNow)
+	require.Equal(t, ConflictReviewOutcomeOverdue, result.Outcome)
+
+	firstLocalDate := time.Date(2026, time.August, 2, 0, 30, 0, 0, time.FixedZone("UTC+14", 14*60*60))
+	for day := 0; day < conflictAssessmentMaxFailedDays-1; day++ {
+		reservation, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+			TeamID:              teamID,
+			ConflictID:          conflictID,
+			ReviewRunID:         uuid.NewString(),
+			WorkerID:            "worker-overdue-abandoned-assessment",
+			LocalAssessmentDate: firstLocalDate.AddDate(0, 0, day),
+			Model:               "test-model",
+			PolicyVersion:       domain.ConflictOverduePolicyVersion,
+		})
+		require.NoError(t, err)
+		require.True(t, reserved)
+		require.NotNil(t, reservation)
+		completed, err := ledgerRepo.CompleteOverdueConflictAssessment(ctx, CompleteOverdueConflictAssessmentInput{
+			TeamID:              teamID,
+			ConflictID:          conflictID,
+			AssessmentAttemptID: reservation.AssessmentAttemptID,
+			CaseVersion:         reservation.CaseVersion,
+			ReviewRunID:         uuid.NewString(),
+			Decision:            "failed",
+			FailureClass:        "provider_unavailable",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, day+1, completed.FailureCount)
+	}
+
+	abandoned, _, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-abandoned-assessment",
+		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, conflictAssessmentMaxFailedDays-1),
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, abandoned)
+
+	fallback, dossier, reserved, err := ledgerRepo.ReserveOverdueConflictAssessment(ctx, ReserveOverdueConflictAssessmentInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-abandoned-recovery",
+		LocalAssessmentDate: firstLocalDate.AddDate(0, 0, conflictAssessmentMaxFailedDays),
+		Model:               "test-model",
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.NotNil(t, fallback)
+	require.NotNil(t, dossier)
+	assert.True(t, fallback.LastWriteWins)
+	assert.Equal(t, abandoned.AssessmentAttemptID, fallback.AssessmentAttemptID)
+
+	positions := make([]domain.ConflictResolutionPosition, 0, len(dossier.Positions))
+	for _, position := range dossier.Positions {
+		positions = append(positions, domain.ConflictResolutionPosition{
+			PositionID: position.PositionID,
+			Supports:   position.Supports,
+		})
+	}
+	winner, ok := domain.SelectConflictLastWriteWinner(positions)
+	require.True(t, ok)
+	applied, err := ledgerRepo.ApplyOverdueConflictResolution(ctx, ApplyOverdueConflictResolutionInput{
+		TeamID:              teamID,
+		ConflictID:          conflictID,
+		ReviewRunID:         uuid.NewString(),
+		WorkerID:            "worker-overdue-abandoned-apply",
+		ExpectedCaseVersion: fallback.CaseVersion,
+		PreferredPositionID: winner.PositionID,
+		AssessmentAttemptID: fallback.AssessmentAttemptID,
+		Method:              "last_write_wins",
+		Now:                 reviewNow.AddDate(0, 0, conflictAssessmentMaxFailedDays),
+	})
+	require.NoError(t, err)
+	assert.True(t, applied.Resolved)
 }
 
 func reviewConflictCaseForTest(

--- a/internal/repository/conflict_review_repository_integration_test.go
+++ b/internal/repository/conflict_review_repository_integration_test.go
@@ -381,6 +381,8 @@ func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDeri
 	require.NotNil(t, dossier)
 	assert.Len(t, dossier.Positions, 2)
 	assert.Len(t, dossier.Evidence, 4)
+	assert.Len(t, dossier.Positions[0].Supports, 2)
+	assert.Len(t, dossier.Positions[1].Supports, 2)
 	var storedLocalAssessmentDate string
 	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
 		return tx.Raw(`
@@ -453,14 +455,37 @@ func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDeri
 	require.True(t, applied.Resolved)
 	assert.Contains(t, applied.RetractedEvidenceIDs, losingFragmentID)
 	require.Len(t, applied.DerivedEvidence, 1)
+	assert.NotEmpty(t, applied.DerivedEvidence[0].TaskID)
 
-	derived, err := ledgerRepo.StageConflictDerivedEvidence(ctx, applied.DerivedEvidence[0])
+	claimedDerived, err := ledgerRepo.ClaimConflictDerivedEvidenceTasks(ctx, ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      teamID,
+		ReviewRunID: uuid.NewString(),
+		WorkerID:    "worker-overdue-derived-first",
+		Limit:       1,
+		Lease:       time.Minute,
+	})
+	require.NoError(t, err)
+	require.Len(t, claimedDerived, 1)
+	assert.Equal(t, applied.DerivedEvidence[0].TaskID, claimedDerived[0].TaskID)
+	require.NoError(t, ledgerRepo.RecordConflictDerivedEvidenceFailure(ctx, claimedDerived[0], "staging_failed"))
+
+	claimedDerived, err = ledgerRepo.ClaimConflictDerivedEvidenceTasks(ctx, ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      teamID,
+		ReviewRunID: uuid.NewString(),
+		WorkerID:    "worker-overdue-derived-retry",
+		Limit:       1,
+		Lease:       time.Minute,
+	})
+	require.NoError(t, err)
+	require.Len(t, claimedDerived, 1)
+	derived, err := ledgerRepo.StageConflictDerivedEvidence(ctx, claimedDerived[0])
 	require.NoError(t, err)
 	require.NotEmpty(t, derived.IngestID)
 	require.NotEmpty(t, derived.ReplacementFragment)
 
 	var conflictStatus, resolutionReason, loserStatus, searchState, systemProfileID, authSource, replacementAuthority string
-	var loserSupportCount, derivationCount, replacementSearchDocuments, relationshipCountBeforeDerived int64
+	var loserSupportCount, derivationCount, replacementSearchDocuments, relationshipCountBeforeDerived, derivedTaskAttempts int64
+	var derivedTaskStatus string
 	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
 		require.NoError(t, tx.Raw(`
 			SELECT status, resolution_reason
@@ -504,6 +529,12 @@ func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDeri
 			  AND conflict_id = ?::uuid
 		`, teamID, conflictID).Scan(&derivationCount).Error)
 		require.NoError(t, tx.Raw(`
+			SELECT status, attempts
+			FROM relationship_conflict_derived_evidence_tasks
+			WHERE team_id = ?::uuid
+			  AND derived_evidence_task_id = ?::uuid
+		`, teamID, applied.DerivedEvidence[0].TaskID).Row().Scan(&derivedTaskStatus, &derivedTaskAttempts))
+		require.NoError(t, tx.Raw(`
 			SELECT count(*)
 			FROM relationship_records
 			WHERE team_id = ?::uuid
@@ -525,6 +556,8 @@ func TestOverdueConflictResolutionRetiresLosingEvidenceAndStagesDeletionOnlyDeri
 	assert.Equal(t, "system", authSource)
 	assert.Equal(t, "inferred", replacementAuthority)
 	assert.Equal(t, int64(1), derivationCount)
+	assert.Equal(t, "completed", derivedTaskStatus)
+	assert.Equal(t, int64(2), derivedTaskAttempts)
 	assert.Equal(t, int64(0), replacementSearchDocuments)
 
 	derivedIngest, err := ledgerRepo.GetPlacementRun(ctx, GetPlacementRunInput{

--- a/internal/repository/conflict_snapshot_repository.go
+++ b/internal/repository/conflict_snapshot_repository.go
@@ -123,17 +123,18 @@ func upsertRelationshipConflictMember(
 		INSERT INTO relationship_conflict_position_members (
 			    team_id, conflict_id, position_id, relationship_id, owner_profile_id,
 			    support_id, verification_event_id, fragment_id, source_group_key, authority,
-			    effective_at, effective_time_basis, recorded_fallback, active, retired_at, metadata
-			) VALUES (
+			    accepted_at, effective_at, effective_time_basis, recorded_fallback, active, retired_at, metadata
+		) VALUES (
 			    ?::uuid, ?::uuid, ?::uuid, ?::uuid, ?::uuid,
 			    NULLIF(?, '')::uuid, NULLIF(?, '')::uuid, NULLIF(?, '')::uuid, ?, ?,
-			    ?, ?, ?, true, NULL, ?::jsonb
-			)
+			    ?, ?, ?, ?, true, NULL, ?::jsonb
+		)
 			ON CONFLICT (team_id, position_id, relationship_id, source_group_key)
 			DO UPDATE SET support_id = EXCLUDED.support_id,
 			              verification_event_id = EXCLUDED.verification_event_id,
 			              fragment_id = EXCLUDED.fragment_id,
 			              authority = EXCLUDED.authority,
+			              accepted_at = EXCLUDED.accepted_at,
 			              effective_at = EXCLUDED.effective_at,
 			              effective_time_basis = EXCLUDED.effective_time_basis,
 			              recorded_fallback = EXCLUDED.recorded_fallback,
@@ -143,7 +144,7 @@ func upsertRelationshipConflictMember(
 			              metadata = EXCLUDED.metadata
 	`, teamID, conflictID, positionID, row.RelationshipID, row.OwnerProfileID,
 		row.SupportID, row.VerificationEventID, row.FragmentID, row.SourceGroupKey, row.Authority,
-		row.EffectiveAt, row.EffectiveTimeBasis, row.RecordedFallback, string(metadata))
+		row.AcceptedAt, row.EffectiveAt, row.EffectiveTimeBasis, row.RecordedFallback, string(metadata))
 	if result.Error != nil {
 		return false, result.Error
 	}
@@ -227,6 +228,7 @@ func relationshipConflictMemberWouldChange(
 	var verificationEventID string
 	var fragmentID string
 	var authority string
+	var acceptedAt time.Time
 	var effectiveAt sql.NullTime
 	var effectiveTimeBasis string
 	var recordedFallback bool
@@ -237,6 +239,7 @@ func relationshipConflictMemberWouldChange(
 		       COALESCE(verification_event_id::text, ''),
 		       COALESCE(fragment_id::text, ''),
 		       authority,
+		       accepted_at,
 		       effective_at,
 		       effective_time_basis,
 		       recorded_fallback,
@@ -252,6 +255,7 @@ func relationshipConflictMemberWouldChange(
 		&verificationEventID,
 		&fragmentID,
 		&authority,
+		&acceptedAt,
 		&effectiveAt,
 		&effectiveTimeBasis,
 		&recordedFallback,
@@ -268,6 +272,7 @@ func relationshipConflictMemberWouldChange(
 		verificationEventID != row.VerificationEventID ||
 		fragmentID != row.FragmentID ||
 		authority != row.Authority ||
+		!acceptedAt.Equal(row.AcceptedAt.UTC()) ||
 		!conflictNullableTimesEqual(effectiveAt, row.EffectiveAt) ||
 		effectiveTimeBasis != row.EffectiveTimeBasis ||
 		recordedFallback != row.RecordedFallback ||

--- a/internal/repository/conflict_snapshot_repository.go
+++ b/internal/repository/conflict_snapshot_repository.go
@@ -272,12 +272,16 @@ func relationshipConflictMemberWouldChange(
 		verificationEventID != row.VerificationEventID ||
 		fragmentID != row.FragmentID ||
 		authority != row.Authority ||
-		!acceptedAt.Equal(row.AcceptedAt.UTC()) ||
+		!conflictTimesEqualAtDatabasePrecision(acceptedAt, row.AcceptedAt) ||
 		!conflictNullableTimesEqual(effectiveAt, row.EffectiveAt) ||
 		effectiveTimeBasis != row.EffectiveTimeBasis ||
 		recordedFallback != row.RecordedFallback ||
 		!active ||
 		retiredAt.Valid, nil
+}
+
+func conflictTimesEqualAtDatabasePrecision(left, right time.Time) bool {
+	return left.UTC().Truncate(time.Microsecond).Equal(right.UTC().Truncate(time.Microsecond))
 }
 
 func conflictNullableTimesEqual(left sql.NullTime, right *time.Time) bool {

--- a/internal/repository/conflict_system_profile_repository.go
+++ b/internal/repository/conflict_system_profile_repository.go
@@ -1,0 +1,85 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	conflictSystemProfileNamePrefix     = "__dense_mem_conflict_system__:"
+	conflictSystemProfileCreateAttempts = 5
+)
+
+func ensureConflictSystemProfile(ctx context.Context, tx *gorm.DB, teamID string) (string, error) {
+	var profileID string
+	err := tx.WithContext(ctx).Raw(`
+		SELECT id::text
+		FROM team_profiles
+		WHERE team_id = ?::uuid
+		  AND is_system
+		LIMIT 1
+	`, teamID).Row().Scan(&profileID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+	if profileID == "" {
+		for attempt := 0; attempt < conflictSystemProfileCreateAttempts && profileID == ""; attempt++ {
+			err = tx.WithContext(ctx).Raw(`
+				INSERT INTO team_profiles (
+				    team_id, key_hash, key_prefix, key_suffix, name, scopes, role, rate_limit,
+				    revoked_at, auth_source, is_system
+				) VALUES (
+				    ?::uuid, NULL, NULL, NULL, ?, ARRAY[]::text[], 'member', 0, now(), 'system', true
+				)
+				ON CONFLICT DO NOTHING
+				RETURNING id::text
+			`, teamID, newConflictSystemProfileName()).Row().Scan(&profileID)
+			if err == nil {
+				break
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return "", err
+			}
+			err = tx.WithContext(ctx).Raw(`
+				SELECT id::text
+				FROM team_profiles
+				WHERE team_id = ?::uuid
+				  AND is_system
+				LIMIT 1
+			`, teamID).Row().Scan(&profileID)
+			if err == nil {
+				break
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return "", err
+			}
+		}
+		if profileID == "" {
+			return "", fmt.Errorf("create conflict system profile after %d attempts", conflictSystemProfileCreateAttempts)
+		}
+	}
+	if err := tx.WithContext(ctx).Exec(`
+		INSERT INTO semantic_team_refs (team_id)
+		VALUES (?::uuid)
+		ON CONFLICT (team_id) DO NOTHING
+	`, teamID).Error; err != nil {
+		return "", err
+	}
+	if err := tx.WithContext(ctx).Exec(`
+		INSERT INTO semantic_profile_refs (team_id, profile_id)
+		VALUES (?::uuid, ?::uuid)
+		ON CONFLICT (team_id, profile_id) DO NOTHING
+	`, teamID, profileID).Error; err != nil {
+		return "", err
+	}
+	return profileID, nil
+}
+
+func newConflictSystemProfileName() string {
+	return conflictSystemProfileNamePrefix + uuid.NewString()
+}

--- a/internal/repository/evidence_lifecycle_repository.go
+++ b/internal/repository/evidence_lifecycle_repository.go
@@ -40,6 +40,7 @@ type EvidenceLifecycleResult struct {
 type evidenceLifecycleOperationInput struct {
 	TeamID              string
 	OwnerProfileID      string
+	ActorProfileID      string
 	Action              string
 	EvidenceIDs         []string
 	Reason              string
@@ -541,13 +542,13 @@ func insertEvidenceLifecycleOperation(
 	}
 	rows, err := tx.WithContext(ctx).Raw(`
 		INSERT INTO evidence_lifecycle_operations (
-		    team_id, owner_profile_id, action, idempotency_key, request_hash,
+		    team_id, owner_profile_id, actor_profile_id, action, idempotency_key, request_hash,
 		    reason, replacement_ingest_id, result
 		) VALUES (
-		    ?::uuid, ?::uuid, ?, ?, ?, ?, NULLIF(?, '')::uuid, ?::jsonb
+		    ?::uuid, ?::uuid, NULLIF(?, '')::uuid, ?, ?, ?, ?, NULLIF(?, '')::uuid, ?::jsonb
 		)
 		RETURNING lifecycle_operation_id::text
-	`, input.TeamID, input.OwnerProfileID, input.Action, input.IdempotencyKey, input.RequestHash,
+	`, input.TeamID, input.OwnerProfileID, input.ActorProfileID, input.Action, input.IdempotencyKey, input.RequestHash,
 		input.Reason, input.ReplacementIngestID, string(encoded)).Rows()
 	if err != nil {
 		if isPostgresUniqueConstraint(err, "evidence_lifecycle_operations_idempotency_unique") {
@@ -626,15 +627,25 @@ func applyEvidenceLifecycleEffects(
 	plan *evidenceLifecyclePlan,
 ) error {
 	return withSystemModeInTx(ctx, tx, input.TeamID, input.OwnerProfileID, func(systemTx *gorm.DB) error {
-		relationshipsToRetire, err := revokeEvidenceLifecycleSupports(ctx, systemTx, input, operationID, plan.Supports)
-		if err != nil {
-			return err
-		}
-		if err := retireEvidenceLifecycleSearchDocuments(ctx, systemTx, input.TeamID, "evidence", plan.EvidenceIDs); err != nil {
-			return err
-		}
-		return retireEvidenceLifecycleSearchDocuments(ctx, systemTx, input.TeamID, "relationship", relationshipsToRetire)
+		return applyEvidenceLifecycleEffectsInSystem(ctx, systemTx, input, operationID, plan)
 	})
+}
+
+func applyEvidenceLifecycleEffectsInSystem(
+	ctx context.Context,
+	tx *gorm.DB,
+	input evidenceLifecycleOperationInput,
+	operationID string,
+	plan *evidenceLifecyclePlan,
+) error {
+	relationshipsToRetire, err := revokeEvidenceLifecycleSupports(ctx, tx, input, operationID, plan.Supports)
+	if err != nil {
+		return err
+	}
+	if err := retireEvidenceLifecycleSearchDocuments(ctx, tx, input.TeamID, "evidence", plan.EvidenceIDs); err != nil {
+		return err
+	}
+	return retireEvidenceLifecycleSearchDocuments(ctx, tx, input.TeamID, "relationship", relationshipsToRetire)
 }
 
 func revokeEvidenceLifecycleSupports(
@@ -649,7 +660,7 @@ func revokeEvidenceLifecycleSupports(
 		decisionID, err := insertSupportDecisionEvent(ctx, tx, supportDecisionInput{
 			TeamID:         input.TeamID,
 			OwnerProfileID: support.OwnerProfileID,
-			ActorProfileID: input.OwnerProfileID,
+			ActorProfileID: lifecycleActorProfileID(input),
 			SupportID:      support.SupportID,
 			RelationshipID: support.RelationshipID,
 			Decision:       string(domain.SupportRevoke),
@@ -688,6 +699,13 @@ func revokeEvidenceLifecycleSupports(
 		}
 	}
 	return retire, nil
+}
+
+func lifecycleActorProfileID(input evidenceLifecycleOperationInput) string {
+	if input.ActorProfileID != "" {
+		return input.ActorProfileID
+	}
+	return input.OwnerProfileID
 }
 
 func retireEvidenceLifecycleSearchDocuments(

--- a/internal/repository/ledger_repository.go
+++ b/internal/repository/ledger_repository.go
@@ -115,6 +115,7 @@ type EvidenceFragment struct {
 	EvidenceIndex         int
 	Content               string
 	ContentHash           string
+	Authority             string
 	SourceID              string
 	SourceRevisionID      string
 	SupersededEvidenceIDs []string
@@ -738,6 +739,7 @@ func insertEvidenceFragment(ctx context.Context, tx *gorm.DB, input CreateIngest
 		EvidenceIndex:    index,
 		Content:          item.Content,
 		ContentHash:      item.ContentHash,
+		Authority:        item.Authority,
 		SourceID:         sourceID,
 		SourceRevisionID: sourceRevisionID,
 	}
@@ -813,7 +815,7 @@ func loadCreateIngestResult(ctx context.Context, tx *gorm.DB, teamID string, ing
 		return nil, err
 	}
 	rows, err := tx.WithContext(ctx).Raw(`
-			SELECT fragment_id::text, evidence_index, content, content_hash,
+			SELECT fragment_id::text, evidence_index, content, content_hash, authority,
 			       COALESCE(source_id::text, ''), COALESCE(source_revision_id::text, '')
 			FROM evidence_fragments
 			WHERE team_id = ?::uuid
@@ -826,7 +828,7 @@ func loadCreateIngestResult(ctx context.Context, tx *gorm.DB, teamID string, ing
 	defer rows.Close()
 	for rows.Next() {
 		var item EvidenceFragment
-		if err := rows.Scan(&item.FragmentID, &item.EvidenceIndex, &item.Content, &item.ContentHash, &item.SourceID, &item.SourceRevisionID); err != nil {
+		if err := rows.Scan(&item.FragmentID, &item.EvidenceIndex, &item.Content, &item.ContentHash, &item.Authority, &item.SourceID, &item.SourceRevisionID); err != nil {
 			return nil, err
 		}
 		result.Evidence = append(result.Evidence, item)

--- a/internal/repository/ledger_repository.go
+++ b/internal/repository/ledger_repository.go
@@ -724,7 +724,7 @@ func insertEvidenceFragment(ctx context.Context, tx *gorm.DB, input CreateIngest
 		    ?::uuid, ?::uuid, ?::uuid, ?, ?, ?, ?, ?, ?,
 		    NULLIF(?, '')::uuid, NULLIF(?, '')::uuid, ?, ?::jsonb
 		)
-	RETURNING fragment_id::text
+	RETURNING fragment_id::text, authority
 	`, input.TeamID, ingestID, input.OwnerProfileID, index, item.Content, item.ContentHash,
 		item.SourceType, item.Authority, item.SourceRef, sourceID, sourceRevisionID,
 		pqStringArray(item.Labels), string(metadata)).Rows()
@@ -739,11 +739,10 @@ func insertEvidenceFragment(ctx context.Context, tx *gorm.DB, input CreateIngest
 		EvidenceIndex:    index,
 		Content:          item.Content,
 		ContentHash:      item.ContentHash,
-		Authority:        item.Authority,
 		SourceID:         sourceID,
 		SourceRevisionID: sourceRevisionID,
 	}
-	if err := rows.Scan(&fragment.FragmentID); err != nil {
+	if err := rows.Scan(&fragment.FragmentID, &fragment.Authority); err != nil {
 		return EvidenceFragment{}, err
 	}
 	return fragment, rows.Err()

--- a/internal/repository/ledger_repository_integration_test.go
+++ b/internal/repository/ledger_repository_integration_test.go
@@ -263,8 +263,9 @@ func TestLedgerCreateIngestIsIdempotentAndOwnerScoped(t *testing.T) {
 			}},
 		},
 		Evidence: []EvidenceInput{{
-			Content: "Dense-Mem stores exact evidence durably before acknowledgement.",
-			Labels:  []string{"canonical", "ledger"},
+			Content:   "Dense-Mem stores exact evidence durably before acknowledgement.",
+			Authority: string(domain.AuthorityAuthoritative),
+			Labels:    []string{"canonical", "ledger"},
 			InitialEvent: &SecurityEventDraft{
 				EventKind: "deterministic_scan",
 				Decision:  "pass",
@@ -276,6 +277,7 @@ func TestLedgerCreateIngestIsIdempotentAndOwnerScoped(t *testing.T) {
 	require.Len(t, first.Evidence, 1)
 	require.Equal(t, ownerA, first.OwnerProfileID)
 	require.Equal(t, "Dense-Mem stores exact evidence durably before acknowledgement.", first.Evidence[0].Content)
+	require.Equal(t, string(domain.AuthorityAuthoritative), first.Evidence[0].Authority)
 
 	loaded, err := repo.GetPlacementRun(ctx, GetPlacementRunInput{
 		TeamID:         teamA,
@@ -286,6 +288,7 @@ func TestLedgerCreateIngestIsIdempotentAndOwnerScoped(t *testing.T) {
 	require.Equal(t, ownerA, loaded.OwnerProfileID)
 	require.Len(t, loaded.Evidence, 1)
 	require.Equal(t, first.Evidence[0].Content, loaded.Evidence[0].Content)
+	require.Equal(t, string(domain.AuthorityAuthoritative), loaded.Evidence[0].Authority)
 	relationshipHints, ok := loaded.Proposal["relationship_hints"].([]any)
 	require.True(t, ok, "relationship_hints = %#v", loaded.Proposal["relationship_hints"])
 	require.Len(t, relationshipHints, 1)
@@ -345,6 +348,7 @@ func TestLedgerCreateIngestIsIdempotentAndOwnerScoped(t *testing.T) {
 	require.True(t, second.Existing)
 	assert.Equal(t, first.IngestID, second.IngestID)
 	assert.Equal(t, first.PlacementRunID, second.PlacementRunID)
+	assert.Equal(t, string(domain.AuthorityAuthoritative), second.Evidence[0].Authority)
 
 	_, err = repo.CreateIngest(ctx, CreateIngestInput{
 		TeamID:         teamA,
@@ -881,6 +885,20 @@ func TestLedgerAuthorityConstraintsUseCanonicalValues(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authority is unsupported")
+
+	err = rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO evidence_fragments (
+				team_id, ingest_id, owner_profile_id, evidence_index, content, content_hash, authority
+			)
+			VALUES (
+				?::uuid, ?::uuid, ?::uuid, 1,
+				'Legacy derived fragment authority is rejected.', 'sha256:legacy-derived-fragment', 'derived'
+			)
+		`, teamID, created.IngestID, ownerID).Error
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evidence_fragments_authority_check")
 
 	err = rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
 		return tx.Exec(`

--- a/internal/repository/placement_commit_repository.go
+++ b/internal/repository/placement_commit_repository.go
@@ -67,13 +67,19 @@ func (r *LedgerRepositoryImpl) CommitPlacementSemanticResult(
 			}
 			return err
 		}
-		if err := ensureRelationshipConflictContextsCurrent(ctx, tx, input); err != nil {
+		deletionOnly, err := isConflictResolutionDeletionOnlyFragment(ctx, tx, input.TeamID, placementFragmentID)
+		if err != nil {
 			return err
+		}
+		if !deletionOnly {
+			if err := ensureRelationshipConflictContextsCurrent(ctx, tx, input); err != nil {
+				return err
+			}
 		}
 		if err := ensureSemanticRefs(ctx, tx, input.TeamID, input.OwnerProfileID); err != nil {
 			return err
 		}
-		if placementEvidenceSearchableStatus(input.Status) {
+		if placementEvidenceSearchableStatus(input.Status) && !deletionOnly {
 			document, err := upsertPlacementItemEvidenceSearchDocument(
 				ctx,
 				tx,
@@ -86,29 +92,41 @@ func (r *LedgerRepositoryImpl) CommitPlacementSemanticResult(
 			}
 			appendPlacementSearchDocument(result, document)
 		}
-		entitiesByRef := make(map[string]string, len(input.EntityResolutions))
-		for _, resolution := range input.EntityResolutions {
-			resolutionID, entityID, err := insertPlacementEntityResolution(ctx, tx, input, resolution)
-			if err != nil {
-				return err
-			}
-			result.EntityResolutionIDs = append(result.EntityResolutionIDs, resolutionID)
-			if entityID != "" {
-				entitiesByRef[resolution.MentionRef] = entityID
-			}
-			if resolution.Action == string(domain.EntityResolutionAmbiguous) {
-				taskID, err := insertEntityReviewTask(ctx, tx, input, resolution, resolutionID)
+		if !deletionOnly {
+			entitiesByRef := make(map[string]string, len(input.EntityResolutions))
+			for _, resolution := range input.EntityResolutions {
+				resolutionID, entityID, err := insertPlacementEntityResolution(ctx, tx, input, resolution)
 				if err != nil {
 					return err
 				}
-				appendPlacementReviewTaskID(result, taskID)
+				result.EntityResolutionIDs = append(result.EntityResolutionIDs, resolutionID)
+				if entityID != "" {
+					entitiesByRef[resolution.MentionRef] = entityID
+				}
+				if resolution.Action == string(domain.EntityResolutionAmbiguous) {
+					taskID, err := insertEntityReviewTask(ctx, tx, input, resolution, resolutionID)
+					if err != nil {
+						return err
+					}
+					appendPlacementReviewTaskID(result, taskID)
+				}
 			}
-		}
-		for _, observation := range input.RelationshipObservations {
-			decision, err := relationshipDecisionFromPlacementObservation(ctx, tx, input, observation, entitiesByRef)
-			if err != nil {
-				if errors.Is(err, errPlacementPredicateReview) {
-					review, reviewErr := insertRelationshipPredicateReview(ctx, tx, input, observation, err.Error())
+			for _, observation := range input.RelationshipObservations {
+				decision, err := relationshipDecisionFromPlacementObservation(ctx, tx, input, observation, entitiesByRef)
+				if err != nil {
+					if errors.Is(err, errPlacementPredicateReview) {
+						review, reviewErr := insertRelationshipPredicateReview(ctx, tx, input, observation, err.Error())
+						if reviewErr != nil {
+							return reviewErr
+						}
+						appendPlacementRelationshipResult(result, review)
+						appendPlacementReviewTaskID(result, review.ReviewTaskID)
+						continue
+					}
+					if !errors.Is(err, errPlacementUnresolvedEndpoint) {
+						return err
+					}
+					review, reviewErr := insertRelationshipDependencyReview(ctx, tx, input, observation, err.Error())
 					if reviewErr != nil {
 						return reviewErr
 					}
@@ -116,68 +134,63 @@ func (r *LedgerRepositoryImpl) CommitPlacementSemanticResult(
 					appendPlacementReviewTaskID(result, review.ReviewTaskID)
 					continue
 				}
-				if !errors.Is(err, errPlacementUnresolvedEndpoint) {
+				if observation.ConflictContext != nil {
+					if err := requireRelationshipConflictContextMatchesDecision(ctx, tx, input.TeamID, *observation.ConflictContext, decision); err != nil {
+						return err
+					}
+				}
+				if err := applyPlacementRelationshipDecision(
+					ctx,
+					tx,
+					input,
+					decision,
+					observation.CorrectionTarget,
+					observation.ConflictContext,
+					placementFragmentID,
+					r.embeddingJobMaxAttempts,
+					ConflictRuntimeConfig{
+						ReviewTTLDays: r.conflictReviewTTLDays,
+						Timezone:      r.conflictReviewTimezone,
+					},
+					result,
+				); err != nil {
 					return err
 				}
-				review, reviewErr := insertRelationshipDependencyReview(ctx, tx, input, observation, err.Error())
-				if reviewErr != nil {
-					return reviewErr
-				}
-				appendPlacementRelationshipResult(result, review)
-				appendPlacementReviewTaskID(result, review.ReviewTaskID)
-				continue
 			}
-			if observation.ConflictContext != nil {
-				if err := requireRelationshipConflictContextMatchesDecision(ctx, tx, input.TeamID, *observation.ConflictContext, decision); err != nil {
+			for _, review := range input.RelationshipReviews {
+				recorded, err := insertRelationshipReview(ctx, tx, input, review)
+				if err != nil {
 					return err
 				}
+				appendPlacementRelationshipResult(result, recorded)
+				appendPlacementReviewTaskID(result, recorded.ReviewTaskID)
 			}
-			if err := applyPlacementRelationshipDecision(
-				ctx,
-				tx,
-				input,
-				decision,
-				observation.CorrectionTarget,
-				observation.ConflictContext,
-				placementFragmentID,
-				r.embeddingJobMaxAttempts,
-				ConflictRuntimeConfig{
-					ReviewTTLDays: r.conflictReviewTTLDays,
-					Timezone:      r.conflictReviewTimezone,
-				},
-				result,
-			); err != nil {
-				return err
-			}
-		}
-		for _, review := range input.RelationshipReviews {
-			recorded, err := insertRelationshipReview(ctx, tx, input, review)
-			if err != nil {
-				return err
-			}
-			appendPlacementRelationshipResult(result, recorded)
-			appendPlacementReviewTaskID(result, recorded.ReviewTaskID)
-		}
-		for _, decision := range input.RelationshipDecisions {
-			if err := applyPlacementRelationshipDecision(
-				ctx,
-				tx,
-				input,
-				withPlacementDecisionScope(input, decision),
-				nil,
-				nil,
-				placementFragmentID,
-				r.embeddingJobMaxAttempts,
-				ConflictRuntimeConfig{
-					ReviewTTLDays: r.conflictReviewTTLDays,
-					Timezone:      r.conflictReviewTimezone,
-				},
-				result,
-			); err != nil {
-				return err
+			for _, decision := range input.RelationshipDecisions {
+				if err := applyPlacementRelationshipDecision(
+					ctx,
+					tx,
+					input,
+					withPlacementDecisionScope(input, decision),
+					nil,
+					nil,
+					placementFragmentID,
+					r.embeddingJobMaxAttempts,
+					ConflictRuntimeConfig{
+						ReviewTTLDays: r.conflictReviewTTLDays,
+						Timezone:      r.conflictReviewTimezone,
+					},
+					result,
+				); err != nil {
+					return err
+				}
 			}
 		}
 		payload := placementCommitPayload(input.Payload, result)
+		if deletionOnly {
+			payload["conflict_resolution_deletion_only"] = true
+			payload["semantic_projection"] = "not_allowed"
+			input.Category = "candidate"
+		}
 		itemStatus := string(domain.PlacementRunCompleted)
 		runStatus := string(domain.PlacementRunCompleted)
 		if len(result.ReviewTaskIDs) > 0 {

--- a/internal/repository/placement_commit_search.go
+++ b/internal/repository/placement_commit_search.go
@@ -13,6 +13,8 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 )
 
+const conflictResolutionDeletionOnlySourceSummary = "overdue conflict deletion-only derivation"
+
 func loadActiveSearchContractInTx(ctx context.Context, tx *gorm.DB) (*ActiveSearchContract, error) {
 	var contract ActiveSearchContract
 	err := tx.WithContext(ctx).Raw(`
@@ -513,11 +515,24 @@ func isConflictResolutionDeletionOnlyFragment(
 ) (bool, error) {
 	var deletionOnly bool
 	err := tx.WithContext(ctx).Raw(`
-		SELECT COALESCE(metadata->>'conflict_resolution_deletion_only', '') = 'true'
-		FROM evidence_fragments
-		WHERE team_id = ?::uuid
-		  AND fragment_id = ?::uuid
-	`, teamID, fragmentID).Row().Scan(&deletionOnly)
+		SELECT COALESCE(fragment.metadata->>'conflict_resolution_deletion_only', '') = 'true'
+		   AND COALESCE(ingest.metadata->>'conflict_resolution_deletion_only', '') = 'true'
+		   AND ingest.source_summary = ?
+		   AND profile.auth_source = 'system'
+		   AND profile.is_system
+		FROM evidence_fragments AS fragment
+		JOIN knowledge_ingests AS ingest
+		  ON ingest.team_id = fragment.team_id
+		 AND ingest.ingest_id = fragment.ingest_id
+		JOIN team_profiles AS profile
+		  ON profile.team_id = fragment.team_id
+		 AND profile.id = fragment.owner_profile_id
+		WHERE fragment.team_id = ?::uuid
+		  AND fragment.fragment_id = ?::uuid
+	`, conflictResolutionDeletionOnlySourceSummary, teamID, fragmentID).Row().Scan(&deletionOnly)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}

--- a/internal/repository/placement_commit_search.go
+++ b/internal/repository/placement_commit_search.go
@@ -505,6 +505,25 @@ func loadPlacementItemFragmentID(ctx context.Context, tx *gorm.DB, commit Commit
 	return fragmentID, nil
 }
 
+func isConflictResolutionDeletionOnlyFragment(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	fragmentID string,
+) (bool, error) {
+	var deletionOnly bool
+	err := tx.WithContext(ctx).Raw(`
+		SELECT COALESCE(metadata->>'conflict_resolution_deletion_only', '') = 'true'
+		FROM evidence_fragments
+		WHERE team_id = ?::uuid
+		  AND fragment_id = ?::uuid
+	`, teamID, fragmentID).Row().Scan(&deletionOnly)
+	if err != nil {
+		return false, err
+	}
+	return deletionOnly, nil
+}
+
 func upsertPlacementItemEvidenceSearchDocument(
 	ctx context.Context,
 	tx *gorm.DB,

--- a/internal/repository/placement_conflict_repository_integration_test.go
+++ b/internal/repository/placement_conflict_repository_integration_test.go
@@ -685,8 +685,17 @@ func commitPlacementRelationshipForConflictTest(
 }
 
 type conflictTestRelationshipOptions struct {
-	validFrom *time.Time
-	authority string
+	validFrom          *time.Time
+	authority          string
+	additionalSupports []conflictTestAdditionalSupport
+}
+
+type conflictTestAdditionalSupport struct {
+	sourceGroupKey string
+	spanStart      int
+	spanEnd        int
+	quote          string
+	authority      string
 }
 
 func commitPlacementRelationshipForConflictTestWithOptions(
@@ -741,6 +750,21 @@ func attemptPlacementRelationshipForConflictTest(
 	claimed, err := repo.ClaimNextPlacementRun(ctx, teamID, workerID, time.Minute)
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
+	additionalSupports := make([]EvidenceSupportInput, 0, len(option.additionalSupports))
+	for _, support := range option.additionalSupports {
+		authority := support.authority
+		if authority == "" {
+			authority = option.authority
+		}
+		additionalSupports = append(additionalSupports, EvidenceSupportInput{
+			FragmentID:     ingest.Evidence[0].FragmentID,
+			SourceGroupKey: support.sourceGroupKey,
+			SpanStart:      support.spanStart,
+			SpanEnd:        support.spanEnd,
+			Quote:          support.quote,
+			Authority:      authority,
+		})
+	}
 	return repo.CommitPlacementSemanticResult(ctx, CommitPlacementSemanticInput{
 		TeamID:           teamID,
 		OwnerProfileID:   ownerID,
@@ -774,6 +798,7 @@ func attemptPlacementRelationshipForConflictTest(
 				Quote:          content,
 				Authority:      option.authority,
 			},
+			Supports: additionalSupports,
 		}},
 	})
 }

--- a/internal/repository/placement_review_completion_repository.go
+++ b/internal/repository/placement_review_completion_repository.go
@@ -92,14 +92,23 @@ func (r *LedgerRepositoryImpl) CompletePlacementReviewResult(
 			if err != nil {
 				return err
 			}
-			if _, err := upsertPlacementItemEvidenceSearchDocument(
-				ctx,
-				tx,
-				scope,
-				placementFragmentID,
-				r.embeddingJobMaxAttempts,
-			); err != nil {
+			deletionOnly, err := isConflictResolutionDeletionOnlyFragment(ctx, tx, input.TeamID, placementFragmentID)
+			if err != nil {
 				return err
+			}
+			if !deletionOnly {
+				if _, err := upsertPlacementItemEvidenceSearchDocument(
+					ctx,
+					tx,
+					scope,
+					placementFragmentID,
+					r.embeddingJobMaxAttempts,
+				); err != nil {
+					return err
+				}
+			} else {
+				payload["conflict_resolution_deletion_only"] = true
+				payload["semantic_projection"] = "not_allowed"
 			}
 		}
 		outcomeID, err := insertPlacementOutcome(ctx, tx, PlacementOutcomeInput{

--- a/internal/repository/placement_status_repository.go
+++ b/internal/repository/placement_status_repository.go
@@ -86,7 +86,7 @@ func loadPlacementRunStatus(
 		return nil, err
 	}
 	evidenceRows, err := tx.WithContext(ctx).Raw(`
-		SELECT fragment_id::text, evidence_index, content, content_hash,
+		SELECT fragment_id::text, evidence_index, content, content_hash, authority,
 		       COALESCE(source_id::text, ''), COALESCE(source_revision_id::text, '')
 		FROM evidence_fragments
 		WHERE team_id = ?::uuid
@@ -105,6 +105,7 @@ func loadPlacementRunStatus(
 			&item.EvidenceIndex,
 			&item.Content,
 			&item.ContentHash,
+			&item.Authority,
 			&item.SourceID,
 			&item.SourceRevisionID,
 		); err != nil {

--- a/internal/service/conflictreview/runner.go
+++ b/internal/service/conflictreview/runner.go
@@ -1,0 +1,51 @@
+package conflictreview
+
+import (
+	"context"
+	"errors"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/verifier"
+)
+
+type Runner struct {
+	ledger  *repository.LedgerRepositoryImpl
+	service *Service
+}
+
+func NewRunner(
+	ledger *repository.LedgerRepositoryImpl,
+	provider Provider,
+	timezone string,
+	limits verifier.SemanticAssessmentLimits,
+) (*Runner, error) {
+	if ledger == nil {
+		return nil, errors.New("conflict review runner: ledger is required")
+	}
+	service, err := New(Dependencies{
+		Repository: ledger,
+		Provider:   provider,
+		Timezone:   timezone,
+		Limits:     limits,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Runner{ledger: ledger, service: service}, nil
+}
+
+func (r *Runner) ReserveRelationshipConflictReviewRun(ctx context.Context, input repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error) {
+	return r.ledger.ReserveRelationshipConflictReviewRun(ctx, input)
+}
+
+func (r *Runner) ClaimRelationshipConflictCases(ctx context.Context, input repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error) {
+	return r.ledger.ClaimRelationshipConflictCases(ctx, input)
+}
+
+func (r *Runner) ReviewRelationshipConflictCase(ctx context.Context, input repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	return r.service.ReviewRelationshipConflictCase(ctx, input)
+}
+
+func (r *Runner) CompleteRelationshipConflictReviewRun(ctx context.Context, input repository.ConflictReviewRunCompleteInput) error {
+	return r.ledger.CompleteRelationshipConflictReviewRun(ctx, input)
+}

--- a/internal/service/conflictreview/runner.go
+++ b/internal/service/conflictreview/runner.go
@@ -8,13 +8,20 @@ import (
 	"github.com/markhuangai/dense-mem/internal/verifier"
 )
 
+type RunLedger interface {
+	Repository
+	ReserveRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunInput) (*repository.ConflictReviewRunRecord, bool, error)
+	ClaimRelationshipConflictCases(context.Context, repository.ClaimRelationshipConflictCasesInput) ([]repository.RelationshipConflictCaseRecord, error)
+	CompleteRelationshipConflictReviewRun(context.Context, repository.ConflictReviewRunCompleteInput) error
+}
+
 type Runner struct {
-	ledger  *repository.LedgerRepositoryImpl
+	ledger  RunLedger
 	service *Service
 }
 
 func NewRunner(
-	ledger *repository.LedgerRepositoryImpl,
+	ledger RunLedger,
 	provider Provider,
 	timezone string,
 	limits verifier.SemanticAssessmentLimits,

--- a/internal/service/conflictreview/runner.go
+++ b/internal/service/conflictreview/runner.go
@@ -46,6 +46,10 @@ func (r *Runner) ReviewRelationshipConflictCase(ctx context.Context, input repos
 	return r.service.ReviewRelationshipConflictCase(ctx, input)
 }
 
+func (r *Runner) ProcessPendingConflictDerivedEvidence(ctx context.Context, input repository.ClaimConflictDerivedEvidenceTasksInput) (int, error) {
+	return r.service.ProcessPendingConflictDerivedEvidence(ctx, input)
+}
+
 func (r *Runner) CompleteRelationshipConflictReviewRun(ctx context.Context, input repository.ConflictReviewRunCompleteInput) error {
 	return r.ledger.CompleteRelationshipConflictReviewRun(ctx, input)
 }

--- a/internal/service/conflictreview/service.go
+++ b/internal/service/conflictreview/service.go
@@ -1,0 +1,421 @@
+package conflictreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/verifier"
+)
+
+const AssessmentConfidenceThreshold = 0.70
+
+type Repository interface {
+	ReviewRelationshipConflictCase(context.Context, repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error)
+	ResumePendingOverdueConflictResolution(context.Context, repository.ResumePendingOverdueConflictResolutionInput) (*repository.ApplyOverdueConflictResolutionResult, bool, error)
+	ReserveOverdueConflictAssessment(context.Context, repository.ReserveOverdueConflictAssessmentInput) (*repository.OverdueConflictAssessmentReservation, *repository.OverdueConflictAssessmentDossier, bool, error)
+	CompleteOverdueConflictAssessment(context.Context, repository.CompleteOverdueConflictAssessmentInput) (*repository.CompleteOverdueConflictAssessmentResult, error)
+	ApplyOverdueConflictResolution(context.Context, repository.ApplyOverdueConflictResolutionInput) (*repository.ApplyOverdueConflictResolutionResult, error)
+	StageConflictDerivedEvidence(context.Context, repository.ConflictDerivedEvidenceTarget) (*repository.StageConflictDerivedEvidenceResult, error)
+	RecordConflictDerivedEvidenceFailure(context.Context, repository.ConflictDerivedEvidenceTarget, string) error
+}
+
+type Provider interface {
+	AssessRelationshipConflict(context.Context, verifier.ConflictAssessmentRequest) (verifier.ConflictAssessmentResponse, error)
+	ModelName() string
+}
+
+type Dependencies struct {
+	Repository Repository
+	Provider   Provider
+	Timezone   string
+	Limits     verifier.SemanticAssessmentLimits
+	Now        func() time.Time
+}
+
+type Service struct {
+	repository Repository
+	provider   Provider
+	location   *time.Location
+	limits     verifier.SemanticAssessmentLimits
+	now        func() time.Time
+}
+
+func New(deps Dependencies) (*Service, error) {
+	if deps.Repository == nil {
+		return nil, errors.New("conflict review service: repository is required")
+	}
+	if deps.Provider == nil {
+		return nil, errors.New("conflict review service: provider is required")
+	}
+	if strings.TrimSpace(deps.Provider.ModelName()) == "" {
+		return nil, errors.New("conflict review service: provider model is required")
+	}
+	timezone := strings.TrimSpace(deps.Timezone)
+	if timezone == "" {
+		timezone = "Local"
+	}
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return nil, fmt.Errorf("conflict review service: timezone is invalid: %w", err)
+	}
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{
+		repository: deps.Repository,
+		provider:   deps.Provider,
+		location:   location,
+		limits:     deps.Limits,
+		now:        now,
+	}, nil
+}
+
+func (s *Service) ReviewRelationshipConflictCase(
+	ctx context.Context,
+	input repository.ReviewRelationshipConflictCaseInput,
+) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	if s == nil || s.repository == nil || s.provider == nil {
+		return nil, errors.New("conflict review service is not configured")
+	}
+	if input.Now.IsZero() {
+		input.Now = s.now().UTC()
+	} else {
+		input.Now = input.Now.UTC()
+	}
+	result, err := s.repository.ReviewRelationshipConflictCase(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errors.New("conflict review service: deterministic review returned no result")
+	}
+	if result.Outcome != repository.ConflictReviewOutcomeOverdue {
+		return result, nil
+	}
+
+	pending, found, err := s.repository.ResumePendingOverdueConflictResolution(ctx, repository.ResumePendingOverdueConflictResolutionInput{
+		TeamID:      input.TeamID,
+		ConflictID:  input.ConflictID,
+		ReviewRunID: input.ReviewRunID,
+		WorkerID:    input.WorkerID,
+		Now:         input.Now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return s.applyResolutionResult(ctx, result, input, "", "", pending)
+	}
+
+	localNow := input.Now.In(s.location)
+	reservation, dossier, reserved, err := s.repository.ReserveOverdueConflictAssessment(ctx, repository.ReserveOverdueConflictAssessmentInput{
+		TeamID:              input.TeamID,
+		ConflictID:          input.ConflictID,
+		ReviewRunID:         input.ReviewRunID,
+		WorkerID:            input.WorkerID,
+		LocalAssessmentDate: localNow,
+		Model:               s.provider.ModelName(),
+		PolicyVersion:       domain.ConflictOverduePolicyVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !reserved || reservation == nil || dossier == nil {
+		result.Stage = "overdue_assessment_already_reserved"
+		return result, nil
+	}
+	result.AssessmentAttemptID = reservation.AssessmentAttemptID
+	if reservation.LastWriteWins {
+		return s.applyLastWriteWins(ctx, result, input, reservation, dossier)
+	}
+	request, requestErr := conflictAssessmentRequest(reservation, dossier)
+	if requestErr != nil {
+		return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, "dossier_invalid")
+	}
+	prepared, validationErrors := verifier.PrepareConflictAssessmentRequest(request, s.limits)
+	if len(validationErrors) > 0 {
+		return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, "dossier_bound_exceeded")
+	}
+
+	response, err := s.provider.AssessRelationshipConflict(ctx, prepared)
+	if err != nil {
+		return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, conflictAssessmentFailureClass(err))
+	}
+	return s.applyAssessmentResponse(ctx, result, input, reservation, dossier, response)
+}
+
+func (s *Service) applyAssessmentResponse(
+	ctx context.Context,
+	result *repository.ReviewRelationshipConflictCaseResult,
+	input repository.ReviewRelationshipConflictCaseInput,
+	reservation *repository.OverdueConflictAssessmentReservation,
+	dossier *repository.OverdueConflictAssessmentDossier,
+	response verifier.ConflictAssessmentResponse,
+) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	response.Decision = strings.TrimSpace(response.Decision)
+	if response.Decision == verifier.ConflictAssessmentDecisionSelect {
+		positionID, valid := validSelectedConflictPosition(dossier, response)
+		if !valid {
+			return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, "invalid_response")
+		}
+		if response.Confidence < AssessmentConfidenceThreshold {
+			return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, "below_confidence_threshold")
+		}
+		confidence := response.Confidence
+		if _, err := s.completeAssessment(ctx, input, reservation, repository.CompleteOverdueConflictAssessmentInput{
+			Decision:           "selected",
+			SelectedPositionID: positionID,
+			Confidence:         &confidence,
+			ProviderTurns:      response.ProviderTurns,
+			ResponseHash:       conflictAssessmentResponseHash(response),
+		}); err != nil {
+			return s.handleAssessmentCompletionError(result, err)
+		}
+		applied, err := s.repository.ApplyOverdueConflictResolution(ctx, repository.ApplyOverdueConflictResolutionInput{
+			TeamID:              input.TeamID,
+			ConflictID:          input.ConflictID,
+			ReviewRunID:         input.ReviewRunID,
+			WorkerID:            input.WorkerID,
+			ExpectedCaseVersion: reservation.CaseVersion,
+			PreferredPositionID: positionID,
+			AssessmentAttemptID: reservation.AssessmentAttemptID,
+			Method:              "ai",
+			Now:                 input.Now,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return s.applyResolutionResult(ctx, result, input, reservation.AssessmentAttemptID, "ai", applied)
+	}
+	if response.Decision == verifier.ConflictAssessmentDecisionAbstain && response.PositionID == nil && response.Confidence == 0 {
+		confidence := float64(0)
+		if _, err := s.completeAssessment(ctx, input, reservation, repository.CompleteOverdueConflictAssessmentInput{
+			Decision:      "abstained",
+			Confidence:    &confidence,
+			ProviderTurns: response.ProviderTurns,
+			ResponseHash:  conflictAssessmentResponseHash(response),
+		}); err != nil {
+			return s.handleAssessmentCompletionError(result, err)
+		}
+		return s.applyLastWriteWins(ctx, result, input, reservation, dossier)
+	}
+	return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, "invalid_response")
+}
+
+func (s *Service) recordAssessmentFailure(
+	ctx context.Context,
+	result *repository.ReviewRelationshipConflictCaseResult,
+	input repository.ReviewRelationshipConflictCaseInput,
+	reservation *repository.OverdueConflictAssessmentReservation,
+	dossier *repository.OverdueConflictAssessmentDossier,
+	failureClass string,
+) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	completed, err := s.completeAssessment(ctx, input, reservation, repository.CompleteOverdueConflictAssessmentInput{
+		Decision:     "failed",
+		FailureClass: failureClass,
+	})
+	if err != nil {
+		return s.handleAssessmentCompletionError(result, err)
+	}
+	if completed.FailureCount < 5 {
+		result.Stage = "overdue_assessment_failed"
+		return result, nil
+	}
+	return s.applyLastWriteWins(ctx, result, input, reservation, dossier)
+}
+
+func (s *Service) completeAssessment(
+	ctx context.Context,
+	input repository.ReviewRelationshipConflictCaseInput,
+	reservation *repository.OverdueConflictAssessmentReservation,
+	completion repository.CompleteOverdueConflictAssessmentInput,
+) (*repository.CompleteOverdueConflictAssessmentResult, error) {
+	completion.TeamID = input.TeamID
+	completion.ConflictID = input.ConflictID
+	completion.AssessmentAttemptID = reservation.AssessmentAttemptID
+	completion.CaseVersion = reservation.CaseVersion
+	completion.ReviewRunID = input.ReviewRunID
+	return s.repository.CompleteOverdueConflictAssessment(ctx, completion)
+}
+
+func (s *Service) applyLastWriteWins(
+	ctx context.Context,
+	result *repository.ReviewRelationshipConflictCaseResult,
+	input repository.ReviewRelationshipConflictCaseInput,
+	reservation *repository.OverdueConflictAssessmentReservation,
+	dossier *repository.OverdueConflictAssessmentDossier,
+) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	positions := make([]domain.ConflictResolutionPosition, 0, len(dossier.Positions))
+	for _, position := range dossier.Positions {
+		positions = append(positions, domain.ConflictResolutionPosition{
+			PositionID: position.PositionID,
+			Supports:   append([]domain.ConflictResolutionSupport(nil), position.Supports...),
+		})
+	}
+	winner, ok := domain.SelectConflictLastWriteWinner(positions)
+	if !ok {
+		result.Stage = "overdue_last_write_wins_unavailable"
+		return result, nil
+	}
+	applied, err := s.repository.ApplyOverdueConflictResolution(ctx, repository.ApplyOverdueConflictResolutionInput{
+		TeamID:              input.TeamID,
+		ConflictID:          input.ConflictID,
+		ReviewRunID:         input.ReviewRunID,
+		WorkerID:            input.WorkerID,
+		ExpectedCaseVersion: reservation.CaseVersion,
+		PreferredPositionID: winner.PositionID,
+		AssessmentAttemptID: reservation.AssessmentAttemptID,
+		Method:              "last_write_wins",
+		Now:                 input.Now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.applyResolutionResult(ctx, result, input, reservation.AssessmentAttemptID, "last_write_wins", applied)
+}
+
+func (s *Service) applyResolutionResult(
+	ctx context.Context,
+	result *repository.ReviewRelationshipConflictCaseResult,
+	input repository.ReviewRelationshipConflictCaseInput,
+	assessmentAttemptID string,
+	method string,
+	applied *repository.ApplyOverdueConflictResolutionResult,
+) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	if applied == nil || applied.Stale {
+		result.Stage = "overdue_assessment_stale"
+		return result, nil
+	}
+	if assessmentAttemptID != "" {
+		result.AssessmentAttemptID = assessmentAttemptID
+	}
+	if method != "" {
+		result.ResolutionMethod = method
+	}
+	if result.ResolutionMethod == "" {
+		result.ResolutionMethod = applied.Method
+	}
+	if applied.PreferredPositionID != "" {
+		result.PreferredPositionID = applied.PreferredPositionID
+	}
+	if applied.Pending {
+		result.Stage = "resolution_pending"
+		result.ResolutionPending = true
+		return result, nil
+	}
+	if !applied.Resolved {
+		result.Stage = "overdue_assessment_stale"
+		return result, nil
+	}
+	result.Outcome = repository.ConflictReviewOutcomeResolve
+	result.Stage = "overdue_" + result.ResolutionMethod
+	result.UpdatedRelationships = append([]string(nil), applied.UpdatedRelationships...)
+	result.RetractedEvidenceIDs = append([]string(nil), applied.RetractedEvidenceIDs...)
+	for _, target := range applied.DerivedEvidence {
+		if _, err := s.repository.StageConflictDerivedEvidence(ctx, target); err != nil {
+			failureErr := s.repository.RecordConflictDerivedEvidenceFailure(ctx, target, "staging_failed")
+			if failureErr != nil {
+				return nil, errors.Join(err, failureErr)
+			}
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (s *Service) handleAssessmentCompletionError(result *repository.ReviewRelationshipConflictCaseResult, err error) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	if errors.Is(err, repository.ErrConflictAssessmentReserved) || errors.Is(err, repository.ErrConflictAssessmentStale) {
+		result.Stage = "overdue_assessment_stale"
+		return result, nil
+	}
+	return nil, err
+}
+
+func conflictAssessmentRequest(
+	reservation *repository.OverdueConflictAssessmentReservation,
+	dossier *repository.OverdueConflictAssessmentDossier,
+) (verifier.ConflictAssessmentRequest, error) {
+	if reservation == nil || dossier == nil {
+		return verifier.ConflictAssessmentRequest{}, errors.New("assessment reservation and dossier are required")
+	}
+	request := verifier.ConflictAssessmentRequest{
+		RequestID: reservation.AssessmentAttemptID,
+		CaseID:    dossier.ConflictID,
+		Version:   dossier.CaseVersion,
+		Question:  dossier.Question,
+		Positions: make([]verifier.ConflictAssessmentPosition, 0, len(dossier.Positions)),
+		Evidence:  make([]verifier.ConflictAssessmentEvidence, 0, len(dossier.Evidence)),
+	}
+	for _, position := range dossier.Positions {
+		request.Positions = append(request.Positions, verifier.ConflictAssessmentPosition{
+			PositionID:              position.PositionID,
+			PositionKey:             position.PositionKey,
+			SupportGroupCount:       position.SupportGroupCount,
+			AuthoritativeGroupCount: position.AuthoritativeGroupCount,
+			OwnerProfileCount:       position.OwnerProfileCount,
+		})
+	}
+	for _, evidence := range dossier.Evidence {
+		request.Evidence = append(request.Evidence, verifier.ConflictAssessmentEvidence{
+			EvidenceID:     evidence.FragmentID,
+			PositionID:     evidence.PositionID,
+			SupportID:      evidence.SupportID,
+			SourceGroupKey: evidence.SourceGroupKey,
+			Authority:      evidence.Authority,
+			AcceptedAt:     evidence.AcceptedAt,
+			EffectiveAt:    evidence.EffectiveAt,
+			Content:        evidence.Content,
+		})
+	}
+	return request, nil
+}
+
+func validSelectedConflictPosition(dossier *repository.OverdueConflictAssessmentDossier, response verifier.ConflictAssessmentResponse) (string, bool) {
+	if dossier == nil || response.PositionID == nil || response.Confidence < 0 || response.Confidence > 1 {
+		return "", false
+	}
+	positionID := strings.TrimSpace(*response.PositionID)
+	if positionID == "" {
+		return "", false
+	}
+	for _, position := range dossier.Positions {
+		if position.PositionID == positionID {
+			return positionID, true
+		}
+	}
+	return "", false
+}
+
+func conflictAssessmentFailureClass(err error) string {
+	if errors.Is(err, verifier.ErrVerifierMalformedResponse) {
+		return "malformed_response"
+	}
+	class := strings.TrimSpace(verifier.ProviderFailureDetails(err).Class)
+	if class == "" || len(class) > 128 {
+		return "provider_unavailable"
+	}
+	return class
+}
+
+func conflictAssessmentResponseHash(response verifier.ConflictAssessmentResponse) string {
+	positionID := ""
+	if response.PositionID != nil {
+		positionID = strings.TrimSpace(*response.PositionID)
+	}
+	payload := strings.Join([]string{
+		strings.TrimSpace(response.Decision),
+		positionID,
+		fmt.Sprintf("%.6f", response.Confidence),
+		strings.TrimSpace(response.Rationale),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/service/conflictreview/service.go
+++ b/internal/service/conflictreview/service.go
@@ -253,7 +253,7 @@ func (s *Service) recordAssessmentFailure(
 	if err != nil {
 		return s.handleAssessmentCompletionError(result, err)
 	}
-	if completed.FailureCount < 5 {
+	if completed == nil || completed.FailureCount < repository.ConflictAssessmentMaxFailedDays {
 		result.Stage = "overdue_assessment_failed"
 		return result, nil
 	}

--- a/internal/service/conflictreview/service.go
+++ b/internal/service/conflictreview/service.go
@@ -22,6 +22,7 @@ type Repository interface {
 	ReserveOverdueConflictAssessment(context.Context, repository.ReserveOverdueConflictAssessmentInput) (*repository.OverdueConflictAssessmentReservation, *repository.OverdueConflictAssessmentDossier, bool, error)
 	CompleteOverdueConflictAssessment(context.Context, repository.CompleteOverdueConflictAssessmentInput) (*repository.CompleteOverdueConflictAssessmentResult, error)
 	ApplyOverdueConflictResolution(context.Context, repository.ApplyOverdueConflictResolutionInput) (*repository.ApplyOverdueConflictResolutionResult, error)
+	ClaimConflictDerivedEvidenceTasks(context.Context, repository.ClaimConflictDerivedEvidenceTasksInput) ([]repository.ConflictDerivedEvidenceTarget, error)
 	StageConflictDerivedEvidence(context.Context, repository.ConflictDerivedEvidenceTarget) (*repository.StageConflictDerivedEvidenceResult, error)
 	RecordConflictDerivedEvidenceFailure(context.Context, repository.ConflictDerivedEvidenceTarget, string) error
 }
@@ -150,6 +151,33 @@ func (s *Service) ReviewRelationshipConflictCase(
 		return s.recordAssessmentFailure(ctx, result, input, reservation, dossier, conflictAssessmentFailureClass(err))
 	}
 	return s.applyAssessmentResponse(ctx, result, input, reservation, dossier, response)
+}
+
+func (s *Service) ProcessPendingConflictDerivedEvidence(
+	ctx context.Context,
+	input repository.ClaimConflictDerivedEvidenceTasksInput,
+) (int, error) {
+	if s == nil || s.repository == nil {
+		return 0, errors.New("conflict review service is not configured")
+	}
+	staged := 0
+	for {
+		targets, err := s.repository.ClaimConflictDerivedEvidenceTasks(ctx, input)
+		if err != nil {
+			return staged, err
+		}
+		if len(targets) == 0 {
+			return staged, nil
+		}
+		completed, err := s.stageConflictDerivedEvidence(ctx, targets)
+		staged += completed
+		if err != nil {
+			return staged, err
+		}
+		if len(targets) < input.Limit {
+			return staged, nil
+		}
+	}
 }
 
 func (s *Service) applyAssessmentResponse(
@@ -319,16 +347,25 @@ func (s *Service) applyResolutionResult(
 	result.Stage = "overdue_" + result.ResolutionMethod
 	result.UpdatedRelationships = append([]string(nil), applied.UpdatedRelationships...)
 	result.RetractedEvidenceIDs = append([]string(nil), applied.RetractedEvidenceIDs...)
-	for _, target := range applied.DerivedEvidence {
+	if _, err := s.stageConflictDerivedEvidence(ctx, applied.DerivedEvidence); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *Service) stageConflictDerivedEvidence(ctx context.Context, targets []repository.ConflictDerivedEvidenceTarget) (int, error) {
+	staged := 0
+	for _, target := range targets {
 		if _, err := s.repository.StageConflictDerivedEvidence(ctx, target); err != nil {
 			failureErr := s.repository.RecordConflictDerivedEvidenceFailure(ctx, target, "staging_failed")
 			if failureErr != nil {
-				return nil, errors.Join(err, failureErr)
+				return staged, errors.Join(err, failureErr)
 			}
-			return nil, err
+			return staged, err
 		}
+		staged++
 	}
-	return result, nil
+	return staged, nil
 }
 
 func (s *Service) handleAssessmentCompletionError(result *repository.ReviewRelationshipConflictCaseResult, err error) (*repository.ReviewRelationshipConflictCaseResult, error) {

--- a/internal/service/conflictreview/service_test.go
+++ b/internal/service/conflictreview/service_test.go
@@ -108,6 +108,22 @@ func TestServiceUsesLastWriteWinsAfterFifthFailedAssessment(t *testing.T) {
 	assert.Equal(t, "last_write_wins", repo.applyInputs[0].Method)
 }
 
+func TestServiceLeavesFailedAssessmentPendingWhenCompletionResultIsNil(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.completeNil = true
+	provider := &conflictReviewProviderStub{err: &verifier.ProviderError{
+		Provider:     "test",
+		Message:      "provider failed",
+		FailureClass: verifier.ProviderFailureClassHTTPServer,
+	}}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, "overdue_assessment_failed", result.Stage)
+	assert.Empty(t, repo.applyInputs)
+}
+
 func TestServiceUsesLastWriteWinsAfterAbandonedAssessmentRecoveryWithoutProviderCall(t *testing.T) {
 	repo := newConflictReviewRepositoryStub(t)
 	repo.reservation.LastWriteWins = true
@@ -439,6 +455,7 @@ type conflictReviewRepositoryStub struct {
 	reservation     *repository.OverdueConflictAssessmentReservation
 	dossier         *repository.OverdueConflictAssessmentDossier
 	completeResult  repository.CompleteOverdueConflictAssessmentResult
+	completeNil     bool
 	applyResult     *repository.ApplyOverdueConflictResolutionResult
 	pendingFound    bool
 	pendingResult   *repository.ApplyOverdueConflictResolutionResult
@@ -504,6 +521,9 @@ func (s *conflictReviewRepositoryStub) CompleteOverdueConflictAssessment(_ conte
 	s.completions = append(s.completions, input)
 	if s.completeErr != nil {
 		return nil, s.completeErr
+	}
+	if s.completeNil {
+		return nil, nil
 	}
 	copy := s.completeResult
 	return &copy, nil

--- a/internal/service/conflictreview/service_test.go
+++ b/internal/service/conflictreview/service_test.go
@@ -25,6 +25,7 @@ const (
 	conflictReviewTestFragmentBID = "00000000-0000-0000-0000-000000000302"
 	conflictReviewTestSupportAID  = "00000000-0000-0000-0000-000000000401"
 	conflictReviewTestSupportBID  = "00000000-0000-0000-0000-000000000402"
+	conflictReviewTestTaskID      = "00000000-0000-0000-0000-000000000501"
 	conflictReviewTestWorkerID    = "conflict-review-test"
 )
 
@@ -210,6 +211,7 @@ func TestServiceLeavesUnresolvableLastWriteWinsCaseOverdue(t *testing.T) {
 func TestServiceRecordsDerivedEvidenceStagingFailure(t *testing.T) {
 	repo := newConflictReviewRepositoryStub(t)
 	repo.applyResult.DerivedEvidence = []repository.ConflictDerivedEvidenceTarget{{
+		TaskID:               conflictReviewTestTaskID,
 		TeamID:               conflictReviewTestTeamID,
 		ConflictID:           conflictReviewTestConflictID,
 		SystemProfileID:      conflictReviewTestTeamID,
@@ -234,6 +236,34 @@ func TestServiceRecordsDerivedEvidenceStagingFailure(t *testing.T) {
 	require.Len(t, repo.stagedTargets, 1)
 	require.Len(t, repo.recordedFailures, 1)
 	assert.Equal(t, "staging_failed", repo.recordedFailures[0].failureClass)
+}
+
+func TestServiceProcessesPendingDerivedEvidence(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.derivedBatches = [][]repository.ConflictDerivedEvidenceTarget{{{
+		TaskID:               conflictReviewTestTaskID,
+		TeamID:               conflictReviewTestTeamID,
+		ConflictID:           conflictReviewTestConflictID,
+		SystemProfileID:      conflictReviewTestTeamID,
+		TargetFragmentID:     conflictReviewTestFragmentAID,
+		TargetOwnerProfileID: conflictReviewTestTeamID,
+		SelectedPositionID:   conflictReviewTestPositionAID,
+		SourceGroupKey:       "source-a",
+	}}}
+	service := newConflictReviewService(t, repo, &conflictReviewProviderStub{})
+
+	staged, err := service.ProcessPendingConflictDerivedEvidence(context.Background(), repository.ClaimConflictDerivedEvidenceTasksInput{
+		TeamID:      conflictReviewTestTeamID,
+		ReviewRunID: conflictReviewTestReviewRunID,
+		WorkerID:    conflictReviewTestWorkerID,
+		Limit:       2,
+		Lease:       time.Minute,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, staged)
+	require.Len(t, repo.derivedClaimInputs, 1)
+	require.Len(t, repo.stagedTargets, 1)
 }
 
 func TestServiceLeavesAlreadyReservedAssessmentUntouched(t *testing.T) {
@@ -405,27 +435,30 @@ func newConflictReviewRepositoryStub(t *testing.T) *conflictReviewRepositoryStub
 }
 
 type conflictReviewRepositoryStub struct {
-	reviewResult   *repository.ReviewRelationshipConflictCaseResult
-	reservation    *repository.OverdueConflictAssessmentReservation
-	dossier        *repository.OverdueConflictAssessmentDossier
-	completeResult repository.CompleteOverdueConflictAssessmentResult
-	applyResult    *repository.ApplyOverdueConflictResolutionResult
-	pendingFound   bool
-	pendingResult  *repository.ApplyOverdueConflictResolutionResult
-	reserved       bool
-	reviewErr      error
-	resumeErr      error
-	reserveErr     error
-	completeErr    error
-	applyErr       error
-	stageErr       error
-	recordStageErr error
+	reviewResult    *repository.ReviewRelationshipConflictCaseResult
+	reservation     *repository.OverdueConflictAssessmentReservation
+	dossier         *repository.OverdueConflictAssessmentDossier
+	completeResult  repository.CompleteOverdueConflictAssessmentResult
+	applyResult     *repository.ApplyOverdueConflictResolutionResult
+	pendingFound    bool
+	pendingResult   *repository.ApplyOverdueConflictResolutionResult
+	reserved        bool
+	reviewErr       error
+	resumeErr       error
+	reserveErr      error
+	completeErr     error
+	applyErr        error
+	derivedClaimErr error
+	stageErr        error
+	recordStageErr  error
 
-	reserveInputs    []repository.ReserveOverdueConflictAssessmentInput
-	completions      []repository.CompleteOverdueConflictAssessmentInput
-	applyInputs      []repository.ApplyOverdueConflictResolutionInput
-	stagedTargets    []repository.ConflictDerivedEvidenceTarget
-	recordedFailures []conflictReviewRecordedFailure
+	reserveInputs      []repository.ReserveOverdueConflictAssessmentInput
+	completions        []repository.CompleteOverdueConflictAssessmentInput
+	applyInputs        []repository.ApplyOverdueConflictResolutionInput
+	derivedClaimInputs []repository.ClaimConflictDerivedEvidenceTasksInput
+	derivedBatches     [][]repository.ConflictDerivedEvidenceTarget
+	stagedTargets      []repository.ConflictDerivedEvidenceTarget
+	recordedFailures   []conflictReviewRecordedFailure
 }
 
 type conflictReviewRecordedFailure struct {
@@ -485,6 +518,19 @@ func (s *conflictReviewRepositoryStub) ApplyOverdueConflictResolution(_ context.
 	copy.PreferredPositionID = input.PreferredPositionID
 	copy.Method = input.Method
 	return &copy, nil
+}
+
+func (s *conflictReviewRepositoryStub) ClaimConflictDerivedEvidenceTasks(_ context.Context, input repository.ClaimConflictDerivedEvidenceTasksInput) ([]repository.ConflictDerivedEvidenceTarget, error) {
+	s.derivedClaimInputs = append(s.derivedClaimInputs, input)
+	if s.derivedClaimErr != nil {
+		return nil, s.derivedClaimErr
+	}
+	if len(s.derivedBatches) == 0 {
+		return nil, nil
+	}
+	batch := s.derivedBatches[0]
+	s.derivedBatches = s.derivedBatches[1:]
+	return batch, nil
 }
 
 func (s *conflictReviewRepositoryStub) StageConflictDerivedEvidence(_ context.Context, target repository.ConflictDerivedEvidenceTarget) (*repository.StageConflictDerivedEvidenceResult, error) {

--- a/internal/service/conflictreview/service_test.go
+++ b/internal/service/conflictreview/service_test.go
@@ -1,0 +1,533 @@
+package conflictreview
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/verifier"
+)
+
+const (
+	conflictReviewTestTeamID      = "00000000-0000-0000-0000-000000000101"
+	conflictReviewTestConflictID  = "00000000-0000-0000-0000-000000000102"
+	conflictReviewTestReviewRunID = "00000000-0000-0000-0000-000000000103"
+	conflictReviewTestAttemptID   = "00000000-0000-0000-0000-000000000104"
+	conflictReviewTestPositionAID = "00000000-0000-0000-0000-000000000201"
+	conflictReviewTestPositionBID = "00000000-0000-0000-0000-000000000202"
+	conflictReviewTestFragmentAID = "00000000-0000-0000-0000-000000000301"
+	conflictReviewTestFragmentBID = "00000000-0000-0000-0000-000000000302"
+	conflictReviewTestSupportAID  = "00000000-0000-0000-0000-000000000401"
+	conflictReviewTestSupportBID  = "00000000-0000-0000-0000-000000000402"
+	conflictReviewTestWorkerID    = "conflict-review-test"
+)
+
+func TestServiceResolvesSelectedAssessment(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:      verifier.ConflictAssessmentDecisionSelect,
+			PositionID:    pointer(conflictReviewTestPositionBID),
+			Confidence:    0.91,
+			Rationale:     "The supplied evidence supports this position.",
+			ProviderTurns: 2,
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, repository.ConflictReviewOutcomeResolve, result.Outcome)
+	assert.Equal(t, "overdue_ai", result.Stage)
+	assert.Equal(t, "ai", result.ResolutionMethod)
+	assert.Equal(t, conflictReviewTestPositionBID, result.PreferredPositionID)
+	assert.Equal(t, conflictReviewTestAttemptID, result.AssessmentAttemptID)
+	require.Len(t, repo.completions, 1)
+	assert.Equal(t, "selected", repo.completions[0].Decision)
+	assert.NotEmpty(t, repo.completions[0].ResponseHash)
+	require.Len(t, repo.applyInputs, 1)
+	assert.Equal(t, "ai", repo.applyInputs[0].Method)
+	assert.Equal(t, conflictReviewTestPositionBID, repo.applyInputs[0].PreferredPositionID)
+	require.Len(t, provider.requests, 1)
+	assert.Equal(t, conflictReviewTestConflictID, provider.requests[0].CaseID)
+	assert.Len(t, provider.requests[0].Evidence, 2)
+	assert.Equal(t, 2, provider.requests[0].Positions[0].OwnerProfileCount)
+}
+
+func TestServiceUsesLastWriteWinsAfterExplicitAbstention(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:      verifier.ConflictAssessmentDecisionAbstain,
+			Confidence:    0,
+			Rationale:     "The dossier is not clear enough to choose.",
+			ProviderTurns: 1,
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, repository.ConflictReviewOutcomeResolve, result.Outcome)
+	assert.Equal(t, "overdue_last_write_wins", result.Stage)
+	assert.Equal(t, "last_write_wins", result.ResolutionMethod)
+	assert.Equal(t, conflictReviewTestPositionAID, result.PreferredPositionID)
+	require.Len(t, repo.completions, 1)
+	assert.Equal(t, "abstained", repo.completions[0].Decision)
+	require.Len(t, repo.applyInputs, 1)
+	assert.Equal(t, "last_write_wins", repo.applyInputs[0].Method)
+	assert.Equal(t, conflictReviewTestPositionAID, repo.applyInputs[0].PreferredPositionID)
+}
+
+func TestServiceUsesLastWriteWinsAfterFifthFailedAssessment(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.completeResult.FailureCount = 5
+	provider := &conflictReviewProviderStub{err: &verifier.ProviderError{
+		Provider:     "test",
+		Message:      "provider failed",
+		FailureClass: verifier.ProviderFailureClassHTTPServer,
+	}}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, repository.ConflictReviewOutcomeResolve, result.Outcome)
+	assert.Equal(t, "last_write_wins", result.ResolutionMethod)
+	require.Len(t, repo.completions, 1)
+	assert.Equal(t, "failed", repo.completions[0].Decision)
+	assert.Equal(t, verifier.ProviderFailureClassHTTPServer, repo.completions[0].FailureClass)
+	require.Len(t, repo.applyInputs, 1)
+	assert.Equal(t, "last_write_wins", repo.applyInputs[0].Method)
+}
+
+func TestServiceUsesLastWriteWinsAfterAbandonedAssessmentRecoveryWithoutProviderCall(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.reservation.LastWriteWins = true
+	provider := &conflictReviewProviderStub{err: errors.New("provider must not be called")}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, repository.ConflictReviewOutcomeResolve, result.Outcome)
+	assert.Equal(t, "overdue_last_write_wins", result.Stage)
+	assert.Equal(t, "last_write_wins", result.ResolutionMethod)
+	assert.Empty(t, provider.requests)
+	assert.Empty(t, repo.completions)
+	require.Len(t, repo.applyInputs, 1)
+	assert.Equal(t, "last_write_wins", repo.applyInputs[0].Method)
+}
+
+func TestServiceResumesPendingResolutionWithoutProviderCall(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.pendingFound = true
+	repo.pendingResult = &repository.ApplyOverdueConflictResolutionResult{
+		ConflictID:          conflictReviewTestConflictID,
+		PreferredPositionID: conflictReviewTestPositionAID,
+		Method:              "ai",
+		Pending:             true,
+	}
+	provider := &conflictReviewProviderStub{err: errors.New("provider must not be called")}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, repository.ConflictReviewOutcomeOverdue, result.Outcome)
+	assert.Equal(t, "resolution_pending", result.Stage)
+	assert.True(t, result.ResolutionPending)
+	assert.Equal(t, conflictReviewTestPositionAID, result.PreferredPositionID)
+	assert.Equal(t, 0, len(provider.requests))
+	assert.Empty(t, repo.reserveInputs)
+}
+
+func TestServiceRecordsLowConfidenceSelectionAsFailedAssessment(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:   verifier.ConflictAssessmentDecisionSelect,
+			PositionID: pointer(conflictReviewTestPositionAID),
+			Confidence: AssessmentConfidenceThreshold - 0.01,
+			Rationale:  "The evidence is incomplete.",
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, "overdue_assessment_failed", result.Stage)
+	require.Len(t, repo.completions, 1)
+	assert.Equal(t, "failed", repo.completions[0].Decision)
+	assert.Equal(t, "below_confidence_threshold", repo.completions[0].FailureClass)
+	assert.Empty(t, repo.applyInputs)
+}
+
+func TestServiceTreatsStaleAssessmentCompletionAsNoOp(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.completeErr = repository.ErrConflictAssessmentReserved
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:   verifier.ConflictAssessmentDecisionSelect,
+			PositionID: pointer(conflictReviewTestPositionAID),
+			Confidence: 0.91,
+			Rationale:  "The evidence supports this position.",
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, "overdue_assessment_stale", result.Stage)
+	assert.Empty(t, repo.applyInputs)
+}
+
+func TestServiceLeavesUnresolvableLastWriteWinsCaseOverdue(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	for index := range repo.dossier.Positions {
+		repo.dossier.Positions[index].Supports = nil
+	}
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:   verifier.ConflictAssessmentDecisionAbstain,
+			Rationale:  "The supplied evidence is inconclusive.",
+			Confidence: 0,
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, repository.ConflictReviewOutcomeOverdue, result.Outcome)
+	assert.Equal(t, "overdue_last_write_wins_unavailable", result.Stage)
+	assert.Empty(t, repo.applyInputs)
+}
+
+func TestServiceRecordsDerivedEvidenceStagingFailure(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.applyResult.DerivedEvidence = []repository.ConflictDerivedEvidenceTarget{{
+		TeamID:               conflictReviewTestTeamID,
+		ConflictID:           conflictReviewTestConflictID,
+		SystemProfileID:      conflictReviewTestTeamID,
+		TargetFragmentID:     conflictReviewTestFragmentAID,
+		TargetOwnerProfileID: conflictReviewTestTeamID,
+		SelectedPositionID:   conflictReviewTestPositionBID,
+		SourceGroupKey:       "source-a",
+	}}
+	repo.stageErr = errors.New("derived evidence staging failed")
+	provider := &conflictReviewProviderStub{
+		response: verifier.ConflictAssessmentResponse{
+			Decision:   verifier.ConflictAssessmentDecisionSelect,
+			PositionID: pointer(conflictReviewTestPositionBID),
+			Confidence: 0.91,
+			Rationale:  "The evidence supports this position.",
+		},
+	}
+	service := newConflictReviewService(t, repo, provider)
+
+	_, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.ErrorIs(t, err, repo.stageErr)
+	require.Len(t, repo.stagedTargets, 1)
+	require.Len(t, repo.recordedFailures, 1)
+	assert.Equal(t, "staging_failed", repo.recordedFailures[0].failureClass)
+}
+
+func TestServiceLeavesAlreadyReservedAssessmentUntouched(t *testing.T) {
+	repo := newConflictReviewRepositoryStub(t)
+	repo.reserved = false
+	provider := &conflictReviewProviderStub{err: errors.New("provider must not be called")}
+	service := newConflictReviewService(t, repo, provider)
+
+	result, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+	require.NoError(t, err)
+	assert.Equal(t, "overdue_assessment_already_reserved", result.Stage)
+	assert.Empty(t, provider.requests)
+	assert.Empty(t, repo.completions)
+}
+
+func TestNewRejectsInvalidConflictReviewDependencies(t *testing.T) {
+	provider := &conflictReviewProviderStub{}
+	_, err := New(Dependencies{Provider: provider})
+	require.EqualError(t, err, "conflict review service: repository is required")
+
+	repo := newConflictReviewRepositoryStub(t)
+	_, err = New(Dependencies{Repository: repo})
+	require.EqualError(t, err, "conflict review service: provider is required")
+
+	_, err = New(Dependencies{Repository: repo, Provider: emptyModelConflictReviewProvider{}})
+	require.EqualError(t, err, "conflict review service: provider model is required")
+
+	_, err = New(Dependencies{Repository: repo, Provider: provider, Timezone: "not/a-timezone"})
+	require.ErrorContains(t, err, "timezone is invalid")
+}
+
+func TestServiceStopsBeforeOverdueAssessmentWhenReviewCannotProceed(t *testing.T) {
+	t.Run("service is not configured", func(t *testing.T) {
+		var service *Service
+		_, err := service.ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+		require.EqualError(t, err, "conflict review service is not configured")
+	})
+
+	t.Run("deterministic review error", func(t *testing.T) {
+		repo := newConflictReviewRepositoryStub(t)
+		repo.reviewErr = errors.New("review failed")
+		_, err := newConflictReviewService(t, repo, &conflictReviewProviderStub{}).ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+		require.ErrorIs(t, err, repo.reviewErr)
+	})
+
+	t.Run("deterministic review result is required", func(t *testing.T) {
+		repo := newConflictReviewRepositoryStub(t)
+		repo.reviewResult = nil
+		_, err := newConflictReviewService(t, repo, &conflictReviewProviderStub{}).ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+		require.EqualError(t, err, "conflict review service: deterministic review returned no result")
+	})
+
+	t.Run("already resolved deterministic case does not reserve an assessment", func(t *testing.T) {
+		repo := newConflictReviewRepositoryStub(t)
+		repo.reviewResult.Outcome = repository.ConflictReviewOutcomeResolve
+		input := conflictReviewInput()
+		input.Now = time.Time{}
+		result, err := newConflictReviewService(t, repo, &conflictReviewProviderStub{}).ReviewRelationshipConflictCase(context.Background(), input)
+		require.NoError(t, err)
+		assert.Equal(t, repository.ConflictReviewOutcomeResolve, result.Outcome)
+		assert.Empty(t, repo.reserveInputs)
+	})
+
+	t.Run("pending resolution lookup error", func(t *testing.T) {
+		repo := newConflictReviewRepositoryStub(t)
+		repo.resumeErr = errors.New("resume failed")
+		_, err := newConflictReviewService(t, repo, &conflictReviewProviderStub{}).ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+		require.ErrorIs(t, err, repo.resumeErr)
+	})
+
+	t.Run("assessment reservation error", func(t *testing.T) {
+		repo := newConflictReviewRepositoryStub(t)
+		repo.reserveErr = errors.New("reserve failed")
+		_, err := newConflictReviewService(t, repo, &conflictReviewProviderStub{}).ReviewRelationshipConflictCase(context.Background(), conflictReviewInput())
+		require.ErrorIs(t, err, repo.reserveErr)
+	})
+}
+
+func newConflictReviewService(t *testing.T, repo *conflictReviewRepositoryStub, provider *conflictReviewProviderStub) *Service {
+	t.Helper()
+	service, err := New(Dependencies{
+		Repository: repo,
+		Provider:   provider,
+		Timezone:   "UTC",
+		Limits:     verifier.DefaultSemanticAssessmentLimits(),
+		Now: func() time.Time {
+			return time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+		},
+	})
+	require.NoError(t, err)
+	return service
+}
+
+func conflictReviewInput() repository.ReviewRelationshipConflictCaseInput {
+	return repository.ReviewRelationshipConflictCaseInput{
+		TeamID:      conflictReviewTestTeamID,
+		ConflictID:  conflictReviewTestConflictID,
+		ReviewRunID: conflictReviewTestReviewRunID,
+		WorkerID:    conflictReviewTestWorkerID,
+		Now:         time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func newConflictReviewRepositoryStub(t *testing.T) *conflictReviewRepositoryStub {
+	t.Helper()
+	older := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(24 * time.Hour)
+	dossier := &repository.OverdueConflictAssessmentDossier{
+		TeamID:      conflictReviewTestTeamID,
+		ConflictID:  conflictReviewTestConflictID,
+		CaseVersion: 3,
+		Question:    "Which state is current?",
+		Positions: []repository.OverdueConflictAssessmentPosition{
+			{
+				PositionID:        conflictReviewTestPositionAID,
+				PositionKey:       "value:a",
+				OwnerProfileCount: 2,
+				Supports:          []domain.ConflictResolutionSupport{{Authority: "primary", AcceptedAt: older}},
+			},
+			{
+				PositionID:  conflictReviewTestPositionBID,
+				PositionKey: "value:b",
+				Supports:    []domain.ConflictResolutionSupport{{Authority: "secondary", AcceptedAt: newer}},
+			},
+		},
+		Evidence: []repository.OverdueConflictAssessmentEvidence{
+			{
+				FragmentID:     conflictReviewTestFragmentAID,
+				OwnerProfileID: conflictReviewTestTeamID,
+				PositionID:     conflictReviewTestPositionAID,
+				SupportID:      conflictReviewTestSupportAID,
+				SourceGroupKey: "source-a",
+				Authority:      "primary",
+				AcceptedAt:     older,
+				Content:        "Evidence for position A.",
+			},
+			{
+				FragmentID:     conflictReviewTestFragmentBID,
+				OwnerProfileID: conflictReviewTestTeamID,
+				PositionID:     conflictReviewTestPositionBID,
+				SupportID:      conflictReviewTestSupportBID,
+				SourceGroupKey: "source-b",
+				Authority:      "secondary",
+				AcceptedAt:     newer,
+				Content:        "Evidence for position B.",
+			},
+		},
+	}
+	return &conflictReviewRepositoryStub{
+		reviewResult: &repository.ReviewRelationshipConflictCaseResult{
+			ConflictID: conflictReviewTestConflictID,
+			Outcome:    repository.ConflictReviewOutcomeOverdue,
+			Stage:      repository.ConflictReviewStageDueNoWinner,
+		},
+		reservation: &repository.OverdueConflictAssessmentReservation{
+			AssessmentAttemptID: conflictReviewTestAttemptID,
+			CaseVersion:         3,
+			Model:               "test-model",
+			PolicyVersion:       domain.ConflictOverduePolicyVersion,
+		},
+		dossier: dossier,
+		applyResult: &repository.ApplyOverdueConflictResolutionResult{
+			ConflictID:          conflictReviewTestConflictID,
+			PreferredPositionID: conflictReviewTestPositionBID,
+			Resolved:            true,
+		},
+		reserved: true,
+	}
+}
+
+type conflictReviewRepositoryStub struct {
+	reviewResult   *repository.ReviewRelationshipConflictCaseResult
+	reservation    *repository.OverdueConflictAssessmentReservation
+	dossier        *repository.OverdueConflictAssessmentDossier
+	completeResult repository.CompleteOverdueConflictAssessmentResult
+	applyResult    *repository.ApplyOverdueConflictResolutionResult
+	pendingFound   bool
+	pendingResult  *repository.ApplyOverdueConflictResolutionResult
+	reserved       bool
+	reviewErr      error
+	resumeErr      error
+	reserveErr     error
+	completeErr    error
+	applyErr       error
+	stageErr       error
+	recordStageErr error
+
+	reserveInputs    []repository.ReserveOverdueConflictAssessmentInput
+	completions      []repository.CompleteOverdueConflictAssessmentInput
+	applyInputs      []repository.ApplyOverdueConflictResolutionInput
+	stagedTargets    []repository.ConflictDerivedEvidenceTarget
+	recordedFailures []conflictReviewRecordedFailure
+}
+
+type conflictReviewRecordedFailure struct {
+	target       repository.ConflictDerivedEvidenceTarget
+	failureClass string
+}
+
+func (s *conflictReviewRepositoryStub) ReviewRelationshipConflictCase(_ context.Context, _ repository.ReviewRelationshipConflictCaseInput) (*repository.ReviewRelationshipConflictCaseResult, error) {
+	if s.reviewErr != nil {
+		return nil, s.reviewErr
+	}
+	if s.reviewResult == nil {
+		return nil, nil
+	}
+	copy := *s.reviewResult
+	return &copy, nil
+}
+
+func (s *conflictReviewRepositoryStub) ResumePendingOverdueConflictResolution(_ context.Context, _ repository.ResumePendingOverdueConflictResolutionInput) (*repository.ApplyOverdueConflictResolutionResult, bool, error) {
+	if s.resumeErr != nil {
+		return nil, false, s.resumeErr
+	}
+	if !s.pendingFound {
+		return nil, false, nil
+	}
+	copy := *s.pendingResult
+	return &copy, true, nil
+}
+
+func (s *conflictReviewRepositoryStub) ReserveOverdueConflictAssessment(_ context.Context, input repository.ReserveOverdueConflictAssessmentInput) (*repository.OverdueConflictAssessmentReservation, *repository.OverdueConflictAssessmentDossier, bool, error) {
+	s.reserveInputs = append(s.reserveInputs, input)
+	if s.reserveErr != nil {
+		return nil, nil, false, s.reserveErr
+	}
+	if !s.reserved {
+		return nil, nil, false, nil
+	}
+	reservation := *s.reservation
+	return &reservation, s.dossier, true, nil
+}
+
+func (s *conflictReviewRepositoryStub) CompleteOverdueConflictAssessment(_ context.Context, input repository.CompleteOverdueConflictAssessmentInput) (*repository.CompleteOverdueConflictAssessmentResult, error) {
+	s.completions = append(s.completions, input)
+	if s.completeErr != nil {
+		return nil, s.completeErr
+	}
+	copy := s.completeResult
+	return &copy, nil
+}
+
+func (s *conflictReviewRepositoryStub) ApplyOverdueConflictResolution(_ context.Context, input repository.ApplyOverdueConflictResolutionInput) (*repository.ApplyOverdueConflictResolutionResult, error) {
+	s.applyInputs = append(s.applyInputs, input)
+	if s.applyErr != nil {
+		return nil, s.applyErr
+	}
+	copy := *s.applyResult
+	copy.PreferredPositionID = input.PreferredPositionID
+	copy.Method = input.Method
+	return &copy, nil
+}
+
+func (s *conflictReviewRepositoryStub) StageConflictDerivedEvidence(_ context.Context, target repository.ConflictDerivedEvidenceTarget) (*repository.StageConflictDerivedEvidenceResult, error) {
+	s.stagedTargets = append(s.stagedTargets, target)
+	if s.stageErr != nil {
+		return nil, s.stageErr
+	}
+	return &repository.StageConflictDerivedEvidenceResult{}, nil
+}
+
+func (s *conflictReviewRepositoryStub) RecordConflictDerivedEvidenceFailure(_ context.Context, target repository.ConflictDerivedEvidenceTarget, failureClass string) error {
+	s.recordedFailures = append(s.recordedFailures, conflictReviewRecordedFailure{target: target, failureClass: failureClass})
+	if s.recordStageErr != nil {
+		return s.recordStageErr
+	}
+	return nil
+}
+
+type conflictReviewProviderStub struct {
+	response verifier.ConflictAssessmentResponse
+	err      error
+	requests []verifier.ConflictAssessmentRequest
+}
+
+func (s *conflictReviewProviderStub) AssessRelationshipConflict(_ context.Context, request verifier.ConflictAssessmentRequest) (verifier.ConflictAssessmentResponse, error) {
+	s.requests = append(s.requests, request)
+	return s.response, s.err
+}
+
+func (s *conflictReviewProviderStub) ModelName() string {
+	return "test-model"
+}
+
+type emptyModelConflictReviewProvider struct{}
+
+func (emptyModelConflictReviewProvider) AssessRelationshipConflict(context.Context, verifier.ConflictAssessmentRequest) (verifier.ConflictAssessmentResponse, error) {
+	return verifier.ConflictAssessmentResponse{}, nil
+}
+
+func (emptyModelConflictReviewProvider) ModelName() string {
+	return ""
+}
+
+func pointer(value string) *string {
+	return &value
+}

--- a/internal/service/memoryservice/semantic_assessment_commit_helpers.go
+++ b/internal/service/memoryservice/semantic_assessment_commit_helpers.go
@@ -207,6 +207,10 @@ func semanticAssessmentSupport(
 	if len(spans) == 0 {
 		return nil, errors.New("semantic assessment relationship has no evidence span")
 	}
+	authority, err := semanticSupportAuthority(fragment.Authority)
+	if err != nil {
+		return nil, err
+	}
 	supports := make([]repository.EvidenceSupportInput, 0, len(spans))
 	for _, span := range spans {
 		quote, err := verifier.SemanticEvidenceSpan(fragment.Content, span.Start, span.End)
@@ -221,7 +225,7 @@ func semanticAssessmentSupport(
 			SpanStart:        span.Start,
 			SpanEnd:          span.End,
 			Quote:            quote,
-			Authority:        string(domain.AuthorityPrimary),
+			Authority:        authority,
 			Metadata: map[string]any{
 				"semantic_contract": domain.ContractVersion,
 				"assessment_id":     assessmentID,
@@ -230,6 +234,17 @@ func semanticAssessmentSupport(
 		})
 	}
 	return supports, nil
+}
+
+func semanticSupportAuthority(raw string) (string, error) {
+	authority := domain.Authority(strings.TrimSpace(raw))
+	if authority == "" {
+		return string(domain.AuthorityPrimary), nil
+	}
+	if !authority.IsValid() {
+		return "", fmt.Errorf("semantic support authority is unsupported: %q", authority)
+	}
+	return string(authority), nil
 }
 
 func semanticAssessmentPrimarySupport(supports []repository.EvidenceSupportInput) (*repository.EvidenceSupportInput, []repository.EvidenceSupportInput) {

--- a/internal/service/memoryservice/semantic_assessment_worker_helpers_test.go
+++ b/internal/service/memoryservice/semantic_assessment_worker_helpers_test.go
@@ -146,7 +146,7 @@ func TestSemanticAssessmentRelationshipHelpersRouteAllReviewKinds(t *testing.T) 
 	assert.Equal(t, "time", semanticAssessmentRelationshipReviewKind(result, entities, predicates))
 
 	fragment := repository.EvidenceFragment{
-		FragmentID: uuid.NewString(), Content: "Mark works on Dense-Mem.", SourceID: uuid.NewString(), SourceRevisionID: uuid.NewString(),
+		FragmentID: uuid.NewString(), Content: "Mark works on Dense-Mem.", Authority: string(domain.AuthorityAuthoritative), SourceID: uuid.NewString(), SourceRevisionID: uuid.NewString(),
 	}
 	_, err := semanticAssessmentSupport(fragment, uuid.NewString(), nil)
 	require.ErrorContains(t, err, "no evidence span")
@@ -157,11 +157,18 @@ func TestSemanticAssessmentRelationshipHelpersRouteAllReviewKinds(t *testing.T) 
 	require.Len(t, supports, 2)
 	assert.Equal(t, "Mark", supports[0].Quote)
 	assert.Equal(t, "works", supports[1].Quote)
+	assert.Equal(t, string(domain.AuthorityAuthoritative), supports[0].Authority)
 	assert.Contains(t, supports[1].SourceGroupKey, ":5:10")
 	primarySupport, additionalSupports := semanticAssessmentPrimarySupport(supports)
 	require.NotNil(t, primarySupport)
 	assert.Equal(t, supports[0], *primarySupport)
 	assert.Equal(t, supports[1:], additionalSupports)
+
+	defaultAuthority, err := semanticSupportAuthority("")
+	require.NoError(t, err)
+	assert.Equal(t, string(domain.AuthorityPrimary), defaultAuthority)
+	_, err = semanticSupportAuthority("unsupported")
+	require.ErrorContains(t, err, "authority is unsupported")
 
 	valueResult := verifier.SemanticAssessmentRelationshipResult{Ref: "value", ObjectValue: &verifier.SemanticAssessmentValue{ValueType: "number", CanonicalValue: "42", Display: testStringPointer("forty-two"), Unit: testStringPointer("items")}}
 	ref, value, err := semanticAssessmentObject(valueResult)

--- a/internal/service/memoryservice/semantic_commit.go
+++ b/internal/service/memoryservice/semantic_commit.go
@@ -414,6 +414,10 @@ func semanticPlacementSupport(
 			observation.EvidenceID,
 		)
 	}
+	authority, err := semanticSupportAuthority(evidence.Authority)
+	if err != nil {
+		return nil, err
+	}
 	return &repository.EvidenceSupportInput{
 		FragmentID:       evidence.FragmentID,
 		SourceGroupKey:   "semantic_review:" + evidence.EvidenceID,
@@ -422,7 +426,7 @@ func semanticPlacementSupport(
 		SpanStart:        observation.Start,
 		SpanEnd:          observation.End,
 		Quote:            observation.Quote,
-		Authority:        string(domain.AuthorityPrimary),
+		Authority:        authority,
 	}, nil
 }
 

--- a/internal/service/memoryservice/semantic_commit_test.go
+++ b/internal/service/memoryservice/semantic_commit_test.go
@@ -19,6 +19,7 @@ func TestSemanticCommitMapsAcceptedReviewIntoAtomicRepositoryInput(t *testing.T)
 	targetID := uuid.NewString()
 	conflictID := uuid.NewString()
 	request := semanticReviewServiceRequest(teamID, ownerID)
+	request.Evidence[0].Authority = string(domain.AuthorityAuthoritative)
 	request.Evidence[0].SourceID = uuid.NewString()
 	request.Evidence[0].SourceRevisionID = uuid.NewString()
 	request.EntityMentions[1].IdentityContext = map[string]any{"repo": "dense-mem"}
@@ -109,6 +110,9 @@ func TestSemanticCommitMapsAcceptedReviewIntoAtomicRepositoryInput(t *testing.T)
 	}
 	if relationship.Support.SourceID != request.Evidence[0].SourceID || relationship.Support.SourceRevisionID != request.Evidence[0].SourceRevisionID {
 		t.Fatalf("relationship support source scope = %#v", relationship.Support)
+	}
+	if relationship.Support.Authority != string(domain.AuthorityAuthoritative) {
+		t.Fatalf("relationship support authority = %q", relationship.Support.Authority)
 	}
 	if got.Payload["response_hash"] != "sha256:semantic-response" {
 		t.Fatalf("payload = %#v", got.Payload)

--- a/internal/service/memoryservice/semantic_review_source.go
+++ b/internal/service/memoryservice/semantic_review_source.go
@@ -375,6 +375,7 @@ func semanticReviewEvidence(fragment repository.EvidenceFragment, evidenceID str
 		FragmentID:              fragment.FragmentID,
 		EvidenceIndex:           fragment.EvidenceIndex,
 		Content:                 fragment.Content,
+		Authority:               fragment.Authority,
 		SourceID:                fragment.SourceID,
 		SourceRevisionID:        fragment.SourceRevisionID,
 		CurrentSourceRevisionID: fragment.SourceRevisionID,

--- a/internal/service/memoryservice/semantic_review_source_test.go
+++ b/internal/service/memoryservice/semantic_review_source_test.go
@@ -91,7 +91,7 @@ func TestSemanticPlacementReviewSourceBuildsCurrentEvidenceJob(t *testing.T) {
 		},
 		Evidence: []repository.EvidenceFragment{
 			{FragmentID: uuid.NewString(), EvidenceIndex: 0, Content: "old evidence", ContentHash: "sha256:old"},
-			{FragmentID: uuid.NewString(), EvidenceIndex: 1, Content: currentContent, ContentHash: "sha256:current", SourceRevisionID: uuid.NewString()},
+			{FragmentID: uuid.NewString(), EvidenceIndex: 1, Content: currentContent, ContentHash: "sha256:current", Authority: "authoritative", SourceRevisionID: uuid.NewString()},
 		},
 		Items: []repository.PlacementItem{
 			{PlacementItemID: doneItemID, EvidenceIndex: 0, Status: "completed"},
@@ -230,6 +230,9 @@ func TestSemanticPlacementReviewSourceBuildsCurrentEvidenceJob(t *testing.T) {
 	}
 	if len(job.Request.Evidence) != 1 || job.Request.Evidence[0].EvidenceIndex != 1 || job.Request.Evidence[0].Content != currentContent {
 		t.Fatalf("evidence = %#v", job.Request.Evidence)
+	}
+	if job.Request.Evidence[0].Authority != "authoritative" {
+		t.Fatalf("evidence authority = %q", job.Request.Evidence[0].Authority)
 	}
 	if len(job.Request.EntityMentions) != 3 {
 		t.Fatalf("entity mentions = %#v validation=%#v retryable=%#v", job.Request.EntityMentions, job.ValidationErrors, job.RetryableValidationErrors)

--- a/internal/storage/postgres/overdue_conflict_resolution_migration_integration_test.go
+++ b/internal/storage/postgres/overdue_conflict_resolution_migration_integration_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverdueConflictResolutionMigrationAvoidsLegacySystemProfileNameCollision(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+
+	runGooseUpTo(t, ctx, sqlDB, 2026073002)
+	teamID, userProfileID := insertMigrationTeamProfile(t, ctx, sqlDB)
+	legacyName := "__dense_mem_conflict_system__:" + teamID
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE team_profiles
+			SET name = $1
+			WHERE team_id = $2::uuid
+			  AND id = $3::uuid
+		`, legacyName, teamID, userProfileID)
+		return err
+	}))
+
+	runGooseUpTo(t, ctx, sqlDB, 2026073101)
+
+	var systemProfileID, systemName, authSource string
+	var isSystem bool
+	var semanticRefCount int
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "migration", func(tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx, `
+			SELECT id::text, name, auth_source, is_system
+			FROM team_profiles
+			WHERE team_id = $1::uuid
+			  AND is_system
+		`, teamID).Scan(&systemProfileID, &systemName, &authSource, &isSystem); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM semantic_profile_refs
+			WHERE team_id = $1::uuid
+			  AND profile_id = $2::uuid
+		`, teamID, systemProfileID).Scan(&semanticRefCount)
+	}))
+	assert.NotEqual(t, userProfileID, systemProfileID)
+	assert.NotEqual(t, legacyName, systemName)
+	assert.True(t, strings.HasPrefix(systemName, "__dense_mem_conflict_system__:"))
+	assert.Equal(t, "system", authSource)
+	assert.True(t, isSystem)
+	assert.Equal(t, 1, semanticRefCount)
+}

--- a/internal/verifier/conflict_assessment.go
+++ b/internal/verifier/conflict_assessment.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -277,7 +278,7 @@ func normalizeConflictAssessmentResponse(response ConflictAssessmentResponse) Co
 func validateConflictAssessmentResponse(req ConflictAssessmentRequest, response ConflictAssessmentResponse) []SemanticValidationError {
 	errs := make([]SemanticValidationError, 0)
 	response = normalizeConflictAssessmentResponse(response)
-	if response.Rationale == "" || len(response.Rationale) > ConflictAssessmentMaxRationale {
+	if response.Rationale == "" || utf8.RuneCountInString(response.Rationale) > ConflictAssessmentMaxRationale {
 		errs = append(errs, SemanticValidationError{Field: "rationale", Message: "must be a bounded non-empty string"})
 	}
 	switch response.Decision {

--- a/internal/verifier/conflict_assessment.go
+++ b/internal/verifier/conflict_assessment.go
@@ -1,0 +1,389 @@
+package verifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ConflictAssessmentSchemaName = "dense_mem_conflict_assessment_response"
+
+	ConflictAssessmentDecisionSelect  = "select"
+	ConflictAssessmentDecisionAbstain = "abstain"
+
+	ConflictAssessmentMaxPositions = 50
+	ConflictAssessmentMaxEvidence  = 500
+	ConflictAssessmentMaxContent   = 4000
+	ConflictAssessmentMaxRationale = 1000
+)
+
+const conflictAssessmentSystemPrompt = `You are Dense-Mem's overdue conflict assessor. Assess only the supplied, already accepted evidence and server-owned support metadata. Select one supplied position only when the dossier gives a clear, well-supported answer. Authority, independent source groups, distinct owner counts, accepted time, and explicit effective time can matter. Do not treat counts, deadline expiry, recency alone, or copied evidence as decisive. Do not invent evidence, IDs, sources, lifecycle actions, relationship updates, owners, or durable state.
+
+If the dossier does not support a clear position, abstain. Return one complete JSON object matching the schema and no other text.`
+
+const conflictAssessmentCorrectionInstruction = `Return one complete replacement JSON object matching the schema. Use decision "select" only with one supplied position_id and a confidence in [0,1]. Use decision "abstain" with position_id null and confidence 0. Do not return an explanation outside the JSON object.`
+
+type ConflictAssessmentEvidence struct {
+	EvidenceID     string     `json:"evidence_id"`
+	PositionID     string     `json:"position_id"`
+	SupportID      string     `json:"support_id"`
+	SourceGroupKey string     `json:"source_group_key"`
+	Authority      string     `json:"authority"`
+	AcceptedAt     time.Time  `json:"accepted_at"`
+	EffectiveAt    *time.Time `json:"effective_at,omitempty"`
+	Content        string     `json:"content"`
+}
+
+type ConflictAssessmentPosition struct {
+	PositionID              string `json:"position_id"`
+	PositionKey             string `json:"position_key"`
+	SupportGroupCount       int    `json:"support_group_count"`
+	AuthoritativeGroupCount int    `json:"authoritative_group_count"`
+	OwnerProfileCount       int    `json:"owner_profile_count"`
+}
+
+// ConflictAssessmentRequest is a bounded, immutable case dossier. Team and
+// case version are server-side correlation fields and are not model authority.
+type ConflictAssessmentRequest struct {
+	RequestID string                       `json:"request_id"`
+	CaseID    string                       `json:"case_id"`
+	Version   int                          `json:"version"`
+	Question  string                       `json:"question"`
+	Positions []ConflictAssessmentPosition `json:"positions"`
+	Evidence  []ConflictAssessmentEvidence `json:"evidence"`
+}
+
+type ConflictAssessmentResponse struct {
+	Decision      string  `json:"decision"`
+	PositionID    *string `json:"position_id"`
+	Confidence    float64 `json:"confidence"`
+	Rationale     string  `json:"rationale"`
+	InputTokens   int     `json:"-"`
+	OutputTokens  int     `json:"-"`
+	ProviderTurns int     `json:"-"`
+}
+
+func ConflictAssessmentResponseSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"decision":    map[string]any{"type": "string", "enum": []string{ConflictAssessmentDecisionSelect, ConflictAssessmentDecisionAbstain}},
+			"position_id": map[string]any{"type": []string{"string", "null"}},
+			"confidence":  map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+			"rationale":   map[string]any{"type": "string", "minLength": 1, "maxLength": ConflictAssessmentMaxRationale},
+		},
+		"required":             []string{"decision", "position_id", "confidence", "rationale"},
+		"additionalProperties": false,
+	}
+}
+
+func PrepareConflictAssessmentRequest(req ConflictAssessmentRequest, limits SemanticAssessmentLimits) (ConflictAssessmentRequest, []SemanticValidationError) {
+	limits = normalizeSemanticAssessmentLimits(limits)
+	req.RequestID = strings.TrimSpace(req.RequestID)
+	req.CaseID = strings.TrimSpace(req.CaseID)
+	req.Question = strings.TrimSpace(req.Question)
+	if req.Positions == nil {
+		req.Positions = []ConflictAssessmentPosition{}
+	}
+	if req.Evidence == nil {
+		req.Evidence = []ConflictAssessmentEvidence{}
+	}
+	errs := make([]SemanticValidationError, 0)
+	if req.RequestID == "" {
+		errs = append(errs, SemanticValidationError{Field: "request_id", Message: "is required"})
+	}
+	if req.CaseID == "" {
+		errs = append(errs, SemanticValidationError{Field: "case_id", Message: "is required"})
+	}
+	if req.Version < 1 {
+		errs = append(errs, SemanticValidationError{Field: "version", Message: "must be at least 1"})
+	}
+	if req.Question == "" {
+		errs = append(errs, SemanticValidationError{Field: "question", Message: "is required"})
+	}
+	if len(req.Positions) < 2 || len(req.Positions) > ConflictAssessmentMaxPositions {
+		errs = append(errs, SemanticValidationError{Field: "positions", Message: "must contain between 2 and 50 positions"})
+	}
+	if len(req.Evidence) == 0 || len(req.Evidence) > ConflictAssessmentMaxEvidence {
+		errs = append(errs, SemanticValidationError{Field: "evidence", Message: "must contain between 1 and 500 items"})
+	}
+	positions := make(map[string]struct{}, len(req.Positions))
+	for index := range req.Positions {
+		position := &req.Positions[index]
+		position.PositionID = strings.TrimSpace(position.PositionID)
+		position.PositionKey = strings.TrimSpace(position.PositionKey)
+		if position.PositionID == "" {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("positions[%d].position_id", index), Message: "is required"})
+			continue
+		}
+		if _, exists := positions[position.PositionID]; exists {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("positions[%d].position_id", index), Message: "must be unique"})
+		}
+		positions[position.PositionID] = struct{}{}
+		if position.PositionKey == "" {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("positions[%d].position_key", index), Message: "is required"})
+		}
+		if position.SupportGroupCount < 0 || position.AuthoritativeGroupCount < 0 || position.OwnerProfileCount < 0 {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("positions[%d]", index), Message: "support counts must not be negative"})
+		}
+	}
+	for index := range req.Evidence {
+		evidence := &req.Evidence[index]
+		evidence.EvidenceID = strings.TrimSpace(evidence.EvidenceID)
+		evidence.PositionID = strings.TrimSpace(evidence.PositionID)
+		evidence.SupportID = strings.TrimSpace(evidence.SupportID)
+		evidence.SourceGroupKey = strings.TrimSpace(evidence.SourceGroupKey)
+		evidence.Authority = strings.TrimSpace(evidence.Authority)
+		evidence.Content = strings.TrimSpace(evidence.Content)
+		if evidence.EvidenceID == "" || evidence.PositionID == "" || evidence.SupportID == "" || evidence.SourceGroupKey == "" || evidence.Content == "" {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("evidence[%d]", index), Message: "evidence_id, position_id, support_id, source_group_key, and content are required"})
+		}
+		if _, exists := positions[evidence.PositionID]; !exists {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("evidence[%d].position_id", index), Message: "must reference a supplied position"})
+		}
+		if len(evidence.Content) > ConflictAssessmentMaxContent {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("evidence[%d].content", index), Message: "exceeds maximum length"})
+		}
+		if evidence.AcceptedAt.IsZero() {
+			errs = append(errs, SemanticValidationError{Field: fmt.Sprintf("evidence[%d].accepted_at", index), Message: "is required"})
+		} else {
+			evidence.AcceptedAt = evidence.AcceptedAt.UTC()
+		}
+		if evidence.EffectiveAt != nil {
+			value := evidence.EffectiveAt.UTC()
+			evidence.EffectiveAt = &value
+		}
+	}
+	if len(errs) > 0 {
+		return req, errs
+	}
+	sort.Slice(req.Positions, func(i, j int) bool { return req.Positions[i].PositionID < req.Positions[j].PositionID })
+	sort.Slice(req.Evidence, func(i, j int) bool {
+		if req.Evidence[i].PositionID != req.Evidence[j].PositionID {
+			return req.Evidence[i].PositionID < req.Evidence[j].PositionID
+		}
+		if !req.Evidence[i].AcceptedAt.Equal(req.Evidence[j].AcceptedAt) {
+			return req.Evidence[i].AcceptedAt.Before(req.Evidence[j].AcceptedAt)
+		}
+		return req.Evidence[i].EvidenceID < req.Evidence[j].EvidenceID
+	})
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return req, []SemanticValidationError{{Field: "request", Message: "cannot be encoded"}}
+	}
+	count, err := CountTokens(string(encoded), limits.Tokenizer)
+	if err != nil {
+		return req, []SemanticValidationError{{Field: "request", Message: "cannot count tokens"}}
+	}
+	if count > limits.MaxInputTokens {
+		return req, []SemanticValidationError{{Field: "request", Message: "exceeds input token budget"}}
+	}
+	return req, nil
+}
+
+// DecodeConflictAssessmentResponseJSON rejects unknown, missing, nullable,
+// trailing, and over-budget output before dossier-dependent validation.
+func DecodeConflictAssessmentResponseJSON(
+	data []byte,
+	limits SemanticAssessmentLimits,
+) (ConflictAssessmentResponse, error) {
+	limits = normalizeSemanticAssessmentLimits(limits)
+	outputTokens, err := CountTokens(string(data), limits.Tokenizer)
+	if err != nil {
+		return ConflictAssessmentResponse{}, err
+	}
+	if outputTokens > limits.MaxOutputTokens {
+		return ConflictAssessmentResponse{}, fmt.Errorf("conflict assessment response exceeds %d token limit", limits.MaxOutputTokens)
+	}
+	if validationErrors := validateConflictAssessmentResponseRaw(data); len(validationErrors) > 0 {
+		return ConflictAssessmentResponse{}, errors.New(semanticAssessmentJoinedErrors(validationErrors))
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var response ConflictAssessmentResponse
+	if err := decoder.Decode(&response); err != nil {
+		return ConflictAssessmentResponse{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return ConflictAssessmentResponse{}, errors.New("conflict assessment response contains trailing JSON")
+	}
+	response = normalizeConflictAssessmentResponse(response)
+	response.OutputTokens = outputTokens
+	return response, nil
+}
+
+func validateConflictAssessmentResponseRaw(raw []byte) []SemanticValidationError {
+	errs := conflictAssessmentDuplicateFields(raw)
+	_, objectErrs := assessmentRawObject(
+		raw,
+		"",
+		[]string{"decision", "position_id", "confidence", "rationale"},
+		map[string]bool{"position_id": true},
+	)
+	errs = append(errs, objectErrs...)
+	return errs
+}
+
+func conflictAssessmentDuplicateFields(raw []byte) []SemanticValidationError {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil {
+		return nil
+	}
+	opening, ok := token.(json.Delim)
+	if !ok || opening != '{' {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var errs []SemanticValidationError
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return nil
+		}
+		field, ok := fieldToken.(string)
+		if !ok {
+			return nil
+		}
+		if _, exists := seen[field]; exists {
+			errs = append(errs, SemanticValidationError{Field: field, Message: "must not be duplicated"})
+		}
+		seen[field] = struct{}{}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return nil
+		}
+	}
+	return errs
+}
+
+func normalizeConflictAssessmentResponse(response ConflictAssessmentResponse) ConflictAssessmentResponse {
+	response.Decision = strings.TrimSpace(response.Decision)
+	response.Rationale = strings.TrimSpace(response.Rationale)
+	if response.PositionID != nil {
+		positionID := strings.TrimSpace(*response.PositionID)
+		response.PositionID = &positionID
+	}
+	return response
+}
+
+func validateConflictAssessmentResponse(req ConflictAssessmentRequest, response ConflictAssessmentResponse) []SemanticValidationError {
+	errs := make([]SemanticValidationError, 0)
+	response = normalizeConflictAssessmentResponse(response)
+	if response.Rationale == "" || len(response.Rationale) > ConflictAssessmentMaxRationale {
+		errs = append(errs, SemanticValidationError{Field: "rationale", Message: "must be a bounded non-empty string"})
+	}
+	switch response.Decision {
+	case ConflictAssessmentDecisionSelect:
+		if response.PositionID == nil || strings.TrimSpace(*response.PositionID) == "" {
+			errs = append(errs, SemanticValidationError{Field: "position_id", Message: "is required for select"})
+			break
+		}
+		positionID := strings.TrimSpace(*response.PositionID)
+		known := false
+		for _, position := range req.Positions {
+			if position.PositionID == positionID {
+				known = true
+				break
+			}
+		}
+		if !known {
+			errs = append(errs, SemanticValidationError{Field: "position_id", Message: "must be a supplied position"})
+		}
+		if response.Confidence < 0 || response.Confidence > 1 {
+			errs = append(errs, SemanticValidationError{Field: "confidence", Message: "must be between 0 and 1"})
+		}
+	case ConflictAssessmentDecisionAbstain:
+		if response.PositionID != nil {
+			errs = append(errs, SemanticValidationError{Field: "position_id", Message: "must be null for abstain"})
+		}
+		if response.Confidence != 0 {
+			errs = append(errs, SemanticValidationError{Field: "confidence", Message: "must be 0 for abstain"})
+		}
+	default:
+		errs = append(errs, SemanticValidationError{Field: "decision", Message: "must be select or abstain"})
+	}
+	return errs
+}
+
+// AssessRelationshipConflict runs the bounded complete-response correction
+// loop used by semantic assessment, while keeping this schema independent.
+func (v *OpenAIVerifier) AssessRelationshipConflict(ctx context.Context, req ConflictAssessmentRequest) (ConflictAssessmentResponse, error) {
+	prepared, validationErrors := PrepareConflictAssessmentRequest(req, v.assessmentLimits)
+	if len(validationErrors) > 0 {
+		return ConflictAssessmentResponse{}, &ProviderError{
+			Provider:     openAIVerifierProvider,
+			Message:      "invalid conflict assessment request: " + openAIValidationSummary(validationErrors),
+			FailureClass: ProviderFailureClassProviderUnavailable,
+		}
+	}
+	payload, err := json.Marshal(prepared)
+	if err != nil {
+		return ConflictAssessmentResponse{}, &ProviderError{Provider: openAIVerifierProvider, Message: "failed to marshal conflict assessment request", Cause: err, FailureClass: ProviderFailureClassProviderUnavailable}
+	}
+	messages := []openAIVerifierMessage{{Role: "system", Content: conflictAssessmentSystemPrompt}, {Role: "user", Content: string(payload)}}
+	for turn := 1; turn <= SemanticAssessmentMaxProviderTurns; turn++ {
+		inputTokens, err := semanticAssessmentMessageTokens(messages, v.assessmentLimits.Tokenizer)
+		if err != nil {
+			return ConflictAssessmentResponse{}, &ProviderError{Provider: openAIVerifierProvider, Message: "failed to count conflict assessment tokens", Cause: err, FailureClass: ProviderFailureClassProviderUnavailable}
+		}
+		if inputTokens > v.assessmentLimits.MaxInputTokens {
+			return ConflictAssessmentResponse{}, &MalformedResponseError{Provider: openAIVerifierProvider, Message: "conflict assessment exceeds input token budget", FailureClass: "input_budget", Attempts: turn - 1}
+		}
+		result, err := v.openAIStructuredChatMessagesJSONWithUsage(ctx, v.model, ConflictAssessmentSchemaName, ConflictAssessmentResponseSchema(), messages)
+		if err != nil {
+			return ConflictAssessmentResponse{}, err
+		}
+		if result.Usage != nil && result.Usage.PromptTokens > int64(v.assessmentLimits.MaxInputTokens) {
+			return ConflictAssessmentResponse{}, &MalformedResponseError{
+				Provider:     openAIVerifierProvider,
+				Message:      "provider reported input tokens beyond conflict assessment limit",
+				FailureClass: "input_budget",
+				Attempts:     turn,
+			}
+		}
+		responseErrors := []SemanticValidationError{}
+		response := ConflictAssessmentResponse{}
+		if result.Usage != nil && result.Usage.CompletionTokens > int64(v.assessmentLimits.MaxOutputTokens) {
+			responseErrors = append(responseErrors, SemanticValidationError{
+				Field:   "output_tokens",
+				Message: fmt.Sprintf("provider reported more than the allowed %d tokens", v.assessmentLimits.MaxOutputTokens),
+			})
+		} else {
+			decoded, decodeErr := DecodeConflictAssessmentResponseJSON([]byte(result.Content), v.assessmentLimits)
+			if decodeErr != nil {
+				responseErrors = append(responseErrors, SemanticValidationError{Field: "response", Message: "must be one complete JSON object matching the required field types"})
+			} else {
+				response = decoded
+				responseErrors = append(responseErrors, validateConflictAssessmentResponse(prepared, response)...)
+			}
+		}
+		if len(responseErrors) == 0 {
+			response.InputTokens = inputTokens
+			if result.Usage != nil && result.Usage.PromptTokens > 0 {
+				response.InputTokens = int(result.Usage.PromptTokens)
+			}
+			response.ProviderTurns = turn
+			return response, nil
+		}
+		if turn == SemanticAssessmentMaxProviderTurns {
+			return ConflictAssessmentResponse{}, &MalformedResponseError{Provider: openAIVerifierProvider, Message: "conflict assessment response remained invalid after bounded correction", FailureClass: "malformed_exhausted", Attempts: turn}
+		}
+		correction, err := json.Marshal(map[string]any{
+			"validation_errors": boundedSemanticAssessmentCorrectionErrors(responseErrors),
+			"instruction":       conflictAssessmentCorrectionInstruction,
+		})
+		if err != nil {
+			return ConflictAssessmentResponse{}, &ProviderError{Provider: openAIVerifierProvider, Message: "failed to marshal conflict assessment correction", Cause: err, FailureClass: ProviderFailureClassProviderUnavailable}
+		}
+		messages = append(messages, openAIVerifierMessage{Role: "assistant", Content: result.Content}, openAIVerifierMessage{Role: "user", Content: string(correction)})
+	}
+	return ConflictAssessmentResponse{}, &MalformedResponseError{Provider: openAIVerifierProvider, Message: "conflict assessment response remained invalid after bounded correction", FailureClass: "malformed_exhausted", Attempts: SemanticAssessmentMaxProviderTurns}
+}

--- a/internal/verifier/conflict_assessment_test.go
+++ b/internal/verifier/conflict_assessment_test.go
@@ -1,0 +1,316 @@
+package verifier
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareConflictAssessmentRequestRejectsIncompleteDossier(t *testing.T) {
+	_, errs := PrepareConflictAssessmentRequest(ConflictAssessmentRequest{}, DefaultSemanticAssessmentLimits())
+	require.NotEmpty(t, errs)
+	assert.Contains(t, openAIValidationSummary(errs), "request_id")
+}
+
+func TestValidateConflictAssessmentResponseRequiresKnownSelectedPosition(t *testing.T) {
+	request := conflictAssessmentTestRequest(t)
+	unknown := "unknown-position"
+	errs := validateConflictAssessmentResponse(request, ConflictAssessmentResponse{
+		Decision:   ConflictAssessmentDecisionSelect,
+		PositionID: &unknown,
+		Confidence: 0.9,
+		Rationale:  "the dossier is clear",
+	})
+	require.Len(t, errs, 1)
+	assert.Equal(t, "position_id", errs[0].Field)
+}
+
+func TestConflictAssessmentResponseSchemaIsClosed(t *testing.T) {
+	schema, err := json.Marshal(ConflictAssessmentResponseSchema())
+	require.NoError(t, err)
+	assert.Contains(t, string(schema), `"additionalProperties":false`)
+}
+
+func TestPrepareConflictAssessmentRequestNormalizesAndBoundsDossier(t *testing.T) {
+	localTime := time.Date(2026, 7, 31, 12, 0, 0, 0, time.FixedZone("test", -7*60*60))
+	prepared, errs := PrepareConflictAssessmentRequest(ConflictAssessmentRequest{
+		RequestID: " request-1 ",
+		CaseID:    " case-1 ",
+		Version:   1,
+		Question:  " Which system is current? ",
+		Positions: []ConflictAssessmentPosition{
+			{PositionID: " position-b ", PositionKey: " entity:b ", SupportGroupCount: 1},
+			{PositionID: " position-a ", PositionKey: " entity:a ", SupportGroupCount: 1},
+		},
+		Evidence: []ConflictAssessmentEvidence{
+			{EvidenceID: " evidence-b ", PositionID: " position-b ", SupportID: " support-b ", SourceGroupKey: " source-b ", Authority: " primary ", AcceptedAt: localTime, EffectiveAt: &localTime, Content: " B is current. "},
+			{EvidenceID: " evidence-a ", PositionID: " position-a ", SupportID: " support-a ", SourceGroupKey: " source-a ", Authority: " authoritative ", AcceptedAt: localTime.Add(-time.Hour), Content: " A is current. "},
+		},
+	}, DefaultSemanticAssessmentLimits())
+	require.Empty(t, errs)
+	assert.Equal(t, "request-1", prepared.RequestID)
+	assert.Equal(t, "case-1", prepared.CaseID)
+	assert.Equal(t, "Which system is current?", prepared.Question)
+	assert.Equal(t, []string{"position-a", "position-b"}, []string{prepared.Positions[0].PositionID, prepared.Positions[1].PositionID})
+	assert.Equal(t, []string{"evidence-a", "evidence-b"}, []string{prepared.Evidence[0].EvidenceID, prepared.Evidence[1].EvidenceID})
+	assert.Equal(t, "primary", prepared.Evidence[1].Authority)
+	require.NotNil(t, prepared.Evidence[1].EffectiveAt)
+	assert.Equal(t, localTime.UTC(), *prepared.Evidence[1].EffectiveAt)
+
+	limits := DefaultSemanticAssessmentLimits()
+	limits.MaxInputTokens = 1
+	_, errs = PrepareConflictAssessmentRequest(prepared, limits)
+	require.Len(t, errs, 1)
+	assert.Equal(t, "request", errs[0].Field)
+	assert.Equal(t, "exceeds input token budget", errs[0].Message)
+}
+
+func TestPrepareConflictAssessmentRequestRejectsInvalidPositionAndEvidenceFields(t *testing.T) {
+	request := conflictAssessmentTestRequest(t)
+	request.Positions = []ConflictAssessmentPosition{
+		{},
+		{PositionID: "duplicate", PositionKey: ""},
+		{PositionID: " duplicate ", PositionKey: "same", SupportGroupCount: -1},
+	}
+	request.Evidence = []ConflictAssessmentEvidence{
+		{},
+		{
+			EvidenceID:     "evidence-unknown",
+			PositionID:     "unknown",
+			SupportID:      "support-unknown",
+			SourceGroupKey: "source-unknown",
+			AcceptedAt:     time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
+			Content:        strings.Repeat("x", ConflictAssessmentMaxContent+1),
+		},
+	}
+
+	_, errs := PrepareConflictAssessmentRequest(request, DefaultSemanticAssessmentLimits())
+	summary := openAIValidationSummary(errs)
+	assert.Contains(t, summary, "positions[0].position_id")
+	assert.Contains(t, summary, "positions[1].position_key")
+	assert.Contains(t, summary, "positions[2].position_id")
+	assert.Contains(t, summary, "positions[2]")
+	assert.Contains(t, summary, "evidence[0]")
+	assert.Contains(t, summary, "evidence[0].accepted_at")
+	assert.Contains(t, summary, "evidence[1].position_id")
+	assert.Contains(t, summary, "evidence[1].content")
+}
+
+func TestConflictAssessmentResponseValidationRejectsInvalidDecisionShapes(t *testing.T) {
+	request := conflictAssessmentTestRequest(t)
+	position := "position-a"
+	testCases := []struct {
+		name     string
+		response ConflictAssessmentResponse
+		field    string
+	}{
+		{
+			name:     "select requires position",
+			response: ConflictAssessmentResponse{Decision: ConflictAssessmentDecisionSelect, Confidence: 0.8, Rationale: "reason"},
+			field:    "position_id",
+		},
+		{
+			name:     "select confidence is bounded",
+			response: ConflictAssessmentResponse{Decision: ConflictAssessmentDecisionSelect, PositionID: &position, Confidence: 1.1, Rationale: "reason"},
+			field:    "confidence",
+		},
+		{
+			name:     "abstain has no position or confidence",
+			response: ConflictAssessmentResponse{Decision: ConflictAssessmentDecisionAbstain, PositionID: &position, Confidence: 0.1, Rationale: "reason"},
+			field:    "position_id",
+		},
+		{
+			name:     "decision is closed and rationale required",
+			response: ConflictAssessmentResponse{Decision: "defer"},
+			field:    "decision",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			errs := validateConflictAssessmentResponse(request, testCase.response)
+			require.NotEmpty(t, errs)
+			assert.Contains(t, openAIValidationSummary(errs), testCase.field)
+		})
+	}
+}
+
+func TestDecodeConflictAssessmentResponseJSONRejectsInvalidPayloads(t *testing.T) {
+	limits := DefaultSemanticAssessmentLimits()
+	for _, payload := range []string{
+		"not-json",
+		`{"decision":"abstain","position_id":null,"rationale":"missing confidence"}`,
+		`{"decision":"abstain","position_id":null,"confidence":0,"rationale":"extra field","unexpected":true}`,
+		`{"decision":"abstain","decision":"select","position_id":null,"confidence":0,"rationale":"duplicate decision"}`,
+		`{"decision":null,"position_id":null,"confidence":0,"rationale":"null decision"}`,
+		`{"decision":"abstain","position_id":null,"confidence":0,"rationale":"trailing"} {}`,
+	} {
+		_, err := DecodeConflictAssessmentResponseJSON([]byte(payload), limits)
+		require.Error(t, err, payload)
+	}
+
+	limits.MaxOutputTokens = 1
+	_, err := DecodeConflictAssessmentResponseJSON([]byte(`{"decision":"abstain","position_id":null,"confidence":0,"rationale":"over budget"}`), limits)
+	require.ErrorContains(t, err, "token limit")
+}
+
+func TestOpenAIVerifierAssessesRelationshipConflict(t *testing.T) {
+	var received openAIVerifierRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&received))
+		assert.Equal(t, "dense_mem_conflict_assessment_response", received.ResponseFormat.JSONSchema.Name)
+		assert.Len(t, received.Messages, 2)
+		assert.Contains(t, received.Messages[0].Content, "overdue conflict assessor")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{
+				"content": `{"decision":"select","position_id":"position-b","confidence":0.91,"rationale":"The supplied evidence is clear."}`,
+			}}},
+			"usage": map[string]any{"prompt_tokens": 41, "completion_tokens": 9},
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewOpenAIVerifier(newTestVerifierConfig(srv.URL, "key", "assessor-model"), srv.Client())
+	response, err := provider.AssessRelationshipConflict(context.Background(), conflictAssessmentTestRequest(t))
+	require.NoError(t, err)
+	assert.Equal(t, ConflictAssessmentDecisionSelect, response.Decision)
+	require.NotNil(t, response.PositionID)
+	assert.Equal(t, "position-b", *response.PositionID)
+	assert.Equal(t, 0.91, response.Confidence)
+	assert.Equal(t, 1, response.ProviderTurns)
+	assert.Equal(t, 41, response.InputTokens)
+	assert.Greater(t, response.OutputTokens, 0)
+}
+
+func TestOpenAIVerifierCorrectsInvalidRelationshipConflictAssessment(t *testing.T) {
+	requests := []openAIVerifierRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var received openAIVerifierRequest
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&received))
+		requests = append(requests, received)
+		content := `{"decision":"select","position_id":"position-a","confidence":0.9,"rationale":"Initial invalid selection.","unexpected":true}`
+		if len(requests) == 2 {
+			content = `{"decision":"abstain","position_id":null,"confidence":0,"rationale":"The dossier is not clear enough."}`
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": content}}},
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewOpenAIVerifier(newTestVerifierConfig(srv.URL, "key", "assessor-model"), srv.Client())
+	response, err := provider.AssessRelationshipConflict(context.Background(), conflictAssessmentTestRequest(t))
+	require.NoError(t, err)
+	assert.Equal(t, ConflictAssessmentDecisionAbstain, response.Decision)
+	assert.Nil(t, response.PositionID)
+	assert.Equal(t, 2, response.ProviderTurns)
+	require.Len(t, requests, 2)
+	assert.Equal(t, []string{"system", "user"}, assessmentMessageRoles(requests[0].Messages))
+	assert.Equal(t, []string{"system", "user", "assistant", "user"}, assessmentMessageRoles(requests[1].Messages))
+	assert.Contains(t, requests[1].Messages[3].Content, "position_id")
+}
+
+func TestOpenAIVerifierStopsAfterBoundedInvalidConflictAssessmentResponses(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requestCount++
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]any{"content": "not-json"}}},
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewOpenAIVerifier(newTestVerifierConfig(srv.URL, "key", "assessor-model"), srv.Client())
+	_, err := provider.AssessRelationshipConflict(context.Background(), conflictAssessmentTestRequest(t))
+	require.ErrorIs(t, err, ErrVerifierMalformedResponse)
+	assert.Equal(t, SemanticAssessmentMaxProviderTurns, requestCount)
+}
+
+func TestOpenAIVerifierRejectsReportedConflictAssessmentTokenOverage(t *testing.T) {
+	valid := `{"decision":"abstain","position_id":null,"confidence":0,"rationale":"The dossier is inconclusive."}`
+	for _, testCase := range []struct {
+		name         string
+		usage        map[string]any
+		wantCalls    int
+		wantAttempts int
+		wantClass    string
+		wantDetail   string
+	}{
+		{
+			name: "input token overage",
+			usage: map[string]any{
+				"prompt_tokens": DefaultSemanticAssessmentLimits().MaxInputTokens + 1,
+			},
+			wantCalls:    1,
+			wantAttempts: 1,
+			wantClass:    "input_budget",
+			wantDetail:   "input tokens beyond conflict assessment limit",
+		},
+		{
+			name: "output token overage",
+			usage: map[string]any{
+				"completion_tokens": DefaultSemanticAssessmentLimits().MaxOutputTokens + 1,
+			},
+			wantCalls:    SemanticAssessmentMaxProviderTurns,
+			wantAttempts: SemanticAssessmentMaxProviderTurns,
+			wantClass:    "malformed_exhausted",
+			wantDetail:   "remained invalid after bounded correction",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			requestCount := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requestCount++
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"choices": []map[string]any{{"message": map[string]any{"content": valid}}},
+					"usage":   testCase.usage,
+				}))
+			}))
+			defer srv.Close()
+
+			provider := NewOpenAIVerifier(newTestVerifierConfig(srv.URL, "key", "assessor-model"), srv.Client())
+			_, err := provider.AssessRelationshipConflict(context.Background(), conflictAssessmentTestRequest(t))
+			require.ErrorIs(t, err, ErrVerifierMalformedResponse)
+			var malformed *MalformedResponseError
+			require.ErrorAs(t, err, &malformed)
+			assert.Equal(t, testCase.wantAttempts, malformed.Attempts)
+			assert.Equal(t, testCase.wantClass, malformed.FailureClass)
+			assert.Contains(t, malformed.Message, testCase.wantDetail)
+			assert.Equal(t, testCase.wantCalls, requestCount)
+		})
+	}
+}
+
+func TestOpenAIVerifierRejectsInvalidRelationshipConflictDossierBeforeProviderCall(t *testing.T) {
+	provider := NewOpenAIVerifier(newTestVerifierConfig("https://example.invalid", "key", "assessor-model"), nil)
+	_, err := provider.AssessRelationshipConflict(context.Background(), ConflictAssessmentRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVerifierProvider)
+}
+
+func conflictAssessmentTestRequest(t *testing.T) ConflictAssessmentRequest {
+	t.Helper()
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	request, errs := PrepareConflictAssessmentRequest(ConflictAssessmentRequest{
+		RequestID: "request-1",
+		CaseID:    "case-1",
+		Version:   1,
+		Question:  "Which system is current?",
+		Positions: []ConflictAssessmentPosition{
+			{PositionID: "position-a", PositionKey: "entity:a", SupportGroupCount: 1},
+			{PositionID: "position-b", PositionKey: "entity:b", SupportGroupCount: 1},
+		},
+		Evidence: []ConflictAssessmentEvidence{
+			{EvidenceID: "evidence-a", PositionID: "position-a", SupportID: "support-a", SourceGroupKey: "source-a", Authority: "primary", AcceptedAt: now, Content: "The current system is A."},
+			{EvidenceID: "evidence-b", PositionID: "position-b", SupportID: "support-b", SourceGroupKey: "source-b", Authority: "primary", AcceptedAt: now, Content: "The current system is B."},
+		},
+	}, DefaultSemanticAssessmentLimits())
+	require.Empty(t, errs)
+	return request
+}

--- a/internal/verifier/conflict_assessment_test.go
+++ b/internal/verifier/conflict_assessment_test.go
@@ -96,7 +96,7 @@ func TestPrepareConflictAssessmentRequestRejectsInvalidPositionAndEvidenceFields
 	assert.Contains(t, summary, "positions[0].position_id")
 	assert.Contains(t, summary, "positions[1].position_key")
 	assert.Contains(t, summary, "positions[2].position_id")
-	assert.Contains(t, summary, "positions[2]")
+	assert.Contains(t, summary, "support counts must not be negative")
 	assert.Contains(t, summary, "evidence[0]")
 	assert.Contains(t, summary, "evidence[0].accepted_at")
 	assert.Contains(t, summary, "evidence[1].position_id")
@@ -139,6 +139,19 @@ func TestConflictAssessmentResponseValidationRejectsInvalidDecisionShapes(t *tes
 			assert.Contains(t, openAIValidationSummary(errs), testCase.field)
 		})
 	}
+}
+
+func TestConflictAssessmentResponseValidationCountsUnicodeRationaleRunes(t *testing.T) {
+	request := conflictAssessmentTestRequest(t)
+	valid := ConflictAssessmentResponse{
+		Decision:   ConflictAssessmentDecisionAbstain,
+		Confidence: 0,
+		Rationale:  strings.Repeat("é", ConflictAssessmentMaxRationale),
+	}
+	assert.Empty(t, validateConflictAssessmentResponse(request, valid))
+
+	valid.Rationale += "é"
+	assert.Contains(t, openAIValidationSummary(validateConflictAssessmentResponse(request, valid)), "rationale")
 }
 
 func TestDecodeConflictAssessmentResponseJSONRejectsInvalidPayloads(t *testing.T) {

--- a/internal/verifier/openai_assessor_edge_test.go
+++ b/internal/verifier/openai_assessor_edge_test.go
@@ -68,7 +68,6 @@ func TestOpenAIVerifierAssessSemanticUsesOneTurnForValidResponse(t *testing.T) {
 	defer srv.Close()
 
 	cfg := newTestVerifierConfig(srv.URL, "sk-test", "assessor-model")
-	cfg.AIReviewerModel = ""
 	v := NewOpenAIVerifier(cfg, srv.Client())
 	req, _ := semanticAssessmentTestRequest(t)
 	response, err := v.AssessSemantic(context.Background(), req)

--- a/internal/verifier/openai_verifier_test.go
+++ b/internal/verifier/openai_verifier_test.go
@@ -25,7 +25,6 @@ func newTestVerifierConfig(serverURL, apiKey, model string) *config.Config {
 	return &config.Config{
 		AIAPIURL:        serverURL,
 		AIAPIKey:        apiKey,
-		AIReviewerModel: model,
 		AIVerifierModel: model,
 	}
 }
@@ -261,7 +260,6 @@ func TestOpenAIVerifier(t *testing.T) {
 			AIAPIKey:         "embedding-key",
 			AIVerifierAPIURL: srv.URL,
 			AIVerifierAPIKey: "verifier-key",
-			AIReviewerModel:  "reviewer-model",
 			AIVerifierModel:  "verifier-model",
 		}
 		v := NewOpenAIVerifier(cfg, srv.Client())
@@ -613,7 +611,6 @@ func TestOpenAIVerifierSemanticAdapters(t *testing.T) {
 		defer srv.Close()
 
 		cfg := newTestVerifierConfig(srv.URL, "sk-test", "verifier-model")
-		cfg.AIReviewerModel = "reviewer-model"
 		v := NewOpenAIVerifier(cfg, srv.Client())
 		got, err := v.ProposeSemantic(context.Background(), ProviderProposalRequest{
 			RequestID:        "extract-1",
@@ -666,7 +663,6 @@ func TestOpenAIVerifierSemanticAdapters(t *testing.T) {
 
 		content := "Dense-Mem uses PostgreSQL."
 		cfg := newTestVerifierConfig(srv.URL, "sk-test", "verifier-model")
-		cfg.AIReviewerModel = "reviewer-model"
 		v := NewOpenAIVerifier(cfg, srv.Client())
 		got, err := v.ReviewSemantic(context.Background(), SemanticReviewRequest{
 			RequestID:            "verify-1",

--- a/internal/verifier/retry_verifier_test.go
+++ b/internal/verifier/retry_verifier_test.go
@@ -36,7 +36,6 @@ func (s *stubConfigProvider) GetAIEmbeddingTimeoutSeconds() int   { return 30 }
 func (s *stubConfigProvider) IsEmbeddingConfigured() bool         { return false }
 func (s *stubConfigProvider) GetAIVerifierAPIURL() string         { return "" }
 func (s *stubConfigProvider) GetAIVerifierAPIKey() string         { return "" }
-func (s *stubConfigProvider) GetAIReviewerModel() string          { return "reviewer-model" }
 func (s *stubConfigProvider) GetAIVerifierModel() string          { return "gpt-4o-mini" }
 func (s *stubConfigProvider) GetAIVerifierTimeoutSeconds() int    { return 60 }
 func (s *stubConfigProvider) GetAIVerifierMaxConcurrency() int    { return s.maxConcurrency }

--- a/internal/verifier/semantic_review.go
+++ b/internal/verifier/semantic_review.go
@@ -33,6 +33,7 @@ type SemanticReviewEvidence struct {
 	FragmentID              string `json:"-"`
 	EvidenceIndex           int    `json:"-"`
 	Content                 string `json:"content"`
+	Authority               string `json:"-"`
 	SourceID                string `json:"-"`
 	SourceRevisionID        string `json:"-"`
 	CurrentSourceRevisionID string `json:"-"`

--- a/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
+++ b/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
@@ -1,0 +1,370 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+ALTER TABLE team_profiles
+    ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE team_profiles
+    DROP CONSTRAINT IF EXISTS team_profiles_system_marker_check,
+    DROP CONSTRAINT IF EXISTS team_profiles_auth_source_shape_check,
+    DROP CONSTRAINT IF EXISTS team_profiles_auth_source_check;
+
+ALTER TABLE team_profiles
+    ADD CONSTRAINT team_profiles_auth_source_check
+        CHECK (auth_source IN ('api_key', 'sso', 'system')),
+    ADD CONSTRAINT team_profiles_system_marker_check
+        CHECK ((auth_source = 'system') = is_system),
+    ADD CONSTRAINT team_profiles_auth_source_shape_check
+        CHECK (
+            (
+                auth_source = 'api_key'
+                AND key_hash IS NOT NULL
+                AND key_prefix IS NOT NULL
+                AND sso_identity_id IS NULL
+                AND sso_provider_id IS NULL
+                AND NULLIF(sso_subject, '') IS NULL
+                AND sso_entitlement_status = 'unlinked'
+            )
+            OR (
+                auth_source = 'sso'
+                AND key_hash IS NULL
+                AND key_prefix IS NULL
+                AND NULLIF(sso_subject, '') IS NOT NULL
+                AND sso_entitlement_status IN ('active', 'denied', 'error')
+                AND (
+                    (sso_identity_id IS NOT NULL AND sso_provider_id IS NOT NULL)
+                    OR (sso_identity_id IS NULL AND sso_provider_id IS NULL)
+                )
+            )
+            OR (
+                auth_source = 'system'
+                AND key_hash IS NULL
+                AND key_prefix IS NULL
+                AND sso_identity_id IS NULL
+                AND sso_provider_id IS NULL
+                AND NULLIF(sso_subject, '') IS NULL
+                AND sso_entitlement_status = 'unlinked'
+                AND revoked_at IS NOT NULL
+                AND is_system
+            )
+        );
+
+CREATE UNIQUE INDEX IF NOT EXISTS team_profiles_system_team_unique
+    ON team_profiles(team_id)
+    WHERE is_system;
+
+DROP POLICY IF EXISTS team_profiles_system_conflict_insert_access ON team_profiles;
+CREATE POLICY team_profiles_system_conflict_insert_access ON team_profiles
+    FOR INSERT
+    TO PUBLIC
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        AND auth_source = 'system'
+        AND is_system
+        AND revoked_at IS NOT NULL
+    );
+
+DO $$
+DECLARE
+    team_record RECORD;
+    has_system_profile BOOLEAN;
+BEGIN
+    FOR team_record IN SELECT id FROM teams LOOP
+        SELECT EXISTS (
+            SELECT 1
+            FROM team_profiles
+            WHERE team_id = team_record.id
+              AND is_system
+        ) INTO has_system_profile;
+        CONTINUE WHEN has_system_profile;
+
+        FOR attempt IN 1..5 LOOP
+            INSERT INTO team_profiles (
+                team_id, key_hash, key_prefix, key_suffix, name, scopes, role, rate_limit,
+                revoked_at, auth_source, is_system
+            ) VALUES (
+                team_record.id, NULL, NULL, NULL,
+                '__dense_mem_conflict_system__:' || gen_random_uuid()::text,
+                ARRAY[]::text[], 'member', 0, now(), 'system', true
+            )
+            ON CONFLICT DO NOTHING;
+
+            SELECT EXISTS (
+                SELECT 1
+                FROM team_profiles
+                WHERE team_id = team_record.id
+                  AND is_system
+            ) INTO has_system_profile;
+            EXIT WHEN has_system_profile;
+        END LOOP;
+
+        IF NOT has_system_profile THEN
+            RAISE EXCEPTION 'could not create conflict system profile for team %', team_record.id;
+        END IF;
+    END LOOP;
+END $$;
+
+INSERT INTO semantic_team_refs (team_id)
+SELECT id
+FROM teams
+ON CONFLICT (team_id) DO NOTHING;
+
+INSERT INTO semantic_profile_refs (team_id, profile_id)
+SELECT team_id, id
+FROM team_profiles
+WHERE is_system
+ON CONFLICT (team_id, profile_id) DO NOTHING;
+
+ALTER TABLE evidence_lifecycle_operations
+    ADD COLUMN IF NOT EXISTS actor_profile_id UUID NULL;
+
+ALTER TABLE evidence_lifecycle_operations
+    DROP CONSTRAINT IF EXISTS evidence_lifecycle_operations_actor_profile_fk;
+
+ALTER TABLE evidence_lifecycle_operations
+    ADD CONSTRAINT evidence_lifecycle_operations_actor_profile_fk
+    FOREIGN KEY (team_id, actor_profile_id)
+    REFERENCES semantic_profile_refs(team_id, profile_id) ON DELETE RESTRICT;
+
+ALTER TABLE relationship_conflict_position_members
+    ADD COLUMN IF NOT EXISTS accepted_at TIMESTAMPTZ NULL;
+
+UPDATE relationship_conflict_position_members AS member
+SET accepted_at = COALESCE(support.created_at, member.first_seen_at)
+FROM relationship_evidence_supports AS support
+WHERE support.team_id = member.team_id
+  AND support.support_id = member.support_id
+  AND member.accepted_at IS NULL;
+
+UPDATE relationship_conflict_position_members
+SET accepted_at = first_seen_at
+WHERE accepted_at IS NULL;
+
+ALTER TABLE relationship_conflict_position_members
+    ALTER COLUMN accepted_at SET NOT NULL;
+
+ALTER TABLE evidence_fragments
+    DROP CONSTRAINT IF EXISTS evidence_fragments_authority_check;
+
+ALTER TABLE evidence_fragments
+    ADD CONSTRAINT evidence_fragments_authority_check
+    CHECK (authority IN ('authoritative', 'primary', 'secondary', 'inferred', 'unknown'));
+
+ALTER TABLE relationship_conflict_events
+    DROP CONSTRAINT IF EXISTS relationship_conflict_events_action_check;
+
+ALTER TABLE relationship_conflict_events
+    ADD CONSTRAINT relationship_conflict_events_action_check CHECK (action IN (
+        'opened', 'position_added', 'member_added', 'evaluated', 'marked_overdue',
+        'resolved', 'relationship_updated', 'dismissed', 'ai_assessment_reserved',
+        'ai_assessed', 'resolution_pending', 'evidence_retracted',
+        'derived_replacement_staged', 'derived_replacement_failed'
+    ));
+
+CREATE TABLE IF NOT EXISTS relationship_conflict_ai_assessment_attempts (
+    team_id UUID NOT NULL,
+    assessment_attempt_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    conflict_id UUID NOT NULL,
+    case_version INTEGER NOT NULL,
+    local_assessment_date DATE NOT NULL,
+    model TEXT NOT NULL,
+    policy_version TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'reserved',
+    selected_position_id UUID NULL,
+    confidence DOUBLE PRECISION NULL,
+    provider_turns INTEGER NOT NULL DEFAULT 0,
+    response_hash TEXT NOT NULL DEFAULT '',
+    failure_class TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ NULL,
+    PRIMARY KEY (team_id, assessment_attempt_id),
+    UNIQUE (team_id, conflict_id, case_version, local_assessment_date, model, policy_version),
+    FOREIGN KEY (team_id, conflict_id) REFERENCES relationship_conflict_cases(team_id, conflict_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, selected_position_id) REFERENCES relationship_conflict_positions(team_id, position_id) ON DELETE RESTRICT,
+    CONSTRAINT relationship_conflict_ai_assessment_case_version_check CHECK (case_version >= 1),
+    CONSTRAINT relationship_conflict_ai_assessment_model_nonempty CHECK (btrim(model) <> ''),
+    CONSTRAINT relationship_conflict_ai_assessment_policy_nonempty CHECK (btrim(policy_version) <> ''),
+    CONSTRAINT relationship_conflict_ai_assessment_status_check CHECK (status IN ('reserved', 'selected', 'abstained', 'failed', 'superseded')),
+    CONSTRAINT relationship_conflict_ai_assessment_confidence_check CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+    CONSTRAINT relationship_conflict_ai_assessment_provider_turns_check CHECK (provider_turns >= 0),
+    CONSTRAINT relationship_conflict_ai_assessment_response_hash_length_check CHECK (char_length(response_hash) <= 128),
+    CONSTRAINT relationship_conflict_ai_assessment_failure_class_length_check CHECK (char_length(failure_class) <= 128),
+    CONSTRAINT relationship_conflict_ai_assessment_selected_shape_check CHECK (
+        (status = 'selected' AND selected_position_id IS NOT NULL AND confidence IS NOT NULL)
+        OR (status = 'abstained' AND selected_position_id IS NULL AND confidence = 0)
+        OR (status IN ('reserved', 'failed', 'superseded') AND selected_position_id IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS relationship_conflict_ai_assessment_case_idx
+    ON relationship_conflict_ai_assessment_attempts(team_id, conflict_id, case_version, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS relationship_conflict_ai_assessment_events (
+    team_id UUID NOT NULL,
+    assessment_event_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    assessment_attempt_id UUID NOT NULL,
+    action TEXT NOT NULL,
+    outcome TEXT NOT NULL DEFAULT '',
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (team_id, assessment_event_id),
+    FOREIGN KEY (team_id, assessment_attempt_id)
+        REFERENCES relationship_conflict_ai_assessment_attempts(team_id, assessment_attempt_id) ON DELETE RESTRICT,
+    CONSTRAINT relationship_conflict_ai_assessment_event_action_check CHECK (action IN ('reserved', 'selected', 'abstained', 'failed', 'superseded')),
+    CONSTRAINT relationship_conflict_ai_assessment_event_metadata_object_check CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS relationship_conflict_ai_assessment_events_attempt_idx
+    ON relationship_conflict_ai_assessment_events(team_id, assessment_attempt_id, created_at ASC, assessment_event_id ASC);
+
+DROP TRIGGER IF EXISTS relationship_conflict_ai_assessment_events_append_only ON relationship_conflict_ai_assessment_events;
+CREATE TRIGGER relationship_conflict_ai_assessment_events_append_only
+    BEFORE UPDATE OR DELETE ON relationship_conflict_ai_assessment_events
+    FOR EACH ROW EXECUTE FUNCTION prevent_append_only_mutation();
+
+CREATE TABLE IF NOT EXISTS relationship_conflict_resolution_plans (
+    team_id UUID NOT NULL,
+    resolution_plan_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    conflict_id UUID NOT NULL,
+    expected_case_version INTEGER NOT NULL,
+    preferred_position_id UUID NOT NULL,
+    assessment_attempt_id UUID NULL,
+    method TEXT NOT NULL,
+    effective_at TIMESTAMPTZ NOT NULL,
+    effective_time_basis TEXT NOT NULL DEFAULT 'recorded_at',
+    status TEXT NOT NULL DEFAULT 'resolution_pending',
+    failure_reason TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    applied_at TIMESTAMPTZ NULL,
+    PRIMARY KEY (team_id, resolution_plan_id),
+    UNIQUE (team_id, conflict_id, expected_case_version),
+    FOREIGN KEY (team_id, conflict_id) REFERENCES relationship_conflict_cases(team_id, conflict_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, preferred_position_id) REFERENCES relationship_conflict_positions(team_id, position_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, assessment_attempt_id)
+        REFERENCES relationship_conflict_ai_assessment_attempts(team_id, assessment_attempt_id) ON DELETE RESTRICT,
+    CONSTRAINT relationship_conflict_resolution_plans_version_check CHECK (expected_case_version >= 1),
+    CONSTRAINT relationship_conflict_resolution_plans_method_check CHECK (method IN ('ai', 'last_write_wins')),
+    CONSTRAINT relationship_conflict_resolution_plans_status_check CHECK (status IN ('resolution_pending', 'applied', 'superseded', 'failed')),
+    CONSTRAINT relationship_conflict_resolution_plans_effective_basis_check CHECK (effective_time_basis IN ('valid_from', 'recorded_at'))
+);
+
+CREATE INDEX IF NOT EXISTS relationship_conflict_resolution_plans_pending_idx
+    ON relationship_conflict_resolution_plans(team_id, status, created_at ASC)
+    WHERE status = 'resolution_pending';
+
+CREATE TABLE IF NOT EXISTS relationship_conflict_evidence_derivations (
+    team_id UUID NOT NULL,
+    derivation_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    conflict_id UUID NOT NULL,
+    target_fragment_id UUID NOT NULL,
+    target_owner_profile_id UUID NOT NULL,
+    selected_position_id UUID NOT NULL,
+    replacement_fragment_id UUID NULL,
+    system_profile_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (team_id, derivation_id),
+    UNIQUE (team_id, conflict_id, target_fragment_id),
+    FOREIGN KEY (team_id, conflict_id) REFERENCES relationship_conflict_cases(team_id, conflict_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, target_fragment_id, target_owner_profile_id)
+        REFERENCES evidence_fragments(team_id, fragment_id, owner_profile_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, selected_position_id) REFERENCES relationship_conflict_positions(team_id, position_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, replacement_fragment_id) REFERENCES evidence_fragments(team_id, fragment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, system_profile_id) REFERENCES semantic_profile_refs(team_id, profile_id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS relationship_conflict_evidence_derivations_conflict_idx
+    ON relationship_conflict_evidence_derivations(team_id, conflict_id, created_at ASC);
+
+DROP TRIGGER IF EXISTS relationship_conflict_evidence_derivations_append_only ON relationship_conflict_evidence_derivations;
+CREATE TRIGGER relationship_conflict_evidence_derivations_append_only
+    BEFORE UPDATE OR DELETE ON relationship_conflict_evidence_derivations
+    FOR EACH ROW EXECUTE FUNCTION prevent_append_only_mutation();
+
+ALTER TABLE relationship_conflict_ai_assessment_attempts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_ai_assessment_attempts FORCE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_ai_assessment_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_ai_assessment_events FORCE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_resolution_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_resolution_plans FORCE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_evidence_derivations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_evidence_derivations FORCE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'relationship_conflict_ai_assessment_attempts',
+        'relationship_conflict_ai_assessment_events',
+        'relationship_conflict_resolution_plans',
+        'relationship_conflict_evidence_derivations'
+    ]
+    LOOP
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', table_name || '_select', table_name);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', table_name || '_insert', table_name);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', table_name || '_update', table_name);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR SELECT USING (
+                current_setting(''app.tx_mode'', true) IN (''system'', ''migration'')
+                OR (
+                    current_setting(''app.tx_mode'', true) IN (''team'', ''profile'')
+                    AND team_id = nullif(current_setting(''app.current_team_id'', true), '''')::uuid
+                )
+            )',
+            table_name || '_select', table_name
+        );
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR INSERT WITH CHECK (
+                current_setting(''app.tx_mode'', true) IN (''system'', ''migration'')
+                OR (
+                    current_setting(''app.tx_mode'', true) IN (''team'', ''profile'')
+                    AND team_id = nullif(current_setting(''app.current_team_id'', true), '''')::uuid
+                )
+            )',
+            table_name || '_insert', table_name
+        );
+        IF table_name NOT IN ('relationship_conflict_ai_assessment_events', 'relationship_conflict_evidence_derivations') THEN
+            EXECUTE format(
+                'CREATE POLICY %I ON %I FOR UPDATE USING (
+                    current_setting(''app.tx_mode'', true) IN (''system'', ''migration'')
+                    OR (
+                        current_setting(''app.tx_mode'', true) IN (''team'', ''profile'')
+                        AND team_id = nullif(current_setting(''app.current_team_id'', true), '''')::uuid
+                    )
+                ) WITH CHECK (
+                    current_setting(''app.tx_mode'', true) IN (''system'', ''migration'')
+                    OR (
+                        current_setting(''app.tx_mode'', true) IN (''team'', ''profile'')
+                        AND team_id = nullif(current_setting(''app.current_team_id'', true), '''')::uuid
+                    )
+                )',
+                table_name || '_update', table_name
+            );
+        END IF;
+    END LOOP;
+END $$;
+
+UPDATE app_config
+SET value = regexp_replace(
+        to_char(clock_timestamp() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+        '\.?0+Z$',
+        'Z'
+    ),
+    updated_at = clock_timestamp()
+WHERE key = 'update_time';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DO $$
+BEGIN
+    RAISE EXCEPTION '2026073101_v2_overdue_conflict_resolution is irreversible because it records conflict-review audit lineage';
+END $$;
+
+-- +goose StatementEnd

--- a/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
+++ b/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
@@ -203,6 +203,10 @@ CREATE TABLE IF NOT EXISTS relationship_conflict_ai_assessment_attempts (
 CREATE INDEX IF NOT EXISTS relationship_conflict_ai_assessment_case_idx
     ON relationship_conflict_ai_assessment_attempts(team_id, conflict_id, case_version, created_at ASC);
 
+CREATE INDEX IF NOT EXISTS relationship_conflict_ai_assessment_failure_count_idx
+    ON relationship_conflict_ai_assessment_attempts(team_id, conflict_id, case_version, model, policy_version)
+    WHERE status = 'failed';
+
 CREATE TABLE IF NOT EXISTS relationship_conflict_ai_assessment_events (
     team_id UUID NOT NULL,
     assessment_event_id UUID NOT NULL DEFAULT gen_random_uuid(),
@@ -284,6 +288,46 @@ CREATE TRIGGER relationship_conflict_evidence_derivations_append_only
     BEFORE UPDATE OR DELETE ON relationship_conflict_evidence_derivations
     FOR EACH ROW EXECUTE FUNCTION prevent_append_only_mutation();
 
+CREATE TABLE IF NOT EXISTS relationship_conflict_derived_evidence_tasks (
+    team_id UUID NOT NULL,
+    derived_evidence_task_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    resolution_plan_id UUID NOT NULL,
+    conflict_id UUID NOT NULL,
+    target_fragment_id UUID NOT NULL,
+    target_owner_profile_id UUID NOT NULL,
+    selected_position_id UUID NOT NULL,
+    system_profile_id UUID NOT NULL,
+    source_group_key TEXT NOT NULL,
+    origin_evidence_index INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    lease_worker_id TEXT NULL,
+    lease_until TIMESTAMPTZ NULL,
+    last_review_run_id UUID NULL,
+    last_failure_class TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ NULL,
+    PRIMARY KEY (team_id, derived_evidence_task_id),
+    UNIQUE (team_id, conflict_id, target_fragment_id),
+    FOREIGN KEY (team_id, resolution_plan_id)
+        REFERENCES relationship_conflict_resolution_plans(team_id, resolution_plan_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, conflict_id) REFERENCES relationship_conflict_cases(team_id, conflict_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, target_fragment_id, target_owner_profile_id)
+        REFERENCES evidence_fragments(team_id, fragment_id, owner_profile_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, selected_position_id) REFERENCES relationship_conflict_positions(team_id, position_id) ON DELETE RESTRICT,
+    FOREIGN KEY (team_id, system_profile_id) REFERENCES semantic_profile_refs(team_id, profile_id) ON DELETE RESTRICT,
+    CONSTRAINT relationship_conflict_derived_evidence_tasks_status_check CHECK (status IN ('pending', 'processing', 'completed')),
+    CONSTRAINT relationship_conflict_derived_evidence_tasks_attempts_check CHECK (attempts >= 0),
+    CONSTRAINT relationship_conflict_derived_evidence_tasks_source_group_check CHECK (btrim(source_group_key) <> ''),
+    CONSTRAINT relationship_conflict_derived_evidence_tasks_origin_index_check CHECK (origin_evidence_index >= 0),
+    CONSTRAINT relationship_conflict_derived_evidence_tasks_failure_length_check CHECK (char_length(last_failure_class) <= 128)
+);
+
+CREATE INDEX IF NOT EXISTS relationship_conflict_derived_evidence_tasks_claim_idx
+    ON relationship_conflict_derived_evidence_tasks(team_id, status, lease_until, created_at ASC, derived_evidence_task_id ASC)
+    WHERE status IN ('pending', 'processing');
+
 ALTER TABLE relationship_conflict_ai_assessment_attempts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE relationship_conflict_ai_assessment_attempts FORCE ROW LEVEL SECURITY;
 ALTER TABLE relationship_conflict_ai_assessment_events ENABLE ROW LEVEL SECURITY;
@@ -292,6 +336,8 @@ ALTER TABLE relationship_conflict_resolution_plans ENABLE ROW LEVEL SECURITY;
 ALTER TABLE relationship_conflict_resolution_plans FORCE ROW LEVEL SECURITY;
 ALTER TABLE relationship_conflict_evidence_derivations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE relationship_conflict_evidence_derivations FORCE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_derived_evidence_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE relationship_conflict_derived_evidence_tasks FORCE ROW LEVEL SECURITY;
 
 DO $$
 DECLARE
@@ -301,7 +347,8 @@ BEGIN
         'relationship_conflict_ai_assessment_attempts',
         'relationship_conflict_ai_assessment_events',
         'relationship_conflict_resolution_plans',
-        'relationship_conflict_evidence_derivations'
+        'relationship_conflict_evidence_derivations',
+        'relationship_conflict_derived_evidence_tasks'
     ]
     LOOP
         EXECUTE format('DROP POLICY IF EXISTS %I ON %I', table_name || '_select', table_name);

--- a/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
+++ b/migrations/postgres/2026073101_v2_overdue_conflict_resolution.sql
@@ -1,6 +1,18 @@
 -- +goose Up
 -- +goose StatementBegin
 
+-- Lock/rewrite analysis:
+-- - This migration requires an exclusive maintenance window. Adding and making
+--   accepted_at non-null takes normal transactional table locks; its backfill
+--   visits each existing conflict member once.
+-- - It is intentionally atomic rather than online/resumable: a timeout or
+--   failure rolls back the schema and backfill together. Size the maintenance
+--   window from the target table's row count and lock budget before applying.
+-- - RLS impact: new workflow tables preserve the existing team/profile policy;
+--   normal application mutation paths remain the conflict-review worker.
+-- - Rollback: the Down migration is intentionally blocked once audit lineage
+--   may exist; restoring requires a database backup or a forward migration.
+
 SELECT set_config('app.tx_mode', 'migration', true);
 SELECT set_config('app.current_team_id', '', true);
 SELECT set_config('app.current_profile_id', '', true);
@@ -59,14 +71,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS team_profiles_system_team_unique
 
 DROP POLICY IF EXISTS team_profiles_system_conflict_insert_access ON team_profiles;
 CREATE POLICY team_profiles_system_conflict_insert_access ON team_profiles
-    FOR INSERT
-    TO PUBLIC
-    WITH CHECK (
-        current_setting('app.tx_mode', true) IN ('system', 'migration')
-        AND auth_source = 'system'
-        AND is_system
-        AND revoked_at IS NOT NULL
-    );
+	FOR INSERT
+	TO PUBLIC
+	WITH CHECK (
+		(
+			current_setting('app.tx_mode', true) = 'migration'
+			OR (
+				current_setting('app.tx_mode', true) = 'system'
+				AND team_id = nullif(current_setting('app.current_team_id', true), '')::uuid
+			)
+		)
+		AND auth_source = 'system'
+		AND is_system
+		AND revoked_at IS NOT NULL
+	);
 
 DO $$
 DECLARE

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -375,12 +375,16 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 cd "$ROOT_DIR"
 trap cleanup EXIT
 
-echo "Running disposable PostgreSQL SSO and Dreams regressions."
-DENSE_MEM_REPOSITORY_TESTCONTAINERS=1 go test \
-  ./internal/repository \
-  ./internal/http \
-  -run '^(TestSSORuntimeEntitlementsExcludeArchivedTeams|TestDreamControlRepositoryIsTeamScopedAndAuditsAtomicRefresh|TestSSOOIDCCallbackSkipsArchivedTeamMappingIntegration)$' \
-  -count=1
+if [[ "${DENSE_MEM_E2E_SKIP_PRECHECKS:-0}" == "1" ]]; then
+  echo "Skipping disposable PostgreSQL prechecks by DENSE_MEM_E2E_SKIP_PRECHECKS."
+else
+  echo "Running disposable PostgreSQL SSO and Dreams regressions."
+  DENSE_MEM_REPOSITORY_TESTCONTAINERS=1 go test \
+    ./internal/repository \
+    ./internal/http \
+    -run '^(TestSSORuntimeEntitlementsExcludeArchivedTeams|TestDreamControlRepositoryIsTeamScopedAndAuditsAtomicRefresh|TestSSOOIDCCallbackSkipsArchivedTeamMappingIntegration)$' \
+    -count=1
+fi
 
 prepare_e2e_compose_files
 prepare_e2e_prometheus_files
@@ -413,15 +417,19 @@ seed_json="$(compose exec -T server /app/provision-team --name "E2E Team" --desc
 team_id="$(printf '%s' "$seed_json" | json_field team_id)"
 api_key="$(printf '%s' "$seed_json" | json_field api_key)"
 
-echo "Running compose-backed Playwright tests."
-DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
-DENSE_MEM_USER_URL="$USER_URL" \
-DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
-DENSE_MEM_E2E_TEAM_ID="$team_id" \
-DENSE_MEM_E2E_TEAM_NAME="E2E Team" \
-DENSE_MEM_E2E_API_KEY="$api_key" \
-DENSE_MEM_PROMETHEUS_URL="$PROMETHEUS_URL" \
-npm --prefix "$ROOT_DIR/web" run playwright:compose
+if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then
+  echo "Skipping compose-backed Playwright tests by DENSE_MEM_E2E_SKIP_PLAYWRIGHT."
+else
+  echo "Running compose-backed Playwright tests."
+  DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
+  DENSE_MEM_USER_URL="$USER_URL" \
+  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
+  DENSE_MEM_E2E_TEAM_ID="$team_id" \
+  DENSE_MEM_E2E_TEAM_NAME="E2E Team" \
+  DENSE_MEM_E2E_API_KEY="$api_key" \
+  DENSE_MEM_PROMETHEUS_URL="$PROMETHEUS_URL" \
+  npm --prefix "$ROOT_DIR/web" run playwright:compose
+fi
 
 echo "Running compose-backed MCP conflict e2e."
 DENSE_MEM_CONTROL_URL="$CONTROL_URL" \

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -284,7 +284,11 @@ async function resolveOverdueConflictThroughVerifier() {
     throw new Error(`overdue conflict did not contain the two tied positions: ${JSON.stringify(openOverdueConflict)}`);
   }
 
-  const overdueReviewNow = new Date(Date.parse(reviewNow) + 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const overdueReviewDueAt = Date.parse(stringAt(openOverdueConflict, ["review_due_at"]));
+  if (!Number.isFinite(overdueReviewDueAt)) {
+    throw new Error(`overdue conflict did not return a valid review_due_at: ${JSON.stringify(openOverdueConflict)}`);
+  }
+  const overdueReviewNow = new Date(overdueReviewDueAt + 1_000).toISOString().replace(/\.\d{3}Z$/, "Z");
   const overdueReview = runConflictReview(overdueReviewNow);
   if (overdueReview.status !== "completed") {
     throw new Error(`overdue conflict reviewer did not complete: ${JSON.stringify(overdueReview)}`);

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -8,6 +8,7 @@ const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
 const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
 const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
 const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
+const placementTimeoutSeconds = positiveIntEnv("DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS", 720, 30, 1800);
 
 let rpcID = 0;
 
@@ -48,7 +49,7 @@ const second = await rememberAndWait(profileB.apiKey, {
   relationshipID: "rel:primary-db-b",
 });
 
-const openConflict = await waitForConflict(profileA.apiKey, "open");
+const openConflict = await waitForRelationshipConflict(profileB.apiKey, second.relationshipID, "open");
 const conflictID = String(openConflict.conflict_id);
 const conflictVersion = Number(openConflict.version);
 if (!conflictID || !Number.isInteger(conflictVersion) || conflictVersion < 1) {
@@ -76,7 +77,7 @@ if (!resolved || resolved.outcome !== "resolve") {
   throw new Error(`conflict reviewer did not resolve ${conflictID}: ${JSON.stringify(review)}`);
 }
 
-const resolvedConflict = await waitForConflict(profileA.apiKey, "resolved");
+const resolvedConflict = await waitForRelationshipConflict(profileB.apiKey, second.relationshipID, "resolved");
 if (resolvedConflict.conflict_id !== conflictID || resolvedConflict.status !== "resolved") {
   throw new Error(`resolved recall returned wrong conflict: ${JSON.stringify(resolvedConflict)}`);
 }
@@ -93,12 +94,16 @@ if (!Array.isArray(loserTrace.conflicts) || !loserTrace.conflicts.some((item) =>
   throw new Error(`trace did not include resolved conflict: ${JSON.stringify(loserTrace.conflicts)}`);
 }
 
+const overdueResolution = await resolveOverdueConflictThroughVerifier();
+
 console.log(JSON.stringify({
   status: "ok",
   run_id: runID,
   conflict_id: conflictID,
   first_relationship_id: first.relationshipID,
   losing_relationship_id: second.relationshipID,
+  overdue_conflict_id: overdueResolution.conflictID,
+  overdue_resolution_method: overdueResolution.method,
 }, null, 2));
 
 async function createProfile(name) {
@@ -132,6 +137,7 @@ async function rememberAndWait(apiKey, input) {
       source: input.sourceGroup,
       source_group: input.sourceGroup,
       idempotency_key: input.idempotencyKey,
+      ...(input.authority ? { authority: input.authority } : {}),
     }],
     proposal: {
       entities: [
@@ -171,7 +177,8 @@ function entityProposal(entity) {
 
 async function waitForPlacement(apiKey, ingestID, proposalID) {
   let lastSummary = {};
-  for (let attempt = 0; attempt < 150; attempt += 1) {
+  const attempts = Math.ceil((placementTimeoutSeconds * 1000) / 2_000);
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
     const placement = await mcpTool(apiKey, "get_memory_placement", { ingest_id: ingestID });
     if (placement.processing_state === "failed" || placement.processing_state === "quarantined") {
       throw new Error(`placement failed: ${JSON.stringify(placement)}`);
@@ -206,22 +213,103 @@ async function waitForPlacement(apiKey, ingestID, proposalID) {
     }
     await delay(2_000);
   }
-  throw new Error(`timed out waiting for placement ${ingestID}: ${JSON.stringify(lastSummary)}`);
+  throw new Error(`timed out waiting for placement ${ingestID} after ${placementTimeoutSeconds}s: ${JSON.stringify(lastSummary)}`);
 }
 
-async function waitForConflict(apiKey, status) {
+async function waitForRelationshipConflict(apiKey, relationshipID, status) {
   for (let attempt = 0; attempt < 90; attempt += 1) {
-    const recall = await mcpTool(apiKey, "recall_memory", {
-      query: `ConflictE2E ${runID} primary database`,
-      limit: 10,
-    });
-    const conflict = (recall.conflicts ?? []).find((item) => item.status === status);
+    const trace = await mcpTool(apiKey, "trace_memory", { relationship_id: relationshipID });
+    const conflict = (trace.conflicts ?? []).find((item) => (
+      item.status === status
+      && (item.positions ?? []).some((position) => (position.relationship_ids ?? []).includes(relationshipID))
+    ));
     if (conflict) {
       return conflict;
     }
     await delay(2_000);
   }
-  throw new Error(`timed out waiting for ${status} conflict`);
+  throw new Error(`timed out waiting for ${status} conflict for relationship ${relationshipID}`);
+}
+
+async function waitForConflictID(apiKey, query, conflictID, status) {
+  for (let attempt = 0; attempt < 90; attempt += 1) {
+    const recall = await mcpTool(apiKey, "recall_memory", { query, limit: 10 });
+    const conflict = (recall.conflicts ?? []).find((item) => item.conflict_id === conflictID && item.status === status);
+    if (conflict) {
+      return conflict;
+    }
+    await delay(2_000);
+  }
+  throw new Error(`timed out waiting for ${status} conflict ${conflictID}`);
+}
+
+async function resolveOverdueConflictThroughVerifier() {
+  const marker = `OverdueConflictE2E ${runID}`;
+  const firstOverdue = await rememberAndWait(profileA.apiKey, {
+  idempotencyKey: `${runID}:overdue:a`,
+  evidence: `${marker}: Dense-Mem overdue primary database is PostgreSQL according to profile A.`,
+  sourceGroup: `${runID}:overdue:source:a`,
+  authority: "primary",
+    subject: { ref: "project", name: `${marker} project`, kind: "project" },
+    object: { ref: "postgres", name: "PostgreSQL", kind: "product" },
+    relationshipID: "rel:overdue-primary-db-a",
+  });
+  const overdueTrace = await mcpTool(profileA.apiKey, "trace_memory", {
+    relationship_id: firstOverdue.relationshipID,
+    include_evidence_content: true,
+  });
+  const overdueSubjectEntityID = stringAt(overdueTrace, ["relationship", "subject_entity_id"]);
+  const overduePostgresEntityID = stringAt(overdueTrace, ["relationship", "object_entity_id"]);
+  if (!overdueSubjectEntityID || !overduePostgresEntityID) {
+    throw new Error(`overdue trace did not return canonical entity IDs: ${JSON.stringify(overdueTrace)}`);
+  }
+
+  const secondOverdue = await rememberAndWait(profileB.apiKey, {
+  idempotencyKey: `${runID}:overdue:b`,
+  evidence: `${marker}: Dense-Mem overdue primary database is GraphDB according to profile B.`,
+  sourceGroup: `${runID}:overdue:source:b`,
+  authority: "primary",
+    subject: { ref: "project", name: `${marker} project`, kind: "project", knownEntityID: overdueSubjectEntityID },
+    object: { ref: "graphdb", name: "GraphDB", kind: "product" },
+    relationshipID: "rel:overdue-primary-db-b",
+  });
+  const openOverdueConflict = await waitForRelationshipConflict(profileB.apiKey, secondOverdue.relationshipID, "open");
+  const overdueConflictID = stringAt(openOverdueConflict, ["conflict_id"]);
+  if (!overdueConflictID) {
+    throw new Error(`overdue conflict did not return an ID: ${JSON.stringify(openOverdueConflict)}`);
+  }
+  const overdueRelationshipIDs = new Set((openOverdueConflict.positions ?? [])
+    .flatMap((position) => position.relationship_ids ?? []));
+  if (overdueRelationshipIDs.size !== 2 || !overdueRelationshipIDs.has(firstOverdue.relationshipID) || !overdueRelationshipIDs.has(secondOverdue.relationshipID)) {
+    throw new Error(`overdue conflict did not contain the two tied positions: ${JSON.stringify(openOverdueConflict)}`);
+  }
+
+  const overdueReviewNow = new Date(Date.parse(reviewNow) + 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const overdueReview = runConflictReview(overdueReviewNow);
+  if (overdueReview.status !== "completed") {
+    throw new Error(`overdue conflict reviewer did not complete: ${JSON.stringify(overdueReview)}`);
+  }
+  const resolution = (overdueReview.results ?? []).find((item) => item.conflict_id === overdueConflictID);
+  if (!resolution || resolution.outcome !== "resolve") {
+    throw new Error(`overdue conflict did not resolve: ${JSON.stringify(overdueReview)}`);
+  }
+  if (!["ai", "last_write_wins"].includes(resolution.resolution_method)) {
+    throw new Error(`overdue conflict used an unexpected resolution method: ${JSON.stringify(resolution)}`);
+  }
+  if (!resolution.assessment_attempt_id || !Array.isArray(resolution.retracted_evidence_ids) || resolution.retracted_evidence_ids.length === 0) {
+    throw new Error(`overdue conflict did not record assessment/retraction lineage: ${JSON.stringify(resolution)}`);
+  }
+
+  await waitForConflictID(profileA.apiKey, marker, overdueConflictID, "resolved");
+  const overdueTraces = await Promise.all([
+    mcpTool(profileA.apiKey, "trace_memory", { relationship_id: firstOverdue.relationshipID, include_transitions: true }),
+    mcpTool(profileB.apiKey, "trace_memory", { relationship_id: secondOverdue.relationshipID, include_transitions: true }),
+  ]);
+  const supersededCount = overdueTraces.filter((trace) => stringAt(trace, ["relationship", "relationship_status"]) === "superseded").length;
+  if (supersededCount !== 1) {
+    throw new Error(`overdue conflict did not suppress exactly one losing relationship: ${JSON.stringify(overdueTraces)}`);
+  }
+  return { conflictID: overdueConflictID, method: resolution.resolution_method };
 }
 
 function runConflictReview(now) {
@@ -234,6 +322,7 @@ function runConflictReview(now) {
     "exec",
     "-T",
     "server",
+    "/app/docker-entrypoint.sh",
     "/app/review-conflicts",
     "--team-id",
     teamID,
@@ -298,6 +387,18 @@ function requiredEnv(name) {
   const value = process.env[name];
   if (!value) {
     throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function positiveIntEnv(name, fallback, minimum, maximum) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
   }
   return value;
 }

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -250,8 +250,8 @@ async function resolveOverdueConflictThroughVerifier() {
   evidence: `${marker}: Dense-Mem overdue primary database is PostgreSQL according to profile A.`,
   sourceGroup: `${runID}:overdue:source:a`,
   authority: "primary",
-    subject: { ref: "project", name: `${marker} project`, kind: "project" },
-    object: { ref: "postgres", name: "PostgreSQL", kind: "product" },
+    subject: { ref: "overdue-project", name: `${marker} project`, kind: "project" },
+    object: { ref: "overdue-postgres", name: "PostgreSQL", kind: "product" },
     relationshipID: "rel:overdue-primary-db-a",
   });
   const overdueTrace = await mcpTool(profileA.apiKey, "trace_memory", {
@@ -269,8 +269,8 @@ async function resolveOverdueConflictThroughVerifier() {
   evidence: `${marker}: Dense-Mem overdue primary database is GraphDB according to profile B.`,
   sourceGroup: `${runID}:overdue:source:b`,
   authority: "primary",
-    subject: { ref: "project", name: `${marker} project`, kind: "project", knownEntityID: overdueSubjectEntityID },
-    object: { ref: "graphdb", name: "GraphDB", kind: "product" },
+    subject: { ref: "overdue-project", name: `${marker} project`, kind: "project", knownEntityID: overdueSubjectEntityID },
+    object: { ref: "overdue-graphdb", name: "GraphDB", kind: "product" },
     relationshipID: "rel:overdue-primary-db-b",
   });
   const openOverdueConflict = await waitForRelationshipConflict(profileB.apiKey, secondOverdue.relationshipID, "open");


### PR DESCRIPTION
## Summary

- Reset relationship-conflict retry state when a case becomes overdue or its snapshot changes.
- Assess overdue conflicts with the existing `AI_VERIFIER_MODEL`, use a confidence-gated choice, and fall back to authority then most-recent accepted support when the model abstains or fails for five local days.
- Resolve safely: suppress losing relationships, retract only evidence exclusive to the resolved case, and stage deletion-only derived evidence without search or graph projection.
- Add durable assessment/resolution lineage, system-profile support, migration coverage, CLI/server wiring, and conflict E2E coverage.
- Keep the MCP contract version unchanged.

## Why

Overdue relationship-conflict cases previously remained unresolved and retry attempts could survive a changed case snapshot. This makes resolution durable, explainable, and safe against stale or shared evidence.

## Validation

- `./scripts/ci-check.sh`
- Focused real-PostgreSQL migration, lifecycle, stale-evidence, shared-evidence, and authority-constraint integration tests
- Fresh local MCP conflict E2E through `docker-compose.yml` (browser segment skipped because the host lacks `libglib-2.0.so.0`)
- Independent `codex review --uncommitted` cycles; substantive findings were fixed and regression-tested
- The 1k retrieval evaluation was intentionally not run: this change is confined to conflict workflow behavior, per requested scope

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated assessment and resolution for overdue relationship conflicts.
  * Added deterministic last-write-wins fallback for unavailable or inconclusive assessments.
  * Added evidence authority tracking across reviews and semantic processing.
  * Added resolution status, assessment details, retracted evidence, and derived-evidence metadata to review results.
  * Added safeguards for stale, duplicate, abandoned, and low-confidence assessments.
  * Added automatic processing and failure tracking for derived evidence.

* **Configuration**
  * Updated verifier configuration naming and support for direct PostgreSQL connection strings.

* **Tests**
  * Expanded coverage for conflict resolution, evidence handling, retries, security, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->