### PR TITLE
Fix telemetry cost rollups

### DIFF
--- a/internal/service/embeddingservice/service_test.go
+++ b/internal/service/embeddingservice/service_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -114,6 +116,81 @@ func TestEmbeddingWorkerCompletesValidBatch(t *testing.T) {
 	}
 	if len(provider.gotTexts) != 2 || provider.gotTexts[0] != "document job-a" {
 		t.Fatalf("provider texts = %#v", provider.gotTexts)
+	}
+}
+
+func TestEmbeddingWorkerBackgroundCostUsesTeamOnlyIdentityForMixedOwners(t *testing.T) {
+	teamID := "11111111-1111-4111-8111-111111111111"
+	ownerA := "22222222-2222-4222-8222-222222222222"
+	ownerB := "33333333-3333-4333-8333-333333333333"
+	search := newEmbeddingSearchStub()
+	jobA := embeddingJobForTest("job-a", 1)
+	jobA.TeamID = teamID
+	jobA.OwnerProfileID = ownerA
+	jobB := embeddingJobForTest("job-b", 1)
+	jobB.TeamID = teamID
+	jobB.OwnerProfileID = ownerB
+	search.jobs = []repository.EmbeddingJob{jobA, jobB}
+
+	embeddingInputPrice := 1.0
+	metrics := observability.NewPrometheusMetrics(observability.AIPricingResolverFunc(func(context.Context) (observability.AIPricing, error) {
+		return observability.AIPricing{EmbeddingInputUSDPerMillionTokens: &embeddingInputPrice}, nil
+	}))
+	provider := &embeddingProviderStub{
+		available: true,
+		model:     "test-model",
+		dims:      3,
+		vectors: [][]float32{
+			{1, 0, 0},
+			{0, 1, 0},
+		},
+		observeUsage: func(ctx context.Context, itemCount int) {
+			observability.RecordAIOperationUsage(ctx, metrics, observability.AIOperationUsage{
+				Component:   observability.AIComponentEmbedding,
+				Model:       "test-model",
+				InputTokens: 1_000_000,
+				ItemCount:   itemCount,
+				Source:      observability.AITokenSourceProvider,
+			})
+		},
+	}
+	worker := NewEmbeddingWorkerService(EmbeddingWorkerDependencies{
+		Search:   search,
+		Provider: provider,
+		Metrics:  metrics,
+		TeamID:   teamID,
+		WorkerID: "worker-a",
+	})
+
+	result, err := worker.ProcessNextBatch(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessNextBatch returned error: %v", err)
+	}
+	if result.Completed != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+
+	recorder := httptest.NewRecorder()
+	metrics.Handler().ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
+	var costLine string
+	for _, line := range strings.Split(recorder.Body.String(), "\n") {
+		if strings.HasPrefix(line, "densemem_ai_operation_cost_usd_total{") && strings.Contains(line, `operation="background_embedding"`) {
+			costLine = line
+			break
+		}
+	}
+	if costLine == "" {
+		t.Fatalf("background embedding cost sample missing:\n%s", recorder.Body.String())
+	}
+	for _, label := range []string{`team_id="` + teamID + `"`, `profile_id="unknown"`, `component="embedding"`} {
+		if !strings.Contains(costLine, label) {
+			t.Fatalf("background embedding cost sample missing %s: %s", label, costLine)
+		}
+	}
+	for _, ownerID := range []string{ownerA, ownerB} {
+		if strings.Contains(costLine, ownerID) {
+			t.Fatalf("background embedding cost attributed to owner %s: %s", ownerID, costLine)
+		}
 	}
 }
 
@@ -536,20 +613,24 @@ func (s *embeddingSearchStub) SearchExactVector(context.Context, repository.Exac
 }
 
 type embeddingProviderStub struct {
-	available bool
-	model     string
-	dims      int
-	vectors   [][]float32
-	err       error
-	gotTexts  []string
+	available    bool
+	model        string
+	dims         int
+	vectors      [][]float32
+	err          error
+	gotTexts     []string
+	observeUsage func(context.Context, int)
 }
 
 func (p *embeddingProviderStub) Embed(context.Context, string) ([]float32, string, error) {
 	return nil, "", errors.New("not implemented")
 }
 
-func (p *embeddingProviderStub) EmbedBatch(_ context.Context, texts []string) ([][]float32, string, error) {
+func (p *embeddingProviderStub) EmbedBatch(ctx context.Context, texts []string) ([][]float32, string, error) {
 	p.gotTexts = append([]string(nil), texts...)
+	if p.observeUsage != nil {
+		p.observeUsage(ctx, len(texts))
+	}
 	if p.err != nil {
 		return nil, "", p.err
 	}

--- a/internal/service/telemetry_service.go
+++ b/internal/service/telemetry_service.go
@@ -320,26 +320,10 @@ func telemetryWindowedCardSpecsForAudience(scope TelemetryScope, baseLabels map[
 		return specs
 	}
 	return append(specs,
-		telemetryQuerySpec{ID: "ai_cost_usd", Label: "AI cost", Unit: "USD", Query: telemetrySparseCounterIncrease("densemem_ai_operation_cost_usd_total", scope, baseLabels, nil, window)},
-		telemetryQuerySpec{ID: "verifier_cost_usd", Label: "Verifier cost", Unit: "USD", Query: telemetrySparseCounterIncrease("densemem_ai_operation_cost_usd_total", scope, baseLabels, map[string]string{"component": observability.AIComponentVerifier}, window)},
-		telemetryQuerySpec{ID: "recall_embedding_cost_usd", Label: "Recall embedding cost", Unit: "USD", Query: telemetrySparseCounterIncrease("densemem_ai_operation_cost_usd_total", scope, baseLabels, map[string]string{"operation": observability.AIOperationRecallEmbedding}, window)},
-		telemetryQuerySpec{ID: "background_embedding_cost_usd", Label: telemetryBackgroundEmbeddingCostLabel(scope), Unit: "USD", Query: telemetrySparseCounterIncrease("densemem_ai_operation_cost_usd_total", telemetryBackgroundEmbeddingCostScope(scope), baseLabels, map[string]string{"operation": observability.AIOperationBackgroundEmbedding}, window)},
-		telemetryQuerySpec{ID: "ai_unpriced_operations", Label: "Unpriced AI operations", Unit: "operations", Query: telemetrySparseCounterIncrease("densemem_ai_operation_unpriced_total", scope, baseLabels, nil, window)},
+		telemetryQuerySpec{ID: "ai_cost_usd", Label: "AI cost", Unit: "USD", Query: telemetryAICost(scope, baseLabels, "", window)},
+		telemetryQuerySpec{ID: "verifier_cost_usd", Label: "Verifier cost", Unit: "USD", Query: telemetryAICost(scope, baseLabels, observability.AIComponentVerifier, window)},
+		telemetryQuerySpec{ID: "embedding_cost_usd", Label: "Embedding cost", Unit: "USD", Query: telemetryAICost(scope, baseLabels, observability.AIComponentEmbedding, window)},
 	)
-}
-
-func telemetryBackgroundEmbeddingCostLabel(scope TelemetryScope) string {
-	if telemetryBackgroundEmbeddingCostScope(scope).Type == "team" && (scope.Type == "profile" || scope.Type == "self") {
-		return "Background embedding cost (team-only)"
-	}
-	return "Background embedding cost"
-}
-
-func telemetryBackgroundEmbeddingCostScope(scope TelemetryScope) TelemetryScope {
-	if (scope.Type != "profile" && scope.Type != "self") || scope.TeamID == nil || *scope.TeamID == uuid.Nil {
-		return scope
-	}
-	return TelemetryScope{Type: "team", TeamID: scope.TeamID}
 }
 
 func telemetryCurrentCardSpecs(scope TelemetryScope, baseLabels map[string]string) []telemetryQuerySpec {
@@ -418,6 +402,32 @@ func telemetrySparseCounterIncreaseForSelector(metric string, selector string, w
 	targetScrapeCount := fmt.Sprintf("count_over_time(up[%s])", window)
 	fallback := fmt.Sprintf("((%s unless %s) or (%s * (%s >= bool 0) * (%s < bool on(job, instance) group_left() %s)) or (0 * %s))", first, offset, first, current, sampleCount, targetScrapeCount, ranged)
 	return fmt.Sprintf("sum(%s + %s)", ranged, fallback)
+}
+
+func telemetryAICost(scope TelemetryScope, baseLabels map[string]string, component string, window string) string {
+	extra := map[string]string(nil)
+	if component != "" {
+		extra = map[string]string{"component": component}
+	}
+	cost := telemetrySparseCounterIncrease("densemem_ai_operation_cost_usd_total", scope, baseLabels, extra, window)
+	unpriced := telemetryOrZero(telemetrySparseCounterIncrease("densemem_ai_operation_unpriced_total", scope, baseLabels, extra, window))
+	activity := telemetryAIRequestActivity(scope, baseLabels, component, window)
+	completeCost := fmt.Sprintf("((%s) unless ((%s) > 0))", cost, unpriced)
+	zeroWhenInactive := fmt.Sprintf("(vector(0) unless (((%s) + (%s)) > 0))", activity, unpriced)
+	return fmt.Sprintf("(%s or %s)", completeCost, zeroWhenInactive)
+}
+
+func telemetryAIRequestActivity(scope TelemetryScope, baseLabels map[string]string, component string, window string) string {
+	verifier := telemetryOrZero(telemetrySparseCounterIncrease("densemem_verifier_requests_total", scope, baseLabels, nil, window))
+	embedding := telemetryOrZero(telemetrySparseCounterIncrease("densemem_embedding_requests_total", scope, baseLabels, nil, window))
+	switch component {
+	case observability.AIComponentVerifier:
+		return verifier
+	case observability.AIComponentEmbedding:
+		return embedding
+	default:
+		return fmt.Sprintf("((%s) + (%s))", verifier, embedding)
+	}
 }
 
 func telemetrySparseHistogramAverage(metric string, scope TelemetryScope, baseLabels map[string]string, extra map[string]string, window string, multiplier float64) string {

--- a/internal/service/telemetry_service_test.go
+++ b/internal/service/telemetry_service_test.go
@@ -53,11 +53,13 @@ func TestTelemetryCostCardsAreOperatorOnly(t *testing.T) {
 	require.Subset(t, operatorIDs, []string{
 		"ai_cost_usd",
 		"verifier_cost_usd",
-		"recall_embedding_cost_usd",
-		"background_embedding_cost_usd",
-		"ai_unpriced_operations",
+		"embedding_cost_usd",
 	})
-	for _, id := range []string{"ai_cost_usd", "verifier_cost_usd", "recall_embedding_cost_usd", "background_embedding_cost_usd", "ai_unpriced_operations"} {
+	for _, id := range []string{"ai_cost_usd", "verifier_cost_usd", "embedding_cost_usd"} {
+		require.NotContains(t, userIDs, id)
+	}
+	for _, id := range []string{"recall_embedding_cost_usd", "background_embedding_cost_usd", "ai_unpriced_operations"} {
+		require.NotContains(t, operatorIDs, id)
 		require.NotContains(t, userIDs, id)
 	}
 
@@ -66,26 +68,29 @@ func TestTelemetryCostCardsAreOperatorOnly(t *testing.T) {
 	require.NotNil(t, verifierCost)
 	require.Equal(t, "USD", verifierCost.Unit)
 	require.Contains(t, verifierCost.Query, `component="verifier"`)
+	require.Contains(t, verifierCost.Query, "densemem_verifier_requests_total")
+	require.Contains(t, verifierCost.Query, "densemem_ai_operation_unpriced_total")
+	require.Contains(t, verifierCost.Query, "vector(0) unless")
+
+	embeddingCost := telemetryQuerySpecByID(operator, "embedding_cost_usd")
+	require.NotNil(t, embeddingCost)
+	require.Equal(t, "Embedding cost", embeddingCost.Label)
+	require.Equal(t, "USD", embeddingCost.Unit)
+	require.Contains(t, embeddingCost.Query, `component="embedding"`)
+	require.Contains(t, embeddingCost.Query, "densemem_embedding_requests_total")
+	require.NotContains(t, embeddingCost.Query, "operation=")
 
 	teamID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
 	profileID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
-	profileBackgroundCost := telemetryQuerySpecByID(telemetryWindowedCardSpecsForAudience(TelemetryScope{
+	profileEmbeddingCost := telemetryQuerySpecByID(telemetryWindowedCardSpecsForAudience(TelemetryScope{
 		Type:      "profile",
 		TeamID:    &teamID,
 		ProfileID: &profileID,
-	}, nil, "1h", true), "background_embedding_cost_usd")
-	require.NotNil(t, profileBackgroundCost)
-	require.Equal(t, "Background embedding cost (team-only)", profileBackgroundCost.Label)
-	require.Contains(t, profileBackgroundCost.Query, `team_id="11111111-1111-4111-8111-111111111111"`)
-	require.NotContains(t, profileBackgroundCost.Query, `profile_id="22222222-2222-4222-8222-222222222222"`)
-
-	unscopedProfileBackgroundCost := telemetryQuerySpecByID(telemetryWindowedCardSpecsForAudience(TelemetryScope{
-		Type:      "profile",
-		ProfileID: &profileID,
-	}, nil, "1h", true), "background_embedding_cost_usd")
-	require.NotNil(t, unscopedProfileBackgroundCost)
-	require.Equal(t, "Background embedding cost", unscopedProfileBackgroundCost.Label)
-	require.Contains(t, unscopedProfileBackgroundCost.Query, `profile_id="22222222-2222-4222-8222-222222222222"`)
+	}, nil, "1h", true), "embedding_cost_usd")
+	require.NotNil(t, profileEmbeddingCost)
+	require.Contains(t, profileEmbeddingCost.Query, `team_id="11111111-1111-4111-8111-111111111111"`)
+	require.Contains(t, profileEmbeddingCost.Query, `profile_id="22222222-2222-4222-8222-222222222222"`)
+	require.NotContains(t, profileEmbeddingCost.Query, `operation="background_embedding"`)
 }
 
 func TestPrometheusTelemetryService_QueriesTypedScope(t *testing.T) {

--- a/internal/service/telemetry_service_test.go
+++ b/internal/service/telemetry_service_test.go
@@ -68,6 +68,7 @@ func TestTelemetryCostCardsAreOperatorOnly(t *testing.T) {
 	require.NotNil(t, verifierCost)
 	require.Equal(t, "USD", verifierCost.Unit)
 	require.Contains(t, verifierCost.Query, `component="verifier"`)
+	require.Contains(t, verifierCost.Query, "densemem_ai_operation_cost_usd_total")
 	require.Contains(t, verifierCost.Query, "densemem_verifier_requests_total")
 	require.Contains(t, verifierCost.Query, "densemem_ai_operation_unpriced_total")
 	require.Contains(t, verifierCost.Query, "vector(0) unless")
@@ -77,7 +78,10 @@ func TestTelemetryCostCardsAreOperatorOnly(t *testing.T) {
 	require.Equal(t, "Embedding cost", embeddingCost.Label)
 	require.Equal(t, "USD", embeddingCost.Unit)
 	require.Contains(t, embeddingCost.Query, `component="embedding"`)
+	require.Contains(t, embeddingCost.Query, "densemem_ai_operation_cost_usd_total")
 	require.Contains(t, embeddingCost.Query, "densemem_embedding_requests_total")
+	require.Contains(t, embeddingCost.Query, "densemem_ai_operation_unpriced_total")
+	require.Contains(t, embeddingCost.Query, "vector(0) unless")
 	require.NotContains(t, embeddingCost.Query, "operation=")
 
 	teamID := uuid.MustParse("11111111-1111-4111-8111-111111111111")


### PR DESCRIPTION
## What changed

- consolidate operator cost cards into AI, verifier, and embedding totals
- aggregate recall and background embedding costs by the embedding component at team and system scope
- remove separate background-embedding and unpriced-operation cards while retaining raw unpriced metrics for diagnostics
- report `$0.00` when the selected window has no matching provider activity, while preserving `No data` for incomplete or unpriced accounting

## Why

The dashboard mixed an overall total, a component total, operation-specific subtotals, and an accounting-quality counter. It also rendered verifier cost as `No data` during a zero-verifier-activity window because Prometheus had no cost series to return.

## Impact

Operators get one non-overlapping verifier total and one embedding total. Profile-scoped embedding remains limited to attributable profile work; mixed-owner background batches remain visible through team and system totals rather than being assigned to a profile.

## Validation

- `go test ./internal/service/... -count=1`
- `go test ./internal/observability/... -count=1`
- `go test ./internal/http/... -count=1`
- `npm test --prefix web` (75 tests)
- `./scripts/ci-check.sh` (90.1% coverage)
- live Prometheus validation for zero-activity and active priced-cost windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI cost telemetry so cost cards appear only when pricing and activity data are complete and relevant.
  * Consolidated telemetry into aggregate, verifier, and embedding cost views.
  * Updated embedding cost reporting to accurately reflect operator-only embedding activity.
  * Improved fallback handling and metric filtering for verifier and embedding cost data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->