### PR TITLE
Add bounded conflict supporter provenance and deterministic E2E coverage

### DIFF
--- a/internal/domain/conflict_policy.go
+++ b/internal/domain/conflict_policy.go
@@ -35,14 +35,26 @@ type RelationshipConflictPositionRecord struct {
 	Disposition             string
 	ObjectEntityID          string
 	ObjectValueID           string
+	SupporterCount          int
 	SupportGroupCount       int
 	AuthoritativeGroupCount int
+	SupportersTruncated     bool
+	Supporters              []RelationshipConflictSupporterRecord
 	RelationshipIDs         []string
 	OwnerProfileIDs         []string
 	EvidenceIDs             []string
 	EffectiveAt             *time.Time
 	EffectiveTimeBasis      string
 	RecordedFallback        bool
+}
+
+type RelationshipConflictSupporterRecord struct {
+	ProfileID          string
+	ProfileName        string
+	StrongestAuthority string
+	EvidenceID         string
+	AcceptedAt         time.Time
+	SourceGroupCount   int
 }
 
 type RelationshipConflictEvaluationInput struct {

--- a/internal/repository/conflict_context_repository.go
+++ b/internal/repository/conflict_context_repository.go
@@ -2,8 +2,10 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -39,11 +41,30 @@ func ensureRelationshipConflictContextsCurrent(
 	tx *gorm.DB,
 	input CommitPlacementSemanticInput,
 ) error {
+	contexts := make([]PlacementConflictContextInput, 0, len(input.RelationshipObservations))
 	for _, observation := range input.RelationshipObservations {
 		if observation.ConflictContext == nil {
 			continue
 		}
-		if err := requireRelationshipConflictContextCurrent(ctx, tx, input.TeamID, observation.ConflictContext.ConflictID, observation.ConflictContext.ExpectedVersion); err != nil {
+		contexts = append(contexts, *observation.ConflictContext)
+	}
+	return requireRelationshipConflictContextsCurrent(ctx, tx, input.TeamID, contexts)
+}
+
+func requireRelationshipConflictContextsCurrent(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	contexts []PlacementConflictContextInput,
+) error {
+	sort.Slice(contexts, func(i, j int) bool {
+		if contexts[i].ConflictID == contexts[j].ConflictID {
+			return contexts[i].ExpectedVersion < contexts[j].ExpectedVersion
+		}
+		return contexts[i].ConflictID < contexts[j].ConflictID
+	})
+	for _, conflictContext := range contexts {
+		if err := requireRelationshipConflictContextCurrent(ctx, tx, teamID, conflictContext.ConflictID, conflictContext.ExpectedVersion); err != nil {
 			return err
 		}
 	}
@@ -57,20 +78,22 @@ func requireRelationshipConflictContextCurrent(
 	conflictID string,
 	expectedVersion int,
 ) error {
-	var found bool
-	if err := tx.WithContext(ctx).Raw(`
-		SELECT EXISTS (
-			SELECT 1
-			FROM relationship_conflict_cases
-			WHERE team_id = ?::uuid
-			  AND conflict_id = ?::uuid
-			  AND version = ?
-			  AND status IN ('open', 'overdue')
-		)
-	`, teamID, conflictID, expectedVersion).Scan(&found).Error; err != nil {
+	var currentVersion int
+	err := tx.WithContext(ctx).Raw(`
+		SELECT version
+		FROM relationship_conflict_cases
+		WHERE team_id = ?::uuid
+		  AND conflict_id = ?::uuid
+		  AND status IN ('open', 'overdue')
+		FOR UPDATE
+	`, teamID, conflictID).Row().Scan(&currentVersion)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrConflictContextStale
+	}
+	if err != nil {
 		return err
 	}
-	if !found {
+	if currentVersion != expectedVersion {
 		return ErrConflictContextStale
 	}
 	return nil

--- a/internal/repository/conflict_policy.go
+++ b/internal/repository/conflict_policy.go
@@ -25,6 +25,7 @@ const (
 )
 
 type RelationshipConflictPositionRecord = domain.RelationshipConflictPositionRecord
+type RelationshipConflictSupporterRecord = domain.RelationshipConflictSupporterRecord
 type RelationshipConflictEvaluationInput = domain.RelationshipConflictEvaluationInput
 type RelationshipConflictEvaluation = domain.RelationshipConflictEvaluation
 

--- a/internal/repository/conflict_repository.go
+++ b/internal/repository/conflict_repository.go
@@ -685,6 +685,9 @@ func loadRelationshipConflictRecordsByID(
 	if err != nil {
 		return nil, err
 	}
+	if err := loadRelationshipConflictSupporters(ctx, tx, teamID, conflictIDs, knownAt, positions); err != nil {
+		return nil, err
+	}
 	for i := range cases {
 		cases[i].Positions = positionsForConflict(cases[i].ConflictID, positions)
 		applyConflictPositionKnownAtDispositions(&cases[i], knownAt)

--- a/internal/repository/conflict_supporter_repository.go
+++ b/internal/repository/conflict_supporter_repository.go
@@ -1,0 +1,189 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+const relationshipConflictSupporterLimit = 20
+
+const relationshipConflictSupporterRowsSQL = `
+	WITH effective_members AS (
+		SELECT member.conflict_id,
+		       member.position_id,
+		       member.owner_profile_id,
+		       member.source_group_key,
+		       member.authority,
+		       member.fragment_id,
+		       member.accepted_at
+		FROM relationship_conflict_position_members AS member
+		JOIN relationship_conflict_positions AS position
+		  ON position.team_id = member.team_id
+		 AND position.position_id = member.position_id
+		WHERE member.team_id = ?::uuid
+		  AND member.conflict_id = ANY(?::uuid[])
+		  AND (
+		      (?::timestamptz IS NULL AND member.active)
+		      OR (
+		          ?::timestamptz IS NOT NULL
+		          AND member.first_seen_at <= ?::timestamptz
+		          AND (member.retired_at IS NULL OR member.retired_at > ?::timestamptz)
+		      )
+		  )
+		  AND (
+		      (?::timestamptz IS NULL AND position.active)
+		      OR (
+		          ?::timestamptz IS NOT NULL
+		          AND position.first_seen_at <= ?::timestamptz
+		          AND (position.retired_at IS NULL OR position.retired_at > ?::timestamptz)
+		      )
+		  )
+	),
+	profile_group_counts AS (
+		SELECT conflict_id,
+		       position_id,
+		       owner_profile_id,
+		       COUNT(DISTINCT source_group_key)::int AS source_group_count
+		FROM effective_members
+		GROUP BY conflict_id, position_id, owner_profile_id
+	),
+	profile_representatives AS (
+		SELECT DISTINCT ON (conflict_id, position_id, owner_profile_id)
+		       conflict_id,
+		       position_id,
+		       owner_profile_id,
+		       authority,
+		       fragment_id,
+		       accepted_at
+		FROM effective_members
+		ORDER BY conflict_id,
+		         position_id,
+		         owner_profile_id,
+		         CASE authority
+		             WHEN 'authoritative' THEN 0
+		             WHEN 'primary' THEN 1
+		             WHEN 'secondary' THEN 2
+		             WHEN 'inferred' THEN 3
+		             ELSE 4
+		         END,
+		         accepted_at DESC,
+		         fragment_id
+	),
+	ranked_supporters AS (
+		SELECT representative.conflict_id,
+		       representative.position_id,
+		       representative.owner_profile_id,
+		       profile.name,
+		       representative.authority,
+		       representative.fragment_id,
+		       representative.accepted_at,
+		       counts.source_group_count,
+		       COUNT(*) OVER (
+		           PARTITION BY representative.conflict_id, representative.position_id
+		       )::int AS supporter_count,
+		       ROW_NUMBER() OVER (
+		           PARTITION BY representative.conflict_id, representative.position_id
+		           ORDER BY CASE representative.authority
+		                        WHEN 'authoritative' THEN 0
+		                        WHEN 'primary' THEN 1
+		                        WHEN 'secondary' THEN 2
+		                        WHEN 'inferred' THEN 3
+		                        ELSE 4
+		                    END,
+		                    representative.accepted_at DESC,
+		                    representative.owner_profile_id
+		       ) AS supporter_rank
+		FROM profile_representatives AS representative
+		JOIN profile_group_counts AS counts
+		  ON counts.conflict_id = representative.conflict_id
+		 AND counts.position_id = representative.position_id
+		 AND counts.owner_profile_id = representative.owner_profile_id
+		JOIN team_profiles AS profile
+		  ON profile.team_id = ?::uuid
+		 AND profile.id = representative.owner_profile_id
+	)
+	SELECT conflict_id::text,
+	       position_id::text,
+	       supporter_count,
+	       owner_profile_id::text,
+	       name,
+	       authority,
+	       fragment_id::text,
+	       accepted_at,
+	       source_group_count
+	FROM ranked_supporters
+	WHERE supporter_rank <= ?
+	ORDER BY conflict_id, position_id, supporter_rank`
+
+func loadRelationshipConflictSupporters(
+	ctx context.Context,
+	tx *gorm.DB,
+	teamID string,
+	conflictIDs []string,
+	knownAt *time.Time,
+	positions []RelationshipConflictPositionRecord,
+) error {
+	if len(positions) == 0 {
+		return nil
+	}
+	rows, err := tx.WithContext(ctx).Raw(
+		relationshipConflictSupporterRowsSQL,
+		relationshipConflictSupporterRowsArgs(teamID, conflictIDs, knownAt)...,
+	).Rows()
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	positionsByID := make(map[string]*RelationshipConflictPositionRecord, len(positions))
+	for i := range positions {
+		positions[i].Supporters = []RelationshipConflictSupporterRecord{}
+		positionsByID[positions[i].PositionID] = &positions[i]
+	}
+	for rows.Next() {
+		var conflictID, positionID string
+		var supporterCount int
+		var supporter RelationshipConflictSupporterRecord
+		if err := rows.Scan(
+			&conflictID,
+			&positionID,
+			&supporterCount,
+			&supporter.ProfileID,
+			&supporter.ProfileName,
+			&supporter.StrongestAuthority,
+			&supporter.EvidenceID,
+			&supporter.AcceptedAt,
+			&supporter.SourceGroupCount,
+		); err != nil {
+			return err
+		}
+		position := positionsByID[positionID]
+		if position == nil || position.ConflictID != conflictID {
+			return fmt.Errorf("conflict supporter position %s is not in the loaded team projection", positionID)
+		}
+		position.SupporterCount = supporterCount
+		position.Supporters = append(position.Supporters, supporter)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for i := range positions {
+		positions[i].SupportersTruncated = positions[i].SupporterCount > len(positions[i].Supporters)
+	}
+	return nil
+}
+
+func relationshipConflictSupporterRowsArgs(teamID string, conflictIDs []string, knownAt *time.Time) []any {
+	return []any{
+		teamID,
+		pq.Array(conflictIDs),
+		knownAt, knownAt, knownAt, knownAt,
+		knownAt, knownAt, knownAt, knownAt,
+		teamID,
+		relationshipConflictSupporterLimit,
+	}
+}

--- a/internal/repository/conflict_supporter_repository_integration_test.go
+++ b/internal/repository/conflict_supporter_repository_integration_test.go
@@ -1,0 +1,183 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestRelationshipConflictSupporterProjectionIsBoundedCurrentAndTeamScoped(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "conflict-supporters", 3, "exact", "")
+
+	teamID := createLedgerTeam(t, adminDB, rls, "conflict-supporters-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "Profile A")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "Profile B")
+	otherTeamID := createLedgerTeam(t, adminDB, rls, "conflict-supporters-other-team")
+	otherOwner := createLedgerProfile(t, adminDB, rls, otherTeamID, "Other Profile")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+
+	preferred := commitPlacementRelationshipForConflictTestWithOptions(
+		t, ctx, ledgerRepo, teamID, ownerA, "worker-supporters-a",
+		"supporters-a", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "shared-source",
+		conflictTestRelationshipOptions{
+			authority: "secondary",
+			additionalSupports: []conflictTestAdditionalSupport{{
+				sourceGroupKey: "profile-a-independent",
+				spanStart:      0,
+				spanEnd:        len("Dense-Mem uses PostgreSQL"),
+				quote:          "Dense-Mem uses PostgreSQL",
+				authority:      "authoritative",
+			}},
+		},
+	)
+	loser := commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerB, "worker-supporters-b",
+		"supporters-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "graphdb-source",
+	)
+	conflictID, _ := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+
+	var historicalKnownAt time.Time
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`SELECT clock_timestamp()`).Scan(&historicalKnownAt).Error
+	}))
+
+	for i := 0; i < 20; i++ {
+		ownerID := createLedgerProfile(t, adminDB, rls, teamID, fmt.Sprintf("Profile %02d", i+3))
+		sourceGroup := "shared-source"
+		if i > 0 {
+			sourceGroup = fmt.Sprintf("independent-source-%02d", i)
+		}
+		commitPlacementRelationshipForConflictTest(
+			t, ctx, ledgerRepo, teamID, ownerID, fmt.Sprintf("worker-supporters-%02d", i+3),
+			fmt.Sprintf("supporters-%02d", i+3), fmt.Sprintf("Dense-Mem uses PostgreSQL according to profile %02d.", i+3),
+			subject.EntityID, postgres.EntityID, sourceGroup,
+		)
+	}
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE team_profiles
+			SET name = 'Profile A Renamed', updated_at = now()
+			WHERE team_id = ?::uuid
+			  AND id = ?::uuid
+		`, teamID, ownerA).Error
+	}))
+
+	current := loadConflictSupporterTestRecords(
+		t, ctx, appDB, rls, teamID, ownerA, conflictID,
+		[]string{
+			preferred.RelationshipResults[0].Relationship.RelationshipID,
+			loser.RelationshipResults[0].Relationship.RelationshipID,
+		},
+		nil,
+	)
+	require.Len(t, current, 1)
+	preferredPosition := conflictSupporterTestPosition(t, current[0].Positions, postgres.EntityID)
+	assert.Equal(t, 21, preferredPosition.SupporterCount)
+	assert.Equal(t, 21, preferredPosition.SupportGroupCount)
+	assert.Equal(t, 1, preferredPosition.AuthoritativeGroupCount)
+	assert.True(t, preferredPosition.SupportersTruncated)
+	require.Len(t, preferredPosition.Supporters, relationshipConflictSupporterLimit)
+	assert.Equal(t, ownerA, preferredPosition.Supporters[0].ProfileID)
+	assert.Equal(t, "Profile A Renamed", preferredPosition.Supporters[0].ProfileName)
+	assert.Equal(t, "authoritative", preferredPosition.Supporters[0].StrongestAuthority)
+	assert.Equal(t, 2, preferredPosition.Supporters[0].SourceGroupCount)
+	assert.NotEmpty(t, preferredPosition.Supporters[0].EvidenceID)
+	assert.False(t, preferredPosition.Supporters[0].AcceptedAt.IsZero())
+
+	historical := loadConflictSupporterTestRecords(
+		t, ctx, appDB, rls, teamID, ownerA, conflictID,
+		[]string{preferred.RelationshipResults[0].Relationship.RelationshipID},
+		&historicalKnownAt,
+	)
+	require.Len(t, historical, 1)
+	historicalPosition := conflictSupporterTestPosition(t, historical[0].Positions, postgres.EntityID)
+	assert.Equal(t, 1, historicalPosition.SupporterCount)
+	assert.Equal(t, 2, historicalPosition.SupportGroupCount)
+	assert.Equal(t, 1, historicalPosition.AuthoritativeGroupCount)
+	assert.False(t, historicalPosition.SupportersTruncated)
+	require.Len(t, historicalPosition.Supporters, 1)
+	assert.Equal(t, "Profile A Renamed", historicalPosition.Supporters[0].ProfileName)
+
+	foreign := loadConflictSupporterTestRecords(t, ctx, appDB, rls, otherTeamID, otherOwner, conflictID, nil, nil)
+	assert.Empty(t, foreign)
+	var foreignVisible int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, otherTeamID, otherOwner, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT COUNT(*)
+			FROM relationship_conflict_position_members
+			WHERE conflict_id = ?::uuid
+		`, conflictID).Scan(&foreignVisible).Error
+	}))
+	assert.Zero(t, foreignVisible)
+
+	var plan string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+		if err := tx.Exec(`SET LOCAL enable_seqscan = off`).Error; err != nil {
+			return err
+		}
+		return tx.Raw(
+			`EXPLAIN (FORMAT JSON) `+relationshipConflictSupporterRowsSQL,
+			relationshipConflictSupporterRowsArgs(teamID, []string{conflictID}, nil)...,
+		).Row().Scan(&plan)
+	}))
+	assert.True(t,
+		strings.Contains(plan, "relationship_conflict_members_case_idx") ||
+			strings.Contains(plan, "relationship_conflict_position_members_pkey"),
+		"supporter projection plan did not use a conflict-member index: %s", plan,
+	)
+}
+
+func loadConflictSupporterTestRecords(
+	t *testing.T,
+	ctx context.Context,
+	db *gorm.DB,
+	rls rLSHelper,
+	teamID string,
+	profileID string,
+	conflictID string,
+	relationshipIDs []string,
+	knownAt *time.Time,
+) []RelationshipConflictCaseRecord {
+	t.Helper()
+	var records []RelationshipConflictCaseRecord
+	require.NoError(t, rls.WithTeamProfileTx(ctx, db, teamID, profileID, func(tx *gorm.DB) error {
+		var err error
+		if relationshipIDs == nil {
+			records, err = loadRelationshipConflictRecordsByID(ctx, tx, teamID, []string{conflictID}, knownAt)
+		} else {
+			records, err = loadRelationshipConflictRecords(ctx, tx, teamID, relationshipIDs, knownAt)
+		}
+		return err
+	}))
+	return records
+}
+
+func conflictSupporterTestPosition(
+	t *testing.T,
+	positions []RelationshipConflictPositionRecord,
+	objectEntityID string,
+) RelationshipConflictPositionRecord {
+	t.Helper()
+	for _, position := range positions {
+		if position.ObjectEntityID == objectEntityID {
+			return position
+		}
+	}
+	t.Fatalf("missing conflict position for object %s", objectEntityID)
+	return RelationshipConflictPositionRecord{}
+}

--- a/internal/repository/submission_assessment_commit_repository.go
+++ b/internal/repository/submission_assessment_commit_repository.go
@@ -61,20 +61,16 @@ func (r *LedgerRepositoryImpl) CommitSubmissionAssessment(
 				return ErrPlacementStaleSource
 			}
 		}
+		conflictContexts := make([]PlacementConflictContextInput, 0, len(input.RelationshipObservations))
 		for _, entry := range input.RelationshipObservations {
 			conflictContext := entry.Observation.ConflictContext
 			if conflictContext == nil {
 				continue
 			}
-			if err := requireRelationshipConflictContextCurrent(
-				ctx,
-				tx,
-				input.TeamID,
-				conflictContext.ConflictID,
-				conflictContext.ExpectedVersion,
-			); err != nil {
-				return err
-			}
+			conflictContexts = append(conflictContexts, *conflictContext)
+		}
+		if err := requireRelationshipConflictContextsCurrent(ctx, tx, input.TeamID, conflictContexts); err != nil {
+			return err
 		}
 		if err := ensureSemanticRefs(ctx, tx, input.TeamID, input.OwnerProfileID); err != nil {
 			return err

--- a/internal/repository/submission_assessment_commit_repository.go
+++ b/internal/repository/submission_assessment_commit_repository.go
@@ -61,6 +61,21 @@ func (r *LedgerRepositoryImpl) CommitSubmissionAssessment(
 				return ErrPlacementStaleSource
 			}
 		}
+		for _, entry := range input.RelationshipObservations {
+			conflictContext := entry.Observation.ConflictContext
+			if conflictContext == nil {
+				continue
+			}
+			if err := requireRelationshipConflictContextCurrent(
+				ctx,
+				tx,
+				input.TeamID,
+				conflictContext.ConflictID,
+				conflictContext.ExpectedVersion,
+			); err != nil {
+				return err
+			}
+		}
 		if err := ensureSemanticRefs(ctx, tx, input.TeamID, input.OwnerProfileID); err != nil {
 			return err
 		}
@@ -126,6 +141,17 @@ func (r *LedgerRepositoryImpl) CommitSubmissionAssessment(
 			decision, err := relationshipDecisionFromPlacementObservation(ctx, tx, commit, entry.Observation, entitiesByRef)
 			if err != nil {
 				return err
+			}
+			if entry.Observation.ConflictContext != nil {
+				if err := requireRelationshipConflictContextMatchesDecision(
+					ctx,
+					tx,
+					input.TeamID,
+					*entry.Observation.ConflictContext,
+					decision,
+				); err != nil {
+					return err
+				}
 			}
 			appliedBefore := len(semanticResult.RelationshipResults)
 			if err := applyPlacementRelationshipDecision(

--- a/internal/repository/submission_assessment_repository_integration_test.go
+++ b/internal/repository/submission_assessment_repository_integration_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -232,6 +234,87 @@ func TestSubmissionAssessmentCommitValidatesConflictContextAtomically(t *testing
 
 	after := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerA, staleIngest.PlacementRunID)
 	assert.Equal(t, before, after)
+}
+
+func TestRelationshipConflictContextValidationLocksConcurrentVersionChange(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "submission-assessment-conflict-lock", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "submission-assessment-conflict-lock-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "submission-assessment-conflict-lock-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "submission-assessment-conflict-lock-owner-b")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerA, "submission-context-lock-seed-a",
+		"submission-context-lock-seed-a", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "submission-context-lock-source-a",
+	)
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, ledgerRepo, teamID, ownerB, "submission-context-lock-seed-b",
+		"submission-context-lock-seed-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "submission-context-lock-source-b",
+	)
+	conflictID, conflictVersion := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+
+	lockAcquired := make(chan struct{})
+	releaseLock := make(chan struct{})
+	validationDone := make(chan error, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseLock) })
+	}
+	defer release()
+	go func() {
+		validationDone <- rls.WithTeamProfileTx(ctx, appDB, teamID, ownerA, func(tx *gorm.DB) error {
+			if err := requireRelationshipConflictContextCurrent(ctx, tx, teamID, conflictID, conflictVersion); err != nil {
+				return err
+			}
+			close(lockAcquired)
+			<-releaseLock
+			return nil
+		})
+	}()
+
+	select {
+	case <-lockAcquired:
+	case err := <-validationDone:
+		require.NoError(t, err)
+		t.Fatal("conflict-context validation ended before its row lock could be observed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for conflict-context row lock")
+	}
+
+	var competingVersion int
+	lockErr := rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT version
+			FROM relationship_conflict_cases
+			WHERE team_id = ?::uuid
+			  AND conflict_id = ?::uuid
+			FOR UPDATE NOWAIT
+		`, teamID, conflictID).Row().Scan(&competingVersion)
+	})
+	require.Error(t, lockErr)
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, lockErr, &pgErr)
+	assert.Equal(t, "55P03", pgErr.Code)
+
+	release()
+	select {
+	case err := <-validationDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for conflict-context validation to commit")
+	}
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return bumpRelationshipConflictCaseVersion(ctx, tx, teamID, conflictID)
+	}))
+	_, advancedVersion := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	assert.Greater(t, advancedVersion, conflictVersion)
 }
 
 func TestSubmissionAssessmentCommitRequiresAssessmentForTheSameRun(t *testing.T) {

--- a/internal/repository/submission_assessment_repository_integration_test.go
+++ b/internal/repository/submission_assessment_repository_integration_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -166,6 +167,70 @@ func TestSubmissionAssessmentRollsBackEverySemanticWriteWhenOneRelationshipFails
 	assert.Contains(t, err.Error(), "unresolved relationship endpoint")
 
 	after := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerID, ingest.PlacementRunID)
+	assert.Equal(t, before, after)
+}
+
+func TestSubmissionAssessmentCommitValidatesConflictContextAtomically(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	insertSearchTestContract(t, adminDB, rls, "submission-assessment-conflict-context", 3, "exact", "")
+	teamID := createLedgerTeam(t, adminDB, rls, "submission-assessment-conflict-context-team")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamID, "submission-assessment-conflict-context-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamID, "submission-assessment-conflict-context-owner-b")
+	ownerC := createLedgerProfile(t, adminDB, rls, teamID, "submission-assessment-conflict-context-owner-c")
+	repo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Dense-Mem")
+	otherSubject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "project", "Other Project")
+	postgres := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "PostgreSQL")
+	graphdb := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerA, "product", "GraphDB")
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, repo, teamID, ownerA, "submission-context-seed-a",
+		"submission-context-seed-a", "Dense-Mem uses PostgreSQL.", subject.EntityID, postgres.EntityID, "submission-context-source-a",
+	)
+	commitPlacementRelationshipForConflictTest(
+		t, ctx, repo, teamID, ownerB, "submission-context-seed-b",
+		"submission-context-seed-b", "Dense-Mem uses GraphDB.", subject.EntityID, graphdb.EntityID, "submission-context-source-b",
+	)
+	conflictID, conflictVersion := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+
+	_, freshInput := submissionAssessmentConflictCommitFixture(
+		t, ctx, repo, teamID, ownerC, "submission-context-fresh-worker", "submission-context-fresh",
+		"Dense-Mem uses PostgreSQL according to owner C.", subject.EntityID, postgres.EntityID,
+		"submission-context-source-c", PlacementConflictContextInput{ConflictID: conflictID, ExpectedVersion: conflictVersion},
+	)
+	committed, err := repo.CommitSubmissionAssessment(ctx, freshInput)
+	require.NoError(t, err)
+	require.Len(t, committed.RelationshipResults, 1)
+	_, currentVersion := loadConflictCaseVersionForSubject(t, ctx, appDB, rls, teamID, ownerA, subject.EntityID)
+	require.Greater(t, currentVersion, conflictVersion)
+
+	mismatchedIngest, mismatchedInput := submissionAssessmentConflictCommitFixture(
+		t, ctx, repo, teamID, ownerC, "submission-context-mismatched-worker", "submission-context-mismatched",
+		"Other Project uses PostgreSQL according to owner C.", otherSubject.EntityID, postgres.EntityID,
+		"submission-context-source-mismatched", PlacementConflictContextInput{ConflictID: conflictID, ExpectedVersion: currentVersion},
+	)
+	beforeMismatch := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerA, mismatchedIngest.PlacementRunID)
+	_, err = repo.CommitSubmissionAssessment(ctx, mismatchedInput)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConflictContextStale), err)
+	afterMismatch := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerA, mismatchedIngest.PlacementRunID)
+	assert.Equal(t, beforeMismatch, afterMismatch)
+
+	staleIngest, staleInput := submissionAssessmentConflictCommitFixture(
+		t, ctx, repo, teamID, ownerC, "submission-context-stale-worker", "submission-context-stale",
+		"Dense-Mem still uses PostgreSQL according to owner C.", subject.EntityID, postgres.EntityID,
+		"submission-context-source-stale", PlacementConflictContextInput{ConflictID: conflictID, ExpectedVersion: conflictVersion},
+	)
+	before := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerA, staleIngest.PlacementRunID)
+
+	_, err = repo.CommitSubmissionAssessment(ctx, staleInput)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConflictContextStale), err)
+
+	after := submissionAssessmentSemanticCounts(t, ctx, appDB, rls, teamID, ownerA, staleIngest.PlacementRunID)
 	assert.Equal(t, before, after)
 }
 
@@ -592,6 +657,75 @@ func submissionAssessmentPersistInput(run PlacementRun) PersistSubmissionAssessm
 		ResponseHash:            "sha256:submission-assessment-test",
 		ValidatedAt:             time.Now().UTC(),
 	}
+}
+
+func submissionAssessmentConflictCommitFixture(
+	t *testing.T,
+	ctx context.Context,
+	repo *LedgerRepositoryImpl,
+	teamID string,
+	ownerID string,
+	workerID string,
+	idempotencyKey string,
+	content string,
+	subjectEntityID string,
+	objectEntityID string,
+	sourceGroupKey string,
+	conflictContext PlacementConflictContextInput,
+) (*CreateIngestResult, CommitSubmissionAssessmentInput) {
+	t.Helper()
+	ingest := createSemanticIngest(t, ctx, repo, teamID, ownerID, idempotencyKey, content)
+	claimed, err := repo.ClaimNextPlacementRun(ctx, teamID, workerID, time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assessment := persistSubmissionAssessment(t, ctx, repo, *claimed)
+	threshold := 0.7
+	confidence := 0.9
+	input := CommitSubmissionAssessmentInput{
+		SubmissionAssessmentRunScope: SubmissionAssessmentRunScope{
+			TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID, PlacementRunID: ingest.PlacementRunID,
+			WorkerID: workerID, ExpectedAttempts: claimed.Attempts,
+		},
+		AssessmentID: assessment.AssessmentID,
+		Items: []SubmissionAssessmentItemInput{{
+			PlacementItemID: ingest.Items[0].PlacementItemID,
+			FragmentID:      ingest.Evidence[0].FragmentID,
+		}},
+		EntityResolutions: []SubmissionAssessmentEntityResolutionInput{
+			{
+				PlacementItemID: ingest.Items[0].PlacementItemID,
+				Resolution: PlacementEntityResolutionInput{
+					MentionRef: "subject", Action: string(domain.EntityResolutionReuse), EntityID: subjectEntityID,
+					FragmentID: ingest.Evidence[0].FragmentID, AssessmentID: assessment.AssessmentID,
+				},
+			},
+			{
+				PlacementItemID: ingest.Items[0].PlacementItemID,
+				Resolution: PlacementEntityResolutionInput{
+					MentionRef: "object", Action: string(domain.EntityResolutionReuse), EntityID: objectEntityID,
+					FragmentID: ingest.Evidence[0].FragmentID, AssessmentID: assessment.AssessmentID,
+				},
+			},
+		},
+		RelationshipObservations: []SubmissionAssessmentRelationshipObservationInput{{
+			PlacementItemID: ingest.Items[0].PlacementItemID,
+			Observation: PlacementRelationshipDecisionInput{
+				Ref: "relationship", SubjectRef: "subject", OriginalPredicate: "primary database",
+				PredicateKey: "primary_database", PredicateVersion: 1, ObjectRef: "object", Polarity: "+",
+				EvidenceVerdict: string(domain.VerificationEntailed), Confidence: &confidence,
+				Rationale: "The evidence explicitly states the relationship.", Model: "submission-assessment-test",
+				ResponseHash: "sha256:submission-assessment-test", AssessmentID: assessment.AssessmentID,
+				AssessmentPolicyVersion: "submission-assessment-test", ThresholdUsed: &threshold,
+				GateResult: "meets_write_threshold", ConflictContext: &conflictContext,
+				Support: &EvidenceSupportInput{
+					FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: sourceGroupKey,
+					SpanStart: 0, SpanEnd: len(content), Quote: content, Authority: "primary",
+				},
+			},
+		}},
+		Payload: map[string]any{"assessor_contract": domain.ContractVersion},
+	}
+	return ingest, input
 }
 
 func submissionAssessmentCommitFixture(run PlacementRun, ingest *CreateIngestResult, assessmentID string, invalidSecondRelationship bool) CommitSubmissionAssessmentInput {

--- a/internal/service/contextservice/semantic_trace.go
+++ b/internal/service/contextservice/semantic_trace.go
@@ -12,7 +12,10 @@ import (
 	"github.com/markhuangai/dense-mem/internal/requestctx"
 )
 
-var ErrTraceAuthContext = errors.New("trace: authenticated actor context is required")
+var (
+	ErrTraceAuthContext            = errors.New("trace: authenticated actor context is required")
+	ErrTraceRepositoryTeamMismatch = errors.New("trace: repository returned a mismatched team")
+)
 
 type SemanticTraceStore interface {
 	TraceRelationship(ctx context.Context, input repository.TraceRelationshipInput) (*repository.RelationshipTraceResult, error)
@@ -78,7 +81,22 @@ func (s *semanticTraceService) Trace(ctx context.Context, _ string, req TraceReq
 	if err != nil {
 		return nil, fmt.Errorf("trace: %w", err)
 	}
+	if err := validateTraceConflictTeams(trace, actor.TeamID.String()); err != nil {
+		return nil, err
+	}
 	return &TraceResult{Semantic: semanticTraceFromRepository(trace)}, nil
+}
+
+func validateTraceConflictTeams(trace *repository.RelationshipTraceResult, expectedTeamID string) error {
+	if trace == nil {
+		return nil
+	}
+	for _, conflict := range trace.Conflicts {
+		if conflict.TeamID != expectedTeamID {
+			return ErrTraceRepositoryTeamMismatch
+		}
+	}
+	return nil
 }
 
 func semanticTraceFromRepository(trace *repository.RelationshipTraceResult) *SemanticTrace {

--- a/internal/service/contextservice/semantic_trace_test.go
+++ b/internal/service/contextservice/semantic_trace_test.go
@@ -39,3 +39,24 @@ func TestSemanticTraceRejectsMismatchedConflictTeam(t *testing.T) {
 	require.ErrorIs(t, err, ErrTraceRepositoryTeamMismatch)
 	require.Equal(t, teamID.String(), store.input.TeamID)
 }
+
+func TestSemanticTraceAllowsMatchingConflictTeam(t *testing.T) {
+	teamID := uuid.New()
+	conflictID := uuid.NewString()
+	store := &semanticTraceStoreStub{result: &repository.RelationshipTraceResult{
+		Conflicts: []repository.RelationshipConflictCaseRecord{{
+			TeamID:     teamID.String(),
+			ConflictID: conflictID,
+		}},
+	}}
+	service := NewSemantic(store)
+	ctx := requestctx.WithActorProfile(context.Background(), requestctx.ActorProfile{
+		TeamID:    teamID,
+		ProfileID: uuid.New(),
+	})
+
+	result, err := service.Trace(ctx, "", TraceRequest{RelationshipID: uuid.NewString()})
+	require.NoError(t, err)
+	require.Len(t, result.Semantic.Conflicts, 1)
+	require.Equal(t, conflictID, result.Semantic.Conflicts[0].ConflictID)
+}

--- a/internal/service/contextservice/semantic_trace_test.go
+++ b/internal/service/contextservice/semantic_trace_test.go
@@ -1,0 +1,41 @@
+package contextservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+)
+
+type semanticTraceStoreStub struct {
+	result *repository.RelationshipTraceResult
+	input  repository.TraceRelationshipInput
+}
+
+func (s *semanticTraceStoreStub) TraceRelationship(_ context.Context, input repository.TraceRelationshipInput) (*repository.RelationshipTraceResult, error) {
+	s.input = input
+	return s.result, nil
+}
+
+func TestSemanticTraceRejectsMismatchedConflictTeam(t *testing.T) {
+	teamID := uuid.New()
+	store := &semanticTraceStoreStub{result: &repository.RelationshipTraceResult{
+		Conflicts: []repository.RelationshipConflictCaseRecord{{
+			TeamID:     uuid.NewString(),
+			ConflictID: uuid.NewString(),
+		}},
+	}}
+	service := NewSemantic(store)
+	ctx := requestctx.WithActorProfile(context.Background(), requestctx.ActorProfile{
+		TeamID:    teamID,
+		ProfileID: uuid.New(),
+	})
+
+	_, err := service.Trace(ctx, "", TraceRequest{RelationshipID: uuid.NewString()})
+	require.ErrorIs(t, err, ErrTraceRepositoryTeamMismatch)
+	require.Equal(t, teamID.String(), store.input.TeamID)
+}

--- a/internal/service/memoryservice/recall.go
+++ b/internal/service/memoryservice/recall.go
@@ -213,14 +213,6 @@ type RecallConflictSummary struct {
 	PositionsTruncated  bool                     `json:"positions_truncated"`
 }
 
-type RecallConflictPosition struct {
-	PositionID        string   `json:"position_id"`
-	Disposition       string   `json:"disposition"`
-	RelationshipIDs   []string `json:"relationship_ids"`
-	OwnerProfileIDs   []string `json:"owner_profile_ids"`
-	ResultEvidenceIDs []string `json:"result_evidence_ids"`
-}
-
 type RecallRelationshipHandle struct {
 	RelationshipID string         `json:"relationship_id"`
 	Subject        EntityHandle   `json:"subject"`
@@ -333,6 +325,9 @@ func (s *recallService) Recall(ctx context.Context, req RecallRequest) (result *
 		ExpandFromEntityIDs:  req.ExpandFromEntityIDs,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := validateRecallConflictTeams(recalled, actor.TeamID.String()); err != nil {
 		return nil, err
 	}
 	result = recallResultFromRepository(recalled, degradations)

--- a/internal/service/memoryservice/recall_conflicts.go
+++ b/internal/service/memoryservice/recall_conflicts.go
@@ -1,0 +1,44 @@
+package memoryservice
+
+import (
+	"errors"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+)
+
+var ErrRecallRepositoryTeamMismatch = errors.New("recall: repository returned a mismatched team")
+
+type RecallConflictPosition struct {
+	PositionID              string                    `json:"position_id"`
+	Disposition             string                    `json:"disposition"`
+	SupporterCount          int                       `json:"supporter_count"`
+	SupportGroupCount       int                       `json:"support_group_count"`
+	AuthoritativeGroupCount int                       `json:"authoritative_group_count"`
+	SupportersTruncated     bool                      `json:"supporters_truncated"`
+	Supporters              []RecallConflictSupporter `json:"supporters"`
+	RelationshipIDs         []string                  `json:"relationship_ids"`
+	OwnerProfileIDs         []string                  `json:"owner_profile_ids"`
+	ResultEvidenceIDs       []string                  `json:"result_evidence_ids"`
+}
+
+type RecallConflictSupporter struct {
+	ProfileID          string    `json:"profile_id"`
+	ProfileName        string    `json:"profile_name"`
+	StrongestAuthority string    `json:"strongest_authority"`
+	EvidenceID         string    `json:"evidence_id"`
+	AcceptedAt         time.Time `json:"accepted_at"`
+	SourceGroupCount   int       `json:"source_group_count"`
+}
+
+func validateRecallConflictTeams(recalled *repository.RecallEvidenceResult, expectedTeamID string) error {
+	if recalled == nil {
+		return nil
+	}
+	for _, conflict := range recalled.Conflicts {
+		if conflict.TeamID != expectedTeamID {
+			return ErrRecallRepositoryTeamMismatch
+		}
+	}
+	return nil
+}

--- a/internal/service/memoryservice/recall_result_helpers.go
+++ b/internal/service/memoryservice/recall_result_helpers.go
@@ -31,6 +31,7 @@ func recallConflictSummaries(records []repository.RelationshipConflictCaseRecord
 
 const (
 	recallConflictPositionLimit         = 10
+	recallConflictSupporterLimit        = 20
 	recallConflictRelationshipIDLimit   = 20
 	recallConflictOwnerProfileIDLimit   = 20
 	recallConflictResultEvidenceIDLimit = 50
@@ -42,12 +43,36 @@ func recallConflictPositions(records []repository.RelationshipConflictPositionRe
 	}
 	out := make([]RecallConflictPosition, 0, len(records))
 	for _, record := range records {
+		supportersTruncated := record.SupportersTruncated || len(record.Supporters) > recallConflictSupporterLimit
 		out = append(out, RecallConflictPosition{
-			PositionID:        record.PositionID,
-			Disposition:       record.Disposition,
-			RelationshipIDs:   limitStrings(record.RelationshipIDs, recallConflictRelationshipIDLimit),
-			OwnerProfileIDs:   limitStrings(record.OwnerProfileIDs, recallConflictOwnerProfileIDLimit),
-			ResultEvidenceIDs: limitStrings(record.EvidenceIDs, recallConflictResultEvidenceIDLimit),
+			PositionID:              record.PositionID,
+			Disposition:             record.Disposition,
+			SupporterCount:          record.SupporterCount,
+			SupportGroupCount:       record.SupportGroupCount,
+			AuthoritativeGroupCount: record.AuthoritativeGroupCount,
+			SupportersTruncated:     supportersTruncated,
+			Supporters:              recallConflictSupporters(record.Supporters),
+			RelationshipIDs:         limitStrings(record.RelationshipIDs, recallConflictRelationshipIDLimit),
+			OwnerProfileIDs:         limitStrings(record.OwnerProfileIDs, recallConflictOwnerProfileIDLimit),
+			ResultEvidenceIDs:       limitStrings(record.EvidenceIDs, recallConflictResultEvidenceIDLimit),
+		})
+	}
+	return out
+}
+
+func recallConflictSupporters(records []repository.RelationshipConflictSupporterRecord) []RecallConflictSupporter {
+	if len(records) > recallConflictSupporterLimit {
+		records = records[:recallConflictSupporterLimit]
+	}
+	out := make([]RecallConflictSupporter, 0, len(records))
+	for _, record := range records {
+		out = append(out, RecallConflictSupporter{
+			ProfileID:          record.ProfileID,
+			ProfileName:        record.ProfileName,
+			StrongestAuthority: record.StrongestAuthority,
+			EvidenceID:         record.EvidenceID,
+			AcceptedAt:         record.AcceptedAt,
+			SourceGroupCount:   record.SourceGroupCount,
 		})
 	}
 	return out

--- a/internal/service/memoryservice/recall_test.go
+++ b/internal/service/memoryservice/recall_test.go
@@ -23,6 +23,7 @@ func TestRecallUsesAuthenticatedTeamAndVectorQuery(t *testing.T) {
 	conflictID := uuid.NewString()
 	positionID := uuid.NewString()
 	evidenceCreatedAt := time.Date(2026, 7, 20, 10, 30, 0, 0, time.UTC)
+	supportAcceptedAt := time.Date(2026, 7, 20, 10, 31, 0, 0, time.UTC)
 	reviewDueAt := time.Date(2026, 7, 25, 4, 0, 0, 0, time.UTC)
 	search := &recallSearchStub{
 		contract: &repository.ActiveSearchContract{
@@ -43,6 +44,7 @@ func TestRecallUsesAuthenticatedTeamAndVectorQuery(t *testing.T) {
 				CreatedAt:       evidenceCreatedAt,
 			}},
 			Conflicts: []repository.RelationshipConflictCaseRecord{{
+				TeamID:              teamID.String(),
 				ConflictID:          conflictID,
 				Version:             1,
 				Kind:                "cross_profile_current_state",
@@ -52,12 +54,22 @@ func TestRecallUsesAuthenticatedTeamAndVectorQuery(t *testing.T) {
 				PolicyVersion:       domain.ConflictPolicyVersion,
 				PreferredPositionID: "",
 				Positions: []repository.RelationshipConflictPositionRecord{{
-					PositionID:        positionID,
-					Disposition:       "candidate",
-					RelationshipIDs:   []string{relationshipID},
-					OwnerProfileIDs:   []string{profileID.String()},
-					EvidenceIDs:       []string{evidenceID},
-					SupportGroupCount: 1,
+					PositionID:              positionID,
+					Disposition:             "candidate",
+					SupporterCount:          1,
+					SupportGroupCount:       1,
+					AuthoritativeGroupCount: 1,
+					Supporters: []repository.RelationshipConflictSupporterRecord{{
+						ProfileID:          profileID.String(),
+						ProfileName:        "Profile A",
+						StrongestAuthority: "authoritative",
+						EvidenceID:         evidenceID,
+						AcceptedAt:         supportAcceptedAt,
+						SourceGroupCount:   1,
+					}},
+					RelationshipIDs: []string{relationshipID},
+					OwnerProfileIDs: []string{profileID.String()},
+					EvidenceIDs:     []string{evidenceID},
 				}},
 			}},
 		},
@@ -86,6 +98,18 @@ func TestRecallUsesAuthenticatedTeamAndVectorQuery(t *testing.T) {
 	require.Equal(t, conflictID, result.Conflicts[0].ConflictID)
 	require.Equal(t, &reviewDueAt, result.Conflicts[0].ReviewDueAt)
 	require.Equal(t, []string{relationshipID}, result.Conflicts[0].Positions[0].RelationshipIDs)
+	require.Equal(t, 1, result.Conflicts[0].Positions[0].SupporterCount)
+	require.Equal(t, 1, result.Conflicts[0].Positions[0].SupportGroupCount)
+	require.Equal(t, 1, result.Conflicts[0].Positions[0].AuthoritativeGroupCount)
+	require.False(t, result.Conflicts[0].Positions[0].SupportersTruncated)
+	require.Equal(t, []RecallConflictSupporter{{
+		ProfileID:          profileID.String(),
+		ProfileName:        "Profile A",
+		StrongestAuthority: "authoritative",
+		EvidenceID:         evidenceID,
+		AcceptedAt:         supportAcceptedAt,
+		SourceGroupCount:   1,
+	}}, result.Conflicts[0].Positions[0].Supporters)
 	require.NotEmpty(t, result.DiscoveryGuidance)
 	require.Empty(t, result.DiscoveryPaths)
 	require.Empty(t, result.RelatedHypotheses)
@@ -94,12 +118,34 @@ func TestRecallUsesAuthenticatedTeamAndVectorQuery(t *testing.T) {
 	require.Equal(t, "PostgreSQL memory", provider.query)
 }
 
+func TestRecallRejectsMismatchedConflictTeam(t *testing.T) {
+	teamID := uuid.New()
+	search := &recallSearchStub{
+		contract: &repository.ActiveSearchContract{},
+		result: &repository.RecallEvidenceResult{
+			SearchState: string(domain.SearchProjectionCurrent),
+			Conflicts: []repository.RelationshipConflictCaseRecord{{
+				TeamID:     uuid.NewString(),
+				ConflictID: uuid.NewString(),
+			}},
+		},
+	}
+	svc := NewRecallService(RecallDependencies{Search: search})
+
+	_, err := svc.Recall(authenticatedRememberContext(teamID, uuid.New(), uuid.New()), RecallRequest{
+		ContractVersion: domain.ContractVersion,
+	})
+	require.ErrorIs(t, err, ErrRecallRepositoryTeamMismatch)
+}
+
 func TestRecallConflictSummariesEnforcePositionBounds(t *testing.T) {
 	records := make([]repository.RelationshipConflictPositionRecord, 0, 11)
 	for i := 0; i < 11; i++ {
+		supporters := make([]repository.RelationshipConflictSupporterRecord, 21)
 		records = append(records, repository.RelationshipConflictPositionRecord{
 			PositionID:      uuid.NewString(),
 			Disposition:     "candidate",
+			Supporters:      supporters,
 			RelationshipIDs: make([]string, 21),
 			OwnerProfileIDs: make([]string, 21),
 			EvidenceIDs:     make([]string, 51),
@@ -121,6 +167,8 @@ func TestRecallConflictSummariesEnforcePositionBounds(t *testing.T) {
 	require.Len(t, summaries[0].Positions[0].RelationshipIDs, 20)
 	require.Len(t, summaries[0].Positions[0].OwnerProfileIDs, 20)
 	require.Len(t, summaries[0].Positions[0].ResultEvidenceIDs, 50)
+	require.Len(t, summaries[0].Positions[0].Supporters, 20)
+	require.True(t, summaries[0].Positions[0].SupportersTruncated)
 }
 
 func TestPublicHypothesisGeneratorKindPreservesProvider(t *testing.T) {

--- a/internal/service/memoryservice/submission_assessment_worker.go
+++ b/internal/service/memoryservice/submission_assessment_worker.go
@@ -218,6 +218,9 @@ func (s *submissionAssessmentPlacementWorkerService) ProcessNextSubmissionAssess
 			return s.completeTerminal(ctx, scope, string(domain.SemanticReviewTerminalFailure), "failed", "replacement_conflict")
 		})
 	}
+	if errors.Is(err, repository.ErrConflictContextStale) {
+		return true, s.completeTerminal(ctx, scope, string(domain.SemanticReviewReviewRequired), "candidate", "conflict_context_stale")
+	}
 	if errors.Is(err, repository.ErrSubmissionAssessmentScopeMismatch) {
 		return true, terminalizeAfterError(err, func() error {
 			return s.completeTerminal(ctx, scope, string(domain.SemanticReviewTerminalFailure), "failed", "assessment_scope")

--- a/internal/service/memoryservice/submission_assessment_worker_failure_test.go
+++ b/internal/service/memoryservice/submission_assessment_worker_failure_test.go
@@ -36,7 +36,7 @@ func TestSubmissionAssessmentWorkerClassifiesCommitOutcomes(t *testing.T) {
 			wantStage:  "commit_review",
 		},
 		{
-			name:       "stale conflict context requires replacement",
+			name:       "stale conflict context requires review",
 			commitErr:  repository.ErrConflictContextStale,
 			wantStatus: string(domain.SemanticReviewReviewRequired),
 			wantStage:  "conflict_context_stale",

--- a/internal/service/memoryservice/submission_assessment_worker_failure_test.go
+++ b/internal/service/memoryservice/submission_assessment_worker_failure_test.go
@@ -36,6 +36,12 @@ func TestSubmissionAssessmentWorkerClassifiesCommitOutcomes(t *testing.T) {
 			wantStage:  "commit_review",
 		},
 		{
+			name:       "stale conflict context requires replacement",
+			commitErr:  repository.ErrConflictContextStale,
+			wantStatus: string(domain.SemanticReviewReviewRequired),
+			wantStage:  "conflict_context_stale",
+		},
+		{
 			name:       "scope mismatch terminalizes",
 			commitErr:  repository.ErrSubmissionAssessmentScopeMismatch,
 			wantStatus: string(domain.SemanticReviewTerminalFailure),

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -345,6 +345,7 @@ func traceConflictOutputs(records []repository.RelationshipConflictCaseRecord) [
 
 const (
 	traceConflictPositionLimit         = 10
+	traceConflictSupporterLimit        = 20
 	traceConflictRelationshipIDLimit   = 20
 	traceConflictOwnerProfileIDLimit   = 20
 	traceConflictResultEvidenceIDLimit = 50
@@ -356,12 +357,36 @@ func traceConflictPositionOutputs(records []repository.RelationshipConflictPosit
 	}
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
+		supportersTruncated := record.SupportersTruncated || len(record.Supporters) > traceConflictSupporterLimit
 		out = append(out, map[string]any{
-			"position_id":         record.PositionID,
-			"disposition":         record.Disposition,
-			"relationship_ids":    traceBoundedStringArray(record.RelationshipIDs, traceConflictRelationshipIDLimit),
-			"owner_profile_ids":   traceBoundedStringArray(record.OwnerProfileIDs, traceConflictOwnerProfileIDLimit),
-			"result_evidence_ids": traceBoundedStringArray(record.EvidenceIDs, traceConflictResultEvidenceIDLimit),
+			"position_id":               record.PositionID,
+			"disposition":               record.Disposition,
+			"supporter_count":           record.SupporterCount,
+			"support_group_count":       record.SupportGroupCount,
+			"authoritative_group_count": record.AuthoritativeGroupCount,
+			"supporters_truncated":      supportersTruncated,
+			"supporters":                traceConflictSupporterOutputs(record.Supporters),
+			"relationship_ids":          traceBoundedStringArray(record.RelationshipIDs, traceConflictRelationshipIDLimit),
+			"owner_profile_ids":         traceBoundedStringArray(record.OwnerProfileIDs, traceConflictOwnerProfileIDLimit),
+			"result_evidence_ids":       traceBoundedStringArray(record.EvidenceIDs, traceConflictResultEvidenceIDLimit),
+		})
+	}
+	return out
+}
+
+func traceConflictSupporterOutputs(records []repository.RelationshipConflictSupporterRecord) []map[string]any {
+	if len(records) > traceConflictSupporterLimit {
+		records = records[:traceConflictSupporterLimit]
+	}
+	out := make([]map[string]any, 0, len(records))
+	for _, record := range records {
+		out = append(out, map[string]any{
+			"profile_id":          record.ProfileID,
+			"profile_name":        record.ProfileName,
+			"strongest_authority": record.StrongestAuthority,
+			"evidence_id":         record.EvidenceID,
+			"accepted_at":         record.AcceptedAt.UTC().Format(time.RFC3339Nano),
+			"source_group_count":  record.SourceGroupCount,
 		})
 	}
 	return out

--- a/internal/tools/registry/contract_outputs_test.go
+++ b/internal/tools/registry/contract_outputs_test.go
@@ -17,6 +17,7 @@ func TestFirstNonEmptyReturnsTrimmedNonNilValue(t *testing.T) {
 func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 	dueAt := time.Date(2026, 7, 25, 4, 0, 0, 0, time.UTC)
 	effectiveAt := dueAt.Add(time.Hour)
+	acceptedAt := dueAt.Add(-time.Hour)
 	out := traceConflictOutputs([]repository.RelationshipConflictCaseRecord{{
 		ConflictID:          "00000000-0000-0000-0000-000000000101",
 		Version:             2,
@@ -28,8 +29,19 @@ func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 		EffectiveTimeBasis:  "valid_from",
 		PreferredPositionID: "00000000-0000-0000-0000-000000000201",
 		Positions: []repository.RelationshipConflictPositionRecord{{
-			PositionID:      "00000000-0000-0000-0000-000000000201",
-			Disposition:     "preferred",
+			PositionID:              "00000000-0000-0000-0000-000000000201",
+			Disposition:             "preferred",
+			SupporterCount:          1,
+			SupportGroupCount:       2,
+			AuthoritativeGroupCount: 1,
+			Supporters: []repository.RelationshipConflictSupporterRecord{{
+				ProfileID:          "00000000-0000-0000-0000-000000000401",
+				ProfileName:        "Profile A",
+				StrongestAuthority: "authoritative",
+				EvidenceID:         "00000000-0000-0000-0000-000000000501",
+				AcceptedAt:         acceptedAt,
+				SourceGroupCount:   2,
+			}},
 			RelationshipIDs: []string{"00000000-0000-0000-0000-000000000301"},
 			OwnerProfileIDs: []string{"00000000-0000-0000-0000-000000000401"},
 			EvidenceIDs:     []string{"00000000-0000-0000-0000-000000000501"},
@@ -55,6 +67,20 @@ func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 		position["disposition"] != "preferred" {
 		t.Fatalf("position output = %#v", position)
 	}
+	if position["supporter_count"] != 1 || position["support_group_count"] != 2 ||
+		position["authoritative_group_count"] != 1 || position["supporters_truncated"] != false {
+		t.Fatalf("position provenance output = %#v", position)
+	}
+	supporters, ok := position["supporters"].([]map[string]any)
+	if !ok || len(supporters) != 1 {
+		t.Fatalf("supporters = %#v", position["supporters"])
+	}
+	if supporters[0]["profile_name"] != "Profile A" ||
+		supporters[0]["strongest_authority"] != "authoritative" ||
+		supporters[0]["accepted_at"] != acceptedAt.Format(time.RFC3339Nano) ||
+		supporters[0]["source_group_count"] != 2 {
+		t.Fatalf("supporter output = %#v", supporters[0])
+	}
 	if got := position["relationship_ids"].([]string); len(got) != 1 || got[0] != "00000000-0000-0000-0000-000000000301" {
 		t.Fatalf("relationship_ids = %#v", position["relationship_ids"])
 	}
@@ -72,6 +98,7 @@ func TestTraceConflictOutputsEnforcePositionBounds(t *testing.T) {
 		positions = append(positions, repository.RelationshipConflictPositionRecord{
 			PositionID:      "00000000-0000-0000-0000-000000000201",
 			Disposition:     "candidate",
+			Supporters:      make([]repository.RelationshipConflictSupporterRecord, 21),
 			RelationshipIDs: make([]string, 21),
 			OwnerProfileIDs: make([]string, 21),
 			EvidenceIDs:     make([]string, 51),
@@ -97,7 +124,39 @@ func TestTraceConflictOutputsEnforcePositionBounds(t *testing.T) {
 	first := bounded[0]
 	if len(first["relationship_ids"].([]string)) != 20 ||
 		len(first["owner_profile_ids"].([]string)) != 20 ||
-		len(first["result_evidence_ids"].([]string)) != 50 {
+		len(first["result_evidence_ids"].([]string)) != 50 ||
+		len(first["supporters"].([]map[string]any)) != 20 ||
+		first["supporters_truncated"] != true {
 		t.Fatalf("bounded position = %#v", first)
+	}
+}
+
+func TestRecallConflictPositionSchemaValidatesSupporterProvenance(t *testing.T) {
+	acceptedAt := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	output := map[string]any{
+		"position_id":               "00000000-0000-0000-0000-000000000201",
+		"disposition":               "candidate",
+		"supporter_count":           1,
+		"support_group_count":       2,
+		"authoritative_group_count": 1,
+		"supporters_truncated":      false,
+		"supporters": []any{map[string]any{
+			"profile_id":          "00000000-0000-0000-0000-000000000401",
+			"profile_name":        "Profile A",
+			"strongest_authority": "authoritative",
+			"evidence_id":         "00000000-0000-0000-0000-000000000501",
+			"accepted_at":         acceptedAt.Format(time.RFC3339),
+			"source_group_count":  2,
+		}},
+		"relationship_ids":    []any{"00000000-0000-0000-0000-000000000301"},
+		"owner_profile_ids":   []any{"00000000-0000-0000-0000-000000000401"},
+		"result_evidence_ids": []any{"00000000-0000-0000-0000-000000000501"},
+	}
+	if err := ValidateInput(Tool{InputSchema: recallConflictPositionSchema()}, output); err != nil {
+		t.Fatalf("validate conflict supporter output: %v", err)
+	}
+	delete(output, "supporters")
+	if err := ValidateInput(Tool{InputSchema: recallConflictPositionSchema()}, output); err == nil {
+		t.Fatal("missing supporters unexpectedly passed closed output validation")
 	}
 }

--- a/internal/tools/registry/contract_read_outputs.go
+++ b/internal/tools/registry/contract_read_outputs.go
@@ -86,13 +86,36 @@ func recallConflictSchema() map[string]any {
 
 func recallConflictPositionSchema() map[string]any {
 	return closedObject(
-		[]string{"position_id", "disposition", "relationship_ids", "owner_profile_ids", "result_evidence_ids"},
+		[]string{
+			"position_id", "disposition", "supporter_count", "support_group_count",
+			"authoritative_group_count", "supporters_truncated", "supporters",
+			"relationship_ids", "owner_profile_ids", "result_evidence_ids",
+		},
 		map[string]any{
-			"position_id":         schemaString("Conflict position ID.", 128),
-			"disposition":         schemaEnum([]string{"candidate", "preferred", "suppressed_current"}),
-			"relationship_ids":    stringArraySchema("Relationship ID in this position.", 20, 128),
-			"owner_profile_ids":   stringArraySchema("Owner profile ID in this position.", 20, 128),
-			"result_evidence_ids": stringArraySchema("Returned evidence ID for this position.", 50, 128),
+			"position_id":               schemaString("Conflict position ID.", 128),
+			"disposition":               schemaEnum([]string{"candidate", "preferred", "suppressed_current"}),
+			"supporter_count":           map[string]any{"type": "integer", "minimum": 0},
+			"support_group_count":       map[string]any{"type": "integer", "minimum": 0},
+			"authoritative_group_count": map[string]any{"type": "integer", "minimum": 0},
+			"supporters_truncated":      map[string]any{"type": "boolean"},
+			"supporters":                array(recallConflictSupporterSchema(), 0, 20),
+			"relationship_ids":          stringArraySchema("Relationship ID in this position.", 20, 128),
+			"owner_profile_ids":         stringArraySchema("Owner profile ID in this position.", 20, 128),
+			"result_evidence_ids":       stringArraySchema("Returned evidence ID for this position.", 50, 128),
+		},
+	)
+}
+
+func recallConflictSupporterSchema() map[string]any {
+	return closedObject(
+		[]string{"profile_id", "profile_name", "strongest_authority", "evidence_id", "accepted_at", "source_group_count"},
+		map[string]any{
+			"profile_id":          schemaString("Immutable supporter profile ID.", 128),
+			"profile_name":        schemaString("Current supporter profile display name.", 256),
+			"strongest_authority": schemaEnum([]string{"authoritative", "primary", "secondary", "inferred", "unknown"}),
+			"evidence_id":         schemaString("Representative supporting evidence ID.", 128),
+			"accepted_at":         map[string]any{"type": "string", "format": "date-time"},
+			"source_group_count":  map[string]any{"type": "integer", "minimum": 1},
 		},
 	)
 }

--- a/scripts/e2e-compose-conflict.sh
+++ b/scripts/e2e-compose-conflict.sh
@@ -28,13 +28,6 @@ const mount = JSON.stringify(`${rootDir}/tests/uat/conflict_openai_stub.mjs:/e2e
 const contents = `${marker}
 services:
   server:
-    environment:
-      AI_API_URL: http://conflict-provider:8081/v1
-      AI_API_KEY: dense-mem-conflict-e2e-key
-      AI_VERIFIER_API_URL: http://conflict-provider:8081/v1
-      AI_VERIFIER_API_KEY: dense-mem-conflict-e2e-key
-      AI_VERIFIER_MODEL: dense-mem-conflict-e2e-verifier
-      AI_VERIFIER_DISABLE_TEMPERATURE: "true"
     depends_on:
       conflict-provider:
         condition: service_healthy

--- a/scripts/e2e-compose-conflict.sh
+++ b/scripts/e2e-compose-conflict.sh
@@ -1,0 +1,91 @@
+E2E_CONFLICT_PROVIDER_PORT=""
+E2E_CONFLICT_REVIEW_DRIVER=""
+
+append_conflict_e2e_environment() {
+  if [[ "$E2E_SCENARIO" != "conflict" ]]; then
+    return
+  fi
+  printf '%s\n' \
+    "AI_API_URL=http://conflict-provider:8081/v1" \
+    "AI_API_KEY=dense-mem-conflict-e2e-key" \
+    "AI_API_EMBEDDING_MODEL=dense-mem-conflict-e2e-embedding" \
+    "AI_VERIFIER_API_URL=http://conflict-provider:8081/v1" \
+    "AI_VERIFIER_API_KEY=dense-mem-conflict-e2e-key" \
+    "AI_VERIFIER_MODEL=dense-mem-conflict-e2e-verifier" \
+    "AI_VERIFIER_DISABLE_TEMPERATURE=true" >> "$E2E_ENV_FILE"
+}
+
+prepare_conflict_provider_files() {
+  if [[ "$E2E_SCENARIO" != "conflict" ]]; then
+    return
+  fi
+  E2E_COMPOSE_OVERLAY_FILE="${ROOT_DIR}/docker-compose.conflict-e2e-${E2E_FILE_ID}.yml"
+  node - "$E2E_COMPOSE_OVERLAY_FILE" "$ROOT_DIR" "$E2E_CONFLICT_PROVIDER_PORT" "$E2E_MARKER" <<'NODE'
+const fs = require("node:fs");
+
+const [destination, rootDir, providerPort, marker] = process.argv.slice(2);
+const mount = JSON.stringify(`${rootDir}/tests/uat/conflict_openai_stub.mjs:/e2e/conflict_openai_stub.mjs:ro`);
+const contents = `${marker}
+services:
+  server:
+    environment:
+      AI_API_URL: http://conflict-provider:8081/v1
+      AI_API_KEY: dense-mem-conflict-e2e-key
+      AI_VERIFIER_API_URL: http://conflict-provider:8081/v1
+      AI_VERIFIER_API_KEY: dense-mem-conflict-e2e-key
+      AI_VERIFIER_MODEL: dense-mem-conflict-e2e-verifier
+      AI_VERIFIER_DISABLE_TEMPERATURE: "true"
+    depends_on:
+      conflict-provider:
+        condition: service_healthy
+  conflict-provider:
+    image: node:24-alpine
+    working_dir: /e2e
+    command: ["node", "/e2e/conflict_openai_stub.mjs"]
+    volumes:
+      - ${mount}
+    ports:
+      - "127.0.0.1:${providerPort}:8081"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8081/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+`;
+fs.writeFileSync(destination, contents);
+NODE
+}
+
+prepare_conflict_review_driver() {
+  if [[ "$E2E_SCENARIO" != "conflict" ]]; then
+    return
+  fi
+  E2E_CONFLICT_REVIEW_DRIVER="${TEMP_DIR}/conflict-review-driver"
+  go build -o "$E2E_CONFLICT_REVIEW_DRIVER" ./tests/uat/conflict_review_driver
+}
+
+run_conflict_e2e() {
+  local team_id="$1"
+  local runtime_postgres_user
+  local runtime_postgres_password
+  local runtime_postgres_database
+
+  echo "Running deterministic compose-backed MCP conflict e2e."
+  runtime_postgres_user="$(compose_server_environment_value POSTGRES_USER)"
+  runtime_postgres_password="$(compose_server_environment_value POSTGRES_PASSWORD)"
+  runtime_postgres_database="$(compose_server_environment_value POSTGRES_DB)"
+  DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
+  DENSE_MEM_USER_URL="$USER_URL" \
+  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
+  DENSE_MEM_E2E_TEAM_ID="$team_id" \
+  DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
+  DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
+  DENSE_MEM_E2E_CONFLICT_REVIEW_DRIVER="$E2E_CONFLICT_REVIEW_DRIVER" \
+  DENSE_MEM_E2E_CONFLICT_PROVIDER_URL="http://127.0.0.1:${E2E_CONFLICT_PROVIDER_PORT}/v1" \
+  DENSE_MEM_E2E_POSTGRES_HOST="127.0.0.1" \
+  DENSE_MEM_E2E_POSTGRES_PORT="$POSTGRES_HOST_PORT" \
+  DENSE_MEM_E2E_POSTGRES_USER="$runtime_postgres_user" \
+  DENSE_MEM_E2E_POSTGRES_PASSWORD="$runtime_postgres_password" \
+  DENSE_MEM_E2E_POSTGRES_DB="$runtime_postgres_database" \
+  node "$ROOT_DIR/tests/uat/conflict_mcp_e2e.mjs"
+}

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -23,6 +23,8 @@ E2E_FILE_ID=""
 E2E_SERVER_IMAGE=""
 E2E_PLAYWRIGHT_CONTAINER=""
 
+source "${ROOT_DIR}/scripts/e2e-compose-conflict.sh"
+
 sanitize_project_name() {
   local raw="$1"
   local sanitized
@@ -289,6 +291,7 @@ prepare_e2e_environment() {
   printf '%s\n' \
     "CONFLICT_REVIEW_START_TIME_LOCAL=00:00" \
     "CONFLICT_REVIEW_JITTER_SECONDS=0" >> "$E2E_ENV_FILE"
+  append_conflict_e2e_environment
   ROOT_ENV_FILE="$E2E_ENV_FILE"
 }
 
@@ -704,8 +707,8 @@ if [[ "$E2E_MODE" != "standard" && "$E2E_MODE" != "entra_scim" ]]; then
   exit 1
 fi
 
-if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "all" ]]; then
-  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, submission_status, security_intake, submission_assessment, semantic_holds, community, or all." >&2
+if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "conflict" && "$E2E_SCENARIO" != "all" ]]; then
+  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, submission_status, security_intake, submission_assessment, semantic_holds, community, conflict, or all." >&2
   exit 1
 fi
 
@@ -719,7 +722,7 @@ if [[ "$E2E_SCENARIO" == "all" ]]; then
     echo "DENSE_MEM_E2E_SCENARIO=all requires DENSE_MEM_E2E_MODE=standard." >&2
     exit 1
   fi
-  for scenario in mcp_boundaries submission_status security_intake submission_assessment semantic_holds community full; do
+  for scenario in mcp_boundaries submission_status security_intake submission_assessment semantic_holds community conflict full; do
     echo "Running compose e2e scenario ${scenario} as part of all."
     DENSE_MEM_E2E_SCENARIO="$scenario" \
     DENSE_MEM_E2E_RUN_ID="${DENSE_MEM_E2E_RUN_ID:-all}-$(printf '%s' "$scenario" | tr '[:upper:]' '[:lower:]')" \
@@ -754,7 +757,8 @@ read -r \
   generated_neo4j_http_port \
   generated_neo4j_bolt_port \
   generated_redis_port \
-  generated_entra_port < <(pick_ports 8)
+  generated_entra_port \
+  generated_conflict_provider_port < <(pick_ports 9)
 DENSE_MEM_PORT="${DENSE_MEM_E2E_API_PORT:-$generated_api_port}"
 CONTROL_PORTAL_PORT="${DENSE_MEM_E2E_CONTROL_PORT:-$generated_control_port}"
 PROMETHEUS_PORT="${DENSE_MEM_E2E_PROMETHEUS_PORT:-$generated_prometheus_port}"
@@ -763,6 +767,7 @@ NEO4J_HTTP_HOST_PORT="${DENSE_MEM_E2E_NEO4J_HTTP_PORT:-$generated_neo4j_http_por
 NEO4J_BOLT_HOST_PORT="${DENSE_MEM_E2E_NEO4J_BOLT_PORT:-$generated_neo4j_bolt_port}"
 REDIS_PORT="${DENSE_MEM_E2E_REDIS_PORT:-$generated_redis_port}"
 E2E_ENTRA_PORT="${DENSE_MEM_E2E_ENTRA_PORT:-$generated_entra_port}"
+E2E_CONFLICT_PROVIDER_PORT="${DENSE_MEM_E2E_CONFLICT_PROVIDER_PORT:-$generated_conflict_provider_port}"
 PROMETHEUS_CONTAINER_NAME="${DENSE_MEM_E2E_PROMETHEUS_CONTAINER_NAME:-${COMPOSE_PROJECT_NAME}-prometheus}"
 CONTROL_URL="${DENSE_MEM_CONTROL_URL:-http://127.0.0.1:${CONTROL_PORTAL_PORT}}"
 USER_URL="${DENSE_MEM_USER_URL:-http://127.0.0.1:${DENSE_MEM_PORT}}"
@@ -825,10 +830,13 @@ else
     -count=1
 fi
 
+prepare_conflict_review_driver
+
 prepare_e2e_compose_files
 prepare_postgres_e2e_overlay
 prepare_e2e_prometheus_files
 prepare_entra_mock_files
+prepare_conflict_provider_files
 
 if ! compose config -q; then
   echo "Generated E2E compose configuration is invalid." >&2
@@ -959,6 +967,10 @@ if [[ "$E2E_SCENARIO" == "community" ]]; then
   echo "Running compose-backed community recall e2e with the configured live verifier."; export DENSE_MEM_CONTROL_URL="$CONTROL_URL" DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" DENSE_MEM_E2E_TEAM_ID="$team_id" DENSE_MEM_E2E_API_KEY="$api_key" DENSE_MEM_PROMETHEUS_URL="$PROMETHEUS_URL" DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE"; node "$ROOT_DIR/tests/uat/community_recall_mcp_e2e.mjs"
   if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then echo "Skipping compose-backed community Playwright tests by DENSE_MEM_E2E_SKIP_PLAYWRIGHT."; else echo "Running compose-backed community Playwright tests."; export DENSE_MEM_E2E_TEAM_NAME="E2E Team"; run_compose_playwright_tests community; fi; exit 0
 fi
+if [[ "$E2E_SCENARIO" == "conflict" ]]; then
+  run_conflict_e2e "$team_id"
+  exit 0
+fi
 echo "Running compose-backed scheduled team dreaming e2e."
 dream_json="$(DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
 DENSE_MEM_USER_URL="$USER_URL" \
@@ -985,15 +997,3 @@ else
   echo "Running compose-backed Playwright tests."
   run_compose_playwright_tests
 fi
-
-echo "Running compose-backed MCP conflict e2e."
-echo "Seeding isolated conflict e2e team through the private control API."
-create_control_team "Conflict E2E Team" "compose conflict e2e seed"
-conflict_team_id="$CREATED_TEAM_ID"
-DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
-DENSE_MEM_USER_URL="$USER_URL" \
-DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
-DENSE_MEM_E2E_TEAM_ID="$conflict_team_id" \
-DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
-DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
-node "$ROOT_DIR/tests/uat/conflict_mcp_e2e.mjs"

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -1,185 +1,410 @@
 #!/usr/bin/env node
+
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const userUrl = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
-const controlUrl = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
 const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
-const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+const seededTeamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
 const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
 const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
-const placementTimeoutSeconds = positiveIntEnv("DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS", 720, 30, 1800);
-const conflictReviewTimeoutSeconds = positiveIntEnv("DENSE_MEM_E2E_CONFLICT_REVIEW_TIMEOUT_SECONDS", 240, 60, 600);
+const reviewDriver = requiredEnv("DENSE_MEM_E2E_CONFLICT_REVIEW_DRIVER");
+const placementTimeoutSeconds = positiveIntEnv("DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS", 180, 30, 900);
+const runID = `conflict-e2e-${Date.now()}`;
 
 let rpcID = 0;
 
-const runID = `conflict-e2e-${Date.now()}`;
-const olderEffectiveAt = "2026-07-20T00:00:00Z";
-const newerEffectiveAt = "2026-07-22T00:00:00Z";
-const primaryProjectName = `ConflictE2E ${runID} project`;
-const postgresName = `ConflictE2E ${runID} PostgreSQL`;
-const graphDBName = `ConflictE2E ${runID} GraphDB`;
-
-const profileA = await createProfile("Conflict E2E A");
-const profileB = await createProfile("Conflict E2E B");
-const profileC = await createProfile("Conflict E2E C");
-
-const first = await rememberAndWait(profileA.apiKey, {
-  idempotencyKey: `${runID}:a`,
-  evidence: `ConflictE2E ${runID}: Effective ${newerEffectiveAt}, 🚀 ${primaryProjectName} primary database is ${postgresName} according to profile A.`,
-  sourceGroup: `${runID}:source:a`,
-  validFrom: newerEffectiveAt,
-  subject: { ref: "project", name: primaryProjectName, kind: "project" },
-  object: { ref: "postgres", name: postgresName, kind: "product" },
-  relationshipID: "rel:primary-db-a",
-});
-const firstTrace = await mcpTool(profileA.apiKey, "trace_memory", {
-  relationship_id: first.relationshipID,
-  include_evidence_content: true,
-});
-const subjectEntityID = stringAt(firstTrace, ["relationship", "subject_entity_id"]);
-const postgresEntityID = stringAt(firstTrace, ["relationship", "object_entity_id"]);
-if (!subjectEntityID || !postgresEntityID) {
-  throw new Error(`trace did not return canonical entity IDs: ${JSON.stringify(firstTrace)}`);
-}
-
-const second = await rememberAndWait(profileB.apiKey, {
-  idempotencyKey: `${runID}:b`,
-  evidence: `ConflictE2E ${runID}: Effective ${olderEffectiveAt}, ${primaryProjectName} primary database is ${graphDBName} according to profile B.`,
-  sourceGroup: `${runID}:source:b`,
-  validFrom: olderEffectiveAt,
-  subject: { ref: "project", name: primaryProjectName, kind: "project", knownEntityID: subjectEntityID },
-  object: { ref: "graphdb", name: graphDBName, kind: "product" },
-  relationshipID: "rel:primary-db-b",
-});
-
-const openConflict = await waitForRelationshipConflict(profileB.apiKey, second.relationshipID, "open");
-const conflictID = String(openConflict.conflict_id);
-const conflictVersion = Number(openConflict.version);
-if (!conflictID || !Number.isInteger(conflictVersion) || conflictVersion < 1) {
-  throw new Error(`invalid open conflict summary: ${JSON.stringify(openConflict)}`);
-}
-
-await rememberAndWait(profileC.apiKey, {
-  idempotencyKey: `${runID}:c`,
-  evidence: `ConflictE2E ${runID}: Effective ${newerEffectiveAt}, ${primaryProjectName} primary database is ${postgresName} according to profile C.`,
-  sourceGroup: `${runID}:source:c`,
-  validFrom: newerEffectiveAt,
-  subject: { ref: "project", name: primaryProjectName, kind: "project", knownEntityID: subjectEntityID },
-  object: { ref: "postgres", name: postgresName, kind: "product", knownEntityID: postgresEntityID },
-  relationshipID: "rel:primary-db-c",
-  conflictContext: { conflict_id: conflictID, expected_version: conflictVersion },
-});
-
-const review = await runAutomaticConflictReview(conflictID);
-if (review.status !== "resolved") {
-  throw new Error(`automatic conflict reviewer did not resolve ${conflictID}: ${JSON.stringify(review)}`);
-}
-
-const resolvedConflict = await waitForRelationshipConflict(profileB.apiKey, second.relationshipID, "resolved");
-if (resolvedConflict.conflict_id !== conflictID || resolvedConflict.status !== "resolved") {
-  throw new Error(`resolved recall returned wrong conflict: ${JSON.stringify(resolvedConflict)}`);
-}
-
-const loserTrace = await mcpTool(profileB.apiKey, "trace_memory", {
-  relationship_id: second.relationshipID,
-  include_transitions: true,
-  include_evidence_content: true,
-});
-if (stringAt(loserTrace, ["relationship", "relationship_status"]) !== "superseded") {
-  throw new Error(`losing relationship was not superseded: ${JSON.stringify(loserTrace.relationship)}`);
-}
-if (!Array.isArray(loserTrace.conflicts) || !loserTrace.conflicts.some((item) => item.conflict_id === conflictID && item.status === "resolved")) {
-  throw new Error(`trace did not include resolved conflict: ${JSON.stringify(loserTrace.conflicts)}`);
-}
-
-const overdueResolution = await resolveOverdueConflictThroughVerifier();
+const early = await earlyQuorumScenario(seededTeamID);
+await assertRemovedPlacementTools(early.profileA.apiKey);
+const authoritative = await dueUniqueAuthoritativeScenario();
+const majority = await dueMajorityScenario();
+const selected = await aiSelectionScenario();
+const abstained = await aiAbstentionScenario();
+const failedDays = await fiveFailedDaysScenario();
+const provenance = await provenanceAndIsolationScenario();
 
 console.log(JSON.stringify({
   status: "ok",
   run_id: runID,
-  conflict_id: conflictID,
-  first_relationship_id: first.relationshipID,
-  losing_relationship_id: second.relationshipID,
-  overdue_conflict_id: overdueResolution.conflictID,
-  overdue_resolution_method: overdueResolution.method,
+  contract_version: "dense-mem.v2.4",
+  early_quorum: early.summary,
+  due_unique_authoritative: authoritative,
+  due_majority: majority,
+  ai_selection: selected,
+  ai_abstention_last_write_wins: abstained,
+  five_failed_days_last_write_wins: failedDays,
+  supporter_provenance: provenance,
+  removed_placement_tools_absent: true,
 }, null, 2));
 
-async function createProfile(name) {
-  const response = await httpJSON(`${controlUrl}/control/api/teams/${teamID}/profiles`, {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${controlToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      name,
-      role: "member",
-      scopes: ["read", "write"],
-      rate_limit: 300,
-    }),
+async function earlyQuorumScenario(teamID) {
+  const fixture = await createConflictFixture("early-quorum", {
+    teamID,
+    authorityA: "primary",
+    authorityB: "secondary",
   });
-  const apiKey = stringAt(response, ["data", "api_key"]);
-  const profileID = stringAt(response, ["data", "key", "id"]);
-  if (!apiKey || !profileID) {
-    throw new Error(`profile creation response missing api key/profile id (api_key_present=${Boolean(apiKey)}, profile_id_present=${Boolean(profileID)})`);
+  for (let index = 2; index <= 4; index += 1) {
+    await submitPositionSupport(fixture, fixture.profileA, {
+      label: `early-quorum-a-${index}`,
+      sourceGroup: `${runID}:early-quorum:independent:${index}`,
+      authority: "primary",
+    });
   }
-  return { apiKey, profileID };
+  const open = await currentConflict(fixture.profileA.apiKey, fixture.relationshipA, "open");
+  const winner = positionForRelationship(open, fixture.relationshipA);
+  assert(winner.support_group_count === 4, `early quorum winner group count = ${winner.support_group_count}`);
+  const result = runReview(fixture, offsetTime(open.review_due_at, -60_000));
+  assertReview(result, "resolve", "early_quorum", fixture.positionAID, "");
+  const state = conflictState(fixture.teamID, fixture.conflictID);
+  assert(state.status === "resolved" && state.resolution_reason === "early_quorum_support", `early quorum lineage is invalid: ${JSON.stringify(state)}`);
+  return {
+    profileA: fixture.profileA,
+    summary: { conflict_id: fixture.conflictID, preferred_position_id: fixture.positionAID, stage: result.stage },
+  };
 }
 
-async function rememberAndWait(apiKey, input) {
-  const evidence = input.evidence;
-  const result = await mcpTool(apiKey, "remember", {
+async function dueUniqueAuthoritativeScenario() {
+  const fixture = await createConflictFixture("due-authoritative", {
+    authorityA: "authoritative",
+    authorityB: "primary",
+    validFromA: "2026-08-01T00:00:00Z",
+    validFromB: "2026-08-01T00:00:00Z",
+  });
+  const result = runReview(fixture, offsetTime(fixture.reviewDueAt, 1_000));
+  assertReview(result, "resolve", "due_unique_authoritative", fixture.positionAID, "");
+  const state = conflictState(fixture.teamID, fixture.conflictID);
+  assert(state.status === "resolved" && state.resolution_reason === "unique_authoritative_source", `authoritative lineage is invalid: ${JSON.stringify(state)}`);
+  return { conflict_id: fixture.conflictID, preferred_position_id: fixture.positionAID, stage: result.stage };
+}
+
+async function dueMajorityScenario() {
+  const fixture = await createConflictFixture("due-majority", {
+    authorityA: "primary",
+    authorityB: "secondary",
+  });
+  await submitPositionSupport(fixture, fixture.profileA, {
+    label: "due-majority-a-2",
+    sourceGroup: `${runID}:due-majority:independent:2`,
+    authority: "primary",
+  });
+  const open = await currentConflict(fixture.profileA.apiKey, fixture.relationshipA, "open");
+  const winner = positionForRelationship(open, fixture.relationshipA);
+  assert(winner.support_group_count === 2, `due majority winner group count = ${winner.support_group_count}`);
+  const result = runReview(fixture, offsetTime(open.review_due_at, 1_000));
+  assertReview(result, "resolve", "due_majority", fixture.positionAID, "");
+  const state = conflictState(fixture.teamID, fixture.conflictID);
+  assert(state.status === "resolved" && state.resolution_reason === "due_majority_support", `majority lineage is invalid: ${JSON.stringify(state)}`);
+  return { conflict_id: fixture.conflictID, preferred_position_id: fixture.positionAID, stage: result.stage };
+}
+
+async function aiSelectionScenario() {
+  const fixture = await createConflictFixture("ai-selection", {
+    authorityA: "primary",
+    authorityB: "primary",
+    markerA: "[conflict-ai-select-winner]",
+  });
+  const result = runReview(fixture, offsetTime(fixture.reviewDueAt, 1_000));
+  assertReview(result, "resolve", "overdue_ai", fixture.positionAID, "ai");
+  const attempts = assessmentAttempts(fixture.teamID, fixture.conflictID);
+  assert(attempts.length === 1 && attempts[0].status === "selected" && attempts[0].selected_position_id === fixture.positionAID, `AI selection attempt lineage is invalid: ${JSON.stringify(attempts)}`);
+  const plan = latestResolutionPlan(fixture.teamID, fixture.conflictID);
+  assert(plan.method === "ai" && plan.status === "applied" && plan.preferred_position_id === fixture.positionAID, `AI selection plan is invalid: ${JSON.stringify(plan)}`);
+  assert(conflictDerivationCount(fixture.teamID, fixture.conflictID) >= 1, "AI selection did not preserve retraction derivation lineage");
+  return { conflict_id: fixture.conflictID, preferred_position_id: fixture.positionAID, method: plan.method };
+}
+
+async function aiAbstentionScenario() {
+  const fixture = await createConflictFixture("ai-abstention", {
+    authorityA: "authoritative",
+    authorityB: "secondary",
+    markerA: "[conflict-ai-abstain]",
+  });
+  const accepted = positionAcceptedTimes(fixture.teamID, fixture.conflictID, fixture.positionAID, fixture.positionBID);
+  assert(Date.parse(accepted.position_b) > Date.parse(accepted.position_a), `abstention fixture does not make the lower-authority position newer: ${JSON.stringify(accepted)}`);
+  const result = runReview(fixture, offsetTime(fixture.reviewDueAt, 1_000));
+  assertReview(result, "resolve", "overdue_last_write_wins", fixture.positionAID, "last_write_wins");
+  const attempts = assessmentAttempts(fixture.teamID, fixture.conflictID);
+  assert(attempts.length === 1 && attempts[0].status === "abstained", `abstention attempt lineage is invalid: ${JSON.stringify(attempts)}`);
+  const plan = latestResolutionPlan(fixture.teamID, fixture.conflictID);
+  assert(plan.method === "last_write_wins" && plan.status === "applied" && plan.preferred_position_id === fixture.positionAID, `abstention fallback plan is invalid: ${JSON.stringify(plan)}`);
+  return { conflict_id: fixture.conflictID, preferred_position_id: fixture.positionAID, method: plan.method, authority_preceded_recency: true };
+}
+
+async function fiveFailedDaysScenario() {
+  const fixture = await createConflictFixture("five-failed-days", {
+    authorityA: "primary",
+    authorityB: "secondary",
+    markerA: "[conflict-ai-fail]",
+  });
+  const firstReviewAt = Date.parse(fixture.reviewDueAt) + 1_000;
+  let finalResult;
+  for (let day = 0; day < 5; day += 1) {
+    finalResult = runReview(fixture, new Date(firstReviewAt + day * 25 * 60 * 60 * 1_000).toISOString());
+    const attempts = assessmentAttempts(fixture.teamID, fixture.conflictID);
+    assert(attempts.length === day + 1 && attempts.every((attempt) => attempt.status === "failed" && attempt.failure_class), `failed assessment day ${day + 1} lineage is invalid: ${JSON.stringify(attempts)}`);
+    const state = conflictState(fixture.teamID, fixture.conflictID);
+    if (day < 4) {
+      assert(finalResult.outcome === "overdue" && finalResult.stage === "overdue_assessment_failed", `failed assessment day ${day + 1} resolved too early: ${JSON.stringify(finalResult)}`);
+      assert(state.status === "overdue" && Object.keys(latestResolutionPlan(fixture.teamID, fixture.conflictID)).length === 0, `failed assessment day ${day + 1} changed terminal state: ${JSON.stringify(state)}`);
+    }
+  }
+  assertReview(finalResult, "resolve", "overdue_last_write_wins", fixture.positionAID, "last_write_wins");
+  const plan = latestResolutionPlan(fixture.teamID, fixture.conflictID);
+  assert(plan.method === "last_write_wins" && plan.status === "applied", `fifth-day fallback plan is invalid: ${JSON.stringify(plan)}`);
+  return { conflict_id: fixture.conflictID, failed_assessment_days: 5, preferred_position_id: fixture.positionAID, method: plan.method };
+}
+
+async function provenanceAndIsolationScenario() {
+  const fixture = await createConflictFixture("supporter-provenance", {
+    authorityA: "authoritative",
+    authorityB: "secondary",
+  });
+  const profileC = await createProfile(fixture.teamID, `${runID} provenance C`);
+  await submitPositionSupport(fixture, profileC, {
+    label: "provenance-copied-c",
+    sourceGroup: fixture.sourceGroupA,
+    authority: "primary",
+  });
+  for (let index = 1; index <= 19; index += 1) {
+    const profile = await createProfile(fixture.teamID, `${runID} provenance copied ${index}`);
+    await submitPositionSupport(fixture, profile, {
+      label: `provenance-copied-${index}`,
+      sourceGroup: fixture.sourceGroupA,
+      authority: "primary",
+    });
+  }
+
+  const beforeIndependent = await currentConflict(profileC.apiKey, fixture.relationshipA, "open");
+  const copiedPosition = positionForRelationship(beforeIndependent, fixture.relationshipA);
+  assert(copiedPosition.supporter_count === 21, `copied supporter count = ${copiedPosition.supporter_count}`);
+  assert(copiedPosition.support_group_count === 1, `copied source group increased independent weight: ${copiedPosition.support_group_count}`);
+  const staleVersion = Number(beforeIndependent.version);
+  await submitPositionSupport(fixture, profileC, {
+    label: "provenance-independent-c",
+    sourceGroup: `${runID}:provenance:independent:c`,
+    authority: "primary",
+    conflictContext: { conflict_id: fixture.conflictID, expected_version: staleVersion },
+  });
+
+  const afterIndependent = await currentConflict(profileC.apiKey, fixture.relationshipA, "open");
+  const independentPosition = positionForRelationship(afterIndependent, fixture.relationshipA);
+  assert(independentPosition.supporter_count === 21 && independentPosition.support_group_count === 2, `independent support counts are invalid: ${JSON.stringify(independentPosition)}`);
+  assert(Number(afterIndependent.version) > staleVersion, "fresh conflict_context support did not advance the conflict version");
+
+  const semanticBeforeStale = conflictSemanticSnapshot(fixture.teamID, fixture.conflictID);
+  const stale = await submitPositionSupport(fixture, profileC, {
+    label: "provenance-stale-c",
+    sourceGroup: `${runID}:provenance:stale:c`,
+    authority: "primary",
+    conflictContext: { conflict_id: fixture.conflictID, expected_version: staleVersion },
+    expectedState: "rejected",
+  });
+  assert(stale.status.processing_state === "rejected", `stale conflict submission was not rejected: ${JSON.stringify(stale.status)}`);
+  const semanticAfterStale = conflictSemanticSnapshot(fixture.teamID, fixture.conflictID);
+  assert(stableJSON(semanticAfterStale) === stableJSON(semanticBeforeStale), `stale conflict submission changed semantic state: before=${JSON.stringify(semanticBeforeStale)} after=${JSON.stringify(semanticAfterStale)}`);
+
+  const renamedA = `${runID} provenance A renamed`;
+  await renameProfile(fixture.teamID, fixture.profileA.profileID, renamedA);
+  const traceA = await mcpSuccess(profileC.apiKey, "trace_memory", {
+    relationship_id: fixture.relationshipA,
+    include_transitions: true,
+  });
+  const traceB = await mcpSuccess(profileC.apiKey, "trace_memory", { relationship_id: fixture.relationshipB });
+  assert(stringAt(traceA, ["relationship", "relationship_id"]) === fixture.relationshipA, "same-team profile C could not trace profile A");
+  assert(stringAt(traceB, ["relationship", "relationship_id"]) === fixture.relationshipB, "same-team profile C could not trace profile B");
+  const recall = await waitForConflictRecall(profileC.apiKey, fixture.subjectName, fixture.conflictID);
+  const traceConflict = conflictByID(traceA.conflicts, fixture.conflictID);
+  const recallConflict = conflictByID(recall.conflicts, fixture.conflictID);
+  const tracePosition = positionByID(traceConflict, fixture.positionAID);
+  const recallPosition = positionByID(recallConflict, fixture.positionAID);
+  assert(stableJSON(provenanceFields(tracePosition)) === stableJSON(provenanceFields(recallPosition)), `recall/trace supporter provenance differs: trace=${JSON.stringify(tracePosition)} recall=${JSON.stringify(recallPosition)}`);
+  assert(tracePosition.supporter_count === 21 && tracePosition.supporters.length === 20 && tracePosition.supporters_truncated === true, `supporter bound is invalid: ${JSON.stringify(tracePosition)}`);
+  const supporterA = tracePosition.supporters.find((supporter) => supporter.profile_id === fixture.profileA.profileID);
+  const supporterC = tracePosition.supporters.find((supporter) => supporter.profile_id === profileC.profileID);
+  assert(supporterA?.profile_name === renamedA && supporterA.strongest_authority === "authoritative", `current profile rename was not hydrated: ${JSON.stringify(supporterA)}`);
+  assert(supporterC?.source_group_count === 2, `one profile's independent source groups were not projected: ${JSON.stringify(supporterC)}`);
+
+  const nonOwnerRetraction = await mcpRaw(profileC.apiKey, "retract_evidence", {
+    evidence_ids: [fixture.evidenceA],
+    reason: "Conflict e2e verifies owner-only mutation.",
+    idempotency_key: `${runID}:provenance:non-owner-retract`,
+  });
+  assert(nonOwnerRetraction.error && nonOwnerRetraction.result === undefined && !JSON.stringify(nonOwnerRetraction).includes(fixture.evidenceA), "same-team non-owner retraction was allowed or leaked the evidence ID");
+
+  const foreignTeamID = await createTeam("foreign-isolation");
+  const foreign = await createProfile(foreignTeamID, `${runID} foreign reader`);
+  const foreignRecall = await mcpSuccess(foreign.apiKey, "recall_memory", { query: fixture.subjectName, limit: 10 });
+  assert(!(foreignRecall.conflicts ?? []).some((conflict) => conflict.conflict_id === fixture.conflictID), "separate-team recall disclosed the conflict");
+  const foreignTrace = await mcpRaw(foreign.apiKey, "trace_memory", { relationship_id: fixture.relationshipA });
+  assert(foreignTrace.error && foreignTrace.result === undefined && !JSON.stringify(foreignTrace).includes(fixture.conflictID), "separate-team trace disclosed the conflict");
+
+  const ownerRetraction = await mcpSuccess(fixture.profileA.apiKey, "retract_evidence", {
+    evidence_ids: [fixture.evidenceA],
+    reason: "Conflict e2e owner mutation control.",
+    idempotency_key: `${runID}:provenance:owner-retract`,
+  });
+  assert(ownerRetraction.processing_state === "completed", `owner retraction did not complete: ${JSON.stringify(ownerRetraction)}`);
+
+  return {
+    conflict_id: fixture.conflictID,
+    supporter_count: tracePosition.supporter_count,
+    returned_supporters: tracePosition.supporters.length,
+    supporters_truncated: tracePosition.supporters_truncated,
+    support_group_count: tracePosition.support_group_count,
+    recall_trace_parity: true,
+    current_profile_name_hydrated: true,
+    fresh_conflict_context_applied: true,
+    stale_version_rejected_without_semantic_change: true,
+    same_team_read_visibility: true,
+    owner_only_mutation: true,
+    separate_team_isolation: true,
+  };
+}
+
+async function createConflictFixture(label, options = {}) {
+  const teamID = options.teamID ?? await createTeam(label);
+  const profileA = await createProfile(teamID, `${runID} ${label} A`);
+  const profileB = await createProfile(teamID, `${runID} ${label} B`);
+  const subjectName = `${runID} ${label} project`;
+  const objectAName = `${runID} ${label} PostgreSQL`;
+  const objectBName = `${runID} ${label} GraphDB`;
+  const sourceGroupA = `${runID}:${label}:source:a`;
+  const first = await submitRelationship(profileA.apiKey, {
+    label: `${label}-a`,
+    subjectName,
+    objectName: objectAName,
+    sourceGroup: sourceGroupA,
+    authority: options.authorityA ?? "primary",
+    validFrom: options.validFromA,
+    marker: options.markerA,
+  });
+  const firstTrace = await mcpSuccess(profileA.apiKey, "trace_memory", {
+    relationship_id: first.relationshipID,
+    include_evidence_content: true,
+  });
+  const subjectEntityID = stringAt(firstTrace, ["relationship", "subject_entity_id"]);
+  const objectAEntityID = stringAt(firstTrace, ["relationship", "object_entity_id"]);
+  assert(subjectEntityID && objectAEntityID, `first ${label} trace did not return canonical entity IDs`);
+
+  const second = await submitRelationship(profileB.apiKey, {
+    label: `${label}-b`,
+    subjectName,
+    objectName: objectBName,
+    subjectEntityID,
+    sourceGroup: `${runID}:${label}:source:b`,
+    authority: options.authorityB ?? "primary",
+    validFrom: options.validFromB,
+    marker: options.markerB,
+  });
+  const conflict = await currentConflict(profileB.apiKey, second.relationshipID, "open");
+  const positionA = positionForRelationship(conflict, first.relationshipID);
+  const positionB = positionForRelationship(conflict, second.relationshipID);
+  return {
+    label,
+    teamID,
+    profileA,
+    profileB,
+    subjectName,
+    objectAName,
+    objectBName,
+    subjectEntityID,
+    objectAEntityID,
+    sourceGroupA,
+    relationshipA: first.relationshipID,
+    relationshipB: second.relationshipID,
+    evidenceA: first.evidenceID,
+    evidenceB: second.evidenceID,
+    conflictID: String(conflict.conflict_id),
+    positionAID: String(positionA.position_id),
+    positionBID: String(positionB.position_id),
+    reviewDueAt: String(conflict.review_due_at),
+  };
+}
+
+async function submitPositionSupport(fixture, profile, options) {
+  return submitRelationship(profile.apiKey, {
+    label: options.label,
+    subjectName: fixture.subjectName,
+    objectName: fixture.objectAName,
+    subjectEntityID: fixture.subjectEntityID,
+    objectEntityID: fixture.objectAEntityID,
+    sourceGroup: options.sourceGroup,
+    authority: options.authority,
+    conflictContext: options.conflictContext,
+    expectedState: options.expectedState,
+  });
+}
+
+async function submitRelationship(apiKey, input) {
+  const evidence = relationshipEvidence(input);
+  const receipt = await mcpSuccess(apiKey, "remember", {
+    idempotency_key: `${runID}:${input.label}`,
     evidence: [{
       content: evidence,
       source_type: "document",
       source: input.sourceGroup,
       source_group: input.sourceGroup,
-      idempotency_key: input.idempotencyKey,
-      ...(input.authority ? { authority: input.authority } : {}),
+      authority: input.authority,
+      idempotency_key: `${runID}:${input.label}:evidence`,
     }],
     relationships: [relationshipHint(input, evidence)],
   });
-  const submissionID = String(result.submission_id ?? "");
-  if (!submissionID) {
-    throw new Error(`remember did not return submission_id: ${JSON.stringify(result)}`);
+  const submissionID = String(receipt.submission_id ?? "");
+  assert(submissionID && receipt.status_tool === "get_submission_status", `remember receipt is invalid: ${JSON.stringify(receipt)}`);
+  const status = await waitForSubmission(apiKey, submissionID);
+  const expectedState = input.expectedState ?? "completed";
+  assert(status.processing_state === expectedState, `submission ${input.label} state = ${status.processing_state}, want ${expectedState}: ${JSON.stringify(status)}`);
+  const evidenceID = String(status.evidence?.[0]?.evidence_id ?? "");
+  assert(evidenceID, `submission ${input.label} did not return evidence lineage`);
+  if (expectedState !== "completed") {
+    return { submissionID, evidenceID, status };
   }
-  return await waitForPlacement(apiKey, submissionID, input.relationshipID);
+  const relationshipID = postgresQuery(`
+    SELECT observation.relationship_id::text
+    FROM relationship_observations AS observation
+    WHERE observation.team_id = ${sqlLiteral(statusTeamID(submissionID))}::uuid
+      AND observation.ingest_id = ${sqlLiteral(submissionID)}::uuid
+      AND observation.relationship_id IS NOT NULL
+    ORDER BY observation.created_at, observation.observation_id
+    LIMIT 1
+  `, { allowAnyTeam: true });
+  assert(relationshipID, `completed submission ${input.label} did not create a relationship observation`);
+  return { submissionID, relationshipID, evidenceID, status };
+}
+
+function relationshipEvidence(input) {
+  const effective = input.validFrom ? `Effective ${input.validFrom}, ` : "";
+  const marker = input.marker ? ` ${input.marker}` : "";
+  return `${effective}${input.subjectName} primary database is ${input.objectName}.${marker}`;
 }
 
 function relationshipHint(input, evidence) {
   const predicateSurface = "primary database";
-  const subjectStart = evidence.indexOf(input.subject.name);
+  const subjectStart = evidence.indexOf(input.subjectName);
   const predicateStart = evidence.indexOf(predicateSurface, subjectStart);
-  const objectStart = evidence.indexOf(input.object.name, predicateStart);
-  if (subjectStart < 0 || predicateStart < 0 || objectStart < 0) {
-    throw new Error(`could not derive relationship spans for ${input.relationshipID}`);
-  }
-  const codePointOffset = (utf16Offset) => Array.from(evidence.slice(0, utf16Offset)).length;
-  const subjectEnd = subjectStart + input.subject.name.length;
-  const predicateEnd = predicateStart + predicateSurface.length;
-  const objectEnd = objectStart + input.object.name.length;
+  const objectStart = evidence.indexOf(input.objectName, predicateStart);
+  assert(subjectStart >= 0 && predicateStart >= 0 && objectStart >= 0, `could not derive spans for ${input.label}`);
+  const runeOffset = (offset) => Array.from(evidence.slice(0, offset)).length;
   return {
-    ref: input.relationshipID,
+    ref: `${input.label}:relationship`,
     subject: {
-      name: input.subject.name,
-      entity_kind: input.subject.kind,
-      ...(input.subject.knownEntityID ? { known_entity_id: input.subject.knownEntityID } : {}),
-      span: { evidence_index: 0, start: codePointOffset(subjectStart), end: codePointOffset(subjectEnd) },
+      name: input.subjectName,
+      entity_kind: "project",
+      ...(input.subjectEntityID ? { known_entity_id: input.subjectEntityID } : {}),
+      span: { evidence_index: 0, start: runeOffset(subjectStart), end: runeOffset(subjectStart + input.subjectName.length) },
     },
     predicate: {
       proposed_key: "primary_database",
       surface: predicateSurface,
-      span: { evidence_index: 0, start: codePointOffset(predicateStart), end: codePointOffset(predicateEnd) },
+      span: { evidence_index: 0, start: runeOffset(predicateStart), end: runeOffset(predicateStart + predicateSurface.length) },
     },
-    object: {
-      entity: {
-        name: input.object.name,
-        entity_kind: input.object.kind,
-        ...(input.object.knownEntityID ? { known_entity_id: input.object.knownEntityID } : {}),
-        span: { evidence_index: 0, start: codePointOffset(objectStart), end: codePointOffset(objectEnd) },
-      },
-    },
+    object: { entity: {
+      name: input.objectName,
+      entity_kind: "product",
+      ...(input.objectEntityID ? { known_entity_id: input.objectEntityID } : {}),
+      span: { evidence_index: 0, start: runeOffset(objectStart), end: runeOffset(objectStart + input.objectName.length) },
+    } },
     polarity: "+",
     modality: "statement",
     ...(input.validFrom ? { valid_from: input.validFrom } : {}),
@@ -188,342 +413,346 @@ function relationshipHint(input, evidence) {
   };
 }
 
-async function waitForPlacement(apiKey, submissionID, proposalID) {
-  let lastSummary = {};
-  const attempts = Math.ceil((placementTimeoutSeconds * 1000) / 2_000);
+async function waitForSubmission(apiKey, submissionID) {
+  const attempts = Math.ceil((placementTimeoutSeconds * 1_000) / 250);
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const placement = await mcpTool(apiKey, "get_submission_status", { submission_id: submissionID });
-    if (["rejected", "failed", "quarantined"].includes(placement.processing_state)) {
-      throw new Error(`placement failed: ${JSON.stringify(placement)}`);
-    }
-    const row = postgresQuery(`
-      SELECT COALESCE(observation.relationship_id::text, ''), observation.owner_profile_id::text
-      FROM relationship_observations AS observation
-      WHERE observation.team_id = ${sqlLiteral(teamID)}::uuid
-        AND observation.ingest_id = ${sqlLiteral(submissionID)}::uuid
-        AND observation.relationship_id IS NOT NULL
-      ORDER BY observation.created_at ASC, observation.observation_id ASC
-      LIMIT 1
-    `).split("|");
-    lastSummary = { processing_state: placement.processing_state, relationship_id: row[0] || "" };
-    if (placement.processing_state === "completed" && row[0]) {
-      return {
-        ingestID: submissionID,
-        relationshipID: String(row[0]),
-        ownerProfileID: String(row[1]),
-      };
-    }
-    await delay(2_000);
+    const status = await mcpSuccess(apiKey, "get_submission_status", { submission_id: submissionID });
+    if (["completed", "rejected", "failed", "quarantined"].includes(status.processing_state)) return status;
+    await delay(250);
   }
-  throw new Error(`timed out waiting for placement ${submissionID} after ${placementTimeoutSeconds}s: ${JSON.stringify(lastSummary)}`);
+  throw new Error(`timed out waiting for submission ${submissionID} after ${placementTimeoutSeconds}s`);
 }
 
-async function waitForRelationshipConflict(apiKey, relationshipID, status) {
-  for (let attempt = 0; attempt < 90; attempt += 1) {
-    const trace = await mcpTool(apiKey, "trace_memory", { relationship_id: relationshipID });
-    const conflict = (trace.conflicts ?? []).find((item) => (
-      item.status === status
-      && (item.positions ?? []).some((position) => (position.relationship_ids ?? []).includes(relationshipID))
-    ));
-    if (conflict) {
-      return conflict;
-    }
-    await delay(2_000);
+async function currentConflict(apiKey, relationshipID, status) {
+  for (let attempt = 0; attempt < 240; attempt += 1) {
+    const trace = await mcpSuccess(apiKey, "trace_memory", { relationship_id: relationshipID });
+    const conflict = (trace.conflicts ?? []).find((item) => item.status === status && (item.positions ?? []).some((position) => (position.relationship_ids ?? []).includes(relationshipID)));
+    if (conflict) return conflict;
+    await delay(250);
   }
   throw new Error(`timed out waiting for ${status} conflict for relationship ${relationshipID}`);
 }
 
-async function waitForConflictID(apiKey, query, conflictID, status) {
-  for (let attempt = 0; attempt < 90; attempt += 1) {
-    const recall = await mcpTool(apiKey, "recall_memory", { query, limit: 10 });
-    const conflict = (recall.conflicts ?? []).find((item) => item.conflict_id === conflictID && item.status === status);
-    if (conflict) {
-      return conflict;
-    }
-    await delay(2_000);
+async function waitForConflictRecall(apiKey, query, conflictID) {
+  for (let attempt = 0; attempt < 240; attempt += 1) {
+    const recall = await mcpSuccess(apiKey, "recall_memory", { query, limit: 10, relationship_limit: 10 });
+    if ((recall.conflicts ?? []).some((conflict) => conflict.conflict_id === conflictID)) return recall;
+    await delay(250);
   }
-  throw new Error(`timed out waiting for ${status} conflict ${conflictID}`);
+  throw new Error(`timed out waiting for recall conflict ${conflictID}`);
 }
 
-async function resolveOverdueConflictThroughVerifier() {
-  const marker = `Overdue Conflict E2E ${runID}`;
-  const overdueProjectName = `${marker} project`;
-  const overduePostgresName = `${marker} PostgreSQL`;
-  const overdueGraphDBName = `${marker} GraphDB`;
-  const firstOverdue = await rememberAndWait(profileA.apiKey, {
-    idempotencyKey: `${runID}:overdue:a`,
-    evidence: `${marker}: ${overdueProjectName} primary database is ${overduePostgresName} according to profile A.`,
-    sourceGroup: `${runID}:overdue:source:a`,
-    authority: "primary",
-    subject: { ref: "overdue-project", name: overdueProjectName, kind: "project" },
-    object: { ref: "overdue-postgres", name: overduePostgresName, kind: "product" },
-    relationshipID: "rel:overdue-primary-db-a",
+function runReview(fixture, now) {
+  const result = spawnSync(reviewDriver, [
+    "--team-id", fixture.teamID,
+    "--conflict-id", fixture.conflictID,
+    "--now", now,
+  ], {
+    cwd: fileURLToPath(new URL("../..", import.meta.url)),
+    env: process.env,
+    encoding: "utf8",
+    timeout: 60_000,
   });
-  const overdueTrace = await mcpTool(profileA.apiKey, "trace_memory", {
-    relationship_id: firstOverdue.relationshipID,
-    include_evidence_content: true,
-  });
-  const overdueSubjectEntityID = stringAt(overdueTrace, ["relationship", "subject_entity_id"]);
-  const overduePostgresEntityID = stringAt(overdueTrace, ["relationship", "object_entity_id"]);
-  if (!overdueSubjectEntityID || !overduePostgresEntityID) {
-    throw new Error(`overdue trace did not return canonical entity IDs: ${JSON.stringify(overdueTrace)}`);
+  if (result.status !== 0) {
+    throw new Error(`conflict review driver failed (${result.status}): ${redactText(result.stderr || result.stdout)}`);
   }
-  if (overdueSubjectEntityID === subjectEntityID) {
-    throw new Error(`overdue fixture resolved onto the earlier conflict subject: ${JSON.stringify(overdueTrace.relationship)}`);
-  }
-
-  const secondOverdue = await rememberAndWait(profileB.apiKey, {
-    idempotencyKey: `${runID}:overdue:b`,
-    evidence: `${marker}: ${overdueProjectName} primary database is ${overdueGraphDBName} according to profile B.`,
-    sourceGroup: `${runID}:overdue:source:b`,
-    authority: "primary",
-    subject: { ref: "overdue-project", name: overdueProjectName, kind: "project", knownEntityID: overdueSubjectEntityID },
-    object: { ref: "overdue-graphdb", name: overdueGraphDBName, kind: "product" },
-    relationshipID: "rel:overdue-primary-db-b",
-  });
-  const openOverdueConflict = await waitForRelationshipConflict(profileB.apiKey, secondOverdue.relationshipID, "open");
-  const overdueConflictID = stringAt(openOverdueConflict, ["conflict_id"]);
-  if (!overdueConflictID) {
-    throw new Error(`overdue conflict did not return an ID: ${JSON.stringify(openOverdueConflict)}`);
-  }
-  const overdueRelationshipIDs = new Set((openOverdueConflict.positions ?? [])
-    .flatMap((position) => position.relationship_ids ?? []));
-  if (overdueRelationshipIDs.size !== 2 || !overdueRelationshipIDs.has(firstOverdue.relationshipID) || !overdueRelationshipIDs.has(secondOverdue.relationshipID)) {
-    throw new Error(`overdue conflict did not contain the two tied positions: ${JSON.stringify(openOverdueConflict)}`);
-  }
-
-  if (!Number.isFinite(Date.parse(stringAt(openOverdueConflict, ["review_due_at"])))) {
-    throw new Error(`overdue conflict did not return a valid review_due_at: ${JSON.stringify(openOverdueConflict)}`);
-  }
-  const overdueReview = await runAutomaticConflictReview(overdueConflictID);
-  if (overdueReview.status !== "resolved" || overdueReview.planStatus !== "applied") {
-    throw new Error(`overdue conflict reviewer did not complete: ${JSON.stringify(overdueReview)}`);
-  }
-  if (!["ai", "last_write_wins"].includes(overdueReview.method)) {
-    throw new Error(`overdue conflict used an unexpected resolution method: ${JSON.stringify(overdueReview)}`);
-  }
-  if (!overdueReview.assessmentAttemptID || overdueReview.derivationCount < 1) {
-    throw new Error(`overdue conflict did not record assessment/retraction lineage: ${JSON.stringify(overdueReview)}`);
-  }
-
-  await waitForConflictID(profileA.apiKey, marker, overdueConflictID, "resolved");
-  const overdueTraces = await Promise.all([
-    mcpTool(profileA.apiKey, "trace_memory", { relationship_id: firstOverdue.relationshipID, include_transitions: true }),
-    mcpTool(profileB.apiKey, "trace_memory", { relationship_id: secondOverdue.relationshipID, include_transitions: true }),
-  ]);
-  const supersededCount = overdueTraces.filter((trace) => stringAt(trace, ["relationship", "relationship_status"]) === "superseded").length;
-  if (supersededCount !== 1) {
-    throw new Error(`overdue conflict did not suppress exactly one losing relationship: ${JSON.stringify(overdueTraces)}`);
-  }
-  return { conflictID: overdueConflictID, method: overdueReview.method };
+  const line = result.stdout.trim().split(/\r?\n/).findLast((item) => item.trim().startsWith("{"));
+  if (!line) throw new Error(`conflict review driver returned no JSON: ${redactText(result.stdout)}`);
+  return JSON.parse(line);
 }
 
-async function runAutomaticConflictReview(conflictID) {
-  markConflictReviewDue(conflictID);
-
-  let last = {};
-  const attempts = Math.ceil((conflictReviewTimeoutSeconds * 1000) / 2_000);
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const row = postgresQuery(`
-      SELECT conflict.status,
-             COALESCE(plan.method, ''),
-             COALESCE(plan.assessment_attempt_id::text, ''),
-             COALESCE(plan.status, ''),
-             (
-               SELECT count(*)
-               FROM relationship_conflict_evidence_derivations derivation
-               WHERE derivation.team_id = conflict.team_id
-                 AND derivation.conflict_id = conflict.conflict_id
-             )
-      FROM relationship_conflict_cases conflict
-      LEFT JOIN LATERAL (
-        SELECT method, assessment_attempt_id, status
-        FROM relationship_conflict_resolution_plans
-        WHERE team_id = conflict.team_id
-          AND conflict_id = conflict.conflict_id
-        ORDER BY created_at DESC, resolution_plan_id DESC
-        LIMIT 1
-      ) plan ON true
-      WHERE conflict.team_id = ${sqlLiteral(teamID)}::uuid
-        AND conflict.conflict_id = ${sqlLiteral(conflictID)}::uuid;
-    `);
-    const [status, method, assessmentAttemptID, planStatus, derivationCountRaw] = row.split("|");
-    last = {
-      status,
-      method,
-      assessmentAttemptID,
-      planStatus,
-      derivationCount: Number(derivationCountRaw),
-    };
-    if (status === "resolved") {
-      return last;
-    }
-    if (attempt % 5 === 0) {
-      markConflictReviewDue(conflictID);
-      requeueCompletedConflictReviewRun(conflictID);
-    }
-    await delay(2_000);
-  }
-  throw new Error(`timed out waiting for automatic conflict review ${conflictID}: ${JSON.stringify(last)}`);
+function assertReview(result, outcome, stage, preferredPositionID, method) {
+  assert(result.outcome === outcome, `review outcome = ${result.outcome}, want ${outcome}: ${JSON.stringify(result)}`);
+  assert(result.stage === stage, `review stage = ${result.stage}, want ${stage}: ${JSON.stringify(result)}`);
+  assert(result.preferred_position_id === preferredPositionID, `review preferred position = ${result.preferred_position_id}, want ${preferredPositionID}`);
+  assert(result.resolution_method === method, `review method = ${result.resolution_method}, want ${method}`);
 }
 
-function markConflictReviewDue(conflictID) {
-  postgresQuery(`
-    UPDATE relationship_conflict_cases
-    SET review_due_at = clock_timestamp() - interval '1 second',
-        next_review_at = clock_timestamp() - interval '1 second',
-        attempts = 0,
-        lease_worker_id = '',
-        lease_until = NULL,
-        last_error = '',
-        updated_at = now()
-    WHERE team_id = ${sqlLiteral(teamID)}::uuid
-      AND conflict_id = ${sqlLiteral(conflictID)}::uuid
-      AND status IN ('open', 'overdue')
-      AND (lease_until IS NULL OR lease_until < clock_timestamp());
-  `);
-}
-
-function requeueCompletedConflictReviewRun(conflictID) {
-  postgresQuery(`
-    WITH latest_run AS (
-      SELECT review_run_id
-      FROM relationship_conflict_review_runs
-      WHERE team_id = ${sqlLiteral(teamID)}::uuid
-        AND status = 'completed'
-        AND local_run_date = CURRENT_DATE
-      ORDER BY completed_at DESC NULLS LAST, review_run_id DESC
-      LIMIT 1
-    )
-    UPDATE relationship_conflict_cases AS conflict
-    SET last_review_run_id = latest_run.review_run_id,
-        updated_at = now()
-    FROM latest_run
+function conflictState(teamID, conflictID) {
+  return postgresJSON(`
+    SELECT json_build_object(
+      'status', conflict.status,
+      'version', conflict.version,
+      'preferred_position_id', COALESCE(conflict.preferred_position_id::text, ''),
+      'resolution_reason', conflict.resolution_reason
+    )::text
+    FROM relationship_conflict_cases AS conflict
     WHERE conflict.team_id = ${sqlLiteral(teamID)}::uuid
       AND conflict.conflict_id = ${sqlLiteral(conflictID)}::uuid
-      AND conflict.last_review_run_id IS NULL
-      AND conflict.status IN ('open', 'overdue')
-      AND conflict.next_review_at <= clock_timestamp();
-  `);
-  postgresQuery(`
-    UPDATE relationship_conflict_review_runs AS review_run
-    SET status = 'failed',
-        lease_until = NULL,
-        completed_at = NULL,
-        last_error = 'compose e2e automatic review requeue',
-        updated_at = now()
-      WHERE review_run.team_id = ${sqlLiteral(teamID)}::uuid
-      AND review_run.status = 'completed'
-      AND review_run.local_run_date = CURRENT_DATE
-      AND EXISTS (
-        SELECT 1
-        FROM relationship_conflict_cases AS conflict
-        WHERE conflict.team_id = review_run.team_id
-          AND conflict.conflict_id = ${sqlLiteral(conflictID)}::uuid
-          AND conflict.last_review_run_id = review_run.review_run_id
-          AND conflict.status IN ('open', 'overdue')
-          AND conflict.next_review_at <= clock_timestamp()
-      );
   `);
 }
 
-function postgresQuery(sql) {
+function assessmentAttempts(teamID, conflictID) {
+  return postgresJSON(`
+    SELECT COALESCE(json_agg(item ORDER BY local_assessment_date), '[]'::json)::text
+    FROM (
+      SELECT assessment.local_assessment_date,
+             json_build_object(
+               'assessment_attempt_id', assessment.assessment_attempt_id::text,
+               'status', assessment.status,
+               'selected_position_id', COALESCE(assessment.selected_position_id::text, ''),
+               'failure_class', assessment.failure_class,
+               'local_assessment_date', assessment.local_assessment_date
+             ) AS item
+      FROM relationship_conflict_ai_assessment_attempts AS assessment
+      WHERE assessment.team_id = ${sqlLiteral(teamID)}::uuid
+        AND assessment.conflict_id = ${sqlLiteral(conflictID)}::uuid
+    ) AS attempts
+  `);
+}
+
+function latestResolutionPlan(teamID, conflictID) {
+  return postgresJSON(`
+    SELECT COALESCE((
+      SELECT json_build_object(
+        'method', plan.method,
+        'status', plan.status,
+        'preferred_position_id', plan.preferred_position_id::text,
+        'assessment_attempt_id', COALESCE(plan.assessment_attempt_id::text, '')
+      )::text
+      FROM relationship_conflict_resolution_plans AS plan
+      WHERE plan.team_id = ${sqlLiteral(teamID)}::uuid
+        AND plan.conflict_id = ${sqlLiteral(conflictID)}::uuid
+      ORDER BY plan.created_at DESC, plan.resolution_plan_id DESC
+      LIMIT 1
+    ), '{}')
+  `);
+}
+
+function conflictDerivationCount(teamID, conflictID) {
+  return Number(postgresQuery(`
+    SELECT count(*)
+    FROM relationship_conflict_evidence_derivations
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid
+      AND conflict_id = ${sqlLiteral(conflictID)}::uuid
+  `));
+}
+
+function positionAcceptedTimes(teamID, conflictID, positionAID, positionBID) {
+  return postgresJSON(`
+    SELECT json_build_object(
+      'position_a', max(member.accepted_at) FILTER (WHERE member.position_id = ${sqlLiteral(positionAID)}::uuid),
+      'position_b', max(member.accepted_at) FILTER (WHERE member.position_id = ${sqlLiteral(positionBID)}::uuid)
+    )::text
+    FROM relationship_conflict_position_members AS member
+    WHERE member.team_id = ${sqlLiteral(teamID)}::uuid
+      AND member.conflict_id = ${sqlLiteral(conflictID)}::uuid
+      AND member.active
+  `);
+}
+
+function conflictSemanticSnapshot(teamID, conflictID) {
+  return postgresJSON(`
+    SELECT json_build_object(
+      'version', conflict.version,
+      'active_positions', (
+        SELECT count(*) FROM relationship_conflict_positions AS position
+        WHERE position.team_id = conflict.team_id AND position.conflict_id = conflict.conflict_id AND position.active
+      ),
+      'active_members', (
+        SELECT count(*) FROM relationship_conflict_position_members AS member
+        WHERE member.team_id = conflict.team_id AND member.conflict_id = conflict.conflict_id AND member.active
+      ),
+      'member_relationships', (
+        SELECT count(DISTINCT member.relationship_id) FROM relationship_conflict_position_members AS member
+        WHERE member.team_id = conflict.team_id AND member.conflict_id = conflict.conflict_id AND member.active
+      ),
+      'member_supports', (
+        SELECT count(DISTINCT member.support_id) FROM relationship_conflict_position_members AS member
+        WHERE member.team_id = conflict.team_id AND member.conflict_id = conflict.conflict_id AND member.active
+      )
+    )::text
+    FROM relationship_conflict_cases AS conflict
+    WHERE conflict.team_id = ${sqlLiteral(teamID)}::uuid
+      AND conflict.conflict_id = ${sqlLiteral(conflictID)}::uuid
+  `);
+}
+
+function postgresJSON(sql) {
+  const raw = postgresQuery(sql);
+  if (!raw) throw new Error("PostgreSQL lineage query returned no JSON");
+  return JSON.parse(raw);
+}
+
+function postgresQuery(sql, options = {}) {
+  const normalized = sql.trim();
+  if (!/^(SELECT|WITH)\b/i.test(normalized)) throw new Error("conflict e2e PostgreSQL helper permits read-only queries only");
   const result = spawnSync("docker", [
-    "compose",
-    "-p",
-    composeProject,
-    "-f",
-    composeFile,
-    "exec",
-    "-T",
-    "postgres",
-    "sh",
-    "-ec",
-    'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "$1"',
-    "conflict-e2e",
-    sql,
+    "compose", "-p", composeProject, "-f", composeFile,
+    "exec", "-T", "postgres", "sh", "-ec",
+    'psql -X -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "$1"',
+    "conflict-e2e", sql,
   ], {
     cwd: fileURLToPath(new URL("../..", import.meta.url)),
     encoding: "utf8",
   });
-  if (result.status !== 0) {
-    throw new Error(`postgres query failed (${result.status}): ${result.stderr || result.stdout}`);
-  }
+  if (result.status !== 0) throw new Error(`PostgreSQL read failed (${result.status}): ${redactText(result.stderr || result.stdout)}`);
   return result.stdout.trim();
+}
+
+async function assertRemovedPlacementTools(apiKey) {
+  const listed = await rpc(apiKey, "tools/list", {});
+  assert(!listed.error && listed.result, "tools/list failed in conflict e2e");
+  const names = new Set((listed.result.tools ?? []).map((tool) => tool.name));
+  for (const name of ["get_memory_placement", "resolve_memory_placement"]) {
+    assert(!names.has(name), `removed placement tool ${name} is listed`);
+    const response = await rpc(apiKey, "tools/call", { name, arguments: {} });
+    assert(response.error?.code === -32601 && response.result === undefined, `removed placement tool ${name} is callable`);
+  }
+}
+
+async function createTeam(label) {
+  const response = await controlJSON("/teams", {
+    method: "POST",
+    body: JSON.stringify({ name: `${runID} ${label} team`, description: "isolated conflict e2e fixture" }),
+  });
+  const teamID = String(response.data?.id ?? "");
+  assert(teamID, `control API did not create team ${label}`);
+  return teamID;
+}
+
+async function createProfile(teamID, name) {
+  const response = await controlJSON(`/teams/${teamID}/profiles`, {
+    method: "POST",
+    body: JSON.stringify({ name, role: "member", scopes: ["read", "write"], rate_limit: 300 }),
+  });
+  const apiKey = String(response.data?.api_key ?? "");
+  const profileID = String(response.data?.key?.id ?? "");
+  assert(apiKey && profileID, "control API profile response omitted credentials or profile ID");
+  return { apiKey, profileID, name };
+}
+
+async function renameProfile(teamID, profileID, name) {
+  const response = await controlJSON(`/teams/${teamID}/profiles/${profileID}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name }),
+  });
+  assert(response.data?.id === profileID && response.data?.name === name, "control API did not rename the profile");
+}
+
+async function mcpSuccess(apiKey, name, args) {
+  const response = await mcpRaw(apiKey, name, args);
+  if (response.error || response.result === undefined) throw new Error(`MCP ${name} returned an error: ${redactText(JSON.stringify(response.error ?? {}))}`);
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} result omitted JSON content`);
+  return JSON.parse(text);
+}
+
+async function mcpRaw(apiKey, name, args) {
+  return rpc(apiKey, "tools/call", { name, arguments: args });
+}
+
+async function rpc(apiKey, method, params) {
+  return httpJSON(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }),
+  });
+}
+
+async function controlJSON(path, options) {
+  return httpJSON(`${controlURL}/control/api${path}`, {
+    ...options,
+    headers: { Authorization: `Bearer ${controlToken}`, "Content-Type": "application/json" },
+  });
+}
+
+async function httpJSON(url, options) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  if (!response.ok) throw new Error(`HTTP ${response.status} ${url}: ${redactText(text)}`);
+  return text ? JSON.parse(text) : {};
+}
+
+function positionForRelationship(conflict, relationshipID) {
+  const position = (conflict.positions ?? []).find((item) => (item.relationship_ids ?? []).includes(relationshipID));
+  if (!position) throw new Error(`conflict ${conflict.conflict_id} omitted relationship ${relationshipID}`);
+  return position;
+}
+
+function positionByID(conflict, positionID) {
+  const position = (conflict?.positions ?? []).find((item) => item.position_id === positionID);
+  if (!position) throw new Error(`conflict ${conflict?.conflict_id ?? "unknown"} omitted position ${positionID}`);
+  return position;
+}
+
+function conflictByID(conflicts, conflictID) {
+  const conflict = (conflicts ?? []).find((item) => item.conflict_id === conflictID);
+  if (!conflict) throw new Error(`output omitted conflict ${conflictID}`);
+  return conflict;
+}
+
+function provenanceFields(position) {
+  return {
+    supporter_count: position.supporter_count,
+    support_group_count: position.support_group_count,
+    authoritative_group_count: position.authoritative_group_count,
+    supporters_truncated: position.supporters_truncated,
+    supporters: position.supporters,
+  };
+}
+
+function statusTeamID(submissionID) {
+  const value = postgresQuery(`
+    SELECT team_id::text
+    FROM knowledge_ingests
+    WHERE ingest_id = ${sqlLiteral(submissionID)}::uuid
+    LIMIT 1
+  `);
+  assert(value, `submission ${submissionID} has no durable team`);
+  return value;
+}
+
+function offsetTime(value, milliseconds) {
+  const parsed = Date.parse(value);
+  assert(Number.isFinite(parsed), `invalid RFC3339 time ${value}`);
+  return new Date(parsed + milliseconds).toISOString();
+}
+
+function stableJSON(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJSON).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJSON(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
 }
 
 function sqlLiteral(value) {
   return `'${String(value).replaceAll("'", "''")}'`;
 }
 
-async function mcpTool(apiKey, name, args) {
-  const response = await httpJSON(`${userUrl}/mcp`, {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: ++rpcID,
-      method: "tools/call",
-      params: { name, arguments: args },
-    }),
-  });
-  if (response.error) {
-    throw new Error(`MCP ${name} error: ${JSON.stringify(response.error)}`);
-  }
-  const text = response.result?.content?.[0]?.text;
-  if (typeof text !== "string") {
-    throw new Error(`MCP ${name} result missing text: ${JSON.stringify(response)}`);
-  }
-  return JSON.parse(text);
-}
-
-async function httpJSON(url, options) {
-  const response = await fetch(url, options);
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} ${url}: ${redactHTTPBody(text)}`);
-  }
-  return text ? JSON.parse(text) : {};
-}
-
-function redactHTTPBody(text) {
-  return text.replace(/"api_key"\s*:\s*"[^"]*"/g, "\"api_key\":\"<redacted>\"");
-}
-
-function requiredEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
-}
-
-function positiveIntEnv(name, fallback, minimum, maximum) {
-  const raw = process.env[name];
-  if (!raw) {
-    return fallback;
-  }
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value < minimum || value > maximum) {
-    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
-  }
-  return value;
-}
-
 function stringAt(value, path) {
   let current = value;
   for (const key of path) {
-    if (current === null || typeof current !== "object") {
-      return "";
-    }
+    if (!current || typeof current !== "object") return "";
     current = current[key];
   }
   return typeof current === "string" ? current : "";
 }
 
-function delay(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function redactText(value) {
+  return String(value)
+    .replace(/"api_key"\s*:\s*"[^"]*"/g, '"api_key":"<redacted>"')
+    .replace(/postgres:\/\/[^@\s]+@/g, "postgres://<redacted>@")
+    .slice(0, 2_000);
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function positiveIntEnv(name, fallback, minimum, maximum) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < minimum || value > maximum) throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  return value;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -10,7 +10,10 @@ const seededTeamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
 const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
 const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
 const reviewDriver = requiredEnv("DENSE_MEM_E2E_CONFLICT_REVIEW_DRIVER");
-const placementTimeoutSeconds = positiveIntEnv("DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS", 180, 30, 900);
+const submissionTimeoutEnv = process.env.DENSE_MEM_E2E_SUBMISSION_TIMEOUT_SECONDS
+  ? "DENSE_MEM_E2E_SUBMISSION_TIMEOUT_SECONDS"
+  : "DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS";
+const submissionTimeoutSeconds = positiveIntEnv(submissionTimeoutEnv, 180, 30, 900);
 const runID = `conflict-e2e-${Date.now()}`;
 
 let rpcID = 0;
@@ -179,25 +182,26 @@ async function provenanceAndIsolationScenario() {
   const copiedPosition = positionForRelationship(beforeIndependent, fixture.relationshipA);
   assert(copiedPosition.supporter_count === 21, `copied supporter count = ${copiedPosition.supporter_count}`);
   assert(copiedPosition.support_group_count === 1, `copied source group increased independent weight: ${copiedPosition.support_group_count}`);
-  const staleVersion = Number(beforeIndependent.version);
+  const observedVersion = Number(beforeIndependent.version);
+  // Reusing this observed version must succeed once and be rejected after that commit advances the case.
   await submitPositionSupport(fixture, profileC, {
     label: "provenance-independent-c",
     sourceGroup: `${runID}:provenance:independent:c`,
     authority: "primary",
-    conflictContext: { conflict_id: fixture.conflictID, expected_version: staleVersion },
+    conflictContext: { conflict_id: fixture.conflictID, expected_version: observedVersion },
   });
 
   const afterIndependent = await currentConflict(profileC.apiKey, fixture.relationshipA, "open");
   const independentPosition = positionForRelationship(afterIndependent, fixture.relationshipA);
   assert(independentPosition.supporter_count === 21 && independentPosition.support_group_count === 2, `independent support counts are invalid: ${JSON.stringify(independentPosition)}`);
-  assert(Number(afterIndependent.version) > staleVersion, "fresh conflict_context support did not advance the conflict version");
+  assert(Number(afterIndependent.version) > observedVersion, "fresh conflict_context support did not advance the conflict version");
 
   const semanticBeforeStale = conflictSemanticSnapshot(fixture.teamID, fixture.conflictID);
   const stale = await submitPositionSupport(fixture, profileC, {
     label: "provenance-stale-c",
     sourceGroup: `${runID}:provenance:stale:c`,
     authority: "primary",
-    conflictContext: { conflict_id: fixture.conflictID, expected_version: staleVersion },
+    conflictContext: { conflict_id: fixture.conflictID, expected_version: observedVersion },
     expectedState: "rejected",
   });
   assert(stale.status.processing_state === "rejected", `stale conflict submission was not rejected: ${JSON.stringify(stale.status)}`);
@@ -368,7 +372,7 @@ async function submitRelationship(apiKey, input) {
       AND observation.relationship_id IS NOT NULL
     ORDER BY observation.created_at, observation.observation_id
     LIMIT 1
-  `, { allowAnyTeam: true });
+  `);
   assert(relationshipID, `completed submission ${input.label} did not create a relationship observation`);
   return { submissionID, relationshipID, evidenceID, status };
 }
@@ -414,13 +418,13 @@ function relationshipHint(input, evidence) {
 }
 
 async function waitForSubmission(apiKey, submissionID) {
-  const attempts = Math.ceil((placementTimeoutSeconds * 1_000) / 250);
+  const attempts = Math.ceil((submissionTimeoutSeconds * 1_000) / 250);
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const status = await mcpSuccess(apiKey, "get_submission_status", { submission_id: submissionID });
     if (["completed", "rejected", "failed", "quarantined"].includes(status.processing_state)) return status;
     await delay(250);
   }
-  throw new Error(`timed out waiting for submission ${submissionID} after ${placementTimeoutSeconds}s`);
+  throw new Error(`timed out waiting for submission ${submissionID} after ${submissionTimeoutSeconds}s`);
 }
 
 async function currentConflict(apiKey, relationshipID, status) {
@@ -454,7 +458,8 @@ function runReview(fixture, now) {
     timeout: 60_000,
   });
   if (result.status !== 0) {
-    throw new Error(`conflict review driver failed (${result.status}): ${redactText(result.stderr || result.stdout)}`);
+    const details = [result.error?.message, result.stderr || result.stdout].filter(Boolean).join(": ");
+    throw new Error(`conflict review driver failed (${result.status}): ${redactText(details)}`);
   }
   const line = result.stdout.trim().split(/\r?\n/).findLast((item) => item.trim().startsWith("{"));
   if (!line) throw new Error(`conflict review driver returned no JSON: ${redactText(result.stdout)}`);
@@ -574,7 +579,7 @@ function postgresJSON(sql) {
   return JSON.parse(raw);
 }
 
-function postgresQuery(sql, options = {}) {
+function postgresQuery(sql) {
   const normalized = sql.trim();
   if (!/^(SELECT|WITH)\b/i.test(normalized)) throw new Error("conflict e2e PostgreSQL helper permits read-only queries only");
   const result = spawnSync("docker", [
@@ -693,6 +698,7 @@ function provenanceFields(position) {
 }
 
 function statusTeamID(submissionID) {
+  // The globally unique ingest ID is the only unscoped fixture key; later lineage reads include its resolved team.
   const value = postgresQuery(`
     SELECT team_id::text
     FROM knowledge_ingests

--- a/tests/uat/conflict_openai_stub.mjs
+++ b/tests/uat/conflict_openai_stub.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import http from "node:http";
+
+const port = positiveInteger(process.env.DENSE_MEM_CONFLICT_STUB_PORT ?? "8081", "DENSE_MEM_CONFLICT_STUB_PORT");
+const host = process.env.DENSE_MEM_CONFLICT_STUB_HOST ?? "0.0.0.0";
+
+const server = http.createServer(async (request, response) => {
+  try {
+    if (request.method === "GET" && request.url === "/health") {
+      return sendJSON(response, 200, { status: "ok" });
+    }
+    if (request.method !== "POST") {
+      return sendJSON(response, 405, { error: { message: "method not allowed" } });
+    }
+    const payload = await readJSON(request);
+    if (request.url === "/v1/embeddings") {
+      return sendJSON(response, 200, embeddingResponse(payload));
+    }
+    if (request.url !== "/v1/chat/completions") {
+      return sendJSON(response, 404, { error: { message: "not found" } });
+    }
+
+    const schemaName = payload?.response_format?.json_schema?.name;
+    const providerInput = initialProviderInput(payload?.messages);
+    if (schemaName === "dense_mem_semantic_assessment_response") {
+      return sendChat(response, semanticAssessmentResponse(providerInput));
+    }
+    if (schemaName === "dense_mem_conflict_assessment_response") {
+      const contents = (providerInput.evidence ?? []).map((item) => String(item?.content ?? ""));
+      if (contents.some((content) => content.includes("[conflict-ai-fail]"))) {
+        return sendJSON(response, 503, { error: { message: "deterministic conflict provider failure" } });
+      }
+      return sendChat(response, conflictAssessmentResponse(providerInput));
+    }
+    return sendJSON(response, 400, { error: { message: "unsupported response schema" } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "invalid request";
+    return sendJSON(response, 400, { error: { message } });
+  }
+});
+
+server.listen(port, host);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}
+
+function embeddingResponse(payload) {
+  const input = Array.isArray(payload?.input) ? payload.input : [];
+  const dimensions = positiveInteger(payload?.dimensions, "embedding dimensions");
+  return {
+    object: "list",
+    model: String(payload?.model ?? "dense-mem-conflict-e2e-embedding"),
+    data: input.map((text, index) => ({
+      object: "embedding",
+      index,
+      embedding: deterministicVector(String(text), dimensions),
+    })),
+    usage: { prompt_tokens: Math.max(1, input.length), total_tokens: Math.max(1, input.length) },
+  };
+}
+
+function deterministicVector(text, dimensions) {
+  let seed = 2166136261;
+  for (const rune of text) {
+    seed ^= rune.codePointAt(0);
+    seed = Math.imul(seed, 16777619) >>> 0;
+  }
+  return Array.from({ length: dimensions }, (_, index) => (((seed + index * 2654435761) >>> 0) % 2001 - 1000) / 1000);
+}
+
+function semanticAssessmentResponse(input) {
+  const candidateGroups = Array.isArray(input.entity_candidate_groups) ? input.entity_candidate_groups : [];
+  const predicateOptions = Array.isArray(input.predicate_options) ? input.predicate_options : [];
+  const submittedEntities = Array.isArray(input.submitted_entities) ? input.submitted_entities : [];
+  const submittedRelationships = Array.isArray(input.submitted_relationships) ? input.submitted_relationships : [];
+
+  const entityResults = submittedEntities.map((entity) => {
+    const group = candidateGroups.find((candidate) => (
+      candidate?.evidence_id === entity.evidence_id
+      && candidate?.start === entity.start
+      && candidate?.end === entity.end
+    ));
+    const compatible = (group?.candidates ?? []).filter((candidate) => candidate?.kind === entity.kind);
+    const reusable = compatible.length === 1 && !group?.candidate_context_truncated;
+    return {
+      ref: entity.ref,
+      surface: entity.surface,
+      kind: entity.kind,
+      evidence_id: entity.evidence_id,
+      start: entity.start,
+      end: entity.end,
+      action: reusable ? "reuse" : compatible.length === 0 ? "create" : "ambiguous",
+      candidate_entity_id: reusable ? compatible[0].entity_id : null,
+      confidence: 0.99,
+      rationale: reusable ? "The submitted candidate is an exact compatible match." : "The submitted span is evidence grounded.",
+    };
+  });
+
+  const relationshipResults = submittedRelationships.map((relationship) => {
+    const hint = findRef(input.client_proposal, relationship.ref);
+    const proposedKey = String(hint?.predicate?.proposed_key ?? "");
+    const predicate = predicateOptions.find((option) => option?.predicate_key === proposedKey)
+      ?? predicateOptions.find((option) => option?.predicate_key === "primary_database");
+    if (!predicate) {
+      throw new Error(`no predicate option for submitted relationship ${relationship.ref}`);
+    }
+    const validFrom = nullableString(hint?.valid_from);
+    const validTo = nullableString(hint?.valid_to);
+    return {
+      ref: relationship.ref,
+      subject_ref: relationship.subject_ref,
+      original_predicate: relationship.original_predicate,
+      predicate_status: "resolved",
+      predicate_key: predicate.predicate_key,
+      predicate_version: predicate.version,
+      object_ref: relationship.object_ref ?? null,
+      object_value: relationship.object_value ?? null,
+      polarity: relationship.polarity,
+      modality: relationship.modality,
+      evidence: relationship.evidence,
+      valid_from: validFrom,
+      valid_to: validTo,
+      scope_status: "absent",
+      scope_key: null,
+      evidence_verdict: "entailed",
+      temporal_verdict: validFrom || validTo ? "entailed" : "absent",
+      confidence: 0.99,
+      rationale: "The submitted evidence directly supports the relationship.",
+    };
+  });
+
+  return {
+    request_id: input.request_id,
+    security_signals: [],
+    entity_results: entityResults,
+    relationship_results: relationshipResults,
+  };
+}
+
+function conflictAssessmentResponse(input) {
+  const evidence = Array.isArray(input.evidence) ? input.evidence : [];
+  const selected = evidence.find((item) => String(item?.content ?? "").includes("[conflict-ai-select-winner]"));
+  if (selected) {
+    return {
+      decision: "select",
+      position_id: selected.position_id,
+      confidence: 0.99,
+      rationale: "The deterministic fixture marks this position for selection.",
+    };
+  }
+  return {
+    decision: "abstain",
+    position_id: null,
+    confidence: 0,
+    rationale: "The deterministic fixture requires abstention.",
+  };
+}
+
+function initialProviderInput(messages) {
+  if (!Array.isArray(messages)) {
+    throw new Error("messages must be an array");
+  }
+  for (const message of messages) {
+    if (message?.role !== "user" || typeof message.content !== "string") {
+      continue;
+    }
+    try {
+      const value = JSON.parse(message.content);
+      if (value && typeof value === "object" && !Object.hasOwn(value, "validation_errors")) {
+        return value;
+      }
+    } catch {
+      // The initial structured payload is the only user message that must parse.
+    }
+  }
+  throw new Error("initial provider payload is missing");
+}
+
+function findRef(value, ref) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findRef(item, ref);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+  if (value.ref === ref) return value;
+  for (const child of Object.values(value)) {
+    const found = findRef(child, ref);
+    if (found) return found;
+  }
+  return null;
+}
+
+function sendChat(response, content) {
+  sendJSON(response, 200, {
+    choices: [{ message: { content: JSON.stringify(content) } }],
+    usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+  });
+}
+
+async function readJSON(request) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.length;
+    if (size > 4 * 1024 * 1024) throw new Error("request exceeds 4 MiB");
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function sendJSON(response, status, body) {
+  response.writeHead(status, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function nullableString(value) {
+  return typeof value === "string" && value ? value : null;
+}

--- a/tests/uat/conflict_review_driver/main.go
+++ b/tests/uat/conflict_review_driver/main.go
@@ -43,12 +43,12 @@ func main() {
 	nowRaw := flag.String("now", "", "explicit RFC3339 review time")
 	flag.Parse()
 
+	if strings.TrimSpace(*teamID) == "" || strings.TrimSpace(*conflictID) == "" {
+		fatal("--team-id and --conflict-id are required")
+	}
 	now, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*nowRaw))
 	if err != nil {
 		fatal("parse --now: %v", err)
-	}
-	if strings.TrimSpace(*teamID) == "" || strings.TrimSpace(*conflictID) == "" {
-		fatal("--team-id and --conflict-id are required")
 	}
 
 	cfg := driverConfig()
@@ -211,7 +211,7 @@ func driverConfig() config.Config {
 		PostgresDSN:                         postgresDSN(),
 		AIVerifierAPIURL:                    requiredEnv("DENSE_MEM_E2E_CONFLICT_PROVIDER_URL"),
 		AIVerifierAPIKey:                    "dense-mem-conflict-e2e-key",
-		AIVerifierModel:                     "dense-mem-conflict-e2e-reviewer",
+		AIVerifierModel:                     "dense-mem-conflict-e2e-verifier",
 		AIVerifierDisableTemperature:        true,
 		AIVerifierTimeoutSeconds:            10,
 		AIVerifierMaxConcurrency:            1,

--- a/tests/uat/conflict_review_driver/main.go
+++ b/tests/uat/conflict_review_driver/main.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service/conflictreview"
+	postgresstorage "github.com/markhuangai/dense-mem/internal/storage/postgres"
+	"github.com/markhuangai/dense-mem/internal/verifier"
+)
+
+const (
+	reviewLease = 2 * time.Minute
+	claimWait   = 15 * time.Second
+)
+
+type output struct {
+	TeamID               string   `json:"team_id"`
+	ConflictID           string   `json:"conflict_id"`
+	ReviewRunID          string   `json:"review_run_id"`
+	Outcome              string   `json:"outcome"`
+	Stage                string   `json:"stage"`
+	PreferredPositionID  string   `json:"preferred_position_id"`
+	ResolutionMethod     string   `json:"resolution_method"`
+	AssessmentAttemptID  string   `json:"assessment_attempt_id"`
+	UpdatedRelationships []string `json:"updated_relationship_ids"`
+	RetractedEvidenceIDs []string `json:"retracted_evidence_ids"`
+}
+
+func main() {
+	teamID := flag.String("team-id", "", "team containing the conflict")
+	conflictID := flag.String("conflict-id", "", "conflict to review")
+	nowRaw := flag.String("now", "", "explicit RFC3339 review time")
+	flag.Parse()
+
+	now, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*nowRaw))
+	if err != nil {
+		fatal("parse --now: %v", err)
+	}
+	if strings.TrimSpace(*teamID) == "" || strings.TrimSpace(*conflictID) == "" {
+		fatal("--team-id and --conflict-id are required")
+	}
+
+	cfg := driverConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	db, err := postgresstorage.Open(ctx, &cfg)
+	if err != nil {
+		fatal("open PostgreSQL connection: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		fatal("resolve PostgreSQL connection: %v", err)
+	}
+	defer sqlDB.Close()
+
+	rls := postgresstorage.NewRLS()
+	ledger := repository.NewLedgerRepository(db, rls)
+	limits := verifier.DefaultSemanticAssessmentLimits()
+	provider := verifier.NewOpenAIVerifierWithAssessmentLimits(&cfg, nil, limits)
+	reviewer, err := conflictreview.New(conflictreview.Dependencies{
+		Repository: ledger,
+		Provider:   provider,
+		Timezone:   "UTC",
+		Limits:     limits,
+	})
+	if err != nil {
+		fatal("build conflict reviewer: %v", err)
+	}
+
+	workerID := fmt.Sprintf("conflict-e2e-%s-%d", compactID(*conflictID), now.Unix())
+	run, claimed, err := ledger.ReserveRelationshipConflictReviewRun(ctx, repository.ConflictReviewRunInput{
+		TeamID:       *teamID,
+		WorkerID:     workerID,
+		LocalRunDate: now,
+		Timezone:     "UTC",
+		Lease:        reviewLease,
+	})
+	if err != nil {
+		fatal("reserve conflict review run: %v", err)
+	}
+	if run == nil || !claimed {
+		fatal("conflict review run was not claimable for %s", now.Format("2006-01-02"))
+	}
+
+	record, err := claimTarget(ctx, ledger, *teamID, *conflictID, run.ReviewRunID, workerID, now)
+	if err != nil {
+		completeFailedRun(ctx, ledger, *teamID, run.ReviewRunID, workerID)
+		fatal("claim conflict: %v", err)
+	}
+	result, err := reviewer.ReviewRelationshipConflictCase(ctx, repository.ReviewRelationshipConflictCaseInput{
+		TeamID:      *teamID,
+		WorkerID:    workerID,
+		ReviewRunID: run.ReviewRunID,
+		ConflictID:  record.ConflictID,
+		Now:         now,
+	})
+	if err != nil {
+		completeFailedRun(ctx, ledger, *teamID, run.ReviewRunID, workerID)
+		fatal("review conflict: %v", err)
+	}
+
+	completion := repository.ConflictReviewRunCompleteInput{
+		TeamID:       *teamID,
+		ReviewRunID:  run.ReviewRunID,
+		WorkerID:     workerID,
+		Status:       "completed",
+		ClaimedCases: 1,
+	}
+	switch result.Outcome {
+	case repository.ConflictReviewOutcomeResolve:
+		completion.ResolvedCases = 1
+	case repository.ConflictReviewOutcomeOverdue:
+		completion.OverdueCases = 1
+	default:
+		completion.NoOpCases = 1
+	}
+	if err := ledger.CompleteRelationshipConflictReviewRun(ctx, completion); err != nil {
+		fatal("complete conflict review run: %v", err)
+	}
+
+	encoded, err := json.Marshal(output{
+		TeamID:               *teamID,
+		ConflictID:           result.ConflictID,
+		ReviewRunID:          run.ReviewRunID,
+		Outcome:              result.Outcome,
+		Stage:                result.Stage,
+		PreferredPositionID:  result.PreferredPositionID,
+		ResolutionMethod:     result.ResolutionMethod,
+		AssessmentAttemptID:  result.AssessmentAttemptID,
+		UpdatedRelationships: append([]string(nil), result.UpdatedRelationships...),
+		RetractedEvidenceIDs: append([]string(nil), result.RetractedEvidenceIDs...),
+	})
+	if err != nil {
+		fatal("encode conflict review result: %v", err)
+	}
+	fmt.Println(string(encoded))
+}
+
+func claimTarget(
+	ctx context.Context,
+	ledger *repository.LedgerRepositoryImpl,
+	teamID string,
+	conflictID string,
+	reviewRunID string,
+	workerID string,
+	now time.Time,
+) (*repository.RelationshipConflictCaseRecord, error) {
+	deadline := time.Now().Add(claimWait)
+	for {
+		records, err := ledger.ClaimRelationshipConflictCases(ctx, repository.ClaimRelationshipConflictCasesInput{
+			TeamID:      teamID,
+			WorkerID:    workerID,
+			ReviewRunID: reviewRunID,
+			Limit:       10,
+			Lease:       reviewLease,
+			MaxAttempts: 20,
+			Now:         now,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for i := range records {
+			if records[i].ConflictID == conflictID {
+				return &records[i], nil
+			}
+		}
+		if len(records) > 0 {
+			return nil, fmt.Errorf("claimed %d unexpected conflict cases", len(records))
+		}
+		if time.Now().After(deadline) {
+			return nil, errors.New("target conflict was not claimable before the deadline")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+func completeFailedRun(
+	ctx context.Context,
+	ledger *repository.LedgerRepositoryImpl,
+	teamID string,
+	reviewRunID string,
+	workerID string,
+) {
+	_ = ledger.CompleteRelationshipConflictReviewRun(ctx, repository.ConflictReviewRunCompleteInput{
+		TeamID:      teamID,
+		ReviewRunID: reviewRunID,
+		WorkerID:    workerID,
+		Status:      "failed",
+		FailedCases: 1,
+		LastError:   "conflict e2e driver failed",
+	})
+}
+
+func driverConfig() config.Config {
+	return config.Config{
+		PostgresDSN:                         postgresDSN(),
+		AIVerifierAPIURL:                    requiredEnv("DENSE_MEM_E2E_CONFLICT_PROVIDER_URL"),
+		AIVerifierAPIKey:                    "dense-mem-conflict-e2e-key",
+		AIVerifierModel:                     "dense-mem-conflict-e2e-reviewer",
+		AIVerifierDisableTemperature:        true,
+		AIVerifierTimeoutSeconds:            10,
+		AIVerifierMaxConcurrency:            1,
+		AIVerifierMaxInputTokens:            verifier.DefaultSemanticAssessmentLimits().MaxInputTokens,
+		AIVerifierMaxOutputTokens:           verifier.DefaultSemanticAssessmentLimits().MaxOutputTokens,
+		AIVerifierMaxCandidateContextTokens: verifier.DefaultSemanticAssessmentLimits().MaxCandidateContextTokens,
+		AIVerifierMaxPredicateOptions:       verifier.DefaultSemanticAssessmentLimits().MaxPredicateOptions,
+		AIVerifierTokenizer:                 verifier.DefaultSemanticAssessmentLimits().Tokenizer,
+	}
+}
+
+func postgresDSN() string {
+	host := requiredEnv("DENSE_MEM_E2E_POSTGRES_HOST")
+	port := requiredEnv("DENSE_MEM_E2E_POSTGRES_PORT")
+	user := requiredEnv("DENSE_MEM_E2E_POSTGRES_USER")
+	password := requiredEnv("DENSE_MEM_E2E_POSTGRES_PASSWORD")
+	database := requiredEnv("DENSE_MEM_E2E_POSTGRES_DB")
+	value := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, password),
+		Host:     net.JoinHostPort(host, port),
+		Path:     "/" + database,
+		RawQuery: "sslmode=disable",
+	}
+	return value.String()
+}
+
+func compactID(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "-", "")
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
+}
+
+func requiredEnv(name string) string {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		fatal("%s is required", name)
+	}
+	return value
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- Add bounded supporter provenance to conflict positions in both `recall_memory` and `trace_memory` while keeping the public contract at `dense-mem.v2.4`.
- Report distinct supporter, source-group, and authoritative-group counts with deterministic top-20 summaries, current same-team profile names, historical effective membership, and explicit truncation.
- Enforce conflict team parity and close the submission-wide assessor gap by validating current conflict versions and semantic scope before any atomic commit.
- Add a deterministic Compose-backed conflict matrix covering every resolution branch, provenance semantics, stale/fresh conflict context, A/B/C visibility and ownership, cross-team isolation, and retired tool absence.

## Impact

Clients gain bounded, auditable supporter identity and source-independence context without raw source-group keys or evidence content. Stale or semantically mismatched conflict context now reaches a bounded rejected submission state without partial semantic writes.

## Root cause

The submission-wide assessment commit path carried `conflict_context` into placement but did not apply the existing current-version and semantic-match guards used by the earlier placement path.

## Validation

- `go test ./internal/domain ./internal/repository ./internal/service/memoryservice ./internal/service/contextservice ./internal/tools/registry -count=1`
- `DENSE_MEM_REPOSITORY_TESTCONTAINERS=1 go test ./internal/repository -run '^(TestRelationshipConflictSupporterProjectionIsBoundedCurrentAndTeamScoped|TestSubmissionAssessmentCommitValidatesConflictContextAtomically)$' -count=1`
- Clean Compose conflict scenario: `status: ok`, `contract_version: dense-mem.v2.4`
- `./scripts/ci-check.sh` (90.1% coverage)
- Evaluation not run per requested implementation scope.

Closes #161
Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conflict positions now include supporter counts, provenance, authority, evidence, acceptance times, and source-group counts.
  * Supporter lists are limited to 20 entries, with truncation status reported.
  * Conflict recall and trace outputs include expanded supporter and relationship metadata.
  * Added deterministic conflict-review scenarios covering resolution, visibility, stale data, provenance, and review workflows.

* **Bug Fixes**
  * Added team-isolation validation for conflict recall and semantic traces.
  * Stale conflict contexts are rejected atomically and routed for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->