### PR TITLE
Stabilize scheduled dreaming minute boundaries

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run repository lint
         run: npm run --prefix .lint lint:lines
 
+      - name: Run scheduled-dreaming timing test
+        run: node --test tests/uat/team_dreaming_schedule.test.mjs
+
       - name: Run evaluation monitor shell test
         run: bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -6,6 +6,7 @@ cd "${ROOT_DIR}"
 
 npm ci --prefix .lint
 npm run --prefix .lint lint:lines
+node --test tests/uat/team_dreaming_schedule.test.mjs
 bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 packages="$(
 	git ls-files '*.go' |

--- a/tests/uat/team_dreaming_e2e.mjs
+++ b/tests/uat/team_dreaming_e2e.mjs
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
+import { nextScheduledUTCMinute } from "./team_dreaming_schedule.mjs";
+
 const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
 const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
 const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
@@ -68,12 +70,6 @@ console.log(JSON.stringify({
   statement,
   scheduled_at: scheduledAt.toISOString(),
 }, null, 2));
-
-function nextScheduledUTCMinute() {
-  const target = new Date(Date.now() + 4 * 60_000);
-  target.setUTCSeconds(0, 0);
-  return target;
-}
 
 function formatDate(value) {
   return value.toISOString().slice(0, 10);

--- a/tests/uat/team_dreaming_schedule.mjs
+++ b/tests/uat/team_dreaming_schedule.mjs
@@ -1,0 +1,4 @@
+export function nextScheduledUTCMinute(now = Date.now()) {
+  const minimum = now + 4 * 60_000;
+  return new Date(Math.ceil(minimum / 60_000) * 60_000);
+}

--- a/tests/uat/team_dreaming_schedule.test.mjs
+++ b/tests/uat/team_dreaming_schedule.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nextScheduledUTCMinute } from "./team_dreaming_schedule.mjs";
+
+const minute = 60_000;
+const boundary = Date.UTC(2026, 7, 7, 12, 35, 0, 0);
+
+const cases = [
+  {
+    name: "immediately before a minute boundary",
+    now: boundary - 1,
+    expected: boundary + 4 * minute,
+  },
+  {
+    name: "exactly on a minute boundary",
+    now: boundary,
+    expected: boundary + 4 * minute,
+  },
+  {
+    name: "immediately after a minute boundary",
+    now: boundary + 1,
+    expected: boundary + 5 * minute,
+  },
+];
+
+for (const { name, now, expected } of cases) {
+  test(`nextScheduledUTCMinute: ${name}`, () => {
+    const target = nextScheduledUTCMinute(now);
+
+    assert.equal(target.getTime(), expected);
+    assert.equal(target.getTime() % minute, 0);
+    assert.ok(target.getTime() >= now + 4 * minute);
+  });
+}


### PR DESCRIPTION
## Summary

- Fix the scheduled-dreaming UAT timestamp helper so its target is always at least four minutes ahead and aligned to an exact UTC minute.
- Share the helper between the UAT and a deterministic Node test covering the three minute-boundary cases.
- Run the focused timing regression in local and shared CI checks.

## Root cause

The previous helper added four minutes and then truncated seconds. Near a minute transition, truncation could schedule the target less than four full minutes in the future.

## Validation

- `node --test tests/uat/team_dreaming_schedule.test.mjs` — 3 passing boundary cases.
- `./scripts/ci-check.sh` — passed; Go coverage 90.1%.
- Compose UAT — scheduled dreaming, telemetry, and conflict scenarios passed; Playwright was skipped for this focused run.
- The compose harness's unrelated disposable SSO prechecks currently fail on an existing `retired_at` timestamp type error, so the UAT was rerun with its explicit precheck-skip option.
- Deterministic 1k evaluation was not run; this is a test-only timing correction.

Closes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled-dreaming timing to consistently select a UTC minute at least four minutes in the future.
  * Standardized scheduling behavior across end-to-end checks.

* **Tests**
  * Added coverage for scheduling near minute boundaries.
  * Integrated scheduling validation into automated quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->