### PR TITLE
Fix portal graph freshness and signal layout

### DIFF
--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -158,6 +158,7 @@ func (h *userPortalHandler) telemetrySnapshot(c echo.Context) error {
 }
 
 func (h *userPortalHandler) graphSnapshot(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
 	if h.graph == nil {
 		return httperr.New(httperr.SERVICE_UNAVAILABLE, "graph view unavailable")
 	}
@@ -197,6 +198,7 @@ func (h *userPortalHandler) graphSnapshot(c echo.Context) error {
 }
 
 func (h *userPortalHandler) graphNodeDetail(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
 	if h.graph == nil {
 		return httperr.New(httperr.SERVICE_UNAVAILABLE, "graph view unavailable")
 	}

--- a/internal/http/user_portal_test.go
+++ b/internal/http/user_portal_test.go
@@ -385,20 +385,21 @@ func TestUserPortalGraphUsesAuthenticatedTeamScope(t *testing.T) {
 	graph := &userPortalGraphSvc{}
 	server := userPortalTestServerWithGraph(t, teamID, authKey, &userPortalKeySvc{keys: []*domain.APIKey{authKey}}, "", nil, graph)
 
-	req := httptest.NewRequest(http.MethodGet, "/ui/api/graph?scope=local&anchor_type=entity&anchor_id=entity-1&depth=2&limit=50&types=entity,value&q=memory", nil)
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/graph?scope=local&anchor_type=entity&anchor_id=entity-1&depth=5&limit=181&types=entity,value&q=memory", nil)
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 	rec := httptest.NewRecorder()
 	server.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "no-store", rec.Header().Get(echo.HeaderCacheControl))
 	require.Contains(t, rec.Body.String(), `"entity:entity-1"`)
 	require.Equal(t, 1, graph.calls)
 	require.Equal(t, teamID.String(), graph.profileID)
 	require.Equal(t, "local", graph.query.Scope)
 	require.Equal(t, "entity", graph.query.AnchorType)
 	require.Equal(t, "entity-1", graph.query.AnchorID)
-	require.Equal(t, 2, graph.query.Depth)
-	require.Equal(t, 50, graph.query.Limit)
+	require.Equal(t, 5, graph.query.Depth)
+	require.Equal(t, 181, graph.query.Limit)
 	require.Equal(t, []string{"entity", "value"}, graph.query.Types)
 	require.Equal(t, "memory", graph.query.Query)
 }
@@ -446,6 +447,7 @@ func TestUserPortalGraphNodeDetailUsesAuthenticatedTeamScope(t *testing.T) {
 	server.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "no-store", rec.Header().Get(echo.HeaderCacheControl))
 	require.Contains(t, rec.Body.String(), `"body":"entity detail"`)
 	require.Equal(t, 1, graph.detailCalls)
 	require.Equal(t, teamID.String(), graph.detailProfileID)

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -148,6 +148,32 @@ func TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport(t *t
 	})
 	require.NoError(t, err)
 
+	freshGraph, err := semantic.SemanticGraph(ctx, SemanticGraphQuery{TeamID: teamA, Limit: 181})
+	require.NoError(t, err)
+	assert.Contains(t, semanticGraphEdgeIDs(freshGraph.Edges), result.Correction.SuccessorRelationshipID)
+	assert.NotContains(t, semanticGraphEdgeIDs(freshGraph.Edges), original.RelationshipID)
+	assertGraphHasNode(t, freshGraph.Nodes, "entity", correctObject.EntityID, "Dense-Mem")
+	assert.NotContains(t, semanticGraphNodeIDs(freshGraph.Nodes), wrongObject.EntityID)
+
+	otherSubject := createSemanticEntity(t, ctx, semantic, teamA, ownerB, "person", "Other Owner")
+	otherContent := "Other Owner works on Wrong Project."
+	otherIngest := createSemanticIngest(t, ctx, ledger, teamA, ownerB, "relationship-correction-shared-endpoint", otherContent)
+	shared := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamA, OwnerProfileID: ownerB, IngestID: otherIngest.IngestID,
+		SubjectEntityID: otherSubject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{
+			FragmentID: otherIngest.Evidence[0].FragmentID, SourceGroupKey: "conversation:correction:shared",
+			SpanStart: 0, SpanEnd: len(otherContent), Authority: "primary",
+		},
+	}).Relationship
+	require.NotNil(t, shared)
+
+	sharedGraph, err := semantic.SemanticGraph(ctx, SemanticGraphQuery{TeamID: teamA, Limit: 181})
+	require.NoError(t, err)
+	assert.Contains(t, semanticGraphEdgeIDs(sharedGraph.Edges), shared.RelationshipID)
+	assert.NotContains(t, semanticGraphEdgeIDs(sharedGraph.Edges), original.RelationshipID)
+	assertGraphHasNode(t, sharedGraph.Nodes, "entity", wrongObject.EntityID, "Wrong Project")
+
 	_, err = semantic.GetRelationshipCorrection(ctx, GetRelationshipCorrectionInput{
 		TeamID: teamA, OwnerProfileID: ownerB, SubmissionID: result.SubmissionID,
 	})

--- a/internal/repository/semantic_graph_repository_test.go
+++ b/internal/repository/semantic_graph_repository_test.go
@@ -1,0 +1,20 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeSemanticGraphQueryDefaultsAndBounds(t *testing.T) {
+	defaults := normalizeSemanticGraphQuery(SemanticGraphQuery{})
+	assert.Equal(t, defaultSemanticGraphDepth, defaults.Depth)
+	assert.Equal(t, defaultSemanticGraphLimit, defaults.Limit)
+
+	explicit := normalizeSemanticGraphQuery(SemanticGraphQuery{Depth: 99, Limit: 181})
+	assert.Equal(t, maxSemanticGraphDepth, explicit.Depth)
+	assert.Equal(t, 181, explicit.Limit)
+
+	large := normalizeSemanticGraphQuery(SemanticGraphQuery{Limit: 1_000_000})
+	assert.Equal(t, 1_000_000, large.Limit)
+}

--- a/internal/repository/semantic_read_repository.go
+++ b/internal/repository/semantic_read_repository.go
@@ -25,9 +25,8 @@ const (
 	defaultTraceFragmentRunes = 2000
 	maxTraceFragmentRunes     = 8000
 	defaultSemanticGraphLimit = 80
-	maxSemanticGraphLimit     = 180
-	defaultSemanticGraphDepth = 1
-	maxSemanticGraphDepth     = 2
+	defaultSemanticGraphDepth = 2
+	maxSemanticGraphDepth     = 5
 )
 
 func (r *SemanticRepositoryImpl) TraceRelationship(
@@ -244,7 +243,7 @@ func normalizeSemanticGraphQuery(input SemanticGraphQuery) SemanticGraphQuery {
 	input.AnchorID = strings.TrimSpace(input.AnchorID)
 	input.Types = normalizeSemanticGraphTypes(input.Types)
 	input.Depth = clampInt(input.Depth, defaultSemanticGraphDepth, maxSemanticGraphDepth)
-	input.Limit = clampInt(input.Limit, defaultSemanticGraphLimit, maxSemanticGraphLimit)
+	input.Limit = defaultPositiveInt(input.Limit, defaultSemanticGraphLimit)
 	input.MinRelevance = normalizeRelevance(input.MinRelevance)
 	return input
 }
@@ -958,6 +957,13 @@ func clampInt(value, defaultValue, maxValue int) int {
 	}
 	if value > maxValue {
 		return maxValue
+	}
+	return value
+}
+
+func defaultPositiveInt(value, defaultValue int) int {
+	if value <= 0 {
+		return defaultValue
 	}
 	return value
 }

--- a/internal/repository/semantic_repository_integration_helpers_test.go
+++ b/internal/repository/semantic_repository_integration_helpers_test.go
@@ -20,6 +20,22 @@ func assertGraphHasNode(t *testing.T, nodes []SemanticGraphNode, nodeType, id, t
 	t.Fatalf("missing %s node %s in %+v", nodeType, id, nodes)
 }
 
+func semanticGraphNodeIDs(nodes []SemanticGraphNode) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		ids = append(ids, node.ID)
+	}
+	return ids
+}
+
+func semanticGraphEdgeIDs(edges []SemanticGraphEdge) []string {
+	ids := make([]string, 0, len(edges))
+	for _, edge := range edges {
+		ids = append(ids, edge.ID)
+	}
+	return ids
+}
+
 func createSemanticEntity(
 	t *testing.T,
 	ctx context.Context,

--- a/internal/repository/semantic_trace_graph_integration_test.go
+++ b/internal/repository/semantic_trace_graph_integration_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -295,4 +296,52 @@ func TestSemanticGraphReadsEntityValueEdgesAndNodeDetail(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "July 17, 2026", valueNode.Title)
+}
+
+func TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "graph-depth-team")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "graph-depth-owner")
+	ledgerRepo := NewLedgerRepository(appDB, rls)
+	semanticRepo := NewSemanticRepository(appDB, rls)
+
+	entities := make([]*EntityRecord, 7)
+	for index := range entities {
+		entities[index] = createSemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "concept", fmt.Sprintf("Depth Node %d", index))
+	}
+	for index := 0; index < len(entities)-1; index++ {
+		content := fmt.Sprintf("Depth Node %d uses Depth Node %d.", index, index+1)
+		ingest := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID, fmt.Sprintf("graph-depth-%d", index), content)
+		applied := applySemanticDecision(t, ctx, semanticRepo, ApplyRelationshipDecisionInput{
+			TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+			SubjectEntityID: entities[index].EntityID, PredicateKey: "uses", ObjectEntityID: entities[index+1].EntityID,
+			Support: &EvidenceSupportInput{
+				FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: fmt.Sprintf("conversation:graph-depth:%d", index),
+				SpanStart: 0, SpanEnd: len(content), Authority: "primary",
+			},
+		})
+		require.NotNil(t, applied.Relationship)
+	}
+
+	defaults, err := semanticRepo.SemanticGraph(ctx, SemanticGraphQuery{
+		TeamID: teamID, Scope: "local", AnchorType: "entity", AnchorID: entities[0].EntityID, Limit: 181,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, defaults.Depth)
+	assert.Equal(t, 181, defaults.Limit)
+	assert.Len(t, defaults.Edges, 2)
+	assert.Contains(t, semanticGraphNodeIDs(defaults.Nodes), entities[2].EntityID)
+	assert.NotContains(t, semanticGraphNodeIDs(defaults.Nodes), entities[3].EntityID)
+
+	capped, err := semanticRepo.SemanticGraph(ctx, SemanticGraphQuery{
+		TeamID: teamID, Scope: "local", AnchorType: "entity", AnchorID: entities[0].EntityID, Depth: 99, Limit: 181,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, capped.Depth)
+	assert.Equal(t, 181, capped.Limit)
+	assert.Len(t, capped.Edges, 5)
+	assert.Contains(t, semanticGraphNodeIDs(capped.Nodes), entities[5].EntityID)
+	assert.NotContains(t, semanticGraphNodeIDs(capped.Nodes), entities[6].EntityID)
 }

--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -16,9 +16,8 @@ const (
 	ScopeLocal    = "local"
 
 	DefaultLimit = 80
-	MaxLimit     = 180
-	DefaultDepth = 1
-	MaxDepth     = 2
+	DefaultDepth = 2
+	MaxDepth     = 5
 
 	maxNodeBodyRunes = 420
 )
@@ -171,7 +170,7 @@ func normalizeSemanticQuery(query Query) (normalizedSemanticQuery, error) {
 		scope:  scope,
 		search: strings.ToLower(strings.TrimSpace(query.Query)),
 		types:  normalizeSemanticGraphTypes(query.Types),
-		limit:  clamp(query.Limit, DefaultLimit, MaxLimit),
+		limit:  defaultPositive(query.Limit, DefaultLimit),
 		depth:  clamp(query.Depth, DefaultDepth, MaxDepth),
 	}
 	if normalized.scope == ScopeLocal {
@@ -224,6 +223,13 @@ func clamp(value, defaultValue, maxValue int) int {
 	}
 	if value > maxValue {
 		return maxValue
+	}
+	return value
+}
+
+func defaultPositive(value, defaultValue int) int {
+	if value <= 0 {
+		return defaultValue
 	}
 	return value
 }

--- a/internal/service/graphview/graphview_test.go
+++ b/internal/service/graphview/graphview_test.go
@@ -1,0 +1,165 @@
+package graphview
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSemanticQueryDefaultsAndBounds(t *testing.T) {
+	defaults, err := normalizeSemanticQuery(Query{})
+	require.NoError(t, err)
+	assert.Equal(t, DefaultDepth, defaults.depth)
+	assert.Equal(t, DefaultLimit, defaults.limit)
+
+	explicit, err := normalizeSemanticQuery(Query{Depth: 99, Limit: 181})
+	require.NoError(t, err)
+	assert.Equal(t, MaxDepth, explicit.depth)
+	assert.Equal(t, 181, explicit.limit)
+
+	large, err := normalizeSemanticQuery(Query{Limit: 1_000_000})
+	require.NoError(t, err)
+	assert.Equal(t, 1_000_000, large.limit)
+
+	local, err := normalizeSemanticQuery(Query{
+		Scope: " LOCAL ", Query: " Project ", Types: []string{"entities", "VALUE", "entity", "unknown"},
+		AnchorType: "values", AnchorID: " value-1 ", Depth: 1, Limit: 7,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ScopeLocal, local.scope)
+	assert.Equal(t, "project", local.search)
+	assert.Equal(t, []string{"entity", "value"}, local.types)
+	assert.Equal(t, "value", local.anchorType)
+	assert.Equal(t, "value-1", local.anchorID)
+	assert.Equal(t, 1, local.depth)
+	assert.Equal(t, 7, local.limit)
+
+	_, err = normalizeSemanticQuery(Query{Scope: ScopeLocal})
+	assert.ErrorIs(t, err, ErrMissingAnchor)
+	_, err = normalizeSemanticQuery(Query{Scope: ScopeLocal, AnchorType: "evidence", AnchorID: "id"})
+	assert.ErrorIs(t, err, ErrInvalidAnchorType)
+}
+
+func TestSemanticServiceGraphNormalizesAndMapsSnapshot(t *testing.T) {
+	recordedAt := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	store := &semanticStoreStub{snapshot: &repository.SemanticGraphSnapshot{
+		Scope: ScopeLocal, Query: "project", Depth: MaxDepth, Limit: 181, Truncated: true,
+		Anchor: &repository.SemanticGraphAnchor{Type: "entity", ID: "entity-1", Key: "entity:entity-1"},
+		Nodes: []repository.SemanticGraphNode{
+			{Key: "entity:entity-1", ID: "entity-1", Type: "entity", Title: strings.Repeat("t", 170), Body: strings.Repeat("b", 430), Status: "active", RecordedAt: &recordedAt},
+			{Key: "value:value-1", ID: "value-1", Type: "value"},
+		},
+		Edges: []repository.SemanticGraphEdge{{ID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "USES", Directed: true}},
+	}}
+	service := NewSemantic(store)
+
+	snapshot, err := service.Graph(context.Background(), " team-1 ", Query{
+		Scope: " LOCAL ", Query: " Project ", Types: []string{"entities", "value", "entity"},
+		AnchorType: "entities", AnchorID: " entity-1 ", Depth: 99, Limit: 181,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, repository.SemanticGraphQuery{
+		TeamID: "team-1", Scope: ScopeLocal, Query: "project", Types: []string{"entity", "value"},
+		AnchorType: "entity", AnchorID: "entity-1", Depth: MaxDepth, Limit: 181,
+	}, store.graphInput)
+	assert.Equal(t, ScopeLocal, snapshot.Scope)
+	assert.Equal(t, "project", snapshot.Query)
+	assert.Equal(t, MaxDepth, snapshot.Depth)
+	assert.Equal(t, 181, snapshot.Limit)
+	assert.True(t, snapshot.Truncated)
+	assert.Equal(t, &Anchor{Type: "entity", ID: "entity-1", Key: "entity:entity-1"}, snapshot.Anchor)
+	require.Len(t, snapshot.Nodes, 2)
+	assert.Equal(t, strings.Repeat("t", 160)+"...", snapshot.Nodes[0].Title)
+	assert.Equal(t, strings.Repeat("b", maxNodeBodyRunes)+"...", snapshot.Nodes[0].Body)
+	assert.Equal(t, "value-1", snapshot.Nodes[1].Title)
+	assert.Equal(t, recordedAt, *snapshot.Nodes[0].RecordedAt)
+	assert.Equal(t, []Edge{{ID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "USES", Directed: true}}, snapshot.Edges)
+}
+
+func TestSemanticServiceGraphErrorsAndEmptySnapshot(t *testing.T) {
+	var nilService *semanticService
+	_, err := nilService.Graph(context.Background(), "team", Query{})
+	assert.ErrorContains(t, err, "not configured")
+
+	storeErr := errors.New("store unavailable")
+	store := &semanticStoreStub{graphErr: storeErr}
+	_, err = NewSemantic(store).Graph(context.Background(), "team", Query{})
+	assert.ErrorIs(t, err, storeErr)
+	assert.ErrorContains(t, err, "semantic graph view")
+
+	store.graphErr = nil
+	store.snapshot = nil
+	snapshot, err := NewSemantic(store).Graph(context.Background(), "team", Query{})
+	require.NoError(t, err)
+	assert.Empty(t, snapshot.Nodes)
+	assert.Empty(t, snapshot.Edges)
+}
+
+func TestSemanticServiceNodeDetail(t *testing.T) {
+	recordedAt := time.Date(2026, time.August, 10, 13, 0, 0, 0, time.UTC)
+	store := &semanticStoreStub{detail: &repository.SemanticGraphNode{
+		Key: "entity:entity-1", ID: "entity-1", Type: "entity", Title: "Dense-Mem", Body: "project", Status: "active", RecordedAt: &recordedAt,
+	}}
+	service := NewSemantic(store)
+
+	detail, err := service.NodeDetail(context.Background(), " team-1 ", " Entities ", " entity-1 ")
+	require.NoError(t, err)
+	assert.Equal(t, repository.SemanticGraphNodeDetailInput{TeamID: "team-1", NodeType: "entity", NodeID: "entity-1"}, store.detailInput)
+	assert.Equal(t, "Dense-Mem", detail.Title)
+	assert.Equal(t, "project", detail.Body)
+	assert.Equal(t, recordedAt, *detail.RecordedAt)
+
+	store.detail = nil
+	_, err = service.NodeDetail(context.Background(), "team", "value", "value-1")
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+
+	store.detailErr = sql.ErrNoRows
+	_, err = service.NodeDetail(context.Background(), "team", "value", "value-1")
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+
+	storeErr := errors.New("detail unavailable")
+	store.detailErr = storeErr
+	_, err = service.NodeDetail(context.Background(), "team", "value", "value-1")
+	assert.ErrorIs(t, err, storeErr)
+	assert.ErrorContains(t, err, "semantic graph node detail")
+}
+
+func TestSemanticServiceNodeDetailValidation(t *testing.T) {
+	var nilService *semanticService
+	_, err := nilService.NodeDetail(context.Background(), "team", "entity", "id")
+	assert.ErrorContains(t, err, "not configured")
+
+	service := NewSemantic(&semanticStoreStub{})
+	_, err = service.NodeDetail(context.Background(), "team", "evidence", "id")
+	assert.ErrorIs(t, err, ErrInvalidNodeType)
+	_, err = service.NodeDetail(context.Background(), "team", "entity", "")
+	assert.ErrorIs(t, err, ErrMissingNode)
+	_, err = service.NodeDetail(context.Background(), "team", "", "id")
+	assert.ErrorIs(t, err, ErrMissingNode)
+}
+
+type semanticStoreStub struct {
+	graphInput  repository.SemanticGraphQuery
+	snapshot    *repository.SemanticGraphSnapshot
+	graphErr    error
+	detailInput repository.SemanticGraphNodeDetailInput
+	detail      *repository.SemanticGraphNode
+	detailErr   error
+}
+
+func (s *semanticStoreStub) SemanticGraph(_ context.Context, input repository.SemanticGraphQuery) (*repository.SemanticGraphSnapshot, error) {
+	s.graphInput = input
+	return s.snapshot, s.graphErr
+}
+
+func (s *semanticStoreStub) SemanticGraphNodeDetail(_ context.Context, input repository.SemanticGraphNodeDetailInput) (*repository.SemanticGraphNode, error) {
+	s.detailInput = input
+	return s.detail, s.detailErr
+}

--- a/scripts/e2e-compose-submission-status.sh
+++ b/scripts/e2e-compose-submission-status.sh
@@ -1,0 +1,41 @@
+E2E_GRAPH_ANCHOR_ENTITY_ID=""
+E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID=""
+E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID=""
+E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID=""
+E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID=""
+
+set_submission_status_playwright_args() {
+  test_args=(
+    "tests-compose/compose-portal.spec.ts"
+    -g
+    "control overview contains every Top Signals diagnostic|user portal renders the corrected live graph"
+  )
+}
+
+run_submission_status_e2e() {
+  local team_id="$1"
+  local submission_status_json
+
+  echo "Running compose-backed submission status and public-contract e2e with the configured live verifier."
+  submission_status_json="$(DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
+  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
+  DENSE_MEM_USER_URL="$USER_URL" \
+  DENSE_MEM_E2E_TEAM_ID="$team_id" \
+  DENSE_MEM_E2E_API_KEY="$api_key" \
+  DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
+  DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
+  node "$ROOT_DIR/tests/uat/submission_status_mcp_e2e.mjs")"
+  printf '%s\n' "$submission_status_json"
+  E2E_GRAPH_ANCHOR_ENTITY_ID="$(printf '%s' "$submission_status_json" | json_field graph_anchor_entity_id)"
+  E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID="$(printf '%s' "$submission_status_json" | json_field graph_original_object_entity_id)"
+  E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID="$(printf '%s' "$submission_status_json" | json_field graph_corrected_object_entity_id)"
+  E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID="$(printf '%s' "$submission_status_json" | json_field relationship_id)"
+  E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID="$(printf '%s' "$submission_status_json" | json_field successor_relationship_id)"
+  dream_statement="submission status e2e"
+  if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then
+    echo "Skipping compose-backed submission-status Playwright tests by DENSE_MEM_E2E_SKIP_PLAYWRIGHT."
+    return
+  fi
+  echo "Running compose-backed submission-status portal regressions."
+  run_compose_playwright_tests submission_status
+}

--- a/scripts/e2e-compose-submission-status.sh
+++ b/scripts/e2e-compose-submission-status.sh
@@ -31,6 +31,12 @@ run_submission_status_e2e() {
   E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID="$(printf '%s' "$submission_status_json" | json_field graph_corrected_object_entity_id)"
   E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID="$(printf '%s' "$submission_status_json" | json_field relationship_id)"
   E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID="$(printf '%s' "$submission_status_json" | json_field successor_relationship_id)"
+  if [[ -z "$E2E_GRAPH_ANCHOR_ENTITY_ID" || -z "$E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID" ||
+        -z "$E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID" || -z "$E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID" ||
+        -z "$E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID" ]]; then
+    echo "submission-status UAT did not return required graph fixture identifiers" >&2
+    return 1
+  fi
   dream_statement="submission status e2e"
   if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then
     echo "Skipping compose-backed submission-status Playwright tests by DENSE_MEM_E2E_SKIP_PLAYWRIGHT."

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -23,7 +23,9 @@ E2E_FILE_ID=""
 E2E_SERVER_IMAGE=""
 E2E_PLAYWRIGHT_CONTAINER=""
 
-source "${ROOT_DIR}/scripts/e2e-compose-conflict.sh"; source "${ROOT_DIR}/scripts/e2e-compose-embedding-reconciliation.sh"
+source "${ROOT_DIR}/scripts/e2e-compose-conflict.sh"
+source "${ROOT_DIR}/scripts/e2e-compose-embedding-reconciliation.sh"
+source "${ROOT_DIR}/scripts/e2e-compose-submission-status.sh"
 
 sanitize_project_name() {
   local raw="$1"
@@ -625,6 +627,8 @@ run_compose_playwright_tests() {
       -g
       "remembered API-key login uses a seven-day server session"
     )
+  elif [[ "${1:-}" == "submission_status" ]]; then
+    set_submission_status_playwright_args
   elif [[ "${1:-}" == "community" ]]; then test_args=("tests-compose/community-recall.spec.ts");
   elif [[ "${1:-}" == "conflict_queue" ]]; then test_args=("tests-compose/compose-conflict-queue.spec.ts");
   fi
@@ -655,6 +659,11 @@ run_compose_playwright_tests() {
     -e "DENSE_MEM_E2E_API_KEY=$api_key" \
     -e "DENSE_MEM_E2E_DREAM_STATEMENT=${dream_statement:-}" \
     -e "DENSE_MEM_PROMETHEUS_URL=$PROMETHEUS_URL" \
+    -e "DENSE_MEM_E2E_GRAPH_ANCHOR_ENTITY_ID=$E2E_GRAPH_ANCHOR_ENTITY_ID" \
+    -e "DENSE_MEM_E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID=$E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID" \
+    -e "DENSE_MEM_E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID=$E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID" \
+    -e "DENSE_MEM_E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID=$E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID" \
+    -e "DENSE_MEM_E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID=$E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID" \
     "$E2E_PLAYWRIGHT_CONTAINER" \
     sh -ec 'cd /tmp/web && npm ci && ./node_modules/.bin/playwright test --config playwright.compose.config.ts "$@"' \
     sh "${test_args[@]}"
@@ -924,15 +933,7 @@ if [[ "$E2E_SCENARIO" == "security_intake" ]]; then
 fi
 
 if [[ "$E2E_SCENARIO" == "submission_status" ]]; then
-  echo "Running compose-backed submission status and public-contract e2e with the configured live verifier."
-  DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
-  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
-  DENSE_MEM_USER_URL="$USER_URL" \
-  DENSE_MEM_E2E_TEAM_ID="$team_id" \
-  DENSE_MEM_E2E_API_KEY="$api_key" \
-  DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
-  DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
-  node "$ROOT_DIR/tests/uat/submission_status_mcp_e2e.mjs"
+  run_submission_status_e2e "$team_id"
   exit 0
 fi
 if [[ "$E2E_SCENARIO" == "submission_assessment" ]]; then

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -23,8 +23,7 @@ E2E_FILE_ID=""
 E2E_SERVER_IMAGE=""
 E2E_PLAYWRIGHT_CONTAINER=""
 
-source "${ROOT_DIR}/scripts/e2e-compose-conflict.sh"
-source "${ROOT_DIR}/scripts/e2e-compose-embedding-reconciliation.sh"
+source "${ROOT_DIR}/scripts/e2e-compose-conflict.sh"; source "${ROOT_DIR}/scripts/e2e-compose-embedding-reconciliation.sh"
 source "${ROOT_DIR}/scripts/e2e-compose-submission-status.sh"
 
 sanitize_project_name() {

--- a/tests/uat/submission_status_mcp_e2e.mjs
+++ b/tests/uat/submission_status_mcp_e2e.mjs
@@ -73,6 +73,36 @@ if (!relationshipID) {
   throw new Error("completed submission did not produce a relationship observation");
 }
 
+const relationshipEndpoints = postgresQuery(`
+  SELECT concat(subject_entity_id::text, '|', object_entity_id::text)
+  FROM relationship_records
+  WHERE team_id = ${sqlLiteral(teamID)}::uuid
+    AND relationship_id = ${sqlLiteral(relationshipID)}::uuid;
+`);
+const [subjectEntityID, originalObjectEntityID] = relationshipEndpoints.split("|");
+if (!subjectEntityID || !originalObjectEntityID) {
+  throw new Error(`could not resolve graph endpoints: ${relationshipEndpoints}`);
+}
+
+const defaultGraph = await userGraph();
+if (defaultGraph.depth !== 2 || defaultGraph.limit !== 80) {
+  throw new Error(`graph defaults are invalid: depth=${defaultGraph.depth}, limit=${defaultGraph.limit}`);
+}
+assertGraphContains(defaultGraph, relationshipID, originalObjectEntityID);
+
+const graphBeforeCorrection = await userGraph({
+  scope: "local",
+  anchor_type: "entity",
+  anchor_id: subjectEntityID,
+  depth: "5",
+  limit: "181",
+  types: "entity,value",
+});
+if (graphBeforeCorrection.depth !== 5 || graphBeforeCorrection.limit !== 181) {
+  throw new Error(`explicit graph bounds are invalid: depth=${graphBeforeCorrection.depth}, limit=${graphBeforeCorrection.limit}`);
+}
+assertGraphContains(graphBeforeCorrection, relationshipID, originalObjectEntityID);
+
 const trace = await mcpSuccess("trace_memory", { relationship_id: relationshipID, include_evidence_content: true });
 assertNoLegacySubmissionFields(trace);
 for (const observation of trace.observations ?? []) {
@@ -175,6 +205,26 @@ if (originalState !== "superseded" || successorState !== "active" || successorOw
   throw new Error(`relationship correction state is invalid: ${correctionState}`);
 }
 
+const correctedObjectEntityID = postgresQuery(`
+  SELECT object_entity_id::text
+  FROM relationship_records
+  WHERE team_id = ${sqlLiteral(teamID)}::uuid
+    AND relationship_id = ${sqlLiteral(successorID)}::uuid;
+`);
+if (!correctedObjectEntityID || correctedObjectEntityID === originalObjectEntityID) {
+  throw new Error(`correction did not replace the graph endpoint: ${correctedObjectEntityID || "missing"}`);
+}
+const graphAfterCorrection = await userGraph({
+  scope: "local",
+  anchor_type: "entity",
+  anchor_id: subjectEntityID,
+  depth: "5",
+  limit: "181",
+  types: "entity,value",
+});
+assertGraphContains(graphAfterCorrection, successorID, correctedObjectEntityID);
+assertGraphOmits(graphAfterCorrection, relationshipID, originalObjectEntityID);
+
 const ledgerTables = postgresQuery(`
   SELECT concat(
     COALESCE(to_regclass('public.skill_pack_imports')::text, ''), '|',
@@ -197,6 +247,9 @@ console.log(JSON.stringify({
   relationship_id: relationshipID,
   correction_submission_id: correction.submission_id,
   successor_relationship_id: successorID,
+  graph_anchor_entity_id: subjectEntityID,
+  graph_original_object_entity_id: originalObjectEntityID,
+  graph_corrected_object_entity_id: correctedObjectEntityID,
   listed_tool_count: listedNames.size,
   removed_tools_absent: true,
   profile_isolation: true,
@@ -336,6 +389,45 @@ async function createProfile(targetTeamID, name) {
     throw new Error("control API did not return a second profile key");
   }
   return { apiKey: key };
+}
+
+async function userGraph(params = {}) {
+  const query = new URLSearchParams(params);
+  const suffix = query.size > 0 ? `?${query.toString()}` : "";
+  const response = await fetch(`${userURL}/ui/api/graph${suffix}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: "no-store",
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`graph HTTP ${response.status}: response body redacted`);
+  }
+  if (response.headers.get("cache-control") !== "no-store") {
+    throw new Error(`graph cache-control = ${response.headers.get("cache-control") ?? "missing"}`);
+  }
+  const graph = text ? JSON.parse(text).data : undefined;
+  if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+    throw new Error("graph response is missing nodes or edges");
+  }
+  return graph;
+}
+
+function assertGraphContains(graph, relationshipID, nodeID) {
+  if (!graph.edges.some((edge) => edge.id === relationshipID)) {
+    throw new Error(`graph is missing relationship ${relationshipID}`);
+  }
+  if (!graph.nodes.some((node) => node.id === nodeID)) {
+    throw new Error(`graph is missing node ${nodeID}`);
+  }
+}
+
+function assertGraphOmits(graph, relationshipID, nodeID) {
+  if (graph.edges.some((edge) => edge.id === relationshipID)) {
+    throw new Error(`graph retained superseded relationship ${relationshipID}`);
+  }
+  if (graph.nodes.some((node) => node.id === nodeID)) {
+    throw new Error(`graph retained orphaned endpoint ${nodeID}`);
+  }
 }
 
 function postgresQuery(sql) {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -527,6 +527,29 @@ describe("App", () => {
     expect(screen.getByLabelText("Top signals")).toHaveTextContent("n/a");
   });
 
+  it("keeps dependency diagnostics in a dedicated wrapping metric row", async () => {
+    const degradedMetrics: ControlMetrics = {
+      ...metricsSnapshot,
+      dependencies: [
+        { name: "postgres", status: "ok", latency_ms: 3 },
+        { name: "search_readiness", status: "error", reason_code: "check_failed", latency_ms: 161 },
+        { name: "redis", status: "degraded", reason_code: "single_node_mode", latency_ms: null },
+      ],
+    };
+    mockPortalFetch({ teams: [profileA], keys: [keyA()], metrics: degradedMetrics });
+    sessionStorage.setItem("denseMem.controlToken", "secret");
+
+    render(<App />);
+    await screen.findByRole("button", { name: /Default/ });
+
+    const dependencyRow = (await screen.findByText("Dependency checks")).closest(".metric-row");
+    expect(dependencyRow).not.toBeNull();
+    expect(within(dependencyRow as HTMLElement).getByText("Dependency checks")).toHaveClass("metric-label");
+    expect(within(dependencyRow as HTMLElement).getByText(/search_readiness/)).toHaveClass("metric-detail");
+    expect(dependencyRow).toHaveTextContent("1/3");
+    expect(dependencyRow).toHaveTextContent("redis · single_node_mode · latency n/a");
+  });
+
   it("shows operation log details, raw log expansion, and page size selection", async () => {
     const fetchMock = mockPortalFetch({ teams: [profileA], keys: [keyA()] });
     sessionStorage.setItem("denseMem.controlToken", "secret");

--- a/web/src/admin-dashboard-components.css
+++ b/web/src/admin-dashboard-components.css
@@ -131,6 +131,60 @@
   box-shadow: none;
 }
 
+.metric-row {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  column-gap: 10px;
+  row-gap: 3px;
+  align-items: center;
+  min-height: 32px;
+  padding: 7px 0;
+  color: var(--muted);
+  font-size: 13px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+}
+
+.metric-row:first-of-type {
+  border-top: 0;
+}
+
+.metric-icon {
+  display: inline-grid;
+  place-items: center;
+  align-self: start;
+  margin-top: 1px;
+  color: var(--accent-strong);
+}
+
+.metric-label {
+  min-width: 0;
+}
+
+.metric-row strong {
+  color: var(--text);
+  font-weight: 760;
+}
+
+.metric-detail {
+  grid-column: 2 / -1;
+  min-width: 0;
+  color: var(--subtle);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.metric-row.danger small,
+.metric-row.danger strong {
+  color: var(--danger);
+}
+
+.metric-row.warning small,
+.metric-row.warning strong {
+  color: var(--warning);
+}
+
 .summary-item,
 .metric-card {
   position: relative;

--- a/web/src/control/TeamWorkspace.tsx
+++ b/web/src/control/TeamWorkspace.tsx
@@ -268,9 +268,9 @@ function MetricRow({
   return (
     <div className={`metric-row ${tone}`}>
       <span className="metric-icon">{icon}</span>
-      <span>{label}</span>
+      <span className="metric-label">{label}</span>
       <strong>{value}</strong>
-      <small>{trend}</small>
+      <small className="metric-detail">{trend}</small>
     </div>
   );
 }

--- a/web/src/graph-view.css
+++ b/web/src/graph-view.css
@@ -95,6 +95,17 @@
   text-align: right;
 }
 
+.graph-limit-row {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.graph-limit-row input {
+  min-width: 0;
+}
+
 .compact-toggle {
   min-height: 34px;
 }

--- a/web/src/http.ts
+++ b/web/src/http.ts
@@ -14,6 +14,7 @@ export type JsonRequestOptions = {
   signal?: AbortSignal;
   token?: string;
   credentials?: RequestCredentials;
+  cache?: RequestCache;
   csrf?: {
     cookieName: string;
     headerName: string;
@@ -39,6 +40,7 @@ export async function requestJson<T>(url: string, options: JsonRequestOptions = 
     method,
     headers,
     credentials: options.credentials,
+    cache: options.cache,
     signal: options.signal,
     body: options.body === undefined ? undefined : JSON.stringify(options.body),
   });

--- a/web/src/resource-explorer.css
+++ b/web/src/resource-explorer.css
@@ -898,47 +898,6 @@
   margin-bottom: 12px;
 }
 
-.metric-row {
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) auto auto;
-  gap: 10px;
-  align-items: center;
-  min-height: 32px;
-  color: var(--muted);
-  font-size: 13px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-}
-
-.metric-row:first-of-type {
-  border-top: 0;
-}
-
-.metric-icon {
-  display: inline-grid;
-  place-items: center;
-  color: var(--accent-strong);
-}
-
-.metric-row strong {
-  color: var(--text);
-  font-weight: 760;
-}
-
-.metric-row small {
-  color: var(--subtle);
-  font-size: 12px;
-}
-
-.metric-row.danger small,
-.metric-row.danger strong {
-  color: var(--danger);
-}
-
-.metric-row.warning small,
-.metric-row.warning strong {
-  color: var(--warning);
-}
-
 .mini-table {
   display: grid;
   border: 1px solid var(--border);

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -272,7 +272,7 @@ describe("UserPortalApp", () => {
 
     expect(await screen.findByLabelText("Knowledge graph")).toBeInTheDocument();
     const controls = screen.getByLabelText("Graph controls");
-    expect(within(controls).queryByLabelText("Limit")).not.toBeInTheDocument();
+    expect(within(controls).getByLabelText("Relationship limit")).toHaveValue(80);
     expect((await screen.findAllByText("Alice")).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByLabelText("Graph totals")).toHaveTextContent("2");
     expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("Select a node");
@@ -284,14 +284,14 @@ describe("UserPortalApp", () => {
     expect(screen.getByLabelText("Graph inspector")).toHaveTextContent("0.940");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2",
+        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2&limit=80",
         expect.any(Object),
       );
     });
     await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2",
+        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2&limit=80",
         expect.any(Object),
       );
     });
@@ -339,7 +339,7 @@ describe("UserPortalApp", () => {
     const controls = await screen.findByLabelText("Graph controls");
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2",
+        "/ui/api/graph?scope=overview&types=entity%2Cvalue&depth=2&limit=80",
         expect.any(Object),
       );
     });

--- a/web/src/user/GraphPanel.test.tsx
+++ b/web/src/user/GraphPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { GraphPanel } from "./GraphPanel";
@@ -28,7 +28,7 @@ vi.mock("react-force-graph-2d", async () => {
 
 describe("GraphPanel", () => {
   it("offers semantic graph types as local anchors", async () => {
-    render(<GraphPanel api={graphApi()} />);
+    render(<GraphPanel api={graphApi().api} />);
 
     const controls = await screen.findByLabelText("Graph controls");
     await userEvent.click(within(controls).getByRole("button", { name: "Local" }));
@@ -39,9 +39,56 @@ describe("GraphPanel", () => {
       "Value",
     ]);
   });
+
+  it("requests depth five and relationship limits above the former cap", async () => {
+    const harness = graphApi();
+    render(<GraphPanel api={harness.api} />);
+
+    const controls = await screen.findByLabelText("Graph controls");
+    expect(within(controls).getByLabelText("Relationship limit")).toHaveValue(80);
+    expect(within(controls).getByLabelText("Depth")).toHaveAttribute("max", "5");
+    await userEvent.click(within(controls).getByRole("button", { name: "Local" }));
+    await userEvent.type(within(controls).getByLabelText("Anchor ID"), "entity-1");
+    fireEvent.change(within(controls).getByLabelText("Depth"), { target: { value: "5" } });
+    fireEvent.change(within(controls).getByLabelText("Relationship limit"), { target: { value: "181" } });
+    await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(harness.graph).toHaveBeenLastCalledWith(expect.objectContaining({
+      scope: "local",
+      anchorId: "entity-1",
+      depth: 5,
+      limit: 181,
+    })));
+  });
+
+  it("rejects invalid relationship limits before requesting", async () => {
+    const harness = graphApi();
+    render(<GraphPanel api={harness.api} />);
+
+    const controls = await screen.findByLabelText("Graph controls");
+    await waitFor(() => expect(harness.graph).toHaveBeenCalledTimes(1));
+    fireEvent.change(within(controls).getByLabelText("Relationship limit"), { target: { value: "1.5" } });
+    await userEvent.click(within(controls).getByRole("button", { name: "Refresh" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("positive integer");
+    expect(harness.graph).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces stale graph nodes on refresh", async () => {
+    const before = snapshotWithNode("entity:wrong", "Wrong Project");
+    const after = snapshotWithNode("entity:correct", "Dense-Mem");
+    const harness = graphApi([before, after]);
+    render(<GraphPanel api={harness.api} />);
+
+    expect(await screen.findByText("Wrong Project")).toBeInTheDocument();
+    await userEvent.click(within(screen.getByLabelText("Graph controls")).getByRole("button", { name: "Refresh" }));
+
+    expect(await screen.findByText("Dense-Mem")).toBeInTheDocument();
+    expect(screen.queryByText("Wrong Project")).not.toBeInTheDocument();
+  });
 });
 
-function graphApi(): UserApi {
+function graphApi(snapshots?: GraphSnapshot[]): { api: UserApi; graph: ReturnType<typeof vi.fn> } {
   const snapshot: GraphSnapshot = {
     scope: "overview",
     depth: 2,
@@ -50,8 +97,25 @@ function graphApi(): UserApi {
     nodes: [],
     edges: [],
   };
-  return {
-    graph: vi.fn().mockResolvedValue(snapshot),
+  const graph = vi.fn();
+  for (const item of snapshots ?? [snapshot]) {
+    graph.mockResolvedValueOnce(item);
+  }
+  graph.mockResolvedValue(snapshots?.at(-1) ?? snapshot);
+  return { api: {
+    graph,
     nodeDetail: vi.fn(),
-  } as unknown as UserApi;
+  } as unknown as UserApi, graph };
+}
+
+function snapshotWithNode(key: string, title: string): GraphSnapshot {
+  const [, id] = key.split(":");
+  return {
+    scope: "overview",
+    depth: 2,
+    limit: 80,
+    truncated: false,
+    nodes: [{ key, id, type: "entity", title }],
+    edges: [],
+  };
 }

--- a/web/src/user/GraphPanel.tsx
+++ b/web/src/user/GraphPanel.tsx
@@ -21,6 +21,7 @@ type ForceNode = NodeObject<GraphNode> & GraphNode;
 type ForceLink = LinkObject<GraphNode, GraphEdge> & GraphEdge;
 
 const graphNodeTypes: GraphNodeType[] = ["entity", "value"];
+const defaultGraphLimit = 80;
 
 const defaultTypes: TypeFilter = {
   entity: true,
@@ -36,6 +37,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [anchorId, setAnchorId] = useState("");
   const [types, setTypes] = useState<TypeFilter>(defaultTypes);
   const [depth, setDepth] = useState(2);
+  const [limitInput, setLimitInput] = useState(String(defaultGraphLimit));
   const [nodeSize, setNodeSize] = useState(5);
   const [linkDistance, setLinkDistance] = useState(92);
   const [showArrows, setShowArrows] = useState(true);
@@ -48,7 +50,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   const [detailError, setDetailError] = useState("");
   const [graphRevision, setGraphRevision] = useState(0);
 
-  async function loadGraph(query: GraphQuery = buildQuery({ searchText, scope, anchorType, anchorId, types, depth })) {
+  async function loadGraph(query: GraphQuery) {
     if (query.types?.length === 0) {
       setError("Select at least one type.");
       return;
@@ -76,7 +78,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
   }
 
   useEffect(() => {
-    void loadGraph(buildQuery({ searchText: "", scope: "overview", anchorType, anchorId: "", types, depth: 2 }));
+    void loadGraph(buildQuery({ searchText: "", scope: "overview", anchorType, anchorId: "", types, depth: 2, limit: defaultGraphLimit }));
   }, [api]);
 
   const selectedNode = selectedKey ? snapshot?.nodes.find((node) => node.key === selectedKey) ?? null : null;
@@ -122,7 +124,12 @@ export function GraphPanel({ api }: { api: UserApi }) {
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    void loadGraph();
+    const limit = parseGraphLimit(limitInput);
+    if (limit === null) {
+      setError("Relationship limit must be a positive integer.");
+      return;
+    }
+    void loadGraph(buildQuery({ searchText, scope, anchorType, anchorId, types, depth, limit }));
   }
 
   function toggleType(type: GraphNodeType) {
@@ -136,7 +143,7 @@ export function GraphPanel({ api }: { api: UserApi }) {
           title="Graph"
           meta={snapshot ? `${snapshot.nodes.length} nodes / ${snapshot.edges.length} edges` : undefined}
         />
-        <form className="graph-control-form" onSubmit={submit}>
+        <form className="graph-control-form" noValidate onSubmit={submit}>
           <label htmlFor="graph-query">Search</label>
           <div className="search-input-wrap">
             <Search size={16} aria-hidden="true" />
@@ -184,8 +191,20 @@ export function GraphPanel({ api }: { api: UserApi }) {
 
           <div className="graph-slider-row">
             <label htmlFor="graph-depth">Depth</label>
-            <input id="graph-depth" type="range" min={1} max={2} step={1} value={depth} disabled={scope !== "local"} onChange={(event) => setDepth(Number(event.target.value))} />
+            <input id="graph-depth" type="range" min={1} max={5} step={1} value={depth} disabled={scope !== "local"} onChange={(event) => setDepth(Number(event.target.value))} />
             <span>{depth}</span>
+          </div>
+          <div className="graph-limit-row">
+            <label htmlFor="graph-relationship-limit">Relationship limit</label>
+            <input
+              id="graph-relationship-limit"
+              type="number"
+              min={1}
+              step={1}
+              inputMode="numeric"
+              value={limitInput}
+              onChange={(event) => setLimitInput(event.target.value)}
+            />
           </div>
           <div className="graph-slider-row">
             <label htmlFor="graph-node-size">Node size</label>
@@ -536,6 +555,7 @@ function buildQuery({
   anchorId,
   types,
   depth,
+  limit,
 }: {
   searchText: string;
   scope: "overview" | "local";
@@ -543,6 +563,7 @@ function buildQuery({
   anchorId: string;
   types: TypeFilter;
   depth: number;
+  limit: number;
 }): GraphQuery {
   const enabledTypes = graphNodeTypes.filter((type) => types[type]);
   return {
@@ -552,7 +573,13 @@ function buildQuery({
     anchorType: scope === "local" ? anchorType : undefined,
     anchorId: scope === "local" ? anchorId.trim() : undefined,
     depth,
+    limit,
   };
+}
+
+function parseGraphLimit(value: string): number | null {
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function drawNode(

--- a/web/src/user/api.test.ts
+++ b/web/src/user/api.test.ts
@@ -142,6 +142,7 @@ describe("UserApi", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "/ui/api/graph?scope=local&q=project+graph&types=entity%2Cvalue&anchor_type=entity&anchor_id=entity-1&depth=2&limit=40",
       expect.objectContaining({
+        cache: "no-store",
         headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
       }),
     );
@@ -165,6 +166,7 @@ describe("UserApi", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "/ui/api/node-detail?type=entity&id=entity-1",
       expect.objectContaining({
+        cache: "no-store",
         headers: expect.objectContaining({ Authorization: "Bearer dm_key" }),
       }),
     );

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -304,6 +304,7 @@ type RequestOptions = {
   method?: string;
   body?: unknown;
   signal?: AbortSignal;
+  cache?: RequestCache;
 };
 
 export type UserAuthMode = "anonymous" | "api_key" | "api_key_session" | "sso";
@@ -473,13 +474,13 @@ export class UserApi {
       params.set("limit", String(query.limit));
     }
     const suffix = params.toString() ? `?${params.toString()}` : "";
-    const payload = await this.request<Envelope<GraphSnapshot>>(`/ui/api/graph${suffix}`);
+    const payload = await this.request<Envelope<GraphSnapshot>>(`/ui/api/graph${suffix}`, { cache: "no-store" });
     return payload.data;
   }
 
   async nodeDetail(type: string, id: string): Promise<GraphNode> {
     const params = new URLSearchParams({ type, id });
-    const payload = await this.request<Envelope<GraphNode>>(`/ui/api/node-detail?${params.toString()}`);
+    const payload = await this.request<Envelope<GraphNode>>(`/ui/api/node-detail?${params.toString()}`, { cache: "no-store" });
     return payload.data;
   }
 
@@ -518,6 +519,7 @@ export class UserApi {
       token: this.token || undefined,
       credentials: this.token ? "same-origin" : "include",
       body: options.body,
+      cache: options.cache,
       signal: options.signal,
       csrf: this.token ? undefined : {
         cookieName: this.authMode === "api_key_session" ? "dense_mem_ui_csrf" : "dense_mem_sso_csrf",

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type APIRequestContext, type Page, test } from "@playwright/test";
+import { expect, type APIRequestContext, type Locator, type Page, test } from "@playwright/test";
 
 const controlUrl = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
 const userUrl = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
@@ -8,6 +8,11 @@ const seedTeamName = requiredEnv("DENSE_MEM_E2E_TEAM_NAME");
 const seedApiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
 const dreamStatement = requiredEnv("DENSE_MEM_E2E_DREAM_STATEMENT");
 const prometheusUrl = requiredEnv("DENSE_MEM_PROMETHEUS_URL").replace(/\/$/, "");
+const graphAnchorEntityId = process.env.DENSE_MEM_E2E_GRAPH_ANCHOR_ENTITY_ID ?? "";
+const graphOriginalObjectEntityId = process.env.DENSE_MEM_E2E_GRAPH_ORIGINAL_OBJECT_ENTITY_ID ?? "";
+const graphCorrectedObjectEntityId = process.env.DENSE_MEM_E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID ?? "";
+const graphOriginalRelationshipId = process.env.DENSE_MEM_E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID ?? "";
+const graphSuccessorRelationshipId = process.env.DENSE_MEM_E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID ?? "";
 
 type CreatedProfile = {
   api_key: string;
@@ -107,6 +112,20 @@ test("control panel shows operational metrics against compose", async ({ page })
   await page.getByLabel("Team", { exact: true }).selectOption(seedTeamId);
   await expect(page.getByRole("heading", { name: "Usage Rollup" })).toBeVisible();
   await expectNoShellOverlap(page);
+});
+
+test("control overview contains every Top Signals diagnostic", async ({ page }) => {
+  await openControlPanel(page);
+  await page.getByRole("button", { name: new RegExp(escapeRegExp(seedTeamName)) }).click();
+
+  const topSignals = page.getByLabel("Top signals");
+  await expect(topSignals).toBeVisible();
+  const rows = topSignals.locator(".metric-row");
+  await expect(rows).toHaveCount(4);
+  for (let index = 0; index < await rows.count(); index += 1) {
+    const row = rows.nth(index);
+    await expectMetricDetailContained(row, row.locator(".metric-detail"));
+  }
 });
 
 test("control panel keeps security settings display-only against compose", async ({ page }) => {
@@ -396,6 +415,52 @@ test("user portal logs in with a real API key and shows only that profile", asyn
   await page.getByRole("button", { name: "Dreams" }).click();
   await expect(page.getByRole("heading", { name: "Dream Outputs" })).toBeVisible();
   await expect(page.getByText(dreamStatement, { exact: true })).toBeVisible();
+});
+
+test("user portal renders the corrected live graph with depth five and an uncapped limit", async ({ page }) => {
+  test.skip(
+    !graphAnchorEntityId || !graphOriginalObjectEntityId || !graphCorrectedObjectEntityId || !graphOriginalRelationshipId || !graphSuccessorRelationshipId,
+    "submission-status graph fixture is required",
+  );
+  await openUserPortal(page, seedApiKey);
+  await page.getByRole("button", { name: "Graph" }).click();
+
+  const controls = page.getByLabel("Graph controls");
+  await expect(controls.getByLabel("Relationship limit")).toHaveValue("80");
+  await expect(controls.getByLabel("Depth")).toHaveValue("2");
+  await expect(controls.getByLabel("Depth")).toHaveAttribute("max", "5");
+  await controls.getByRole("button", { name: "Local" }).click();
+  await controls.getByLabel("Anchor ID").fill(graphAnchorEntityId);
+  await controls.getByLabel("Depth").focus();
+  await controls.getByLabel("Depth").press("End");
+  await expect(controls.getByLabel("Depth")).toHaveValue("5");
+  await controls.getByLabel("Relationship limit").fill("181");
+
+  const graphResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname === "/ui/api/graph" && url.searchParams.get("depth") === "5" && url.searchParams.get("limit") === "181";
+  });
+  await controls.getByRole("button", { name: "Refresh" }).click();
+  const graphResponse = await graphResponsePromise;
+  expect(graphResponse.status()).toBe(200);
+  expect(graphResponse.headers()["cache-control"]).toBe("no-store");
+  const graph = (await graphResponse.json() as {
+    data: {
+      depth: number;
+      limit: number;
+      nodes: Array<{ id: string }>;
+      edges: Array<{ id: string }>;
+    };
+  }).data;
+  expect(graph.depth).toBe(5);
+  expect(graph.limit).toBe(181);
+  expect(graph.nodes.map((node) => node.id)).toContain(graphCorrectedObjectEntityId);
+  expect(graph.nodes.map((node) => node.id)).not.toContain(graphOriginalObjectEntityId);
+  expect(graph.edges.map((edge) => edge.id)).toContain(graphSuccessorRelationshipId);
+  expect(graph.edges.map((edge) => edge.id)).not.toContain(graphOriginalRelationshipId);
+  await expect(page.getByLabel("Graph totals")).toContainText(new RegExp(`Nodes\\s*${graph.nodes.length}`));
+  await expect(page.getByLabel("Graph totals")).toContainText(new RegExp(`Edges\\s*${graph.edges.length}`));
+  await expect(page.locator(".graph-canvas canvas").first()).toBeVisible();
 });
 
 test("read-only user key cannot regenerate itself", async ({ page, request }, testInfo) => {
@@ -814,6 +879,36 @@ function rectanglesOverlap(
   second: { left: number; top: number; right: number; bottom: number },
 ) {
   return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
+}
+
+async function expectMetricDetailContained(row: Locator, detail: Locator) {
+  const geometry = await row.evaluate((element) => {
+    const detailElement = element.querySelector<HTMLElement>(".metric-detail");
+    const labelElement = element.querySelector<HTMLElement>(".metric-label");
+    const valueElement = element.querySelector<HTMLElement>("strong");
+    if (!detailElement || !labelElement || !valueElement) {
+      throw new Error("metric row structure is incomplete");
+    }
+    const rowRect = element.getBoundingClientRect();
+    const detailRect = detailElement.getBoundingClientRect();
+    const labelRect = labelElement.getBoundingClientRect();
+    const valueRect = valueElement.getBoundingClientRect();
+    return {
+      row: { left: rowRect.left, right: rowRect.right, bottom: rowRect.bottom },
+      detail: { left: detailRect.left, right: detailRect.right, top: detailRect.top, bottom: detailRect.bottom },
+      firstLineBottom: Math.max(labelRect.bottom, valueRect.bottom),
+      clientWidth: detailElement.clientWidth,
+      scrollWidth: detailElement.scrollWidth,
+    };
+  });
+
+  expect(geometry.detail.left).toBeGreaterThanOrEqual(geometry.row.left);
+  expect(geometry.detail.right).toBeLessThanOrEqual(geometry.row.right + 1);
+  expect(geometry.detail.bottom).toBeLessThanOrEqual(geometry.row.bottom + 1);
+  expect(geometry.detail.top).toBeGreaterThanOrEqual(geometry.firstLineBottom);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  await expect(detail).toHaveCSS("overflow-wrap", "anywhere");
+  await expect(detail).toHaveCSS("white-space", "normal");
 }
 
 function bearer(token: string) {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -299,6 +299,11 @@ test("graph refresh replaces a corrected endpoint while the graph stays open", a
   await page.addInitScript(() => {
     const trackedWindow = window as Window & { __denseMemGraphLabels?: string[] };
     trackedWindow.__denseMemGraphLabels = [];
+    const clearRect = CanvasRenderingContext2D.prototype.clearRect;
+    CanvasRenderingContext2D.prototype.clearRect = function (x, y, width, height) {
+      trackedWindow.__denseMemGraphLabels = [];
+      return clearRect.call(this, x, y, width, height);
+    };
     const fillText = CanvasRenderingContext2D.prototype.fillText;
     CanvasRenderingContext2D.prototype.fillText = function (text, x, y, maxWidth) {
       const labels = trackedWindow.__denseMemGraphLabels ?? [];
@@ -345,17 +350,13 @@ test("graph refresh replaces a corrected endpoint while the graph stays open", a
   const requestsBeforeRefresh = harness.graphRequests.length;
 
   harness.correctRelationship();
-  await page.evaluate(() => {
-    (window as Window & { __denseMemGraphLabels?: string[] }).__denseMemGraphLabels = [];
-  });
   await page.getByLabel("Graph controls").getByRole("button", { name: "Refresh", exact: true }).click();
   await expect.poll(() => harness.graphRequests.length).toBeGreaterThan(requestsBeforeRefresh);
   await expect.poll(() => graphCanvasLabels(page)).toContain("Corrected Project");
   await page.waitForTimeout(300);
   const labels = await graphCanvasLabels(page);
-  const firstCorrected = labels.indexOf("Corrected Project");
-  expect(firstCorrected).toBeGreaterThanOrEqual(0);
-  expect(labels.lastIndexOf("Wrong Project")).toBeLessThan(firstCorrected);
+  expect(labels).toContain("Corrected Project");
+  expect(labels).not.toContain("Wrong Project");
 });
 
 test("read-only key cannot regenerate itself", async ({ page }) => {

--- a/web/tests-user/user-portal.spec.ts
+++ b/web/tests-user/user-portal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 const team = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -103,7 +103,7 @@ const relationships = [
 
 const graphSnapshot = {
   scope: "overview",
-  depth: 1,
+  depth: 2,
   limit: 80,
   truncated: false,
   nodes: [
@@ -280,6 +280,82 @@ test("graph tab renders a nonblank memory graph", async ({ page }) => {
     return painted;
   })).toBeGreaterThan(0);
   expect(calls.graphRequests.some((url) => url.includes("/ui/api/graph?scope=overview"))).toBe(true);
+
+  const controls = page.getByLabel("Graph controls");
+  await controls.getByRole("button", { name: "Local" }).click();
+  await controls.getByLabel("Anchor ID").fill("entity-alice");
+  await controls.getByLabel("Depth").focus();
+  await controls.getByLabel("Depth").press("End");
+  await expect(controls.getByLabel("Depth")).toHaveValue("5");
+  await controls.getByLabel("Relationship limit").fill("181");
+  await controls.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect.poll(() => calls.graphRequests.some((requestUrl) => {
+    const url = new URL(requestUrl);
+    return url.searchParams.get("depth") === "5" && url.searchParams.get("limit") === "181";
+  })).toBe(true);
+});
+
+test("graph refresh replaces a corrected endpoint while the graph stays open", async ({ page }) => {
+  await page.addInitScript(() => {
+    const trackedWindow = window as Window & { __denseMemGraphLabels?: string[] };
+    trackedWindow.__denseMemGraphLabels = [];
+    const fillText = CanvasRenderingContext2D.prototype.fillText;
+    CanvasRenderingContext2D.prototype.fillText = function (text, x, y, maxWidth) {
+      const labels = trackedWindow.__denseMemGraphLabels ?? [];
+      labels.push(String(text));
+      if (labels.length > 10_000) {
+        labels.splice(0, labels.length - 5_000);
+      }
+      trackedWindow.__denseMemGraphLabels = labels;
+      if (maxWidth === undefined) {
+        return fillText.call(this, text, x, y);
+      }
+      return fillText.call(this, text, x, y, maxWidth);
+    };
+  });
+  const original = {
+    ...graphSnapshot,
+    nodes: [
+      { key: "entity:entity-alice", id: "entity-alice", type: "entity", title: "Alice" },
+      { key: "entity:entity-wrong-project", id: "entity-wrong-project", type: "entity", title: "Wrong Project" },
+    ],
+    edges: [
+      { id: "relationship-original", source: "entity:entity-alice", target: "entity:entity-wrong-project", relationship: "USES", directed: true },
+    ],
+  };
+  const corrected = {
+    ...graphSnapshot,
+    nodes: [
+      { key: "entity:entity-alice", id: "entity-alice", type: "entity", title: "Alice" },
+      { key: "entity:entity-corrected-project", id: "entity-corrected-project", type: "entity", title: "Corrected Project" },
+    ],
+    edges: [
+      { id: "relationship-successor", source: "entity:entity-alice", target: "entity:entity-corrected-project", relationship: "USES", directed: true },
+    ],
+  };
+  const harness = await mockUserApi(page, {
+    key: readKey,
+    canRotate: false,
+    graphSnapshots: [original, corrected],
+  });
+  await openUserPortal(page, "dm_read");
+
+  await page.getByRole("button", { name: "Graph" }).click();
+  await expect.poll(() => graphCanvasLabels(page)).toContain("Wrong Project");
+  const requestsBeforeRefresh = harness.graphRequests.length;
+
+  harness.correctRelationship();
+  await page.evaluate(() => {
+    (window as Window & { __denseMemGraphLabels?: string[] }).__denseMemGraphLabels = [];
+  });
+  await page.getByLabel("Graph controls").getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect.poll(() => harness.graphRequests.length).toBeGreaterThan(requestsBeforeRefresh);
+  await expect.poll(() => graphCanvasLabels(page)).toContain("Corrected Project");
+  await page.waitForTimeout(300);
+  const labels = await graphCanvasLabels(page);
+  const firstCorrected = labels.indexOf("Corrected Project");
+  expect(firstCorrected).toBeGreaterThanOrEqual(0);
+  expect(labels.lastIndexOf("Wrong Project")).toBeLessThan(firstCorrected);
 });
 
 test("read-only key cannot regenerate itself", async ({ page }) => {
@@ -472,7 +548,13 @@ function rectanglesOverlap(
 
 async function mockUserApi(
   page: Page,
-  state: { key: TestKey; canRotate: boolean; canManageTeam?: boolean; profiles?: TestKey[] },
+  state: {
+    key: TestKey;
+    canRotate: boolean;
+    canManageTeam?: boolean;
+    profiles?: TestKey[];
+    graphSnapshots?: Array<typeof graphSnapshot>;
+  },
 ) {
   const calls = {
     rotateBodies: [] as string[],
@@ -485,6 +567,7 @@ async function mockUserApi(
   let currentCanRotate = state.canRotate;
   let currentProfiles = (state.profiles ?? []).map((profile) => ({ ...profile }));
   let portalSessionCreated = false;
+  let graphSnapshotIndex = 0;
 
   await page.route("**/ui/api/sso/providers", async (route) => {
     await route.fulfill({
@@ -620,10 +703,13 @@ async function mockUserApi(
 
   await page.route("**/ui/api/graph**", async (route) => {
     calls.graphRequests.push(route.request().url());
+    const snapshots = state.graphSnapshots ?? [graphSnapshot];
+    const snapshot = snapshots[Math.min(graphSnapshotIndex, snapshots.length - 1)];
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ data: graphSnapshot }),
+      headers: { "Cache-Control": "no-store" },
+      body: JSON.stringify({ data: snapshot }),
     });
   });
 
@@ -646,7 +732,18 @@ async function mockUserApi(
     });
   });
 
-  return calls;
+  return {
+    ...calls,
+    correctRelationship() {
+      graphSnapshotIndex = Math.max(0, (state.graphSnapshots?.length ?? 1) - 1);
+    },
+  };
+}
+
+async function graphCanvasLabels(page: Page): Promise<string[]> {
+  return page.evaluate(() => (
+    (window as Window & { __denseMemGraphLabels?: string[] }).__denseMemGraphLabels ?? []
+  ));
 }
 
 function telemetryForKey(key: TestKey) {

--- a/web/tests/control-portal.spec.ts
+++ b/web/tests/control-portal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 const team = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -75,7 +75,11 @@ const metrics = {
   },
   dependencies: [
     { name: "postgres", status: "ok", latency_ms: 3 },
-    { name: "redis", status: "ok", latency_ms: 8 },
+    { name: "verifier", status: "ok", latency_ms: 52 },
+    { name: "embeddings", status: "ok", latency_ms: 41 },
+    { name: "telemetry", status: "ok", latency_ms: 6 },
+    { name: "search_readiness", status: "error", reason_code: "check_failed", latency_ms: 161 },
+    { name: "redis", status: "degraded", reason_code: "single_node_mode", latency_ms: null },
   ],
   teams: [
     { team_id: team.id, team_name: "Default", requests: 42, errors: 2, avg_latency_ms: 18.5, max_latency_ms: 90 },
@@ -484,6 +488,19 @@ test("team workspace header stays compact across team tabs", async ({ page }) =>
   expect(Math.max(...heights) - Math.min(...heights), `team header heights: ${heights.join(", ")}`).toBeLessThanOrEqual(8);
 });
 
+test("top signals keeps long dependency diagnostics inside its metric row", async ({ page }) => {
+  await mockApi(page, { teams: [team], keys: [key] });
+  await openPortal(page);
+
+  const topSignals = page.getByLabel("Top signals");
+  const dependencyRow = topSignals.locator(".metric-row", { hasText: "Dependency checks" });
+  const detail = dependencyRow.locator(".metric-detail");
+  await expect(dependencyRow).toContainText("4/6");
+  await expect(detail).toContainText("search_readiness · check_failed · 161 ms");
+  await expect(detail).toContainText("redis · single_node_mode · latency n/a");
+  await expectMetricDetailContained(dependencyRow, detail);
+});
+
 test("config tab uses horizontal subnavigation", async ({ page }) => {
   await mockApi(page, { teams: [team], keys: [key] });
   await openPortal(page);
@@ -623,6 +640,40 @@ function rectanglesOverlap(
   second: { left: number; top: number; right: number; bottom: number },
 ) {
   return first.left < second.right && first.right > second.left && first.top < second.bottom && first.bottom > second.top;
+}
+
+async function expectMetricDetailContained(row: Locator, detail: Locator) {
+  const geometry = await row.evaluate((element) => {
+    const detailElement = element.querySelector<HTMLElement>(".metric-detail");
+    const labelElement = element.querySelector<HTMLElement>(".metric-label");
+    const valueElement = element.querySelector<HTMLElement>("strong");
+    if (!detailElement || !labelElement || !valueElement) {
+      throw new Error("metric row structure is incomplete");
+    }
+    const rowRect = element.getBoundingClientRect();
+    const detailRect = detailElement.getBoundingClientRect();
+    const labelRect = labelElement.getBoundingClientRect();
+    const valueRect = valueElement.getBoundingClientRect();
+    const style = getComputedStyle(detailElement);
+    return {
+      row: { left: rowRect.left, right: rowRect.right, bottom: rowRect.bottom },
+      detail: { left: detailRect.left, right: detailRect.right, top: detailRect.top, bottom: detailRect.bottom },
+      firstLineBottom: Math.max(labelRect.bottom, valueRect.bottom),
+      clientWidth: detailElement.clientWidth,
+      scrollWidth: detailElement.scrollWidth,
+      overflowWrap: style.overflowWrap,
+      whiteSpace: style.whiteSpace,
+    };
+  });
+
+  expect(geometry.detail.left).toBeGreaterThanOrEqual(geometry.row.left);
+  expect(geometry.detail.right).toBeLessThanOrEqual(geometry.row.right + 1);
+  expect(geometry.detail.bottom).toBeLessThanOrEqual(geometry.row.bottom + 1);
+  expect(geometry.detail.top).toBeGreaterThanOrEqual(geometry.firstLineBottom);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  expect(geometry.overflowWrap).toBe("anywhere");
+  expect(geometry.whiteSpace).toBe("normal");
+  await expect(detail).toBeVisible();
 }
 
 async function mockApi(page: Page, state: { teams: TestProfile[]; keys: TestKey[]; bans?: TestBan[] }) {


### PR DESCRIPTION
## Summary

- prevent stale user-portal graph and node-detail reads with server and browser `no-store` caching policy
- make graph depth default to 2 and cap at 5, while keeping the relationship result default at 80 without a hard maximum
- add the relationship-limit control and verify refresh replaces a corrected endpoint in the real canvas
- wrap Top Signals diagnostics on a dedicated second grid row so long dependency details remain contained
- extend the live `submission_status` Compose scenario through correction, graph API, and desktop/mobile portal checks

## Root cause

PostgreSQL graph snapshots are derived from active semantic edges, so a superseded relationship cannot retain an unshared endpoint. The graph GET responses and browser requests did not explicitly disable caching, allowing a previously fetched snapshot to outlive a successful `correct_relationship` call in the portal.

## Validation

- `./scripts/ci-check.sh` — passed, 90.2% aggregate coverage
- `npm run typecheck` and `npm test` — passed, 96 tests
- affected PostgreSQL integration tests — passed with Testcontainers
- `DENSE_MEM_E2E_SCENARIO=submission_status DENSE_MEM_E2E_SKIP_PRECHECKS=1 ./scripts/e2e-compose.sh` — passed with the configured live verifier and 4/4 desktop/mobile portal tests
- focused graph canvas and Top Signals Playwright checks — passed on desktop and mobile
- deterministic evaluation — intentionally not run per request

## Notes

The full local Testcontainers package still has unrelated existing placement/search-fixture failures and reaches its 10-minute package timeout; the three affected graph/correction integration cases pass. Full mock-browser runs also retain unrelated existing Dreams/header/Recall-inspector assertions; all new graph and Top Signals cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable relationship limits and graph depth up to 5.
  - Improved graph refresh behavior so corrected relationships and entities replace stale data.
  - Added clearer diagnostics for degraded and unavailable services.
  - Added responsive metric layouts and graph limit controls.

- **Bug Fixes**
  - Prevented graph snapshots and node details from being cached.
  - Improved validation and handling of graph query limits and depth.

- **Tests**
  - Expanded coverage for graph queries, corrections, diagnostics, caching, and end-to-end portal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->