### PR TITLE
Add opt-in API-key portal cookie sessions

### DIFF
--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -98,6 +98,7 @@ func RunActiveServer(
 	profileRepo := repository.NewProfileRepository(pgDB.GetDB(), rlsHelper)
 	apiKeyRepo := repository.NewAPIKeyRepository(pgDB.GetDB(), rlsHelper)
 	ssoRepo := repository.NewSSORepository(pgDB.GetDB(), rlsHelper)
+	portalSessionRepo := repository.NewUserPortalSessionRepository(pgDB.GetDB(), rlsHelper)
 	directoryIdentityRepo := repository.NewDirectoryIdentityRepository(pgDB.GetDB(), rlsHelper)
 	controlIdentityRepo := repository.NewControlIdentityRepository(pgDB.GetDB(), rlsHelper)
 	appConfigRepo := repository.NewAppConfigRepository(pgDB.GetDB(), rlsHelper)
@@ -161,6 +162,7 @@ func RunActiveServer(
 		RuntimeConfig: appConfigService,
 		Logger:        logger,
 	})
+	portalSessionService := service.NewUserPortalSessionService(portalSessionRepo, apiKeyRepo, nil)
 	directoryIdentityService := service.NewDirectoryIdentityService(directoryIdentityRepo, service.DirectoryIdentityConfig{})
 	controlIdentityService := service.NewControlIdentityService(controlIdentityRepo, ssoRepo, service.ControlIdentityConfig{RuntimeConfig: appConfigService})
 	rateLimitService := backend.rateLimitService
@@ -374,20 +376,21 @@ func RunActiveServer(
 		MCPGet:  mcpHandler.HandleGet,
 	})
 	userPortalDeps := http.UserPortalDeps{
-		APIKeyRepo:   apiKeyRepo,
-		ProfileSvc:   profileService,
-		APIKeySvc:    apiKeyService,
-		RateLimitSvc: rateLimitService,
-		UsageMetrics: usageMetricsService,
-		Telemetry:    telemetryReader,
-		GraphView:    graphViewSvc,
-		RecallSvc:    recallSvc,
-		DreamSvc:     dreamSvc,
-		AuditSvc:     auditService,
-		SecuritySvc:  securityService,
-		SSOService:   ssoService,
-		AppConfig:    appConfigService,
-		Config:       &cfg,
+		APIKeyRepo:    apiKeyRepo,
+		ProfileSvc:    profileService,
+		APIKeySvc:     apiKeyService,
+		RateLimitSvc:  rateLimitService,
+		UsageMetrics:  usageMetricsService,
+		Telemetry:     telemetryReader,
+		GraphView:     graphViewSvc,
+		RecallSvc:     recallSvc,
+		DreamSvc:      dreamSvc,
+		AuditSvc:      auditService,
+		SecuritySvc:   securityService,
+		SSOService:    ssoService,
+		PortalSession: portalSessionService,
+		AppConfig:     appConfigService,
+		Config:        &cfg,
 	}
 	userPortalDeps.ExtraMiddleware = append(userPortalDeps.ExtraMiddleware, options.UserPortalMiddleware...)
 	if telemetryHTTPMetrics != nil {

--- a/internal/domain/user_portal_session.go
+++ b/internal/domain/user_portal_session.go
@@ -1,0 +1,18 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserPortalSession is an opaque browser session for API-key portal access.
+// Only token fingerprints are persisted; the raw session and CSRF tokens stay
+// in the browser and are returned once at creation time.
+type UserPortalSession struct {
+	SessionHash string
+	KeyID       uuid.UUID
+	CSRFHash    string
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+}

--- a/internal/http/dto/user_portal.go
+++ b/internal/http/dto/user_portal.go
@@ -1,0 +1,7 @@
+package dto
+
+// CreateUserPortalSessionRequest controls whether the browser session survives
+// closing the browser. The pointer distinguishes an omitted field from false.
+type CreateUserPortalSessionRequest struct {
+	Remember *bool `json:"remember" validate:"required"`
+}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -106,10 +106,15 @@ type SSOSessionAuthenticator interface {
 	AuthenticateSession(ctx context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.APIKey, error)
 }
 
+type UserPortalSessionAuthenticator interface {
+	AuthenticateSession(ctx context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.APIKey, error)
+}
+
 type AuthOptions struct {
-	SSOEntitlementValidator SSOEntitlementValidator
-	SSOSessionAuthenticator SSOSessionAuthenticator
-	AllowMissingCredentials bool
+	SSOEntitlementValidator        SSOEntitlementValidator
+	SSOSessionAuthenticator        SSOSessionAuthenticator
+	UserPortalSessionAuthenticator UserPortalSessionAuthenticator
+	AllowMissingCredentials        bool
 }
 
 func AuthMiddlewareWithOptions(repo repository.APIKeyRepository, auditSvc service.AuditService, securitySvc SecurityBanService, opts AuthOptions) echo.MiddlewareFunc {
@@ -120,6 +125,16 @@ func AuthMiddlewareWithOptions(repo repository.APIKeyRepository, auditSvc servic
 
 			// Missing header
 			if authHeader == "" {
+				if opts.UserPortalSessionAuthenticator != nil {
+					if err := authenticateUserPortalSession(c, opts.UserPortalSessionAuthenticator, opts.SSOEntitlementValidator); err != nil {
+						if err != errNoUserPortalSession {
+							logAuthFailure(c, auditSvc, securitySvc, nil, "UI_SESSION_AUTH_INVALID", "user portal session authentication failed")
+							return err
+						}
+					} else {
+						return next(c)
+					}
+				}
 				if opts.SSOSessionAuthenticator != nil {
 					if err := authenticateSSOSession(c, opts.SSOSessionAuthenticator); err != nil {
 						if err == errNoSSOSession {
@@ -275,6 +290,7 @@ func AuthMiddlewareWithOptions(repo repository.APIKeyRepository, auditSvc servic
 }
 
 var errNoSSOSession = errors.New("no sso session")
+var errNoUserPortalSession = errors.New("no user portal session")
 
 func authenticateSSOSession(c echo.Context, authenticator SSOSessionAuthenticator) error {
 	cookie, err := c.Request().Cookie(service.SSOSessionCookieName)
@@ -292,9 +308,43 @@ func authenticateSSOSession(c echo.Context, authenticator SSOSessionAuthenticato
 	if err != nil {
 		return ssoAuthError(err)
 	}
+	return setSessionPrincipal(c, key, "sso_session")
+}
+
+func authenticateUserPortalSession(c echo.Context, authenticator UserPortalSessionAuthenticator, entitlementValidator SSOEntitlementValidator) error {
+	cookie, err := c.Request().Cookie(service.UserPortalSessionCookieName)
+	if err != nil || strings.TrimSpace(cookie.Value) == "" {
+		return errNoUserPortalSession
+	}
+	requireCSRF := requestRequiresCSRF(c.Request().Method)
+	csrfToken := c.Request().Header.Get(service.SSOCSRFHeaderName)
+	key, err := authenticator.AuthenticateSession(c.Request().Context(), cookie.Value, csrfToken, requireCSRF)
+	if err != nil {
+		return userPortalSessionAuthError(err)
+	}
+	if key == nil {
+		return httperr.New(httperr.AUTH_INVALID, "invalid user portal session")
+	}
+	if entitlementValidator != nil {
+		validated, err := entitlementValidator.ValidateAPIKeyPrincipal(c.Request().Context(), key)
+		if err != nil {
+			return ssoAuthError(err)
+		}
+		if validated == nil {
+			return httperr.New(httperr.FORBIDDEN, "sso access denied")
+		}
+		key = validated
+	}
+	return setSessionPrincipal(c, key, "api_key_session")
+}
+
+func setSessionPrincipal(c echo.Context, key *domain.APIKey, authMethod string) error {
+	if key == nil {
+		return httperr.New(httperr.AUTH_INVALID, "invalid session")
+	}
 	teamID := key.GetTeamID()
 	if teamID == uuid.Nil {
-		return httperr.New(httperr.AUTH_INVALID, "invalid sso session")
+		return httperr.New(httperr.AUTH_INVALID, "invalid session")
 	}
 	profileID := key.ID
 	principal := &Principal{
@@ -305,7 +355,7 @@ func authenticateSSOSession(c echo.Context, authenticator SSOSessionAuthenticato
 		Role:          key.GetRole(),
 		Scopes:        key.Scopes,
 		RateLimit:     key.RateLimit,
-		AuthMethod:    "sso_session",
+		AuthMethod:    authMethod,
 		SSOIdentityID: key.SSOIdentityID,
 		SSOProviderID: key.SSOProviderID,
 		SSOSubject:    key.SSOSubject,
@@ -349,6 +399,17 @@ func ssoAuthError(err error) error {
 	}
 }
 
+func userPortalSessionAuthError(err error) error {
+	switch {
+	case errors.Is(err, service.ErrUserPortalSessionInvalid):
+		return httperr.New(httperr.AUTH_INVALID, "invalid user portal session")
+	case errors.Is(err, service.ErrUserPortalCSRFInvalid):
+		return httperr.New(httperr.FORBIDDEN, "invalid user portal csrf token")
+	default:
+		return httperr.New(httperr.INTERNAL_ERROR, "user portal session authentication failed")
+	}
+}
+
 // LastUsedMiddleware updates API key last_used_at after earlier middleware has
 // admitted the request. Place it after rate limiting to avoid DB writes for
 // over-quota valid keys.
@@ -356,7 +417,7 @@ func LastUsedMiddleware(repo repository.APIKeyRepository) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			principal := GetPrincipal(c.Request().Context())
-			if principal != nil && principal.AuthMethod != "sso_session" && principal.KeyID != uuid.Nil {
+			if principal != nil && principal.AuthMethod != "sso_session" && principal.AuthMethod != "api_key_session" && principal.KeyID != uuid.Nil {
 				go func(keyID uuid.UUID) {
 					touchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()

--- a/internal/http/middleware/bind_validate.go
+++ b/internal/http/middleware/bind_validate.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 
 	"github.com/labstack/echo/v4"
 
@@ -37,6 +39,32 @@ func BindAndValidate[T any](ctxKey string) echo.MiddlewareFunc {
 			ctx := context.WithValue(c.Request().Context(), contextKey(ctxKey), &body)
 			c.SetRequest(c.Request().WithContext(ctx))
 
+			return next(c)
+		}
+	}
+}
+
+// BindAndValidateStrict is the closed-schema variant for JSON bodies that must
+// reject unknown fields and any second JSON value.
+func BindAndValidateStrict[T any](ctxKey string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var body T
+			decoder := json.NewDecoder(c.Request().Body)
+			decoder.DisallowUnknownFields()
+			if err := decoder.Decode(&body); err != nil {
+				return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
+			}
+			var trailing any
+			if err := decoder.Decode(&trailing); err != io.EOF {
+				return httperr.New(httperr.VALIDATION_ERROR, "request body must contain one JSON object")
+			}
+
+			if err := validation.ValidateStruct(&body); err != nil {
+				return httperr.NewWithDetails(httperr.VALIDATION_ERROR, "validation failed", extractValidationErrors(err))
+			}
+			ctx := context.WithValue(c.Request().Context(), contextKey(ctxKey), &body)
+			c.SetRequest(c.Request().WithContext(ctx))
 			return next(c)
 		}
 	}

--- a/internal/http/middleware/bind_validate_test.go
+++ b/internal/http/middleware/bind_validate_test.go
@@ -76,6 +76,26 @@ func TestBindAndValidateRejectsMalformedAndInvalidBodies(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "validation failed")
 }
 
+func TestBindAndValidateStrictRejectsUnknownAndTrailingBodies(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.POST("/body", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	}, BindAndValidateStrict[bindValidateBody]("body"))
+
+	for _, body := range []string{
+		`{"name":"Ada","unexpected":true}`,
+		`{"name":"Ada","email":"ada@example.com"} {}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/body", strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		require.Contains(t, rec.Body.String(), `"code":"VALIDATION_ERROR"`)
+	}
+}
+
 func TestValidatedBodyHelpersAndValidationFormatting(t *testing.T) {
 	ctx := context.Background()
 	_, ok := GetValidatedBody[bindValidateBody](ctx, "missing")

--- a/internal/http/middleware/user_portal_session_auth_test.go
+++ b/internal/http/middleware/user_portal_session_auth_test.go
@@ -17,11 +17,17 @@ import (
 )
 
 type userPortalSessionAuthStub struct {
-	key *domain.APIKey
-	err error
+	key             *domain.APIKey
+	err             error
+	gotSessionToken string
+	gotCSRFToken    string
+	gotRequireCSRF  bool
 }
 
-func (s userPortalSessionAuthStub) AuthenticateSession(context.Context, string, string, bool) (*domain.APIKey, error) {
+func (s *userPortalSessionAuthStub) AuthenticateSession(_ context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.APIKey, error) {
+	s.gotSessionToken = sessionToken
+	s.gotCSRFToken = csrfToken
+	s.gotRequireCSRF = requireCSRF
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -31,17 +37,18 @@ func (s userPortalSessionAuthStub) AuthenticateSession(context.Context, string, 
 func TestAuthMiddlewareAuthenticatesPortalSessionAndSetsAuthMethod(t *testing.T) {
 	teamID := uuid.New()
 	keyID := uuid.New()
+	stub := &userPortalSessionAuthStub{key: &domain.APIKey{
+		ID:        keyID,
+		TeamID:    teamID,
+		Name:      "portal",
+		Role:      service.APIKeyRoleMember,
+		Scopes:    []string{"read"},
+		RateLimit: 120,
+	}}
 	e := echo.New()
 	e.HTTPErrorHandler = httperr.ErrorHandler
 	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
-		UserPortalSessionAuthenticator: userPortalSessionAuthStub{key: &domain.APIKey{
-			ID:        keyID,
-			TeamID:    teamID,
-			Name:      "portal",
-			Role:      service.APIKeyRoleMember,
-			Scopes:    []string{"read"},
-			RateLimit: 120,
-		}},
+		UserPortalSessionAuthenticator: stub,
 	}))
 	e.GET("/ui/api/session", func(c echo.Context) error {
 		principal := GetPrincipal(c.Request().Context())
@@ -58,13 +65,17 @@ func TestAuthMiddlewareAuthenticatesPortalSessionAndSetsAuthMethod(t *testing.T)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), `"auth_method":"api_key_session"`)
+	require.Equal(t, "opaque-session", stub.gotSessionToken)
+	require.Empty(t, stub.gotCSRFToken)
+	require.False(t, stub.gotRequireCSRF)
 }
 
 func TestAuthMiddlewareFailsClosedForInvalidPortalSession(t *testing.T) {
 	e := echo.New()
 	e.HTTPErrorHandler = httperr.ErrorHandler
+	stub := &userPortalSessionAuthStub{err: service.ErrUserPortalSessionInvalid}
 	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
-		UserPortalSessionAuthenticator: userPortalSessionAuthStub{err: service.ErrUserPortalSessionInvalid},
+		UserPortalSessionAuthenticator: stub,
 		AllowMissingCredentials:        true,
 	}))
 	e.GET("/ui/api/session", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
@@ -81,8 +92,9 @@ func TestAuthMiddlewareFailsClosedForInvalidPortalSession(t *testing.T) {
 func TestAuthMiddlewareRequiresPortalCSRFForUnsafeRequests(t *testing.T) {
 	e := echo.New()
 	e.HTTPErrorHandler = httperr.ErrorHandler
+	stub := &userPortalSessionAuthStub{err: service.ErrUserPortalCSRFInvalid}
 	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
-		UserPortalSessionAuthenticator: userPortalSessionAuthStub{err: service.ErrUserPortalCSRFInvalid},
+		UserPortalSessionAuthenticator: stub,
 	}))
 	e.POST("/ui/api/key/rotate", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
 
@@ -93,6 +105,9 @@ func TestAuthMiddlewareRequiresPortalCSRFForUnsafeRequests(t *testing.T) {
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
 	require.Contains(t, rec.Body.String(), `"code":"FORBIDDEN"`)
+	require.Equal(t, "opaque-session", stub.gotSessionToken)
+	require.Empty(t, stub.gotCSRFToken)
+	require.True(t, stub.gotRequireCSRF)
 }
 
 var _ repository.APIKeyRepository = (*mockAPIKeyRepository)(nil)

--- a/internal/http/middleware/user_portal_session_auth_test.go
+++ b/internal/http/middleware/user_portal_session_auth_test.go
@@ -1,0 +1,98 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+type userPortalSessionAuthStub struct {
+	key *domain.APIKey
+	err error
+}
+
+func (s userPortalSessionAuthStub) AuthenticateSession(context.Context, string, string, bool) (*domain.APIKey, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.key, nil
+}
+
+func TestAuthMiddlewareAuthenticatesPortalSessionAndSetsAuthMethod(t *testing.T) {
+	teamID := uuid.New()
+	keyID := uuid.New()
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
+		UserPortalSessionAuthenticator: userPortalSessionAuthStub{key: &domain.APIKey{
+			ID:        keyID,
+			TeamID:    teamID,
+			Name:      "portal",
+			Role:      service.APIKeyRoleMember,
+			Scopes:    []string{"read"},
+			RateLimit: 120,
+		}},
+	}))
+	e.GET("/ui/api/session", func(c echo.Context) error {
+		principal := GetPrincipal(c.Request().Context())
+		if principal == nil {
+			return httperr.New(httperr.AUTH_MISSING, "missing principal")
+		}
+		return c.JSON(http.StatusOK, map[string]string{"auth_method": principal.AuthMethod})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/session", nil)
+	req.AddCookie(&http.Cookie{Name: service.UserPortalSessionCookieName, Value: "opaque-session"})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"auth_method":"api_key_session"`)
+}
+
+func TestAuthMiddlewareFailsClosedForInvalidPortalSession(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
+		UserPortalSessionAuthenticator: userPortalSessionAuthStub{err: service.ErrUserPortalSessionInvalid},
+		AllowMissingCredentials:        true,
+	}))
+	e.GET("/ui/api/session", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/session", nil)
+	req.AddCookie(&http.Cookie{Name: service.UserPortalSessionCookieName, Value: "stale-session"})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), `"code":"AUTH_INVALID"`)
+}
+
+func TestAuthMiddlewareRequiresPortalCSRFForUnsafeRequests(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.Use(AuthMiddlewareWithOptions(&mockAPIKeyRepository{}, nil, nil, AuthOptions{
+		UserPortalSessionAuthenticator: userPortalSessionAuthStub{err: service.ErrUserPortalCSRFInvalid},
+	}))
+	e.POST("/ui/api/key/rotate", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/api/key/rotate", nil)
+	req.AddCookie(&http.Cookie{Name: service.UserPortalSessionCookieName, Value: "opaque-session"})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), `"code":"FORBIDDEN"`)
+}
+
+var _ repository.APIKeyRepository = (*mockAPIKeyRepository)(nil)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -143,7 +143,7 @@ func isAnonymousUserSessionProbe(c echo.Context, v middleware.RequestLoggerValue
 		return false
 	}
 	for _, cookie := range c.Request().Cookies() {
-		if cookie.Name == service.SSOSessionCookieName && strings.TrimSpace(cookie.Value) != "" {
+		if (cookie.Name == service.SSOSessionCookieName || cookie.Name == service.UserPortalSessionCookieName) && strings.TrimSpace(cookie.Value) != "" {
 			return false
 		}
 	}

--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -42,6 +42,7 @@ type UserPortalDeps struct {
 	AuditSvc        service.AuditService
 	SecuritySvc     httpmw.SecurityBanService
 	SSOService      *service.SSOService
+	PortalSession   service.UserPortalSessionManager
 	AppConfig       service.AppConfigService
 	Config          config.ConfigProvider
 	UserStaticDir   string
@@ -57,6 +58,7 @@ type userPortalHandler struct {
 	dreams    *handler.DreamHandler
 	audit     *handler.AuditHandler
 	sso       *service.SSOService
+	portal    service.UserPortalSessionManager
 	appConfig service.AppConfigService
 }
 
@@ -351,10 +353,14 @@ func (h *userPortalHandler) currentSession(c echo.Context) (userPortalSessionRes
 	if err != nil {
 		return userPortalSessionResponse{}, err
 	}
+	authMethod := principal.AuthMethod
+	if authMethod == "" {
+		authMethod = "api_key"
+	}
 	return userPortalSessionResponse{
 		Team:          teamResponse,
 		Key:           toUserPortalKey(key),
-		AuthMethod:    "api_key",
+		AuthMethod:    authMethod,
 		CanRotate:     userPortalHasScope(principal.Scopes, service.APIKeyScopeWrite),
 		CanManageTeam: principal.Role == service.APIKeyRoleManager,
 	}, nil
@@ -466,6 +472,8 @@ func (h *userPortalHandler) completeSSO(c echo.Context) error {
 	cookieSecure := h.sso.CookieSecure(c.Request().Context())
 	setSSOCookie(c, service.SSOSessionCookieName, result.SessionToken, true, result.Session.ExpiresAt, cookieSecure)
 	setSSOCookie(c, service.SSOCSRFCookieName, result.CSRFToken, false, result.Session.ExpiresAt, cookieSecure)
+	clearUserPortalCookie(c, service.UserPortalSessionCookieName, true, cookieSecure)
+	clearUserPortalCookie(c, service.UserPortalCSRFCookieName, false, cookieSecure)
 	return c.Redirect(nethttp.StatusFound, result.RedirectPath)
 }
 

--- a/internal/http/user_portal_routes.go
+++ b/internal/http/user_portal_routes.go
@@ -56,7 +56,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 
 	api := e.Group("/ui/api")
 	useUserPortalMiddleware(api, deps, authOpts)
-	api.POST("/session", portal.createPortalSession)
+	api.POST("/session", portal.createPortalSession, httpmw.BindAndValidateStrict[dto.CreateUserPortalSessionRequest](userPortalCreateSessionBodyKey))
 
 	profileHandler := handler.NewProfileHandler(deps.ProfileSvc)
 	apiKeyHandler := handler.NewAPIKeyHandler(deps.APIKeySvc)

--- a/internal/http/user_portal_routes.go
+++ b/internal/http/user_portal_routes.go
@@ -23,6 +23,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 		dreams:    handler.NewDreamHandler(deps.DreamSvc),
 		audit:     handler.NewAuditHandler(deps.AuditSvc),
 		sso:       deps.SSOService,
+		portal:    deps.PortalSession,
 		appConfig: deps.AppConfig,
 	}
 
@@ -34,11 +35,17 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 		ssoAPI.GET("/callback", portal.completeSSO)
 		ssoAPI.POST("/logout", portal.logoutSSO)
 	}
+	portalSessionAPI := e.Group("/ui/api/session")
+	portalSessionAPI.Use(publicIPRateLimitMiddleware("public-user-session", deps.RateLimitSvc, deps.Config))
+	portalSessionAPI.POST("/logout", portal.logoutPortalSession)
 
 	authOpts := httpmw.AuthOptions{}
 	if deps.SSOService != nil {
 		authOpts.SSOEntitlementValidator = deps.SSOService
 		authOpts.SSOSessionAuthenticator = deps.SSOService
+	}
+	if deps.PortalSession != nil {
+		authOpts.UserPortalSessionAuthenticator = deps.PortalSession
 	}
 
 	sessionAPI := e.Group("/ui/api")
@@ -49,6 +56,7 @@ func RegisterUserPortal(e *echo.Echo, deps UserPortalDeps) {
 
 	api := e.Group("/ui/api")
 	useUserPortalMiddleware(api, deps, authOpts)
+	api.POST("/session", portal.createPortalSession)
 
 	profileHandler := handler.NewProfileHandler(deps.ProfileSvc)
 	apiKeyHandler := handler.NewAPIKeyHandler(deps.APIKeySvc)

--- a/internal/http/user_portal_session.go
+++ b/internal/http/user_portal_session.go
@@ -3,23 +3,21 @@ package http
 import (
 	"context"
 	"crypto/subtle"
-	"encoding/json"
 	"errors"
-	"io"
 	nethttp "net/http"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/markhuangai/dense-mem/internal/http/dto"
 	httpmw "github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/http/response"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/service"
 )
 
-type userPortalCreateSessionRequest struct {
-	Remember *bool `json:"remember"`
-}
+const userPortalCreateSessionBodyKey = "user_portal_create_session"
 
 func (h *userPortalHandler) createPortalSession(c echo.Context) error {
 	principal := httpmw.GetPrincipal(c.Request().Context())
@@ -30,16 +28,7 @@ func (h *userPortalHandler) createPortalSession(c echo.Context) error {
 		return httperr.New(httperr.SERVICE_UNAVAILABLE, "user portal session service unavailable")
 	}
 
-	var body userPortalCreateSessionRequest
-	decoder := json.NewDecoder(c.Request().Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&body); err != nil || body.Remember == nil {
-		return httperr.New(httperr.VALIDATION_ERROR, "session request must contain remember")
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		return httperr.New(httperr.VALIDATION_ERROR, "session request must contain one JSON object")
-	}
+	body := httpmw.MustGetValidatedBody[dto.CreateUserPortalSessionRequest](c.Request().Context(), userPortalCreateSessionBodyKey)
 
 	result, err := h.portal.CreateSession(c.Request().Context(), principal.KeyID)
 	if err != nil {
@@ -50,7 +39,7 @@ func (h *userPortalHandler) createPortalSession(c echo.Context) error {
 	setUserPortalCookie(c, service.UserPortalCSRFCookieName, result.CSRFToken, false, *body.Remember, result.ExpiresAt, secure)
 	clearSSOCookie(c, service.SSOSessionCookieName)
 	clearSSOCookie(c, service.SSOCSRFCookieName)
-	return c.JSON(nethttp.StatusOK, map[string]any{"data": map[string]string{"status": "signed_in"}})
+	return response.SuccessOK(c, map[string]string{"status": "signed_in"})
 }
 
 func (h *userPortalHandler) logoutPortalSession(c echo.Context) error {
@@ -67,7 +56,7 @@ func (h *userPortalHandler) logoutPortalSession(c echo.Context) error {
 	secure := h.portalCookieSecure(c.Request().Context())
 	clearUserPortalCookie(c, service.UserPortalSessionCookieName, true, secure)
 	clearUserPortalCookie(c, service.UserPortalCSRFCookieName, false, secure)
-	return c.JSON(nethttp.StatusOK, map[string]any{"data": map[string]string{"status": "signed_out"}})
+	return response.SuccessOK(c, map[string]string{"status": "signed_out"})
 }
 
 func validateUserPortalLogoutCSRF(c echo.Context) error {

--- a/internal/http/user_portal_session.go
+++ b/internal/http/user_portal_session.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	nethttp "net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	httpmw "github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+type userPortalCreateSessionRequest struct {
+	Remember *bool `json:"remember"`
+}
+
+func (h *userPortalHandler) createPortalSession(c echo.Context) error {
+	principal := httpmw.GetPrincipal(c.Request().Context())
+	if principal == nil || principal.AuthMethod != "api_key" {
+		return httperr.New(httperr.FORBIDDEN, "direct API key authentication required")
+	}
+	if h.portal == nil {
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "user portal session service unavailable")
+	}
+
+	var body userPortalCreateSessionRequest
+	decoder := json.NewDecoder(c.Request().Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || body.Remember == nil {
+		return httperr.New(httperr.VALIDATION_ERROR, "session request must contain remember")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return httperr.New(httperr.VALIDATION_ERROR, "session request must contain one JSON object")
+	}
+
+	result, err := h.portal.CreateSession(c.Request().Context(), principal.KeyID)
+	if err != nil {
+		return userPortalSessionError(err)
+	}
+	secure := h.portalCookieSecure(c.Request().Context())
+	setUserPortalCookie(c, service.UserPortalSessionCookieName, result.SessionToken, true, *body.Remember, result.ExpiresAt, secure)
+	setUserPortalCookie(c, service.UserPortalCSRFCookieName, result.CSRFToken, false, *body.Remember, result.ExpiresAt, secure)
+	clearSSOCookie(c, service.SSOSessionCookieName)
+	clearSSOCookie(c, service.SSOCSRFCookieName)
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": map[string]string{"status": "signed_in"}})
+}
+
+func (h *userPortalHandler) logoutPortalSession(c echo.Context) error {
+	if cookie, err := c.Request().Cookie(service.UserPortalSessionCookieName); err == nil && strings.TrimSpace(cookie.Value) != "" {
+		if err := validateUserPortalLogoutCSRF(c); err != nil {
+			return err
+		}
+		if h.portal != nil {
+			if err := h.portal.Logout(c.Request().Context(), cookie.Value); err != nil {
+				return userPortalSessionError(err)
+			}
+		}
+	}
+	secure := h.portalCookieSecure(c.Request().Context())
+	clearUserPortalCookie(c, service.UserPortalSessionCookieName, true, secure)
+	clearUserPortalCookie(c, service.UserPortalCSRFCookieName, false, secure)
+	return c.JSON(nethttp.StatusOK, map[string]any{"data": map[string]string{"status": "signed_out"}})
+}
+
+func validateUserPortalLogoutCSRF(c echo.Context) error {
+	headerToken := strings.TrimSpace(c.Request().Header.Get(service.SSOCSRFHeaderName))
+	cookie, err := c.Request().Cookie(service.UserPortalCSRFCookieName)
+	if err != nil || headerToken == "" || strings.TrimSpace(cookie.Value) == "" {
+		return httperr.New(httperr.FORBIDDEN, "invalid user portal csrf token")
+	}
+	if subtle.ConstantTimeCompare([]byte(headerToken), []byte(cookie.Value)) != 1 {
+		return httperr.New(httperr.FORBIDDEN, "invalid user portal csrf token")
+	}
+	return nil
+}
+
+func (h *userPortalHandler) portalCookieSecure(ctx context.Context) bool {
+	if h.sso == nil {
+		return false
+	}
+	return h.sso.CookieSecure(ctx)
+}
+
+func setUserPortalCookie(c echo.Context, name, value string, httpOnly, remember bool, expires time.Time, secure bool) {
+	cookie := &nethttp.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/ui",
+		HttpOnly: httpOnly,
+		Secure:   secure,
+		SameSite: nethttp.SameSiteLaxMode,
+	}
+	if remember {
+		cookie.Expires = expires
+		cookie.MaxAge = int(time.Until(expires).Seconds())
+	}
+	c.SetCookie(cookie)
+}
+
+func clearUserPortalCookie(c echo.Context, name string, httpOnly, secure bool) {
+	c.SetCookie(&nethttp.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/ui",
+		Expires:  time.Unix(0, 0).UTC(),
+		MaxAge:   -1,
+		HttpOnly: httpOnly,
+		Secure:   secure,
+		SameSite: nethttp.SameSiteLaxMode,
+	})
+}
+
+func userPortalSessionError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, service.ErrUserPortalSessionInvalid):
+		return httperr.New(httperr.AUTH_INVALID, "invalid user portal session")
+	case errors.Is(err, service.ErrUserPortalCSRFInvalid):
+		return httperr.New(httperr.FORBIDDEN, "invalid user portal csrf token")
+	default:
+		return httperr.New(httperr.INTERNAL_ERROR, "user portal session failed")
+	}
+}

--- a/internal/http/user_portal_session_test.go
+++ b/internal/http/user_portal_session_test.go
@@ -10,9 +10,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/http/dto"
 	httpmw "github.com/markhuangai/dense-mem/internal/http/middleware"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/service"
@@ -22,6 +24,11 @@ type portalSessionManagerStub struct {
 	createdKeyID uuid.UUID
 	logoutToken  string
 	result       *service.UserPortalSessionResult
+}
+
+func invokeCreatePortalSession(t *testing.T, h *userPortalHandler, c echo.Context) error {
+	t.Helper()
+	return httpmw.BindAndValidateStrict[dto.CreateUserPortalSessionRequest](userPortalCreateSessionBodyKey)(h.createPortalSession)(c)
 }
 
 func (s *portalSessionManagerStub) CreateSession(_ context.Context, keyID uuid.UUID) (*service.UserPortalSessionResult, error) {
@@ -53,7 +60,7 @@ func TestCreatePortalSessionSetsHostOnlyUiCookies(t *testing.T) {
 		AuthMethod: "api_key",
 	})
 
-	err := h.createPortalSession(c)
+	err := invokeCreatePortalSession(t, h, c)
 	require.NoError(t, err)
 	require.Equal(t, keyID, manager.createdKeyID)
 
@@ -94,7 +101,7 @@ func TestCreatePortalSessionUsesBrowserSessionCookiesWhenRememberDisabled(t *tes
 		AuthMethod: "api_key",
 	})
 
-	require.NoError(t, h.createPortalSession(c))
+	require.NoError(t, invokeCreatePortalSession(t, h, c))
 	recorder, ok := c.Response().Writer.(*httptest.ResponseRecorder)
 	require.True(t, ok)
 	found := 0
@@ -117,7 +124,7 @@ func TestCreatePortalSessionRejectsUnknownOrMissingFields(t *testing.T) {
 
 	for _, body := range []string{`{}`, `{"remember":true,"unexpected":true}`, `{"remember":true} {}`} {
 		c := userPortalEchoContext(t, http.MethodPost, "/ui/api/session", body, principal)
-		err := h.createPortalSession(c)
+		err := invokeCreatePortalSession(t, h, c)
 		var apiErr *httperr.APIError
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, httperr.VALIDATION_ERROR, apiErr.Code)
@@ -131,14 +138,14 @@ func TestCreatePortalSessionRequiresDirectAPIKeyAndService(t *testing.T) {
 		{KeyID: uuid.New(), TeamID: uuid.New(), AuthMethod: "api_key_session"},
 	} {
 		h := &userPortalHandler{portal: manager}
-		err := h.createPortalSession(userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, principal))
+		err := invokeCreatePortalSession(t, h, userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, principal))
 		var apiErr *httperr.APIError
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, httperr.FORBIDDEN, apiErr.Code)
 	}
 
 	h := &userPortalHandler{}
-	err := h.createPortalSession(userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, &httpmw.Principal{
+	err := invokeCreatePortalSession(t, h, userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, &httpmw.Principal{
 		KeyID:      uuid.New(),
 		TeamID:     uuid.New(),
 		AuthMethod: "api_key",

--- a/internal/http/user_portal_session_test.go
+++ b/internal/http/user_portal_session_test.go
@@ -1,0 +1,203 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	httpmw "github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+type portalSessionManagerStub struct {
+	createdKeyID uuid.UUID
+	logoutToken  string
+	result       *service.UserPortalSessionResult
+}
+
+func (s *portalSessionManagerStub) CreateSession(_ context.Context, keyID uuid.UUID) (*service.UserPortalSessionResult, error) {
+	s.createdKeyID = keyID
+	return s.result, nil
+}
+
+func (*portalSessionManagerStub) AuthenticateSession(context.Context, string, string, bool) (*domain.APIKey, error) {
+	return nil, service.ErrUserPortalSessionInvalid
+}
+
+func (s *portalSessionManagerStub) Logout(_ context.Context, token string) error {
+	s.logoutToken = token
+	return nil
+}
+
+func TestCreatePortalSessionSetsHostOnlyUiCookies(t *testing.T) {
+	keyID := uuid.New()
+	expires := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	manager := &portalSessionManagerStub{result: &service.UserPortalSessionResult{
+		SessionToken: "opaque-session",
+		CSRFToken:    "csrf-token",
+		ExpiresAt:    expires,
+	}}
+	h := &userPortalHandler{portal: manager}
+	c := userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, &httpmw.Principal{
+		KeyID:      keyID,
+		TeamID:     uuid.New(),
+		AuthMethod: "api_key",
+	})
+
+	err := h.createPortalSession(c)
+	require.NoError(t, err)
+	require.Equal(t, keyID, manager.createdKeyID)
+
+	recorder, ok := c.Response().Writer.(*httptest.ResponseRecorder)
+	require.True(t, ok)
+	cookies := recorder.Result().Cookies()
+	var sessionCookie, csrfCookie *http.Cookie
+	for _, cookie := range cookies {
+		switch cookie.Name {
+		case service.UserPortalSessionCookieName:
+			sessionCookie = cookie
+		case service.UserPortalCSRFCookieName:
+			csrfCookie = cookie
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	require.NotNil(t, csrfCookie)
+	require.Equal(t, "/ui", sessionCookie.Path)
+	require.True(t, sessionCookie.HttpOnly)
+	require.False(t, csrfCookie.HttpOnly)
+	require.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite)
+	require.Equal(t, expires, sessionCookie.Expires)
+	require.Greater(t, sessionCookie.MaxAge, 0)
+	require.Empty(t, sessionCookie.Domain)
+	require.False(t, sessionCookie.Secure)
+}
+
+func TestCreatePortalSessionUsesBrowserSessionCookiesWhenRememberDisabled(t *testing.T) {
+	manager := &portalSessionManagerStub{result: &service.UserPortalSessionResult{
+		SessionToken: "opaque-session",
+		CSRFToken:    "csrf-token",
+		ExpiresAt:    time.Now().UTC().Add(7 * 24 * time.Hour),
+	}}
+	h := &userPortalHandler{portal: manager}
+	c := userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":false}`, &httpmw.Principal{
+		KeyID:      uuid.New(),
+		TeamID:     uuid.New(),
+		AuthMethod: "api_key",
+	})
+
+	require.NoError(t, h.createPortalSession(c))
+	recorder, ok := c.Response().Writer.(*httptest.ResponseRecorder)
+	require.True(t, ok)
+	found := 0
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name != service.UserPortalSessionCookieName && cookie.Name != service.UserPortalCSRFCookieName {
+			continue
+		}
+		found++
+		require.Equal(t, "/ui", cookie.Path)
+		require.True(t, cookie.Expires.IsZero())
+		require.Equal(t, 0, cookie.MaxAge)
+	}
+	require.Equal(t, 2, found)
+}
+
+func TestCreatePortalSessionRejectsUnknownOrMissingFields(t *testing.T) {
+	manager := &portalSessionManagerStub{result: &service.UserPortalSessionResult{SessionToken: "s", CSRFToken: "c", ExpiresAt: time.Now().Add(time.Hour)}}
+	h := &userPortalHandler{portal: manager}
+	principal := &httpmw.Principal{KeyID: uuid.New(), TeamID: uuid.New(), AuthMethod: "api_key"}
+
+	for _, body := range []string{`{}`, `{"remember":true,"unexpected":true}`, `{"remember":true} {}`} {
+		c := userPortalEchoContext(t, http.MethodPost, "/ui/api/session", body, principal)
+		err := h.createPortalSession(c)
+		var apiErr *httperr.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, httperr.VALIDATION_ERROR, apiErr.Code)
+	}
+}
+
+func TestCreatePortalSessionRequiresDirectAPIKeyAndService(t *testing.T) {
+	manager := &portalSessionManagerStub{result: &service.UserPortalSessionResult{SessionToken: "s", CSRFToken: "c", ExpiresAt: time.Now().Add(time.Hour)}}
+	for _, principal := range []*httpmw.Principal{
+		nil,
+		{KeyID: uuid.New(), TeamID: uuid.New(), AuthMethod: "api_key_session"},
+	} {
+		h := &userPortalHandler{portal: manager}
+		err := h.createPortalSession(userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, principal))
+		var apiErr *httperr.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, httperr.FORBIDDEN, apiErr.Code)
+	}
+
+	h := &userPortalHandler{}
+	err := h.createPortalSession(userPortalEchoContext(t, http.MethodPost, "/ui/api/session", `{"remember":true}`, &httpmw.Principal{
+		KeyID:      uuid.New(),
+		TeamID:     uuid.New(),
+		AuthMethod: "api_key",
+	}))
+	var apiErr *httperr.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, httperr.SERVICE_UNAVAILABLE, apiErr.Code)
+}
+
+func TestUserPortalSessionErrorMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code httperr.ErrorCode
+	}{
+		{name: "invalid session", err: service.ErrUserPortalSessionInvalid, code: httperr.AUTH_INVALID},
+		{name: "invalid csrf", err: service.ErrUserPortalCSRFInvalid, code: httperr.FORBIDDEN},
+		{name: "unknown", err: errors.New("unexpected"), code: httperr.INTERNAL_ERROR},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var apiErr *httperr.APIError
+			err := userPortalSessionError(tt.err)
+			require.ErrorAs(t, err, &apiErr)
+			require.Equal(t, tt.code, apiErr.Code)
+		})
+	}
+	require.NoError(t, userPortalSessionError(nil))
+}
+
+func TestLogoutPortalSessionRequiresDoubleSubmitCsrfAndClearsCookies(t *testing.T) {
+	manager := &portalSessionManagerStub{}
+	h := &userPortalHandler{portal: manager}
+	c := userPortalEchoContext(t, http.MethodPost, "/ui/api/session/logout", "", nil)
+	cookieHeader := strings.Join([]string{
+		service.UserPortalSessionCookieName + "=opaque-session",
+		service.UserPortalCSRFCookieName + "=csrf-token",
+	}, "; ")
+	c.Request().Header.Set("Cookie", cookieHeader)
+	c.Request().Header.Set(service.SSOCSRFHeaderName, "csrf-token")
+
+	require.NoError(t, h.logoutPortalSession(c))
+	require.Equal(t, "opaque-session", manager.logoutToken)
+	cleared := map[string]*http.Cookie{}
+	recorder, ok := c.Response().Writer.(*httptest.ResponseRecorder)
+	require.True(t, ok)
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.MaxAge < 0 {
+			cleared[cookie.Name] = cookie
+		}
+	}
+	require.Equal(t, "/ui", cleared[service.UserPortalSessionCookieName].Path)
+	require.Equal(t, "/ui", cleared[service.UserPortalCSRFCookieName].Path)
+
+	invalid := userPortalEchoContext(t, http.MethodPost, "/ui/api/session/logout", "", nil)
+	invalid.Request().Header.Set("Cookie", service.UserPortalSessionCookieName+"=opaque-session; "+service.UserPortalCSRFCookieName+"=csrf-token")
+	invalid.Request().Header.Set(service.SSOCSRFHeaderName, "wrong")
+	err := h.logoutPortalSession(invalid)
+	var apiErr *httperr.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, httperr.FORBIDDEN, apiErr.Code)
+}

--- a/internal/repository/apikey_repository.go
+++ b/internal/repository/apikey_repository.go
@@ -304,6 +304,101 @@ func (r *APIKeyRepositoryImpl) GetActiveByPrefix(ctx context.Context, prefix str
 	return &key, nil
 }
 
+// GetActiveByID retrieves the current authorization metadata for a standard
+// API key profile without loading key material. The stable profile ID remains
+// valid across in-place key rotation, while revocation and team state are
+// checked on every portal-cookie request.
+func (r *APIKeyRepositoryImpl) GetActiveByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	var key domain.APIKey
+	var teamID *uuid.UUID
+	var ssoIdentityID, ssoProviderID, ssoOwnerIdentityID string
+	found := false
+
+	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		rows, rerr := tx.Raw(`
+			SELECT
+				k.id,
+				k.team_id,
+				COALESCE(t.name, ''),
+				COALESCE(k.key_suffix, ''),
+				k.name,
+				k.scopes,
+				k.role,
+				k.rate_limit,
+				k.last_used_at,
+				k.expires_at,
+				k.created_at,
+				k.revoked_at,
+				COALESCE(k.auth_source, ''),
+				COALESCE(k.sso_identity_id::text, ''),
+				COALESCE(k.sso_provider_id::text, ''),
+				COALESCE(k.sso_owner_identity_id::text, ''),
+				COALESCE(k.sso_subject, ''),
+				COALESCE(k.sso_email, ''),
+				COALESCE(k.sso_group_id, ''),
+				COALESCE(k.sso_entitlement_status, ''),
+				k.sso_last_entitlement_checked_at,
+				k.sso_last_login_at
+			FROM team_profiles k
+			JOIN teams t ON t.id = k.team_id
+			WHERE k.id = $1
+				AND k.auth_source = 'api_key'
+				AND k.key_hash IS NOT NULL
+				AND k.revoked_at IS NULL
+				AND (k.expires_at IS NULL OR k.expires_at > NOW())
+				AND t.status = 'active'
+				AND t.deleted_at IS NULL
+		`, id).Rows()
+		if rerr != nil {
+			return rerr
+		}
+		defer rows.Close()
+		if !rows.Next() {
+			return rows.Err()
+		}
+		found = true
+		return rows.Scan(
+			&key.ID,
+			&teamID,
+			&key.TeamName,
+			&key.KeySuffix,
+			&key.Label,
+			pq.Array(&key.Scopes),
+			&key.Role,
+			&key.RateLimit,
+			&key.LastUsedAt,
+			&key.ExpiresAt,
+			&key.CreatedAt,
+			&key.RevokedAt,
+			&key.AuthSource,
+			&ssoIdentityID,
+			&ssoProviderID,
+			&ssoOwnerIdentityID,
+			&key.SSOSubject,
+			&key.SSOEmail,
+			&key.SSOGroupID,
+			&key.SSOEntitlementStatus,
+			&key.SSOLastEntitlementCheckedAt,
+			&key.SSOLastLoginAt,
+		)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active api key by id: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	if teamID != nil {
+		key.ProfileID = *teamID
+		key.TeamID = *teamID
+	}
+	key.Name = key.Label
+	key.SSOIdentityID = parseOptionalUUID(ssoIdentityID)
+	key.SSOProviderID = parseOptionalUUID(ssoProviderID)
+	key.SSOOwnerIdentityID = parseOptionalUUID(ssoOwnerIdentityID)
+	return &key, nil
+}
+
 // RevokeForProfile marks an API key as revoked only when it belongs to profileID.
 // Returns the number of rows affected (0 means the id/profile combination did not match).
 func (r *APIKeyRepositoryImpl) RevokeForProfile(ctx context.Context, profileID, id uuid.UUID) (int64, error) {

--- a/internal/repository/user_portal_session_repository.go
+++ b/internal/repository/user_portal_session_repository.go
@@ -35,8 +35,7 @@ func NewUserPortalSessionRepository(db *gorm.DB, rls postgres.RLSHelper) *UserPo
 func (r *UserPortalSessionRepositoryImpl) CreateSession(ctx context.Context, session *domain.UserPortalSession) error {
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		return tx.Exec(`
-			INSERT INTO user_portal_sessions (session_hash, key_id, csrf_hash, expires_at, created_at)
-			VALUES ($1, $2, $3, $4, $5)
+			SELECT public.dense_mem_portal_session_create($1, $2, $3, $4, $5)
 		`, session.SessionHash, session.KeyID, session.CSRFHash, session.ExpiresAt, session.CreatedAt).Error
 	})
 	if err != nil {
@@ -50,8 +49,7 @@ func (r *UserPortalSessionRepositoryImpl) GetSession(ctx context.Context, sessio
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		rows, err := tx.Raw(`
 			SELECT session_hash, key_id, csrf_hash, expires_at, created_at
-			FROM user_portal_sessions
-			WHERE session_hash = $1 AND expires_at > NOW()
+			FROM public.dense_mem_portal_session_get($1)
 		`, sessionHash).Rows()
 		if err != nil {
 			return err
@@ -76,7 +74,7 @@ func (r *UserPortalSessionRepositoryImpl) GetSession(ctx context.Context, sessio
 
 func (r *UserPortalSessionRepositoryImpl) DeleteSession(ctx context.Context, sessionHash string) error {
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
-		return tx.Exec(`DELETE FROM user_portal_sessions WHERE session_hash = $1`, sessionHash).Error
+		return tx.Exec(`SELECT public.dense_mem_portal_session_delete($1)`, sessionHash).Error
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete user portal session: %w", err)
@@ -86,7 +84,7 @@ func (r *UserPortalSessionRepositoryImpl) DeleteSession(ctx context.Context, ses
 
 func (r *UserPortalSessionRepositoryImpl) DeleteExpiredSessions(ctx context.Context, now time.Time) error {
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
-		return tx.Exec(`DELETE FROM user_portal_sessions WHERE expires_at <= $1`, now).Error
+		return tx.Exec(`SELECT public.dense_mem_portal_session_delete_expired($1)`, now).Error
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete expired user portal sessions: %w", err)

--- a/internal/repository/user_portal_session_repository.go
+++ b/internal/repository/user_portal_session_repository.go
@@ -1,0 +1,95 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+// UserPortalSessionRepository stores opaque browser sessions in PostgreSQL.
+// The repository is intentionally system-scoped because the session token is
+// the credential used before a team/profile context exists.
+type UserPortalSessionRepository interface {
+	CreateSession(ctx context.Context, session *domain.UserPortalSession) error
+	GetSession(ctx context.Context, sessionHash string) (*domain.UserPortalSession, error)
+	DeleteSession(ctx context.Context, sessionHash string) error
+	DeleteExpiredSessions(ctx context.Context, now time.Time) error
+}
+
+type UserPortalSessionRepositoryImpl struct {
+	db  *gorm.DB
+	rls postgres.RLSHelper
+}
+
+var _ UserPortalSessionRepository = (*UserPortalSessionRepositoryImpl)(nil)
+
+func NewUserPortalSessionRepository(db *gorm.DB, rls postgres.RLSHelper) *UserPortalSessionRepositoryImpl {
+	return &UserPortalSessionRepositoryImpl{db: db, rls: rls}
+}
+
+func (r *UserPortalSessionRepositoryImpl) CreateSession(ctx context.Context, session *domain.UserPortalSession) error {
+	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO user_portal_sessions (session_hash, key_id, csrf_hash, expires_at, created_at)
+			VALUES ($1, $2, $3, $4, $5)
+		`, session.SessionHash, session.KeyID, session.CSRFHash, session.ExpiresAt, session.CreatedAt).Error
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create user portal session: %w", err)
+	}
+	return nil
+}
+
+func (r *UserPortalSessionRepositoryImpl) GetSession(ctx context.Context, sessionHash string) (*domain.UserPortalSession, error) {
+	var session *domain.UserPortalSession
+	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		rows, err := tx.Raw(`
+			SELECT session_hash, key_id, csrf_hash, expires_at, created_at
+			FROM user_portal_sessions
+			WHERE session_hash = $1 AND expires_at > NOW()
+		`, sessionHash).Rows()
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		if !rows.Next() {
+			return rows.Err()
+		}
+
+		var scanned domain.UserPortalSession
+		if err := rows.Scan(&scanned.SessionHash, &scanned.KeyID, &scanned.CSRFHash, &scanned.ExpiresAt, &scanned.CreatedAt); err != nil {
+			return err
+		}
+		session = &scanned
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user portal session: %w", err)
+	}
+	return session, nil
+}
+
+func (r *UserPortalSessionRepositoryImpl) DeleteSession(ctx context.Context, sessionHash string) error {
+	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		return tx.Exec(`DELETE FROM user_portal_sessions WHERE session_hash = $1`, sessionHash).Error
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete user portal session: %w", err)
+	}
+	return nil
+}
+
+func (r *UserPortalSessionRepositoryImpl) DeleteExpiredSessions(ctx context.Context, now time.Time) error {
+	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		return tx.Exec(`DELETE FROM user_portal_sessions WHERE expires_at <= $1`, now).Error
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete expired user portal sessions: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/user_portal_session_repository_integration_test.go
+++ b/internal/repository/user_portal_session_repository_integration_test.go
@@ -17,6 +17,14 @@ func TestUserPortalSessionsEnforceSystemRLSAndProfileLifecycle(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_create(TEXT, UUID, TEXT, TIMESTAMPTZ, TIMESTAMPTZ) TO densemem_rls_test;
+			GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_get(TEXT) TO densemem_rls_test;
+			GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_delete(TEXT) TO densemem_rls_test;
+			GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_delete_expired(TIMESTAMPTZ) TO densemem_rls_test;
+		`).Error
+	}))
 	teamA := createLedgerTeam(t, adminDB, rls, "portal-session-rls-team-a")
 	profileA := createLedgerProfile(t, adminDB, rls, teamA, "portal-session-rls-profile-a")
 	teamB := createLedgerTeam(t, adminDB, rls, "portal-session-rls-team-b")
@@ -86,6 +94,16 @@ func TestUserPortalSessionsEnforceSystemRLSAndProfileLifecycle(t *testing.T) {
 			return nil
 		}))
 	}
+
+	var systemContextVisible int64
+	require.NoError(t, rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM user_portal_sessions
+			WHERE session_hash IN (?, ?)
+		`, sessionA.SessionHash, sessionB.SessionHash).Scan(&systemContextVisible).Error
+	}))
+	require.Zero(t, systemContextVisible, "the application role must not bypass the dedicated portal-session role")
 
 	require.NoError(t, repo.DeleteSession(ctx, sessionA.SessionHash))
 	deletedA, err := repo.GetSession(ctx, sessionA.SessionHash)

--- a/internal/repository/user_portal_session_repository_integration_test.go
+++ b/internal/repository/user_portal_session_repository_integration_test.go
@@ -105,6 +105,45 @@ func TestUserPortalSessionsEnforceSystemRLSAndProfileLifecycle(t *testing.T) {
 	}))
 	require.Zero(t, systemContextVisible, "the application role must not bypass the dedicated portal-session role")
 
+	var functionVisible int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamA, profileA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM public.dense_mem_portal_session_get(?)
+		`, sessionA.SessionHash).Scan(&functionVisible).Error
+	}))
+	require.Zero(t, functionVisible, "non-system contexts must not read through portal-session functions")
+
+	deniedSession := &domain.UserPortalSession{
+		SessionHash: "portal-session-hash-denied-" + uuid.NewString(),
+		KeyID:       uuid.MustParse(profileA),
+		CSRFHash:    "portal-csrf-hash-denied",
+		ExpiresAt:   createdAt.Add(2 * time.Hour),
+		CreatedAt:   createdAt,
+	}
+	createErr := rls.WithTeamProfileTx(ctx, appDB, teamA, profileA, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			SELECT public.dense_mem_portal_session_create(?, ?, ?, ?, ?)
+		`, deniedSession.SessionHash, deniedSession.KeyID, deniedSession.CSRFHash, deniedSession.ExpiresAt, deniedSession.CreatedAt).Error
+	})
+	require.Error(t, createErr, "non-system contexts must not create through portal-session functions")
+	deniedLoaded, err := repo.GetSession(ctx, deniedSession.SessionHash)
+	require.NoError(t, err)
+	require.Nil(t, deniedLoaded)
+
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamA, profileA, func(tx *gorm.DB) error {
+		return tx.Exec(`SELECT public.dense_mem_portal_session_delete(?)`, sessionA.SessionHash).Error
+	}))
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamA, profileA, func(tx *gorm.DB) error {
+		return tx.Exec(`SELECT public.dense_mem_portal_session_delete_expired(?)`, time.Now().UTC().Add(time.Hour)).Error
+	}))
+	unchangedA, err := repo.GetSession(ctx, sessionA.SessionHash)
+	require.NoError(t, err)
+	require.NotNil(t, unchangedA, "non-system function calls must not delete portal sessions")
+	unchangedB, err := repo.GetSession(ctx, sessionB.SessionHash)
+	require.NoError(t, err)
+	require.NotNil(t, unchangedB, "non-system cleanup must not delete portal sessions")
+
 	require.NoError(t, repo.DeleteSession(ctx, sessionA.SessionHash))
 	deletedA, err := repo.GetSession(ctx, sessionA.SessionHash)
 	require.NoError(t, err)

--- a/internal/repository/user_portal_session_repository_integration_test.go
+++ b/internal/repository/user_portal_session_repository_integration_test.go
@@ -1,0 +1,104 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestUserPortalSessionsEnforceSystemRLSAndProfileLifecycle(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	teamA := createLedgerTeam(t, adminDB, rls, "portal-session-rls-team-a")
+	profileA := createLedgerProfile(t, adminDB, rls, teamA, "portal-session-rls-profile-a")
+	teamB := createLedgerTeam(t, adminDB, rls, "portal-session-rls-team-b")
+	profileB := createLedgerProfile(t, adminDB, rls, teamB, "portal-session-rls-profile-b")
+
+	repo := NewUserPortalSessionRepository(appDB, rls)
+	createdAt := time.Now().UTC()
+	sessionA := &domain.UserPortalSession{
+		SessionHash: "portal-session-hash-a-" + uuid.NewString(),
+		KeyID:       uuid.MustParse(profileA),
+		CSRFHash:    "portal-csrf-hash-a",
+		ExpiresAt:   createdAt.Add(time.Hour),
+		CreatedAt:   createdAt,
+	}
+	sessionB := &domain.UserPortalSession{
+		SessionHash: "portal-session-hash-b-" + uuid.NewString(),
+		KeyID:       uuid.MustParse(profileB),
+		CSRFHash:    "portal-csrf-hash-b",
+		ExpiresAt:   createdAt.Add(time.Hour),
+		CreatedAt:   createdAt,
+	}
+	require.NoError(t, repo.CreateSession(ctx, sessionA))
+	require.NoError(t, repo.CreateSession(ctx, sessionB))
+
+	loadedA, err := repo.GetSession(ctx, sessionA.SessionHash)
+	require.NoError(t, err)
+	require.NotNil(t, loadedA)
+	require.Equal(t, sessionA.KeyID, loadedA.KeyID)
+
+	loadedB, err := repo.GetSession(ctx, sessionB.SessionHash)
+	require.NoError(t, err)
+	require.NotNil(t, loadedB)
+	require.Equal(t, sessionB.KeyID, loadedB.KeyID)
+
+	for _, actor := range []struct {
+		teamID    string
+		profileID string
+	}{
+		{teamID: teamA, profileID: profileA},
+		{teamID: teamB, profileID: profileB},
+	} {
+		require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, actor.teamID, actor.profileID, func(tx *gorm.DB) error {
+			var visible int64
+			if err := tx.Raw(`
+				SELECT count(*)
+				FROM user_portal_sessions
+				WHERE session_hash IN (?, ?)
+			`, sessionA.SessionHash, sessionB.SessionHash).Scan(&visible).Error; err != nil {
+				return err
+			}
+			require.Zero(t, visible, "non-system contexts must not read portal sessions")
+
+			updated := tx.Exec(`
+				UPDATE user_portal_sessions
+				SET csrf_hash = 'cross-context-update'
+				WHERE session_hash IN (?, ?)
+			`, sessionA.SessionHash, sessionB.SessionHash)
+			require.NoError(t, updated.Error)
+			require.Zero(t, updated.RowsAffected, "non-system contexts must not update portal sessions")
+
+			deleted := tx.Exec(`
+				DELETE FROM user_portal_sessions
+				WHERE session_hash IN (?, ?)
+			`, sessionA.SessionHash, sessionB.SessionHash)
+			require.NoError(t, deleted.Error)
+			require.Zero(t, deleted.RowsAffected, "non-system contexts must not delete portal sessions")
+			return nil
+		}))
+	}
+
+	require.NoError(t, repo.DeleteSession(ctx, sessionA.SessionHash))
+	deletedA, err := repo.GetSession(ctx, sessionA.SessionHash)
+	require.NoError(t, err)
+	require.Nil(t, deletedA)
+	remainingB, err := repo.GetSession(ctx, sessionB.SessionHash)
+	require.NoError(t, err)
+	require.NotNil(t, remainingB)
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`DELETE FROM team_profiles WHERE id = ?::uuid`, profileB).Error
+	}))
+	cascadedB, err := repo.GetSession(ctx, sessionB.SessionHash)
+	require.NoError(t, err)
+	require.Nil(t, cascadedB)
+}

--- a/internal/service/user_portal_session_service.go
+++ b/internal/service/user_portal_session_service.go
@@ -106,7 +106,7 @@ func (s *UserPortalSessionService) AuthenticateSession(ctx context.Context, sess
 	if err != nil {
 		return nil, err
 	}
-	if session == nil || session.ExpiresAt.Before(s.now().UTC()) {
+	if session == nil || !session.ExpiresAt.After(s.now().UTC()) {
 		return nil, ErrUserPortalSessionInvalid
 	}
 	if requireCSRF && !hashMatches(csrfToken, session.CSRFHash) {

--- a/internal/service/user_portal_session_service.go
+++ b/internal/service/user_portal_session_service.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
+)
+
+const (
+	UserPortalSessionCookieName = "dense_mem_ui_session"
+	UserPortalCSRFCookieName    = "dense_mem_ui_csrf"
+	UserPortalSessionTTL        = 7 * 24 * time.Hour
+)
+
+var (
+	ErrUserPortalSessionInvalid = errors.New("user portal session invalid")
+	ErrUserPortalCSRFInvalid    = errors.New("user portal csrf invalid")
+)
+
+type UserPortalSessionResult struct {
+	SessionToken string
+	CSRFToken    string
+	ExpiresAt    time.Time
+}
+
+// ActiveAPIKeyRepository is deliberately narrower than the general API-key
+// repository. Portal sessions need only the stable key identity and current
+// authorization metadata on each request.
+type ActiveAPIKeyRepository interface {
+	GetActiveByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error)
+}
+
+type UserPortalSessionManager interface {
+	CreateSession(ctx context.Context, keyID uuid.UUID) (*UserPortalSessionResult, error)
+	AuthenticateSession(ctx context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.APIKey, error)
+	Logout(ctx context.Context, sessionToken string) error
+}
+
+type UserPortalSessionService struct {
+	repo repository.UserPortalSessionRepository
+	keys ActiveAPIKeyRepository
+	now  func() time.Time
+}
+
+var _ UserPortalSessionManager = (*UserPortalSessionService)(nil)
+
+func NewUserPortalSessionService(repo repository.UserPortalSessionRepository, keys ActiveAPIKeyRepository, now func() time.Time) *UserPortalSessionService {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &UserPortalSessionService{repo: repo, keys: keys, now: now}
+}
+
+func (s *UserPortalSessionService) CreateSession(ctx context.Context, keyID uuid.UUID) (*UserPortalSessionResult, error) {
+	if s == nil || s.repo == nil || s.keys == nil || keyID == uuid.Nil {
+		return nil, ErrUserPortalSessionInvalid
+	}
+	key, err := s.keys.GetActiveByID(ctx, keyID)
+	if err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, ErrUserPortalSessionInvalid
+	}
+
+	now := s.now().UTC()
+	if err := s.repo.DeleteExpiredSessions(ctx, now); err != nil {
+		return nil, err
+	}
+	sessionToken, err := secureRandomToken(32)
+	if err != nil {
+		return nil, err
+	}
+	csrfToken, err := secureRandomToken(32)
+	if err != nil {
+		return nil, err
+	}
+	expiresAt := now.Add(UserPortalSessionTTL)
+	if err := s.repo.CreateSession(ctx, &domain.UserPortalSession{
+		SessionHash: HashSSOToken(sessionToken),
+		KeyID:       key.ID,
+		CSRFHash:    HashSSOToken(csrfToken),
+		ExpiresAt:   expiresAt,
+		CreatedAt:   now,
+	}); err != nil {
+		return nil, err
+	}
+	return &UserPortalSessionResult{
+		SessionToken: sessionToken,
+		CSRFToken:    csrfToken,
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+func (s *UserPortalSessionService) AuthenticateSession(ctx context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.APIKey, error) {
+	if s == nil || s.repo == nil || s.keys == nil || strings.TrimSpace(sessionToken) == "" {
+		return nil, ErrUserPortalSessionInvalid
+	}
+	session, err := s.repo.GetSession(ctx, HashSSOToken(sessionToken))
+	if err != nil {
+		return nil, err
+	}
+	if session == nil || session.ExpiresAt.Before(s.now().UTC()) {
+		return nil, ErrUserPortalSessionInvalid
+	}
+	if requireCSRF && !hashMatches(csrfToken, session.CSRFHash) {
+		return nil, ErrUserPortalCSRFInvalid
+	}
+	key, err := s.keys.GetActiveByID(ctx, session.KeyID)
+	if err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, ErrUserPortalSessionInvalid
+	}
+	return key, nil
+}
+
+func (s *UserPortalSessionService) Logout(ctx context.Context, sessionToken string) error {
+	if s == nil || s.repo == nil || strings.TrimSpace(sessionToken) == "" {
+		return nil
+	}
+	return s.repo.DeleteSession(ctx, HashSSOToken(sessionToken))
+}

--- a/internal/service/user_portal_session_service_test.go
+++ b/internal/service/user_portal_session_service_test.go
@@ -130,6 +130,12 @@ func TestUserPortalSessionServiceRejectsMissingOrExpiredCredentials(t *testing.T
 			CSRFHash:    HashSSOToken("csrf"),
 			ExpiresAt:   now.Add(-time.Second),
 		},
+		HashSSOToken("active"): {
+			SessionHash: HashSSOToken("active"),
+			KeyID:       keyID,
+			CSRFHash:    HashSSOToken("csrf"),
+			ExpiresAt:   now.Add(time.Hour),
+		},
 	}}
 	keys := &activePortalKeyRepositoryStub{keys: map[uuid.UUID]*domain.APIKey{
 		keyID: {ID: keyID, TeamID: uuid.New(), AuthSource: "api_key"},
@@ -142,7 +148,7 @@ func TestUserPortalSessionServiceRejectsMissingOrExpiredCredentials(t *testing.T
 	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
 
 	keys.keys[keyID] = nil
-	_, err = service.AuthenticateSession(context.Background(), "expired", "csrf", false)
+	_, err = service.AuthenticateSession(context.Background(), "active", "csrf", false)
 	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
 
 	repo.deleteErr = errors.New("delete failed")

--- a/internal/service/user_portal_session_service_test.go
+++ b/internal/service/user_portal_session_service_test.go
@@ -1,0 +1,204 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+type portalSessionRepositoryStub struct {
+	sessions         map[string]*domain.UserPortalSession
+	deletedExpiredAt time.Time
+	createErr        error
+	getErr           error
+	deleteErr        error
+	deleteExpiredErr error
+}
+
+func (r *portalSessionRepositoryStub) CreateSession(_ context.Context, session *domain.UserPortalSession) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if r.sessions == nil {
+		r.sessions = make(map[string]*domain.UserPortalSession)
+	}
+	copy := *session
+	r.sessions[session.SessionHash] = &copy
+	return nil
+}
+
+func (r *portalSessionRepositoryStub) GetSession(_ context.Context, sessionHash string) (*domain.UserPortalSession, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	session := r.sessions[sessionHash]
+	if session == nil {
+		return nil, nil
+	}
+	copy := *session
+	return &copy, nil
+}
+
+func (r *portalSessionRepositoryStub) DeleteSession(_ context.Context, sessionHash string) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	delete(r.sessions, sessionHash)
+	return nil
+}
+
+func (r *portalSessionRepositoryStub) DeleteExpiredSessions(_ context.Context, now time.Time) error {
+	if r.deleteExpiredErr != nil {
+		return r.deleteExpiredErr
+	}
+	r.deletedExpiredAt = now
+	for hash, session := range r.sessions {
+		if !session.ExpiresAt.After(now) {
+			delete(r.sessions, hash)
+		}
+	}
+	return nil
+}
+
+type activePortalKeyRepositoryStub struct {
+	keys map[uuid.UUID]*domain.APIKey
+	err  error
+}
+
+func (r *activePortalKeyRepositoryStub) GetActiveByID(_ context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	key := r.keys[id]
+	if key == nil {
+		return nil, nil
+	}
+	copy := *key
+	copy.Scopes = append([]string{}, key.Scopes...)
+	return &copy, nil
+}
+
+func TestUserPortalSessionServiceUsesFixedOpaqueSevenDaySessions(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	keyID := uuid.New()
+	repo := &portalSessionRepositoryStub{sessions: make(map[string]*domain.UserPortalSession)}
+	keys := &activePortalKeyRepositoryStub{keys: map[uuid.UUID]*domain.APIKey{
+		keyID: {ID: keyID, TeamID: uuid.New(), AuthSource: "api_key", Scopes: []string{"read"}},
+	}}
+	service := NewUserPortalSessionService(repo, keys, func() time.Time { return now })
+
+	created, err := service.CreateSession(context.Background(), keyID)
+	require.NoError(t, err)
+	require.Equal(t, now.Add(UserPortalSessionTTL), created.ExpiresAt)
+	require.NotEmpty(t, created.SessionToken)
+	require.NotEmpty(t, created.CSRFToken)
+	require.NotContains(t, created.SessionToken, repo.sessions[HashSSOToken(created.SessionToken)].SessionHash)
+	require.NotContains(t, created.CSRFToken, repo.sessions[HashSSOToken(created.SessionToken)].CSRFHash)
+	require.Equal(t, now, repo.deletedExpiredAt)
+
+	authenticated, err := service.AuthenticateSession(context.Background(), created.SessionToken, "", false)
+	require.NoError(t, err)
+	require.Equal(t, keyID, authenticated.ID)
+
+	_, err = service.AuthenticateSession(context.Background(), created.SessionToken, "wrong", true)
+	require.ErrorIs(t, err, ErrUserPortalCSRFInvalid)
+	_, err = service.AuthenticateSession(context.Background(), created.SessionToken, created.CSRFToken, true)
+	require.NoError(t, err)
+
+	stored := repo.sessions[HashSSOToken(created.SessionToken)]
+	require.Equal(t, now.Add(UserPortalSessionTTL), stored.ExpiresAt)
+
+	keys.keys[keyID].Scopes = []string{"read", "write"}
+	rotated, err := service.AuthenticateSession(context.Background(), created.SessionToken, "", false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"read", "write"}, rotated.Scopes)
+}
+
+func TestUserPortalSessionServiceRejectsMissingOrExpiredCredentials(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	keyID := uuid.New()
+	repo := &portalSessionRepositoryStub{sessions: map[string]*domain.UserPortalSession{
+		HashSSOToken("expired"): {
+			SessionHash: HashSSOToken("expired"),
+			KeyID:       keyID,
+			CSRFHash:    HashSSOToken("csrf"),
+			ExpiresAt:   now.Add(-time.Second),
+		},
+	}}
+	keys := &activePortalKeyRepositoryStub{keys: map[uuid.UUID]*domain.APIKey{
+		keyID: {ID: keyID, TeamID: uuid.New(), AuthSource: "api_key"},
+	}}
+	service := NewUserPortalSessionService(repo, keys, func() time.Time { return now })
+
+	_, err := service.AuthenticateSession(context.Background(), "", "", false)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	_, err = service.AuthenticateSession(context.Background(), "expired", "csrf", false)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+
+	keys.keys[keyID] = nil
+	_, err = service.AuthenticateSession(context.Background(), "expired", "csrf", false)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+
+	repo.deleteErr = errors.New("delete failed")
+	require.Error(t, service.Logout(context.Background(), "expired"))
+}
+
+func TestUserPortalSessionServicePropagatesDependencyErrors(t *testing.T) {
+	ctx := context.Background()
+	keyID := uuid.New()
+	dependencyErr := errors.New("dependency failed")
+	repo := &portalSessionRepositoryStub{sessions: make(map[string]*domain.UserPortalSession)}
+	keys := &activePortalKeyRepositoryStub{keys: map[uuid.UUID]*domain.APIKey{
+		keyID: {ID: keyID, TeamID: uuid.New(), AuthSource: "api_key"},
+	}}
+	portal := NewUserPortalSessionService(repo, keys, nil)
+
+	keys.err = dependencyErr
+	_, err := portal.CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, dependencyErr)
+	keys.err = nil
+
+	_, err = portal.CreateSession(ctx, uuid.Nil)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	_, err = NewUserPortalSessionService(nil, keys, nil).CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	keys.keys[keyID] = nil
+	_, err = portal.CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	keys.keys[keyID] = &domain.APIKey{ID: keyID, TeamID: uuid.New(), AuthSource: "api_key"}
+
+	repo.deleteExpiredErr = dependencyErr
+	_, err = portal.CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, dependencyErr)
+	repo.deleteExpiredErr = nil
+	repo.createErr = dependencyErr
+	_, err = portal.CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, dependencyErr)
+	repo.createErr = nil
+	repo.sessions[HashSSOToken("session")] = &domain.UserPortalSession{
+		SessionHash: HashSSOToken("session"),
+		KeyID:       keyID,
+		CSRFHash:    HashSSOToken("csrf"),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+
+	repo.getErr = dependencyErr
+	_, err = portal.AuthenticateSession(ctx, "session", "", false)
+	require.ErrorIs(t, err, dependencyErr)
+	repo.getErr = nil
+	keys.err = dependencyErr
+	_, err = portal.AuthenticateSession(ctx, "session", "", false)
+	require.ErrorIs(t, err, dependencyErr)
+
+	var nilPortal *UserPortalSessionService
+	_, err = nilPortal.CreateSession(ctx, keyID)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	require.NoError(t, nilPortal.Logout(ctx, "session"))
+	require.NoError(t, portal.Logout(ctx, ""))
+}

--- a/internal/service/user_portal_session_service_test.go
+++ b/internal/service/user_portal_session_service_test.go
@@ -136,6 +136,12 @@ func TestUserPortalSessionServiceRejectsMissingOrExpiredCredentials(t *testing.T
 			CSRFHash:    HashSSOToken("csrf"),
 			ExpiresAt:   now.Add(time.Hour),
 		},
+		HashSSOToken("boundary"): {
+			SessionHash: HashSSOToken("boundary"),
+			KeyID:       keyID,
+			CSRFHash:    HashSSOToken("csrf"),
+			ExpiresAt:   now,
+		},
 	}}
 	keys := &activePortalKeyRepositoryStub{keys: map[uuid.UUID]*domain.APIKey{
 		keyID: {ID: keyID, TeamID: uuid.New(), AuthSource: "api_key"},
@@ -145,6 +151,8 @@ func TestUserPortalSessionServiceRejectsMissingOrExpiredCredentials(t *testing.T
 	_, err := service.AuthenticateSession(context.Background(), "", "", false)
 	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
 	_, err = service.AuthenticateSession(context.Background(), "expired", "csrf", false)
+	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
+	_, err = service.AuthenticateSession(context.Background(), "boundary", "csrf", false)
 	require.ErrorIs(t, err, ErrUserPortalSessionInvalid)
 
 	keys.keys[keyID] = nil

--- a/migrations/postgres/2026080602_user_portal_sessions.sql
+++ b/migrations/postgres/2026080602_user_portal_sessions.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+CREATE TABLE IF NOT EXISTS user_portal_sessions (
+    session_hash TEXT PRIMARY KEY,
+    key_id UUID NOT NULL REFERENCES team_profiles(id) ON DELETE CASCADE,
+    csrf_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_portal_sessions_key_id
+    ON user_portal_sessions(key_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_portal_sessions_expires_at
+    ON user_portal_sessions(expires_at);
+
+ALTER TABLE user_portal_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_portal_sessions FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_portal_sessions_system_access ON user_portal_sessions;
+CREATE POLICY user_portal_sessions_system_access ON user_portal_sessions
+    FOR ALL
+    TO PUBLIC
+    USING (current_setting('app.tx_mode', true) = 'system')
+    WITH CHECK (current_setting('app.tx_mode', true) = 'system');
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS user_portal_sessions;
+
+-- +goose StatementEnd

--- a/migrations/postgres/2026080603_user_portal_session_system_role.sql
+++ b/migrations/postgres/2026080603_user_portal_session_system_role.sql
@@ -1,0 +1,152 @@
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_roles
+        WHERE rolname = 'dense_mem_portal_session_system'
+    ) THEN
+        CREATE ROLE dense_mem_portal_session_system NOLOGIN NOSUPERUSER NOBYPASSRLS;
+    ELSE
+        ALTER ROLE dense_mem_portal_session_system
+            WITH NOLOGIN NOSUPERUSER NOBYPASSRLS;
+    END IF;
+END
+$$;
+
+REVOKE ALL ON user_portal_sessions FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO dense_mem_portal_session_system;
+GRANT SELECT, INSERT, UPDATE, DELETE ON user_portal_sessions
+    TO dense_mem_portal_session_system;
+GRANT REFERENCES ON team_profiles TO dense_mem_portal_session_system;
+
+DROP POLICY IF EXISTS user_portal_sessions_system_access ON user_portal_sessions;
+CREATE POLICY user_portal_sessions_system_access ON user_portal_sessions
+    FOR ALL
+    TO dense_mem_portal_session_system
+    USING (current_setting('app.tx_mode', true) = 'system')
+    WITH CHECK (current_setting('app.tx_mode', true) = 'system');
+
+CREATE OR REPLACE FUNCTION public.dense_mem_portal_session_create(
+    p_session_hash TEXT,
+    p_key_id UUID,
+    p_csrf_hash TEXT,
+    p_expires_at TIMESTAMPTZ,
+    p_created_at TIMESTAMPTZ
+)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    INSERT INTO public.user_portal_sessions (
+        session_hash, key_id, csrf_hash, expires_at, created_at
+    )
+    VALUES ($1, $2, $3, $4, $5);
+$$;
+
+CREATE OR REPLACE FUNCTION public.dense_mem_portal_session_get(
+    p_session_hash TEXT
+)
+RETURNS TABLE (
+    session_hash TEXT,
+    key_id UUID,
+    csrf_hash TEXT,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    SELECT s.session_hash, s.key_id, s.csrf_hash, s.expires_at, s.created_at
+    FROM public.user_portal_sessions AS s
+    WHERE s.session_hash = $1
+      AND s.expires_at > NOW();
+$$;
+
+CREATE OR REPLACE FUNCTION public.dense_mem_portal_session_delete(
+    p_session_hash TEXT
+)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    DELETE FROM public.user_portal_sessions
+    WHERE session_hash = $1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.dense_mem_portal_session_delete_expired(
+    p_expires_at TIMESTAMPTZ
+)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    DELETE FROM public.user_portal_sessions
+    WHERE expires_at <= $1;
+$$;
+
+REVOKE ALL ON FUNCTION public.dense_mem_portal_session_create(
+    TEXT, UUID, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_create(
+    TEXT, UUID, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+) TO CURRENT_USER;
+ALTER FUNCTION public.dense_mem_portal_session_create(
+    TEXT, UUID, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+) OWNER TO dense_mem_portal_session_system;
+
+REVOKE ALL ON FUNCTION public.dense_mem_portal_session_get(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_get(TEXT) TO CURRENT_USER;
+ALTER FUNCTION public.dense_mem_portal_session_get(TEXT)
+    OWNER TO dense_mem_portal_session_system;
+
+REVOKE ALL ON FUNCTION public.dense_mem_portal_session_delete(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_delete(TEXT) TO CURRENT_USER;
+ALTER FUNCTION public.dense_mem_portal_session_delete(TEXT)
+    OWNER TO dense_mem_portal_session_system;
+
+REVOKE ALL ON FUNCTION public.dense_mem_portal_session_delete_expired(TIMESTAMPTZ)
+    FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dense_mem_portal_session_delete_expired(TIMESTAMPTZ)
+    TO CURRENT_USER;
+ALTER FUNCTION public.dense_mem_portal_session_delete_expired(TIMESTAMPTZ)
+    OWNER TO dense_mem_portal_session_system;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+DROP FUNCTION IF EXISTS public.dense_mem_portal_session_create(
+    TEXT, UUID, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+);
+DROP FUNCTION IF EXISTS public.dense_mem_portal_session_get(TEXT);
+DROP FUNCTION IF EXISTS public.dense_mem_portal_session_delete(TEXT);
+DROP FUNCTION IF EXISTS public.dense_mem_portal_session_delete_expired(TIMESTAMPTZ);
+
+DROP POLICY IF EXISTS user_portal_sessions_system_access ON user_portal_sessions;
+CREATE POLICY user_portal_sessions_system_access ON user_portal_sessions
+    FOR ALL
+    TO PUBLIC
+    USING (current_setting('app.tx_mode', true) = 'system')
+    WITH CHECK (current_setting('app.tx_mode', true) = 'system');
+
+REVOKE ALL ON user_portal_sessions FROM dense_mem_portal_session_system;
+REVOKE ALL ON SCHEMA public FROM dense_mem_portal_session_system;
+DROP ROLE IF EXISTS dense_mem_portal_session_system;
+
+-- +goose StatementEnd

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -449,6 +449,14 @@ remove_e2e_playwright_container() {
 
 run_compose_playwright_tests() {
   local image
+  local test_args=()
+  if [[ "${1:-}" == "portal" ]]; then
+    test_args=(
+      "tests-compose/compose-portal.spec.ts"
+      -g
+      "remembered API-key login uses a seven-day server session"
+    )
+  fi
   image="${DENSE_MEM_E2E_PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.61.0-noble}"
   E2E_PLAYWRIGHT_CONTAINER="densemem-e2e-${E2E_FILE_ID}-playwright"
   if docker container inspect "$E2E_PLAYWRIGHT_CONTAINER" >/dev/null 2>&1; then
@@ -477,7 +485,8 @@ run_compose_playwright_tests() {
     -e "DENSE_MEM_E2E_DREAM_STATEMENT=$dream_statement" \
     -e "DENSE_MEM_PROMETHEUS_URL=$PROMETHEUS_URL" \
     "$E2E_PLAYWRIGHT_CONTAINER" \
-    sh -ec 'cd /tmp/web && npm ci && ./node_modules/.bin/playwright test --config playwright.compose.config.ts'
+    sh -ec 'cd /tmp/web && npm ci && ./node_modules/.bin/playwright test --config playwright.compose.config.ts "$@"' \
+    sh "${test_args[@]}"
   remove_e2e_playwright_container
 }
 
@@ -524,8 +533,8 @@ if [[ "$E2E_MODE" != "standard" && "$E2E_MODE" != "entra_scim" ]]; then
   exit 1
 fi
 
-if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" ]]; then
-  echo "DENSE_MEM_E2E_SCENARIO must be full, security_intake, submission_assessment, or semantic_holds." >&2
+if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" ]]; then
+  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, security_intake, submission_assessment, or semantic_holds." >&2
   exit 1
 fi
 
@@ -617,6 +626,8 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 
 if [[ "$E2E_MODE" == "entra_scim" ]]; then
   echo "Skipping unrelated compose prechecks for the Entra SCIM scenario."
+elif [[ "$E2E_SCENARIO" == "portal" ]]; then
+  echo "Skipping unrelated disposable PostgreSQL prechecks for the portal scenario."
 elif [[ "${DENSE_MEM_E2E_SKIP_PRECHECKS:-0}" == "1" ]]; then
   echo "Skipping disposable PostgreSQL prechecks by DENSE_MEM_E2E_SKIP_PRECHECKS."
 else
@@ -675,6 +686,21 @@ create_control_team "E2E Team" "compose e2e seed"
 team_id="$CREATED_TEAM_ID"
 create_control_profile "$team_id" "E2E Profile"
 api_key="$CREATED_API_KEY"
+
+if [[ "$E2E_SCENARIO" == "portal" ]]; then
+  echo "Running compose-backed API-key portal cookie-auth e2e."
+  dream_statement="portal cookie-auth e2e"
+  DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
+  DENSE_MEM_USER_URL="$USER_URL" \
+  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
+  DENSE_MEM_E2E_TEAM_ID="$team_id" \
+  DENSE_MEM_E2E_API_KEY="$api_key" \
+  DENSE_MEM_E2E_TEAM_NAME="E2E Team" \
+  DENSE_MEM_E2E_DREAM_STATEMENT="$dream_statement" \
+  DENSE_MEM_PROMETHEUS_URL="$PROMETHEUS_URL" \
+  run_compose_playwright_tests portal
+  exit 0
+fi
 
 if [[ "$E2E_SCENARIO" == "security_intake" ]]; then
   echo "Running compose-backed security intake e2e with the configured live verifier."

--- a/tests/compose/compose_optional_redis_test.go
+++ b/tests/compose/compose_optional_redis_test.go
@@ -3,6 +3,7 @@ package compose_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,15 @@ func TestDockerComposeExpertExample_HasOptionalProfiles(t *testing.T) {
 	assert.NotContains(t, server.Environment, "AI_REVIEWER_MODEL")
 	assert.Contains(t, server.Environment["AI_VERIFIER_MODEL"], "AI_VERIFIER_MODEL must be set")
 	assert.NotContains(t, server.DependsOn, "redis")
+}
+
+func TestDockerComposeExpertExample_PreservesUiPathForCustomDomain(t *testing.T) {
+	text := strings.ToLower(readExample(t, "docker-compose.expert.yml"))
+
+	assert.Contains(t, text, "traefik.http.routers.densemem.rule=host(`${dense_mem_domain:-localhost}`)")
+	assert.Contains(t, text, "traefik.http.services.densemem.loadbalancer.server.port=8080")
+	assert.NotContains(t, text, "stripprefix")
+	assert.NotContains(t, text, "replacepath")
 }
 
 func removedGraphServiceName() string {

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -15,7 +15,7 @@ const CONFIG_LABELS: Record<string, string> = {
   SSO_SESSION_TTL_SECONDS: "Session TTL",
   SSO_STATE_TTL_SECONDS: "OAuth state TTL",
   SSO_HTTP_TIMEOUT_SECONDS: "OIDC HTTP timeout",
-  SSO_COOKIE_SECURE: "Secure cookies",
+  SSO_COOKIE_SECURE: "Secure browser cookies",
   DREAMING_ENABLED: "Enable scheduled cycle",
   DREAMING_FORCE_ENABLED: "Force all teams",
   DREAMING_START_TIME_LOCAL: "Cycle start time",
@@ -394,7 +394,7 @@ function ConfigField({
       <>
         <label htmlFor={item.key}>{label}</label>
         <select id={item.key} value={value} onChange={(event) => onChange(event.target.value)}>
-          <option value="">Auto from public URL</option>
+          <option value="">Auto from SSO public URL</option>
           <option value="true">Enabled</option>
           <option value="false">Disabled</option>
         </select>

--- a/web/src/user/App.cookie-session.test.tsx
+++ b/web/src/user/App.cookie-session.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserPortalApp } from "./App";
+import type { UserSession } from "./api";
+
+const baseSession: UserSession = {
+  team: {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "Research Team",
+    description: "",
+    created_at: "2026-05-01T12:00:00Z",
+    updated_at: "2026-05-01T12:00:00Z",
+  },
+  key: {
+    id: "22222222-2222-4222-8222-222222222222",
+    team_id: "11111111-1111-4111-8111-111111111111",
+    name: "Mine",
+    key_suffix: "abc123",
+    scopes: ["read"],
+    role: "member",
+    rate_limit: 120,
+    last_used_at: null,
+    expires_at: null,
+    created_at: "2026-05-01T12:00:00Z",
+  },
+  can_rotate: false,
+  can_manage_team: false,
+  personal_key: null,
+  can_create_personal_key: false,
+  can_rotate_personal_key: false,
+  personal_key_max_scopes: [],
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+describe("UserPortalApp cookie sessions", () => {
+  it("exchanges a remembered API-key login without storing the raw key", async () => {
+    let portalSessionCreated = false;
+    const cookieSession: UserSession = { ...baseSession, auth_method: "api_key_session" };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      const auth = new Headers(init?.headers).get("Authorization") ?? "";
+      if (url === "/ui/api/sso/providers" && method === "GET") {
+        return jsonResponse({ data: [] });
+      }
+      if (url === "/ui/api/session" && method === "GET") {
+        if (auth === "Bearer dm_key") {
+          return jsonResponse({ data: baseSession });
+        }
+        return portalSessionCreated
+          ? jsonResponse({ data: cookieSession })
+          : jsonResponse({ code: "AUTH_MISSING", message: "authentication required", details: null }, 401);
+      }
+      if (url === "/ui/api/session" && method === "POST") {
+        expect(auth).toBe("Bearer dm_key");
+        expect(init?.body).toBe(JSON.stringify({ remember: true }));
+        portalSessionCreated = true;
+        return jsonResponse({ data: { status: "signed_in" } });
+      }
+      return jsonResponse({ message: "not found" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<UserPortalApp />);
+    await userEvent.type(screen.getByLabelText(/api key/i), "dm_key");
+    await userEvent.click(screen.getByRole("checkbox", { name: /7 days/i }));
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    const workspace = await screen.findByLabelText("Current workspace");
+    expect(workspace).toHaveTextContent("Research Team");
+    expect(sessionStorage.getItem("denseMem.userApiKey")).toBeNull();
+    expect(fetchMock.mock.calls.some(([url, request]) => String(url) === "/ui/api/session" && request?.method === "POST")).toBe(true);
+  });
+});
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -753,6 +753,7 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
   let recallCallCount = 0;
   let graphCallCount = 0;
   let graphNodeDetailCallCount = 0;
+  let portalSessionCreated = false;
   const rotatedSession = {
     ...session,
     key: { ...session.key, key_suffix: "new123", last_used_at: null },
@@ -767,10 +768,16 @@ function mockUserFetch(session: UserSession, profiles: UserKey[] = [], options: 
     if (url === "/ui/api/session" && method === "GET") {
       const auth = authorizationHeader(init);
       if (!auth) {
-        return jsonResponse({ code: "AUTH_MISSING", message: "missing authorization header", details: null }, 401);
+        return portalSessionCreated
+          ? jsonResponse({ data: { ...session, auth_method: "api_key_session", team: currentTeam } })
+          : jsonResponse({ code: "AUTH_MISSING", message: "missing authorization header", details: null }, 401);
       }
       const selectedSession = auth.includes("dm_new_plaintext") ? rotatedSession : session;
       return jsonResponse({ data: { ...selectedSession, team: currentTeam } });
+    }
+    if (url === "/ui/api/session" && method === "POST") {
+      portalSessionCreated = true;
+      return jsonResponse({ data: { status: "signed_in" } });
     }
     if (url === "/ui/api/key/rotate" && method === "POST") {
       return jsonResponse({

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -31,12 +31,15 @@ const TOKEN_STORAGE_KEY = "denseMem.userApiKey";
 const THEME_STORAGE_KEY = "denseMem.userTheme";
 
 type Theme = "light" | "dark";
-type AuthMode = "none" | "api_key" | "sso";
+type AuthMode = "none" | "api_key" | "api_key_session" | "sso";
 type UserTab = "search" | "graph" | "dreams" | "usage" | "team" | "key";
 type ProfilePermission = "read" | "read_write";
 
 function sessionAuthMode(session: UserSession): AuthMode {
-  return session.auth_method === "sso" ? "sso" : "api_key";
+  if (session.auth_method === "sso") {
+    return "sso";
+  }
+  return session.auth_method === "api_key_session" ? "api_key_session" : "api_key";
 }
 
 function canShowMyKey(session: UserSession | null): boolean {
@@ -66,6 +69,7 @@ export function UserPortalApp() {
   const [token, setToken] = useState(() => sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? "");
   const [draftToken, setDraftToken] = useState(token);
   const [authMode, setAuthMode] = useState<AuthMode>(() => token ? "api_key" : "none");
+  const [rememberSession, setRememberSession] = useState(false);
   const [ssoProviders, setSSOProviders] = useState<SSOProvider[]>([]);
   const [authError, setAuthError] = useState("");
   const [theme, setTheme] = useState<Theme>(() => readTheme());
@@ -75,6 +79,23 @@ export function UserPortalApp() {
       return;
     }
     let active = true;
+    if (authMode === "api_key_session") {
+      new UserApi("", "api_key_session").session()
+        .then((session) => {
+          if (active) {
+            setAuthMode(sessionAuthMode(session));
+            setAuthError("");
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setAuthMode("none");
+          }
+        });
+      return () => {
+        active = false;
+      };
+    }
     const api = new UserApi("");
     api.ssoProviders()
       .then((providers) => {
@@ -98,7 +119,7 @@ export function UserPortalApp() {
     return () => {
       active = false;
     };
-  }, [token]);
+  }, [authMode, token]);
 
   function toggleTheme() {
     setTheme((current) => {
@@ -116,10 +137,19 @@ export function UserPortalApp() {
       return;
     }
     try {
-      const session = await new UserApi(nextToken).session();
-      sessionStorage.setItem(TOKEN_STORAGE_KEY, nextToken);
-      setToken(nextToken);
-      setAuthMode(sessionAuthMode(session));
+      await new UserApi(nextToken).session();
+      await new UserApi(nextToken).createPortalSession(rememberSession);
+      let cookieSession: UserSession;
+      try {
+        cookieSession = await new UserApi("", "api_key_session").session();
+      } catch (error) {
+        await new UserApi("", "api_key_session").logoutPortalSession().catch(() => undefined);
+        throw error;
+      }
+      sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+      setToken("");
+      setDraftToken("");
+      setAuthMode(sessionAuthMode(cookieSession));
       setAuthError("");
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : "Authentication failed.");
@@ -130,6 +160,8 @@ export function UserPortalApp() {
     try {
       if (authMode === "sso") {
         await new UserApi("").logoutSSO();
+      } else if (authMode === "api_key_session") {
+        await new UserApi("", "api_key_session").logoutPortalSession();
       }
     } catch (error) {
       setAuthError(readError(error));
@@ -138,11 +170,12 @@ export function UserPortalApp() {
     sessionStorage.removeItem(TOKEN_STORAGE_KEY);
     setToken("");
     setDraftToken("");
+    setRememberSession(false);
     setAuthMode("none");
     setAuthError("");
   }
 
-  if (!token && authMode !== "sso") {
+  if (!token && authMode !== "sso" && authMode !== "api_key_session") {
     return (
       <AuthShell
         theme={theme}
@@ -168,6 +201,15 @@ export function UserPortalApp() {
           onChange={(event) => setDraftToken(event.target.value)}
           autoComplete="current-password"
         />
+        <label className="checkbox-row" htmlFor="remember-user-session">
+          <input
+            id="remember-user-session"
+            type="checkbox"
+            checked={rememberSession}
+            onChange={(event) => setRememberSession(event.target.checked)}
+          />
+          Keep me signed in for 7 days
+        </label>
         {authError && <p className="field-error" role="alert">{authError}</p>}
         <button className="primary-button" type="submit">
           <KeyRound size={17} aria-hidden="true" />
@@ -227,7 +269,7 @@ function UserPortal({
   onToggleTheme: () => void;
   onSignOut: () => Promise<void>;
 }) {
-  const api = useMemo(() => new UserApi(token), [token, authMode]);
+  const api = useMemo(() => new UserApi(token, authMode === "none" ? "anonymous" : authMode), [token, authMode]);
   const [session, setSession] = useState<UserSession | null>(null);
   const [activeTab, setActiveTab] = useState<UserTab>("search");
   const [error, setError] = useState("");

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -41,6 +41,38 @@ describe("UserApi", () => {
     }));
   });
 
+  it("exchanges a bearer key for a remembered portal session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: { status: "signed_in" },
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new UserApi("dm_key").createPortalSession(true);
+
+    expect(fetchMock).toHaveBeenCalledWith("/ui/api/session", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ remember: true }),
+      credentials: "same-origin",
+      headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
+    }));
+  });
+
+  it("uses the portal CSRF cookie for cookie-authenticated writes", async () => {
+    document.cookie = "dense_mem_ui_csrf=portal-csrf";
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: { status: "signed_out" },
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new UserApi("", "api_key_session").logoutPortalSession();
+
+    expect(fetchMock).toHaveBeenCalledWith("/ui/api/session/logout", expect.objectContaining({
+      method: "POST",
+      credentials: "include",
+      headers: expect.objectContaining({ "X-Dense-Mem-CSRF": "portal-csrf" }),
+    }));
+  });
+
   it("requests role-derived telemetry", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: {

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -29,7 +29,7 @@ export type UserSession = {
   team: UserTeam;
   key: UserKey;
   teams?: UserTeamOption[];
-  auth_method?: "api_key" | "sso";
+  auth_method?: "api_key" | "api_key_session" | "sso";
   can_rotate: boolean;
   can_manage_team: boolean;
   personal_key: UserKey | null;
@@ -294,15 +294,19 @@ type RequestOptions = {
   body?: unknown;
 };
 
+export type UserAuthMode = "anonymous" | "api_key" | "api_key_session" | "sso";
+
 type Envelope<T> = {
   data: T;
 };
 
 export class UserApi {
   private readonly token: string;
+  private readonly authMode: UserAuthMode;
 
-  constructor(token: string) {
+  constructor(token: string, authMode: UserAuthMode = token ? "api_key" : "anonymous") {
     this.token = token;
+    this.authMode = authMode;
   }
 
   async session(): Promise<UserSession> {
@@ -326,6 +330,19 @@ export class UserApi {
 
   async logoutSSO(): Promise<{ status: string }> {
     const payload = await this.request<Envelope<{ status: string }>>("/ui/api/sso/logout", { method: "POST" });
+    return payload.data;
+  }
+
+  async createPortalSession(remember: boolean): Promise<{ status: string }> {
+    const payload = await this.request<Envelope<{ status: string }>>("/ui/api/session", {
+      method: "POST",
+      body: { remember },
+    });
+    return payload.data;
+  }
+
+  async logoutPortalSession(): Promise<{ status: string }> {
+    const payload = await this.request<Envelope<{ status: string }>>("/ui/api/session/logout", { method: "POST" });
     return payload.data;
   }
 
@@ -482,7 +499,7 @@ export class UserApi {
       credentials: this.token ? "same-origin" : "include",
       body: options.body,
       csrf: this.token ? undefined : {
-        cookieName: "dense_mem_sso_csrf",
+        cookieName: this.authMode === "api_key_session" ? "dense_mem_ui_csrf" : "dense_mem_sso_csrf",
         headerName: "X-Dense-Mem-CSRF",
       },
     });

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -49,6 +49,7 @@ type TelemetryResponse = {
 
 type UserSessionResponse = {
   data?: {
+    auth_method?: string;
     can_manage_team?: boolean;
     key?: {
       id?: string;
@@ -410,13 +411,82 @@ test("write user key regenerates itself and invalidates the old key", async ({ p
   expect(newApiKey).not.toBe(writable.api_key);
   await expect
     .poll(() => page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey")))
-    .toBe(newApiKey);
+    .toBeNull();
 
   const oldSession = await request.get(`${userUrl}/ui/api/session`, { headers: bearer(writable.api_key) });
   expect(oldSession.status()).toBe(401);
 
   const newSession = await request.get(`${userUrl}/ui/api/session`, { headers: bearer(newApiKey) });
   expect(newSession.status()).toBe(200);
+});
+
+test("remembered API-key login uses a seven-day server session", async ({ page, request, browser }, testInfo) => {
+  await setSSOCookieSecure(request, false);
+  const writable = await createTeamProfile(request, uniqueName("Cookie session", testInfo), ["read", "write"]);
+
+  await page.goto(`${userUrl}/ui/`);
+  await page.getByLabel("API key").fill(writable.api_key);
+  await page.getByRole("checkbox", { name: /7 days/i }).check();
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page.getByRole("heading", { name: "Knowledge", exact: true })).toBeVisible();
+
+  const cookies = await page.context().cookies(`${userUrl}/ui/`);
+  const sessionCookie = cookies.find((cookie) => cookie.name === "dense_mem_ui_session");
+  const csrfCookie = cookies.find((cookie) => cookie.name === "dense_mem_ui_csrf");
+  expect(sessionCookie).toBeDefined();
+  expect(sessionCookie?.path).toBe("/ui");
+  expect(sessionCookie?.httpOnly).toBe(true);
+  expect(sessionCookie?.secure).toBe(false);
+  expect(sessionCookie?.sameSite).toBe("Lax");
+  expect((sessionCookie?.expires ?? 0) - Date.now() / 1000).toBeGreaterThan(6 * 24 * 60 * 60);
+  expect(csrfCookie?.path).toBe("/ui");
+  expect(csrfCookie?.httpOnly).toBe(false);
+  expect(await page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBeNull();
+
+  const storageState = await page.context().storageState();
+  const freshContext = await browser.newContext({ storageState });
+  const freshPage = await freshContext.newPage();
+  try {
+    await freshPage.goto(`${userUrl}/ui/`);
+    await expect(freshPage.getByRole("heading", { name: "Knowledge", exact: true })).toBeVisible();
+    expect(await freshPage.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBeNull();
+  } finally {
+    await freshContext.close();
+  }
+
+  const missingCsrfStatus = await page.evaluate(async () => {
+    const response = await fetch("/ui/api/key/rotate", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    return response.status;
+  });
+  expect(missingCsrfStatus).toBe(403);
+
+  await page.getByRole("button", { name: /My key/i }).click();
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: /Regenerate key/i }).click();
+  const rotatedKey = page.getByLabel("Generated API key");
+  const newApiKey = await rotatedKey.inputValue();
+  expect(newApiKey).not.toBe(writable.api_key);
+  expect(await page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBeNull();
+
+  const oldBearerSession = await request.get(`${userUrl}/ui/api/session`, { headers: bearer(writable.api_key) });
+  expect(oldBearerSession.status()).toBe(401);
+  const cookieSession = await page.evaluate(async () => {
+    const response = await fetch("/ui/api/session", { credentials: "include" });
+    return { status: response.status, body: await response.json() as UserSessionResponse };
+  });
+  expect(cookieSession.status).toBe(200);
+  expect(cookieSession.body.data?.auth_method).toBe("api_key_session");
+
+  await page.getByRole("button", { name: /sign out/i }).click();
+  await expect(page.getByLabel("API key", { exact: true })).toBeVisible();
+  const remainingCookies = await page.context().cookies(`${userUrl}/ui/`);
+  expect(remainingCookies.some((cookie) => cookie.name === "dense_mem_ui_session")).toBe(false);
+  expect(remainingCookies.some((cookie) => cookie.name === "dense_mem_ui_csrf")).toBe(false);
 });
 
 test("user self-rotate endpoint rejects profile edits", async ({ request }, testInfo) => {
@@ -468,6 +538,14 @@ async function createTeamProfile(request: APIRequestContext, name: string, scope
   }
   const payload = await response.json() as { data: CreatedProfile };
   return payload.data;
+}
+
+async function setSSOCookieSecure(request: APIRequestContext, enabled: boolean) {
+  const response = await request.patch(`${controlUrl}/control/api/config/sso`, {
+    headers: bearer(controlToken),
+    data: { items: [{ key: "SSO_COOKIE_SECURE", value: String(enabled) }] },
+  });
+  expect(response.status()).toBe(200);
 }
 
 async function recallFeedbackEnabled(request: APIRequestContext) {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -301,7 +301,7 @@ test("write key regenerates only through the self-rotate endpoint", async ({ pag
   const details = page.getByLabel("Knowledge details");
   await expect(details.getByLabel("Generated API key")).toHaveValue("dm_new_plaintext");
   await expect(details.getByText("******new123")).toBeVisible();
-  await expect.poll(() => page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBe("dm_new_plaintext");
+  await expect.poll(() => page.evaluate(() => sessionStorage.getItem("denseMem.userApiKey"))).toBeNull();
   expect(calls.rotateBodies).toEqual(["{}"]);
   expect(calls.disallowedProfileCalls).toEqual([]);
 });
@@ -484,6 +484,7 @@ async function mockUserApi(
   let currentKey = { ...state.key };
   let currentCanRotate = state.canRotate;
   let currentProfiles = (state.profiles ?? []).map((profile) => ({ ...profile }));
+  let portalSessionCreated = false;
 
   await page.route("**/ui/api/sso/providers", async (route) => {
     await route.fulfill({
@@ -537,8 +538,33 @@ async function mockUserApi(
   });
 
   await page.route("**/ui/api/session", async (route) => {
+    if (route.request().method() === "POST") {
+      portalSessionCreated = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { status: "signed_in" } }),
+      });
+      return;
+    }
     const authorization = route.request().headers().authorization ?? "";
     if (!authorization.startsWith("Bearer ")) {
+      if (portalSessionCreated) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: {
+              team: currentTeam,
+              key: currentKey,
+              auth_method: "api_key_session",
+              can_rotate: currentCanRotate,
+              can_manage_team: state.canManageTeam ?? false,
+            },
+          }),
+        });
+        return;
+      }
       await route.fulfill({
         status: 401,
         contentType: "application/json",


### PR DESCRIPTION
## What changed

- Add an opt-in API-key portal session exchange from `/ui`.
- Persist only hashed session/CSRF tokens and the stable API-key profile ID in PostgreSQL.
- Use a fixed absolute seven-day server expiry, with persistent cookies only when the user checks “Keep me signed in for 7 days”; unchecked cookies last for the browser session.
- Revalidate current key authorization on every request so in-place rotation preserves the portal session while revocation, expiry, team deletion, role/scope changes, and entitlement denial reject it.
- Add host-only `/ui` cookies, double-submit CSRF protection, logout, frontend auth-mode handling, migration, tests, and a targeted Compose E2E scenario.
- Document the runtime `SSO_COOKIE_SECURE` setting and the Traefik custom-domain path-preservation contract.

## Validation

- `./scripts/ci-check.sh`
- `npm test -- --run` (78 tests)
- `npm run typecheck`
- Compose-backed PostgreSQL/Redis/server E2E using the existing local Compose file and environment: desktop and mobile remembered-login scenarios passed.
- Static Traefik contract test passed.

The local HTTP E2E sets `SSO_COOKIE_SECURE=false` through the private control API; HTTPS deployments should keep it true and preserve the original `/ui` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure, cookie-based API-key sessions for the user portal.
  * Added “Keep me signed in” support with seven-day sessions.
  * Added session creation, logout, CSRF protection, and session restoration.
  * API keys are exchanged for sessions and are no longer stored in browser session storage.
* **Bug Fixes**
  * Improved session invalidation, cookie cleanup, and API-key rotation handling.
* **Tests**
  * Added comprehensive unit, integration, and end-to-end coverage for portal sessions, security, logout, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->