### PR TITLE
Remove control portal origin validation

### DIFF
--- a/internal/http/control_portal_auth.go
+++ b/internal/http/control_portal_auth.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	nethttp "net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -40,25 +39,6 @@ func controlPortalMiddleware(token string, securitySvc service.SecurityService, 
 	}
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			origin := c.Request().Header.Get(echo.HeaderOrigin)
-			if origin != "" {
-				requestedOrigin := controlPortalOrigin(origin)
-				allowedOrigin, bootstrap := controlPortalConfiguredOrigin(c.Request().Context(), identityService)
-				if allowedOrigin == "" && bootstrap {
-					allowedOrigin = controlPortalRequestOrigin(c.Request())
-				}
-				if requestedOrigin == "" || allowedOrigin == "" || requestedOrigin != allowedOrigin {
-					return httperr.New(httperr.FORBIDDEN, "control portal origin is not allowed")
-				}
-				c.Response().Header().Set(echo.HeaderVary, echo.HeaderOrigin)
-				c.Response().Header().Set(echo.HeaderAccessControlAllowOrigin, origin)
-				c.Response().Header().Set(echo.HeaderAccessControlAllowCredentials, "true")
-				c.Response().Header().Set(echo.HeaderAccessControlAllowHeaders, "Authorization, Content-Type, X-Control-Portal-Token, "+service.ControlCSRFHeaderName)
-				c.Response().Header().Set(echo.HeaderAccessControlAllowMethods, "GET, POST, PATCH, DELETE, OPTIONS")
-			}
-			if c.Request().Method == nethttp.MethodOptions {
-				return c.NoContent(nethttp.StatusNoContent)
-			}
 			actor := ""
 			if controlTokenMatches(c.Request(), token) {
 				actor = controlPortalActorFromRequest(c.Request())
@@ -81,59 +61,6 @@ func controlPortalMiddleware(token string, securitySvc service.SecurityService, 
 			return next(c)
 		}
 	}
-}
-
-func controlPortalAllowedOrigin(ctx context.Context, identityService *service.ControlIdentityService) string {
-	origin, _ := controlPortalConfiguredOrigin(ctx, identityService)
-	return origin
-}
-
-func controlPortalConfiguredOrigin(ctx context.Context, identityService *service.ControlIdentityService) (string, bool) {
-	if identityService == nil {
-		return "", false
-	}
-	baseURL, err := identityService.ControlPublicBaseURL(ctx)
-	if err != nil {
-		return "", false
-	}
-	if strings.TrimSpace(baseURL) == "" {
-		return "", true
-	}
-	return controlPortalOrigin(baseURL), false
-}
-
-func controlPortalRequestOrigin(request *nethttp.Request) string {
-	if request == nil {
-		return ""
-	}
-	scheme := "http"
-	if request.TLS != nil {
-		scheme = "https"
-	}
-	return controlPortalOrigin(scheme + "://" + request.Host)
-}
-
-func controlPortalOrigin(value string) string {
-	parsed, err := url.Parse(strings.TrimSpace(value))
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
-		return ""
-	}
-	scheme := strings.ToLower(parsed.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return ""
-	}
-	host := strings.ToLower(parsed.Hostname())
-	if host == "" {
-		return ""
-	}
-	if strings.Contains(host, ":") {
-		host = "[" + host + "]"
-	}
-	port := parsed.Port()
-	if port != "" && !(scheme == "http" && port == "80") && !(scheme == "https" && port == "443") {
-		host += ":" + port
-	}
-	return scheme + "://" + host
 }
 
 func recordControlAuthFailure(c echo.Context, securitySvc service.SecurityService) {

--- a/internal/http/control_portal_auth_sso_test.go
+++ b/internal/http/control_portal_auth_sso_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service"
 )
 
-func TestControlPortalMiddlewareUsesConfiguredControlOrigin(t *testing.T) {
+func TestControlPortalMiddlewareIgnoresOriginBehindTLSProxy(t *testing.T) {
 	t.Parallel()
 
 	identity := service.NewControlIdentityService(nil, nil, service.ControlIdentityConfig{
-		RuntimeConfig: controlIdentityHTTPRuntime{config: service.SSORuntimeConfig{ControlPublicBaseURL: "https://control.example.test"}},
+		RuntimeConfig: controlIdentityHTTPRuntime{config: service.SSORuntimeConfig{}},
 	})
 	e := echo.New()
 	e.HTTPErrorHandler = httperr.ErrorHandler
@@ -30,21 +30,15 @@ func TestControlPortalMiddlewareUsesConfiguredControlOrigin(t *testing.T) {
 		return c.String(nethttp.StatusOK, controlPortalActorFromContext(c.Request().Context()))
 	})
 
-	request := httptest.NewRequest(nethttp.MethodOptions, "/session", nil)
-	request.Header.Set(echo.HeaderOrigin, "https://control.example.test")
-	response := httptest.NewRecorder()
-	e.ServeHTTP(response, request)
-	require.Equal(t, nethttp.StatusNoContent, response.Code)
-	require.Equal(t, "https://control.example.test", response.Header().Get(echo.HeaderAccessControlAllowOrigin))
-	require.Contains(t, response.Header().Get(echo.HeaderAccessControlAllowHeaders), service.ControlCSRFHeaderName)
-
-	request = httptest.NewRequest(nethttp.MethodGet, "/session", nil)
+	request := httptest.NewRequest(nethttp.MethodGet, "http://dense-mem:8090/session", nil)
 	request.Header.Set(echo.HeaderOrigin, "https://control.example.test")
 	request.Header.Set("X-Control-Portal-Token", "secret")
-	response = httptest.NewRecorder()
+	response := httptest.NewRecorder()
 	e.ServeHTTP(response, request)
 	require.Equal(t, nethttp.StatusOK, response.Code, response.Body.String())
 	require.Equal(t, "control_portal:x-control-portal-token", response.Body.String())
+	require.Empty(t, response.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	require.Empty(t, response.Header().Get(echo.HeaderAccessControlAllowCredentials))
 
 	request = httptest.NewRequest(nethttp.MethodGet, "/session", nil)
 	request.Header.Set(echo.HeaderAuthorization, "Bearer secret")
@@ -52,65 +46,6 @@ func TestControlPortalMiddlewareUsesConfiguredControlOrigin(t *testing.T) {
 	e.ServeHTTP(response, request)
 	require.Equal(t, nethttp.StatusOK, response.Code, response.Body.String())
 	require.Equal(t, "control_portal:authorization-bearer", response.Body.String())
-
-	request = httptest.NewRequest(nethttp.MethodGet, "/session", nil)
-	request.Header.Set(echo.HeaderOrigin, "https://untrusted.example.test")
-	request.Header.Set("X-Control-Portal-Token", "secret")
-	response = httptest.NewRecorder()
-	e.ServeHTTP(response, request)
-	require.Equal(t, nethttp.StatusForbidden, response.Code)
-}
-
-func TestControlPortalAllowedOriginFailsClosed(t *testing.T) {
-	t.Parallel()
-
-	identity := service.NewControlIdentityService(nil, nil, service.ControlIdentityConfig{
-		RuntimeConfig: controlIdentityHTTPRuntime{err: errors.New("config unavailable")},
-	})
-	require.Empty(t, controlPortalAllowedOrigin(context.Background(), identity))
-	require.Empty(t, controlPortalAllowedOrigin(context.Background(), nil))
-	require.Equal(t, "control_portal", controlPortalActorFromContext(context.Background()))
-}
-
-func TestControlPortalMiddlewareBootstrapsOnlySameOriginAndNormalizesDefaultPorts(t *testing.T) {
-	t.Parallel()
-
-	bootstrap := service.NewControlIdentityService(nil, nil, service.ControlIdentityConfig{
-		RuntimeConfig: controlIdentityHTTPRuntime{config: service.SSORuntimeConfig{}},
-	})
-	e := echo.New()
-	e.HTTPErrorHandler = httperr.ErrorHandler
-	e.Use(controlPortalMiddleware("secret", nil, bootstrap))
-	e.POST("/config", func(c echo.Context) error { return c.NoContent(nethttp.StatusNoContent) })
-
-	request := httptest.NewRequest(nethttp.MethodPost, "http://control.example.test/config", nil)
-	request.Header.Set(echo.HeaderOrigin, "http://control.example.test")
-	request.Header.Set("X-Control-Portal-Token", "secret")
-	response := httptest.NewRecorder()
-	e.ServeHTTP(response, request)
-	require.Equal(t, nethttp.StatusNoContent, response.Code)
-	require.Equal(t, "http://control.example.test", response.Header().Get(echo.HeaderAccessControlAllowOrigin))
-
-	request = httptest.NewRequest(nethttp.MethodPost, "http://control.example.test/config", nil)
-	request.Header.Set(echo.HeaderOrigin, "https://untrusted.example.test")
-	request.Header.Set("X-Control-Portal-Token", "secret")
-	response = httptest.NewRecorder()
-	e.ServeHTTP(response, request)
-	require.Equal(t, nethttp.StatusForbidden, response.Code)
-
-	configured := service.NewControlIdentityService(nil, nil, service.ControlIdentityConfig{
-		RuntimeConfig: controlIdentityHTTPRuntime{config: service.SSORuntimeConfig{ControlPublicBaseURL: "https://control.example.test:443"}},
-	})
-	e = echo.New()
-	e.HTTPErrorHandler = httperr.ErrorHandler
-	e.Use(controlPortalMiddleware("secret", nil, configured))
-	e.GET("/session", func(c echo.Context) error { return c.NoContent(nethttp.StatusNoContent) })
-	request = httptest.NewRequest(nethttp.MethodGet, "https://control.example.test/session", nil)
-	request.Header.Set(echo.HeaderOrigin, "https://control.example.test")
-	request.Header.Set("X-Control-Portal-Token", "secret")
-	response = httptest.NewRecorder()
-	e.ServeHTTP(response, request)
-	require.Equal(t, nethttp.StatusNoContent, response.Code)
 }
 
 func TestControlPortalMiddlewareAcceptsCurrentSSOSessionAndRecordsSafeFailures(t *testing.T) {
@@ -155,11 +90,8 @@ func TestControlPortalMiddlewareAcceptsCurrentSSOSessionAndRecordsSafeFailures(t
 	require.Equal(t, nethttp.StatusUnauthorized, response.Code)
 	require.Equal(t, 1, recorder.calls)
 
+	require.Equal(t, "control_portal", controlPortalActorFromContext(context.Background()))
 	require.Equal(t, "control_portal", controlPortalActorFromRequest(httptest.NewRequest(nethttp.MethodGet, "/", nil)))
-	invalidOrigin := service.NewControlIdentityService(nil, nil, service.ControlIdentityConfig{
-		RuntimeConfig: controlIdentityHTTPRuntime{config: service.SSORuntimeConfig{ControlPublicBaseURL: "://invalid"}},
-	})
-	require.Empty(t, controlPortalAllowedOrigin(context.Background(), invalidOrigin))
 	require.Nil(t, controlDirectoryServiceError(nil))
 	require.Nil(t, controlIdentityHTTPError(nil))
 	directoryErr := controlDirectoryServiceError(errors.New("directory constraint failed: duplicate key value violates unique constraint \"credential_secret\""))

--- a/internal/http/control_portal_test.go
+++ b/internal/http/control_portal_test.go
@@ -436,7 +436,7 @@ func TestControlPortalRejectsUnsafeConfig(t *testing.T) {
 	require.ErrorContains(t, err, "token")
 }
 
-func TestControlPortalAuthAndOrigin(t *testing.T) {
+func TestControlPortalAuthIgnoresOrigin(t *testing.T) {
 	_, _, server := testControlServer(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/control/api/session", nil)
@@ -448,14 +448,15 @@ func TestControlPortalAuthAndOrigin(t *testing.T) {
 	req.Header.Set("Origin", "http://192.168.1.253:8090")
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
 
 	req = httptest.NewRequest(http.MethodGet, "/control/api/session", nil)
 	req.Header.Set("X-Control-Portal-Token", "secret")
 	req.Header.Set("Origin", "https://example.com")
 	rec = httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
 
 	req = httptest.NewRequest(http.MethodGet, "/control/api/session", nil)
 	req.Header.Set("X-Control-Portal-Token", "secret")


### PR DESCRIPTION
## What changed

- Removed `Origin` validation and CORS response handling from the shared control API middleware.
- Kept static-token authentication, SSO session authentication, and state-changing SSO CSRF validation unchanged.
- Replaced origin-allowlist tests with regression coverage for an HTTPS browser origin reaching Dense-Mem through a TLS-terminating reverse proxy.

## Why

`CONTROL_PUBLIC_BASE_URL` is PostgreSQL-backed SSO configuration used to construct the control SSO callback URL and secure-cookie behavior. The control middleware also reused it as an exact origin allowlist for every `/control/api` request.

Behind Traefik or another TLS-terminating proxy, the browser can send an HTTPS `Origin` while Dense-Mem receives an HTTP backend request. When the SSO value is empty—or only supplied as an unsupported process environment variable—the middleware rejected authenticated requests with `403` before handlers such as telemetry-pricing updates ran.

Control-listener exposure is now the deployment owner's responsibility through private networking or dedicated administrative ingress. The application authentication boundary remains in place.

## User impact

Authenticated control-panel operations work behind reverse proxies without depending on SSO configuration. `CONTROL_PUBLIC_BASE_URL` remains available for its SSO callback and cookie purpose. The server does not emit permissive CORS headers, so this does not enable a separate cross-origin browser application.

## Risk

Authenticated requests are no longer rejected based on `Origin`. Deployments must continue to protect the separate control listener or its ingress. Static-token/SSO authentication and SSO CSRF checks remain required.

## Validation

- `go test ./internal/http -run 'TestControlPortal(MiddlewareIgnoresOriginBehindTLSProxy|AuthIgnoresOrigin|MiddlewareAcceptsCurrentSSOSession)' -count=1`
- `go test ./internal/http/... -count=1`
- `git diff --check`
- `./scripts/ci-check.sh` (90.1% coverage)
- Pre-push repository checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control portal authentication no longer depends on the request’s origin.
  * Valid token and SSO-authenticated requests continue to be authorized when routed through a TLS proxy.
  * Unauthenticated requests remain rejected, including preflight requests.
  * Authentication responses no longer include CORS headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->