### PR TITLE
Add label-triggered PR test images

### DIFF
--- a/.github/scripts/image-release-policy.cjs
+++ b/.github/scripts/image-release-policy.cjs
@@ -1,0 +1,308 @@
+"use strict";
+
+const PREVIEW_LABEL = "deploy-test-image";
+const POLICY_STATUS_CONTEXT = "PR test image policy";
+const TRUSTED_LABEL_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+
+function normalizeLabelName(label) {
+  return typeof label === "string" ? label : label?.name;
+}
+
+function hasLabel(labels, name) {
+  return labels.some((label) => normalizeLabelName(label) === name);
+}
+
+function decidePreviewEvent({
+  action,
+  eventLabel,
+  hasPreviewLabel,
+  isFork,
+  triggerHeadMatches,
+  actorPermission,
+  allowForkBuilds = false,
+}) {
+  if (!triggerHeadMatches) {
+    return { mode: "noop", reason: "stale_event" };
+  }
+
+  if (action === "labeled" && eventLabel !== PREVIEW_LABEL) {
+    return { mode: "noop", reason: "irrelevant_label" };
+  }
+  if (action === "unlabeled" && eventLabel !== PREVIEW_LABEL) {
+    return { mode: "noop", reason: "irrelevant_label" };
+  }
+
+  if (action === "unlabeled") {
+    return { mode: "skipped", reason: "label_absent" };
+  }
+
+  if (!hasPreviewLabel) {
+    return { mode: "skipped", reason: "label_absent" };
+  }
+
+  if (isFork && !allowForkBuilds) {
+    return {
+      mode: "skipped",
+      reason: "fork_isolation_unavailable",
+      removeLabel: hasPreviewLabel,
+    };
+  }
+
+  if (isFork && action !== "labeled") {
+    return {
+      mode: "skipped",
+      reason: hasPreviewLabel ? "fork_reapproval_required" : "label_absent",
+      removeLabel: hasPreviewLabel,
+    };
+  }
+
+  if (isFork && !TRUSTED_LABEL_PERMISSIONS.has(actorPermission)) {
+    return {
+      mode: "skipped",
+      reason: "fork_reapproval_required",
+      removeLabel: true,
+    };
+  }
+
+  if (["opened", "reopened", "synchronize", "labeled"].includes(action)) {
+    return { mode: "attempt", reason: "requested" };
+  }
+
+  return { mode: "noop", reason: "unsupported_action" };
+}
+
+function compareContainsMain(compareStatus) {
+  return compareStatus === "ahead" || compareStatus === "identical";
+}
+
+function selectMergedPull(pulls, mainCommit) {
+  const matches = pulls.filter(
+    (pull) =>
+      pull.merged_at !== null &&
+      pull.base?.ref === "main" &&
+      pull.merge_commit_sha === mainCommit,
+  );
+
+  if (matches.length !== 1) {
+    return {
+      pull: null,
+      reason:
+        matches.length === 0
+          ? "no merged pull request is associated with the main commit"
+          : "multiple merged pull requests are associated with the main commit",
+    };
+  }
+
+  return { pull: matches[0], reason: "" };
+}
+
+function parseSuccessfulPolicyStatus({
+  statuses,
+  pullNumber,
+  serverUrl,
+  repository,
+}) {
+  const latest = [...statuses]
+    .filter((status) => status.context === POLICY_STATUS_CONTEXT)
+    .sort((left, right) => right.id - left.id)[0];
+
+  if (!latest) {
+    return { status: null, reason: "the final PR head has no preview policy status" };
+  }
+  if (latest.state !== "success") {
+    return {
+      status: null,
+      reason: `the latest preview policy status is ${latest.state}`,
+    };
+  }
+
+  const match = /^Published test-([1-9][0-9]*) \(run ([1-9][0-9]*), attempt ([1-9][0-9]*)\)\.$/.exec(
+    latest.description || "",
+  );
+  if (!match || Number(match[1]) !== pullNumber) {
+    return { status: null, reason: "the preview policy status receipt is invalid" };
+  }
+
+  const runId = match[2];
+  const runAttempt = match[3];
+  const expectedUrl = `${serverUrl}/${repository}/actions/runs/${runId}`;
+  if (latest.target_url !== expectedUrl) {
+    return { status: null, reason: "the preview policy status run URL is invalid" };
+  }
+
+  return {
+    status: {
+      runId,
+      runAttempt,
+      targetUrl: expectedUrl,
+    },
+    reason: "",
+  };
+}
+
+function decideRcPreview({ pull, hasPreviewLabel, policyStatus, workflowRun }) {
+  if (!pull) {
+    return { eligible: false, reason: "no unique merged pull request" };
+  }
+  if (!hasPreviewLabel) {
+    return { eligible: false, reason: `pull request #${pull.number} is not labeled` };
+  }
+  if (!policyStatus) {
+    return { eligible: false, reason: "the final PR head has no valid preview receipt" };
+  }
+  if (
+    !workflowRun ||
+    workflowRun.id !== Number(policyStatus.runId) ||
+    workflowRun.run_attempt !== Number(policyStatus.runAttempt) ||
+    workflowRun.event !== "pull_request_target" ||
+    workflowRun.conclusion !== "success" ||
+    workflowRun.path !== ".github/workflows/pr-test-image.yml" ||
+    workflowRun.display_title !== `PR test image: PR #${pull.number}`
+  ) {
+    return { eligible: false, reason: "the preview workflow run receipt is invalid" };
+  }
+  return { eligible: true, reason: "" };
+}
+
+function resolvePullRequestEvent(payload, actorPermission) {
+  const pull = payload.pull_request;
+  if (!pull || !Number.isSafeInteger(pull.number)) {
+    throw new Error("The event payload has no valid pull request.");
+  }
+
+  const triggerHead = pull.head?.sha;
+  if (typeof triggerHead !== "string" || !/^[0-9a-f]{40}$/.test(triggerHead)) {
+    throw new Error("The event payload has no valid PR head SHA.");
+  }
+
+  return {
+    action: payload.action,
+    eventLabel: payload.label?.name || "",
+    triggerHead,
+    pullNumber: pull.number,
+    isFork: pull.head.repo.full_name !== pull.base.repo.full_name,
+    actorPermission,
+  };
+}
+
+async function resolvePreviewAttempt({
+  github,
+  context,
+  actorPermission,
+  allowForkBuilds = false,
+}) {
+  const event = resolvePullRequestEvent(context.payload, actorPermission);
+  const { data: pull } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: event.pullNumber,
+  });
+
+  if (pull.state !== "open" || pull.base.ref !== "main") {
+    return { mode: "noop", reason: "pull_request_not_open_for_main" };
+  }
+
+  const hasPreviewLabel = hasLabel(pull.labels, PREVIEW_LABEL);
+  const decision = decidePreviewEvent({
+    ...event,
+    allowForkBuilds,
+    hasPreviewLabel,
+    triggerHeadMatches: pull.head.sha === event.triggerHead,
+  });
+
+  return {
+    ...decision,
+    pull,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    headRepository: pull.head.repo.full_name,
+    isFork: event.isFork,
+    hasPreviewLabel,
+  };
+}
+
+async function resolveRcPreview({ github, context, mainCommit }) {
+  const pulls = await github.paginate(
+    github.rest.repos.listPullRequestsAssociatedWithCommit,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      commit_sha: mainCommit,
+      per_page: 100,
+    },
+  );
+  const selected = selectMergedPull(pulls, mainCommit);
+  if (!selected.pull) {
+    return { eligible: false, reason: selected.reason };
+  }
+
+  const { data: pull } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: selected.pull.number,
+  });
+  const hasPreviewLabel = hasLabel(pull.labels, PREVIEW_LABEL);
+  const statuses = await github.paginate(
+    github.rest.repos.listCommitStatusesForRef,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: pull.head.sha,
+      per_page: 100,
+    },
+  );
+  const receipt = parseSuccessfulPolicyStatus({
+    statuses,
+    pullNumber: pull.number,
+    serverUrl: context.serverUrl,
+    repository: `${context.repo.owner}/${context.repo.repo}`,
+  });
+  if (!receipt.status) {
+    return { eligible: false, reason: receipt.reason };
+  }
+
+  let workflowRun = null;
+  try {
+    ({ data: workflowRun } = await github.rest.actions.getWorkflowRun({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: Number(receipt.status.runId),
+    }));
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+
+  const workflowValid = decideRcPreview({
+    pull,
+    hasPreviewLabel,
+    policyStatus: receipt.status,
+    workflowRun,
+  });
+  if (!workflowValid.eligible) {
+    return workflowValid;
+  }
+
+  return {
+    eligible: true,
+    reason: "",
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    runId: receipt.status.runId,
+    runAttempt: receipt.status.runAttempt,
+  };
+}
+
+module.exports = {
+  POLICY_STATUS_CONTEXT,
+  PREVIEW_LABEL,
+  compareContainsMain,
+  decidePreviewEvent,
+  decideRcPreview,
+  parseSuccessfulPolicyStatus,
+  resolvePreviewAttempt,
+  resolvePullRequestEvent,
+  resolveRcPreview,
+  selectMergedPull,
+};

--- a/.github/scripts/image-release-policy.cjs
+++ b/.github/scripts/image-release-policy.cjs
@@ -44,15 +44,15 @@ function decidePreviewEvent({
     return {
       mode: "skipped",
       reason: "fork_isolation_unavailable",
-      removeLabel: hasPreviewLabel,
+      removeLabel: true,
     };
   }
 
   if (isFork && action !== "labeled") {
     return {
       mode: "skipped",
-      reason: hasPreviewLabel ? "fork_reapproval_required" : "label_absent",
-      removeLabel: hasPreviewLabel,
+      reason: "fork_reapproval_required",
+      removeLabel: true,
     };
   }
 
@@ -180,7 +180,7 @@ function resolvePullRequestEvent(payload, actorPermission) {
     eventLabel: payload.label?.name || "",
     triggerHead,
     pullNumber: pull.number,
-    isFork: pull.head.repo.full_name !== pull.base.repo.full_name,
+    isFork: pull.head.repo?.full_name !== pull.base.repo.full_name,
     actorPermission,
   };
 }
@@ -215,7 +215,7 @@ async function resolvePreviewAttempt({
     pull,
     pullNumber: pull.number,
     headSha: pull.head.sha,
-    headRepository: pull.head.repo.full_name,
+    headRepository: pull.head.repo?.full_name || "",
     isFork: event.isFork,
     hasPreviewLabel,
   };

--- a/.github/scripts/oci-image.sh
+++ b/.github/scripts/oci-image.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGCTL_BIN="${REGCTL_BIN:-regctl}"
+
+fail() {
+	printf 'image policy error: %s\n' "$*" >&2
+	exit 1
+}
+
+require_tools() {
+	command -v "${REGCTL_BIN}" >/dev/null || fail "regctl is not available"
+	command -v jq >/dev/null || fail "jq is not available"
+}
+
+manifest_json() {
+	"${REGCTL_BIN}" manifest get "$1" --format raw-body
+}
+
+require_platforms() {
+	manifest_json "$1" |
+		jq -e '
+			.mediaType == "application/vnd.oci.image.index.v1+json" and
+			([.manifests[] | (.platform.os + "/" + .platform.architecture)] | sort) ==
+			["linux/amd64", "linux/arm64"]
+		' >/dev/null || fail "$1 does not contain exactly linux/amd64 and linux/arm64"
+}
+
+require_labels() {
+	local ref="$1"
+	local version="$2"
+	local revision="$3"
+	local pull_number="$4"
+	local main_revision="$5"
+	local run_id="$6"
+	local run_attempt="$7"
+	local platform
+
+	for platform in linux/amd64 linux/arm64; do
+		"${REGCTL_BIN}" image inspect "${ref}" --platform "${platform}" --format '{{json .}}' |
+			jq -e \
+				--arg version "${version}" \
+				--arg revision "${revision}" \
+				--arg pull_number "${pull_number}" \
+				--arg main_revision "${main_revision}" \
+				--arg run_id "${run_id}" \
+				--arg run_attempt "${run_attempt}" '
+					.config.Labels["org.opencontainers.image.version"] == $version and
+					.config.Labels["org.opencontainers.image.revision"] == $revision and
+					.config.Labels["org.opencontainers.image.variant"] == "production" and
+					.config.Labels["io.dense-mem.preview.pr"] == $pull_number and
+					.config.Labels["io.dense-mem.preview.head"] == $revision and
+					.config.Labels["io.dense-mem.preview.main"] == $main_revision and
+					.config.Labels["io.dense-mem.preview.run-id"] == $run_id and
+					.config.Labels["io.dense-mem.preview.run-attempt"] == $run_attempt
+				' >/dev/null || fail "${ref} has invalid ${platform} preview labels"
+	done
+}
+
+require_preview() {
+	local ref="$1"
+	local pull_number="$2"
+	local head_revision="$3"
+	local main_revision="$4"
+	local run_id="$5"
+	local run_attempt="$6"
+
+	require_platforms "${ref}"
+	require_labels \
+		"${ref}" \
+		"test-${pull_number}" \
+		"${head_revision}" \
+		"${pull_number}" \
+		"${main_revision}" \
+		"${run_id}" \
+		"${run_attempt}"
+}
+
+platform_layers() {
+	local ref="$1"
+	local platform="$2"
+	local digest
+
+	digest="$(
+		manifest_json "${ref}" |
+			jq -er --arg platform "${platform}" '
+				.manifests[] |
+				select((.platform.os + "/" + .platform.architecture) == $platform) |
+				.digest
+			'
+	)"
+	manifest_json "${ref%@*}@${digest}" | jq -cS '.layers'
+}
+
+publish_preview() {
+	local layout="$1"
+	local target_ref="$2"
+	local pull_number="$3"
+	local head_revision="$4"
+	local main_revision="$5"
+	local run_id="$6"
+	local run_attempt="$7"
+	local source_ref="ocidir://${layout}"
+	local source_digest
+	local target_digest
+
+	require_preview \
+		"${source_ref}" \
+		"${pull_number}" \
+		"${head_revision}" \
+		"${main_revision}" \
+		"${run_id}" \
+		"${run_attempt}"
+	source_digest="$("${REGCTL_BIN}" manifest head "${source_ref}")"
+	"${REGCTL_BIN}" image copy --force-recursive "${source_ref}@${source_digest}" "${target_ref}"
+	target_digest="$("${REGCTL_BIN}" manifest head "${target_ref}")"
+	[[ "${target_digest}" == "${source_digest}" ]] ||
+		fail "published digest ${target_digest} does not match artifact ${source_digest}"
+	require_preview \
+		"${target_ref}@${target_digest}" \
+		"${pull_number}" \
+		"${head_revision}" \
+		"${main_revision}" \
+		"${run_id}" \
+		"${run_attempt}"
+	printf '%s\n' "${target_digest}"
+}
+
+preview_receipt() {
+	local ref="$1"
+	local pull_number="$2"
+	local head_revision="$3"
+	local run_id="$4"
+	local run_attempt="$5"
+	local source_digest
+	local main_revision
+
+	source_digest="$("${REGCTL_BIN}" manifest head "${ref}")"
+	[[ "${source_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+		fail "${ref} returned an invalid manifest digest"
+	main_revision="$(
+		"${REGCTL_BIN}" image inspect "${ref}@${source_digest}" \
+			--platform linux/amd64 \
+			--format '{{json .}}' |
+			jq -er '.config.Labels["io.dense-mem.preview.main"]'
+	)"
+	[[ "${main_revision}" =~ ^[0-9a-f]{40}$ ]] ||
+		fail "${ref} contains an invalid tested main revision"
+	require_preview \
+		"${ref}@${source_digest}" \
+		"${pull_number}" \
+		"${head_revision}" \
+		"${main_revision}" \
+		"${run_id}" \
+		"${run_attempt}"
+	printf '%s\t%s\n' "${source_digest}" "${main_revision}"
+}
+
+promote_preview() {
+	local source_ref="$1"
+	local target_ref="$2"
+	local version="$3"
+	local revision="$4"
+	local created="$5"
+	local source_layers_amd64
+	local source_layers_arm64
+	local platform
+	local target_digest
+
+	require_platforms "${source_ref}"
+	source_layers_amd64="$(platform_layers "${source_ref}" linux/amd64)"
+	source_layers_arm64="$(platform_layers "${source_ref}" linux/arm64)"
+	"${REGCTL_BIN}" image mod "${source_ref}" \
+		--create "${target_ref}" \
+		--label "org.opencontainers.image.version=${version}" \
+		--label "org.opencontainers.image.revision=${revision}" \
+		--label "org.opencontainers.image.created=${created}"
+	target_digest="$("${REGCTL_BIN}" manifest head "${target_ref}")"
+	for platform in linux/amd64 linux/arm64; do
+		"${REGCTL_BIN}" image inspect "${target_ref}@${target_digest}" \
+			--platform "${platform}" \
+			--format '{{json .}}' |
+			jq -e \
+				--arg version "${version}" \
+				--arg revision "${revision}" \
+				--arg created "${created}" '
+					.config.Labels["org.opencontainers.image.version"] == $version and
+					.config.Labels["org.opencontainers.image.revision"] == $revision and
+					.config.Labels["org.opencontainers.image.created"] == $created
+				' >/dev/null || fail "${target_ref} has invalid ${platform} RC metadata"
+	done
+	[[ "$(platform_layers "${target_ref}@${target_digest}" linux/amd64)" == "${source_layers_amd64}" ]] ||
+		fail "${target_ref} changed linux/amd64 layer descriptors"
+	[[ "$(platform_layers "${target_ref}@${target_digest}" linux/arm64)" == "${source_layers_arm64}" ]] ||
+		fail "${target_ref} changed linux/arm64 layer descriptors"
+	printf '%s\n' "${target_digest}"
+}
+
+usage() {
+	printf '%s\n' \
+		"usage:" \
+		"  $0 validate-preview REF PR HEAD MAIN RUN_ID RUN_ATTEMPT" \
+		"  $0 preview-receipt REF PR HEAD RUN_ID RUN_ATTEMPT" \
+		"  $0 publish-preview LAYOUT TARGET_REF PR HEAD MAIN RUN_ID RUN_ATTEMPT" \
+		"  $0 promote-preview SOURCE_REF TARGET_REF VERSION REVISION CREATED" >&2
+	exit 2
+}
+
+require_tools
+
+case "${1:-}" in
+validate-preview)
+	[[ "$#" -eq 7 ]] || usage
+	require_preview "$2" "$3" "$4" "$5" "$6" "$7"
+	;;
+publish-preview)
+	[[ "$#" -eq 8 ]] || usage
+	publish_preview "$2" "$3" "$4" "$5" "$6" "$7" "$8"
+	;;
+preview-receipt)
+	[[ "$#" -eq 6 ]] || usage
+	preview_receipt "$2" "$3" "$4" "$5" "$6"
+	;;
+promote-preview)
+	[[ "$#" -eq 6 ]] || usage
+	promote_preview "$2" "$3" "$4" "$5" "$6"
+	;;
+*)
+	usage
+	;;
+esac

--- a/.github/scripts/oci-image.sh
+++ b/.github/scripts/oci-image.sh
@@ -89,6 +89,8 @@ platform_layers() {
 				.digest
 			'
 	)"
+	[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+		fail "${ref} returned an invalid ${platform} manifest digest"
 	manifest_json "${ref%@*}@${digest}" | jq -cS '.layers'
 }
 
@@ -100,7 +102,7 @@ publish_preview() {
 	local main_revision="$5"
 	local run_id="$6"
 	local run_attempt="$7"
-	local source_ref="ocidir://${layout}"
+	local source_ref="ocidir://${layout}:test-${pull_number}"
 	local source_digest
 	local target_digest
 
@@ -172,6 +174,11 @@ promote_preview() {
 	source_layers_arm64="$(platform_layers "${source_ref}" linux/arm64)"
 	"${REGCTL_BIN}" image mod "${source_ref}" \
 		--create "${target_ref}" \
+		--label "io.dense-mem.preview.pr=" \
+		--label "io.dense-mem.preview.head=" \
+		--label "io.dense-mem.preview.main=" \
+		--label "io.dense-mem.preview.run-id=" \
+		--label "io.dense-mem.preview.run-attempt=" \
 		--label "org.opencontainers.image.version=${version}" \
 		--label "org.opencontainers.image.revision=${revision}" \
 		--label "org.opencontainers.image.created=${created}"
@@ -180,14 +187,19 @@ promote_preview() {
 		"${REGCTL_BIN}" image inspect "${target_ref}@${target_digest}" \
 			--platform "${platform}" \
 			--format '{{json .}}' |
-			jq -e \
-				--arg version "${version}" \
-				--arg revision "${revision}" \
-				--arg created "${created}" '
-					.config.Labels["org.opencontainers.image.version"] == $version and
-					.config.Labels["org.opencontainers.image.revision"] == $revision and
-					.config.Labels["org.opencontainers.image.created"] == $created
-				' >/dev/null || fail "${target_ref} has invalid ${platform} RC metadata"
+				jq -e \
+					--arg version "${version}" \
+					--arg revision "${revision}" \
+					--arg created "${created}" '
+						.config.Labels["org.opencontainers.image.version"] == $version and
+						.config.Labels["org.opencontainers.image.revision"] == $revision and
+						.config.Labels["org.opencontainers.image.created"] == $created and
+						(. as $image |
+							(["pr", "head", "main", "run-id", "run-attempt"] |
+								map("io.dense-mem.preview." + .)) as $preview_labels |
+							([$preview_labels[] as $label |
+								select($image.config.Labels | has($label))] | length == 0))
+					' >/dev/null || fail "${target_ref} has invalid ${platform} RC metadata"
 	done
 	[[ "$(platform_layers "${target_ref}@${target_digest}" linux/amd64)" == "${source_layers_amd64}" ]] ||
 		fail "${target_ref} changed linux/amd64 layer descriptors"

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run scheduled-dreaming timing test
         run: node --test tests/uat/team_dreaming_schedule.test.mjs
 
+      - name: Run image release policy tests
+        run: node --test tests/uat/image_release_policy.test.mjs
+
       - name: Run evaluation monitor shell test
         run: bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 

--- a/.github/workflows/pr-test-image.yml
+++ b/.github/workflows/pr-test-image.yml
@@ -1,0 +1,514 @@
+name: PR test image
+run-name: "PR test image: PR #${{ github.event.pull_request.number }}"
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+env:
+  POLICY_STATUS_CONTEXT: PR test image policy
+  PREVIEW_LABEL: deploy-test-image
+
+concurrency:
+  group: pr-test-image-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve preview request
+    runs-on: docker-runner
+    outputs:
+      should_report: ${{ steps.event.outputs.should_report }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      head_created: ${{ steps.resolve.outputs.head_created }}
+      head_repository: ${{ steps.resolve.outputs.head_repository }}
+      main_sha: ${{ steps.resolve.outputs.main_sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      should_build: ${{ steps.resolve.outputs.should_build }}
+
+    steps:
+      - name: Checkout trusted policy helper
+        uses: actions/checkout@v7
+        with:
+          clean: true
+          persist-credentials: false
+          ref: main
+          sparse-checkout: .github/scripts
+
+      - name: Classify event
+        id: event
+        shell: bash
+        env:
+          ACTION: ${{ github.event.action }}
+          EVENT_LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+          if [[ "${ACTION}" == "labeled" || "${ACTION}" == "unlabeled" ]]; then
+            if [[ "${EVENT_LABEL}" != "${PREVIEW_LABEL}" ]]; then
+              echo "should_report=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          fi
+          echo "should_report=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Check actor permission
+        id: permission
+        uses: actions/github-script@v9
+        with:
+          script: |
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.actor,
+              });
+              core.setOutput("level", data.permission);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.setOutput("level", "none");
+            }
+
+      - name: Resolve current pull request state
+        id: resolve
+        uses: actions/github-script@v9
+        env:
+          ACTOR_PERMISSION: ${{ steps.permission.outputs.level }}
+        with:
+          script: |
+            const policy = require("./.github/scripts/image-release-policy.cjs");
+            const resolved = await policy.resolvePreviewAttempt({
+              github,
+              context,
+              actorPermission: process.env.ACTOR_PERMISSION,
+            });
+
+            if (resolved.mode === "noop") {
+              core.info(`No policy update: ${resolved.reason}.`);
+              core.setOutput("should_build", "false");
+              return;
+            }
+
+            if (resolved.removeLabel) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: resolved.pullNumber,
+                name: process.env.PREVIEW_LABEL,
+              }).catch((error) => {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              });
+            }
+
+            const targetUrl = `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
+            if (resolved.mode === "skipped") {
+              const description = resolved.reason === "fork_isolation_unavailable"
+                ? "Fork previews require an isolated build runner."
+                : resolved.reason === "fork_reapproval_required"
+                  ? "Preview approval is required after every fork push."
+                  : "Preview image was not requested.";
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: resolved.headSha,
+                state: "success",
+                context: process.env.POLICY_STATUS_CONTEXT,
+                description,
+                target_url: targetUrl,
+              });
+              if (resolved.reason === "fork_isolation_unavailable") {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: resolved.pullNumber,
+                  body: "Test images for fork pull requests are disabled until an isolated " +
+                    `build runner is available.\n\n${targetUrl}`,
+                });
+              }
+              core.setOutput("should_build", "false");
+              return;
+            }
+
+            const { data: main } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: "main",
+            });
+            const mainSha = main.commit.sha;
+            if (!mainSha) {
+              throw new Error("Could not resolve the current main revision.");
+            }
+
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${mainSha}...${resolved.headSha}`,
+            });
+            if (!policy.compareContainsMain(comparison.data.status)) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: resolved.headSha,
+                state: "failure",
+                context: process.env.POLICY_STATUS_CONTEXT,
+                description: "Update the PR with the latest main before building.",
+                target_url: targetUrl,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: resolved.pullNumber,
+                body: `Test image attempt failed for \`${resolved.headSha}\`: ` +
+                  `the branch does not contain current \`main\` (${mainSha}).\n\n${targetUrl}`,
+              });
+              core.setOutput("should_build", "false");
+              return;
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: resolved.headSha,
+              state: "pending",
+              context: process.env.POLICY_STATUS_CONTEXT,
+              description: "Building the requested test image.",
+              target_url: targetUrl,
+            });
+            const [headOwner, headRepository] = resolved.pull.head.repo.full_name.split("/");
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner: headOwner,
+              repo: headRepository,
+              ref: resolved.headSha,
+            });
+            const headCreated = headCommit.commit.committer?.date || headCommit.commit.author?.date;
+            if (!headCreated) {
+              throw new Error("Could not resolve the PR head commit timestamp.");
+            }
+            core.setOutput("head_sha", resolved.headSha);
+            core.setOutput("head_created", headCreated);
+            core.setOutput("head_repository", resolved.pull.head.repo.full_name);
+            core.setOutput("main_sha", mainSha);
+            core.setOutput("pr_number", String(resolved.pullNumber));
+            core.setOutput("should_build", "true");
+
+  build:
+    name: Build untrusted preview
+    needs: resolve
+    if: needs.resolve.outputs.should_build == 'true'
+    permissions:
+      contents: read
+    runs-on: rootless-docker
+    timeout-minutes: 60
+
+    steps:
+      - name: Validate controller outputs
+        shell: bash
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${MAIN_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]
+
+      - name: Checkout exact pull request head
+        uses: actions/checkout@v7
+        with:
+          clean: true
+          fetch-depth: 1
+          persist-credentials: false
+          repository: ${{ needs.resolve.outputs.head_repository }}
+          ref: ${{ needs.resolve.outputs.head_sha }}
+
+      - name: Verify checkout head
+        shell: bash
+        env:
+          EXPECTED_HEAD: ${{ needs.resolve.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "${EXPECTED_HEAD}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build production OCI layout
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: preview
+          platforms: linux/amd64,linux/arm64/v8
+          push: false
+          provenance: false
+          outputs: type=oci,dest=${{ runner.temp }}/preview-oci,tar=false,name=dense-mem:test-${{ needs.resolve.outputs.pr_number }}
+          build-args: |
+            IMAGE_VERSION=test-${{ needs.resolve.outputs.pr_number }}
+            IMAGE_REVISION=${{ needs.resolve.outputs.head_sha }}
+            IMAGE_CREATED=${{ needs.resolve.outputs.head_created }}
+            PREVIEW_PR=${{ needs.resolve.outputs.pr_number }}
+            PREVIEW_HEAD=${{ needs.resolve.outputs.head_sha }}
+            PREVIEW_MAIN=${{ needs.resolve.outputs.main_sha }}
+            PREVIEW_RUN_ID=${{ github.run_id }}
+            PREVIEW_RUN_ATTEMPT=${{ github.run_attempt }}
+          cache-from: type=gha,scope=dense-mem-preview-${{ needs.resolve.outputs.pr_number }}
+          cache-to: type=gha,mode=max,scope=dense-mem-preview-${{ needs.resolve.outputs.pr_number }}
+
+      - name: Upload immutable OCI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-oci-${{ needs.resolve.outputs.head_sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/preview-oci
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish trusted preview
+    needs: [resolve, build]
+    if: >-
+      ${{
+        always() &&
+        needs.resolve.outputs.should_build == 'true' &&
+        needs.build.result == 'success'
+      }}
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      pull-requests: write
+      statuses: write
+    runs-on: docker-runner
+    timeout-minutes: 20
+
+    steps:
+      - name: Validate controller outputs
+        shell: bash
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${MAIN_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]
+
+      - name: Checkout trusted workflow helpers
+        uses: actions/checkout@v7
+        with:
+          clean: true
+          persist-credentials: false
+          ref: main
+          sparse-checkout: .github/scripts
+
+      - name: Download OCI artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: preview-oci-${{ needs.resolve.outputs.head_sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/preview-oci
+
+      - name: Install pinned regctl
+        shell: bash
+        env:
+          REGCTL_SHA256: c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467
+        run: |
+          set -euo pipefail
+          export REGCTL_CONFIG="${RUNNER_TEMP}/regctl-config.json"
+          echo "REGCTL_CONFIG=${REGCTL_CONFIG}" >> "${GITHUB_ENV}"
+          curl -fsSL -o "${RUNNER_TEMP}/regctl" \
+            https://github.com/regclient/regclient/releases/download/v0.11.5/regctl-linux-amd64
+          printf '%s  %s\n' "${REGCTL_SHA256}" "${RUNNER_TEMP}/regctl" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/regctl"
+          "${RUNNER_TEMP}/regctl" config set --docker-cred=false --docker-cert=false
+
+      - name: Revalidate pull request before publication
+        uses: actions/github-script@v9
+        env:
+          EXPECTED_HEAD: ${{ needs.resolve.outputs.head_sha }}
+          EXPECTED_MAIN: ${{ needs.resolve.outputs.main_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const { data: main } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: "main",
+            });
+            if (pull.state !== "open" || pull.base.ref !== "main") {
+              core.setFailed("The pull request is no longer open against main.");
+            } else if (pull.head.sha !== process.env.EXPECTED_HEAD) {
+              core.setFailed(`The pull request advanced to ${pull.head.sha}.`);
+            } else if (main.commit.sha !== process.env.EXPECTED_MAIN) {
+              core.setFailed(`Main advanced to ${main.commit.sha}.`);
+            } else if (!pull.labels.some((label) => label.name === process.env.PREVIEW_LABEL)) {
+              core.setFailed("The preview label was removed.");
+            }
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "${GITHUB_TOKEN}" | "${RUNNER_TEMP}/regctl" registry login ghcr.io -u "${GITHUB_ACTOR}" --pass-stdin
+
+      - name: Validate and publish preview
+        shell: bash
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          REGCTL_BIN: ${{ runner.temp }}/regctl
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY,,}:test-${PR_NUMBER}"
+          .github/scripts/oci-image.sh publish-preview \
+            "${RUNNER_TEMP}/preview-oci" \
+            "${image}" \
+            "${PR_NUMBER}" \
+            "${HEAD_SHA}" \
+            "${MAIN_SHA}" \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_RUN_ATTEMPT}"
+
+  report:
+    name: Report preview attempt
+    needs: [resolve, build, publish]
+    if: always() && needs.resolve.outputs.should_build == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    runs-on: docker-runner
+
+    steps:
+      - name: Publish attempt result
+        uses: actions/github-script@v9
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          EXPECTED_HEAD: ${{ needs.resolve.outputs.head_sha }}
+          EXPECTED_MAIN: ${{ needs.resolve.outputs.main_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const targetUrl = `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+            if (pull.head.sha !== process.env.EXPECTED_HEAD) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                body: `Test image attempt for \`${process.env.EXPECTED_HEAD}\` was superseded ` +
+                  `by \`${pull.head.sha}\`.\n\n${targetUrl}`,
+              });
+              return;
+            }
+
+            const { data: main } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: "main",
+            });
+            const stateStillValid = pull.state === "open" && pull.base.ref === "main" &&
+              main.commit.sha === process.env.EXPECTED_MAIN &&
+              pull.labels.some((label) => label.name === process.env.PREVIEW_LABEL);
+            const succeeded = process.env.BUILD_RESULT === "success" &&
+              process.env.PUBLISH_RESULT === "success" && stateStillValid;
+            const description = succeeded
+              ? `Published test-${pullNumber} (run ${context.runId}, attempt ${process.env.GITHUB_RUN_ATTEMPT}).`
+              : "Preview image build or publication failed.";
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.EXPECTED_HEAD,
+              state: succeeded ? "success" : "failure",
+              context: process.env.POLICY_STATUS_CONTEXT,
+              description,
+              target_url: targetUrl,
+            });
+
+            const image = `ghcr.io/${context.repo.owner.toLowerCase()}/` +
+              `${context.repo.repo.toLowerCase()}:test-${pullNumber}`;
+            const body = succeeded
+              ? `Published test image \`${image}\` for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`
+              : `Test image attempt failed for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullNumber,
+              body,
+            });
+
+  resolve-failure:
+    name: Report controller failure
+    needs: resolve
+    if: >-
+      ${{
+        always() &&
+        needs.resolve.result == 'failure' &&
+        needs.resolve.outputs.should_report != 'false'
+      }}
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    runs-on: docker-runner
+
+    steps:
+      - name: Publish controller failure
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pullNumber = context.payload.pull_request.number;
+            const eventHead = context.payload.pull_request.head.sha;
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+            if (
+              pull.head.sha !== eventHead ||
+              !pull.labels.some((label) => label.name === process.env.PREVIEW_LABEL)
+            ) {
+              core.info("The failed controller no longer represents a labeled current head.");
+              return;
+            }
+
+            const targetUrl = `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: eventHead,
+              state: "failure",
+              context: process.env.POLICY_STATUS_CONTEXT,
+              description: "Preview request validation failed.",
+              target_url: targetUrl,
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullNumber,
+              body: `Test image request validation failed for \`${eventHead}\`.\n\n${targetUrl}`,
+            });

--- a/.github/workflows/pr-test-image.yml
+++ b/.github/workflows/pr-test-image.yml
@@ -15,7 +15,10 @@ env:
   PREVIEW_LABEL: deploy-test-image
 
 concurrency:
-  group: pr-test-image-${{ github.event.pull_request.number }}
+  group: >-
+    pr-test-image-${{ github.event.pull_request.number }}-${{
+      github.event.label.name || 'pull-request'
+    }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-test-image.yml
+++ b/.github/workflows/pr-test-image.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 env:
   POLICY_STATUS_CONTEXT: PR test image policy
@@ -24,6 +22,10 @@ jobs:
   resolve:
     name: Resolve preview request
     runs-on: docker-runner
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     outputs:
       should_report: ${{ steps.event.outputs.should_report }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -185,7 +187,10 @@ jobs:
               description: "Building the requested test image.",
               target_url: targetUrl,
             });
-            const [headOwner, headRepository] = resolved.pull.head.repo.full_name.split("/");
+            if (!resolved.headRepository) {
+              throw new Error("The pull request head repository is unavailable.");
+            }
+            const [headOwner, headRepository] = resolved.headRepository.split("/");
             const { data: headCommit } = await github.rest.repos.getCommit({
               owner: headOwner,
               repo: headRepository,
@@ -197,7 +202,7 @@ jobs:
             }
             core.setOutput("head_sha", resolved.headSha);
             core.setOutput("head_created", headCreated);
-            core.setOutput("head_repository", resolved.pull.head.repo.full_name);
+            core.setOutput("head_repository", resolved.headRepository);
             core.setOutput("main_sha", mainSha);
             core.setOutput("pr_number", String(resolved.pullNumber));
             core.setOutput("should_build", "true");
@@ -278,7 +283,6 @@ jobs:
     needs: [resolve, build]
     if: >-
       ${{
-        always() &&
         needs.resolve.outputs.should_build == 'true' &&
         needs.build.result == 'success'
       }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -261,7 +261,9 @@ jobs:
           echo "preview_eligible=true" >> "${GITHUB_OUTPUT}"
 
       - name: Install pinned regctl
+        id: regctl
         if: steps.git.outputs.preview_eligible == 'true'
+        continue-on-error: true
         shell: bash
         env:
           REGCTL_SHA256: c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467
@@ -276,7 +278,9 @@ jobs:
           "${RUNNER_TEMP}/regctl" config set --docker-cred=false --docker-cert=false
 
       - name: Log in to GHCR for preview validation
+        id: registry-login
         if: steps.git.outputs.preview_eligible == 'true'
+        continue-on-error: true
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -284,7 +288,12 @@ jobs:
 
       - name: Validate preview receipt for reuse
         id: image
-        if: steps.git.outputs.preview_eligible == 'true'
+        if: >-
+          ${{
+            steps.git.outputs.preview_eligible == 'true' &&
+            steps.regctl.outcome == 'success' &&
+            steps.registry-login.outcome == 'success'
+          }}
         continue-on-error: true
         shell: bash
         env:
@@ -296,14 +305,17 @@ jobs:
         run: |
           set -euo pipefail
           image="ghcr.io/${GITHUB_REPOSITORY,,}:test-${PREVIEW_PR}"
-          IFS=$'\t' read -r preview_digest preview_base < <(
+          receipt="$(
             .github/scripts/oci-image.sh preview-receipt \
               "${image}" \
               "${PREVIEW_PR}" \
               "${PREVIEW_HEAD}" \
               "${PREVIEW_RUN_ID}" \
               "${PREVIEW_RUN_ATTEMPT}"
-          )
+          )"
+          IFS=$'\t' read -r preview_digest preview_base <<<"${receipt}"
+          [[ "${preview_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "${preview_base}" =~ ^[0-9a-f]{40}$ ]]
           echo "preview_base=${preview_base}" >> "${GITHUB_OUTPUT}"
           echo "preview_digest=${preview_digest}" >> "${GITHUB_OUTPUT}"
 
@@ -339,6 +351,7 @@ jobs:
           GIT_ELIGIBLE: ${{ steps.git.outputs.preview_eligible }}
           IMAGE_ELIGIBLE: ${{ steps.image.outcome }}
         run: |
+          set -euo pipefail
           if [[ \
             "${API_ELIGIBLE}" == "true" && \
             "${GIT_ELIGIBLE}" == "true" && \
@@ -354,10 +367,15 @@ jobs:
         id: export
         if: always()
         shell: bash
+        env:
+          PREVIEW_BASE: ${{ steps.image.outputs.preview_base }}
+          PREVIEW_DIGEST: ${{ steps.image.outputs.preview_digest }}
+          REUSE_PREVIEW: ${{ steps.final.outputs.reuse_preview }}
         run: |
-          echo "preview_base=${{ steps.image.outputs.preview_base }}" >> "${GITHUB_OUTPUT}"
-          echo "preview_digest=${{ steps.image.outputs.preview_digest }}" >> "${GITHUB_OUTPUT}"
-          echo "reuse_preview=${{ steps.final.outputs.reuse_preview }}" >> "${GITHUB_OUTPUT}"
+          set -euo pipefail
+          echo "preview_base=${PREVIEW_BASE}" >> "${GITHUB_OUTPUT}"
+          echo "preview_digest=${PREVIEW_DIGEST}" >> "${GITHUB_OUTPUT}"
+          echo "reuse_preview=${REUSE_PREVIEW}" >> "${GITHUB_OUTPUT}"
 
   publish-image:
     name: Publish prerelease image

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -166,16 +166,325 @@ jobs:
               });
             }
 
-  publish-image:
-    name: Publish prerelease image
+  resolve-production-source:
+    name: Resolve production image source
     needs: prepare-prerelease
     if: needs.prepare-prerelease.outputs.should_publish == 'true'
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      pull-requests: read
+      statuses: read
+    runs-on: docker-runner
+    outputs:
+      preview_base: ${{ steps.export.outputs.preview_base }}
+      preview_digest: ${{ steps.export.outputs.preview_digest }}
+      preview_head: ${{ steps.preview.outputs.preview_head }}
+      preview_pr: ${{ steps.preview.outputs.preview_pr }}
+      preview_run_attempt: ${{ steps.preview.outputs.preview_run_attempt }}
+      preview_run_id: ${{ steps.preview.outputs.preview_run_id }}
+      reuse_preview: ${{ steps.export.outputs.reuse_preview }}
+
+    steps:
+      - name: Checkout trusted release policy
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+          sparse-checkout: .github/scripts
+
+      - name: Resolve eligible pull request preview
+        id: preview
+        uses: actions/github-script@v9
+        env:
+          MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const policy = require("./.github/scripts/image-release-policy.cjs");
+            const mainCommit = process.env.MAIN_COMMIT;
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: mainCommit,
+            });
+            if (commit.parents.length !== 1) {
+              core.info("The main commit does not have exactly one parent; rebuilding production.");
+              core.setOutput("reuse_preview", "false");
+              return;
+            }
+
+            const resolved = await policy.resolveRcPreview({
+              github,
+              context,
+              mainCommit,
+            });
+            if (!resolved.eligible) {
+              core.info(`Rebuilding production: ${resolved.reason}.`);
+              core.setOutput("reuse_preview", "false");
+              return;
+            }
+
+            core.setOutput("preview_head", resolved.headSha);
+            core.setOutput("preview_pr", String(resolved.pullNumber));
+            core.setOutput("preview_run_attempt", resolved.runAttempt);
+            core.setOutput("preview_run_id", resolved.runId);
+            core.setOutput("reuse_preview", "true");
+
+      - name: Verify Git ancestry and tree identity
+        id: git
+        if: steps.preview.outputs.reuse_preview == 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PREVIEW_HEAD: ${{ steps.preview.outputs.preview_head }}
+          PREVIEW_PR: ${{ steps.preview.outputs.preview_pr }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+${MAIN_COMMIT}:refs/remotes/release/main" \
+            "+refs/pull/${PREVIEW_PR}/head:refs/remotes/preview/head"
+          if [[ "$(git rev-parse refs/remotes/preview/head)" != "${PREVIEW_HEAD}" ]]; then
+            echo "preview_eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          previous_main="$(git rev-parse "${MAIN_COMMIT}^")"
+          if ! git merge-base --is-ancestor "${previous_main}" "${PREVIEW_HEAD}"; then
+            echo "preview_eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "$(git rev-parse "${PREVIEW_HEAD}^{tree}")" != "$(git rev-parse "${MAIN_COMMIT}^{tree}")" ]]; then
+            echo "preview_eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "preview_eligible=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Install pinned regctl
+        if: steps.git.outputs.preview_eligible == 'true'
+        shell: bash
+        env:
+          REGCTL_SHA256: c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467
+        run: |
+          set -euo pipefail
+          export REGCTL_CONFIG="${RUNNER_TEMP}/regctl-config.json"
+          echo "REGCTL_CONFIG=${REGCTL_CONFIG}" >> "${GITHUB_ENV}"
+          curl -fsSL -o "${RUNNER_TEMP}/regctl" \
+            https://github.com/regclient/regclient/releases/download/v0.11.5/regctl-linux-amd64
+          printf '%s  %s\n' "${REGCTL_SHA256}" "${RUNNER_TEMP}/regctl" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/regctl"
+          "${RUNNER_TEMP}/regctl" config set --docker-cred=false --docker-cert=false
+
+      - name: Log in to GHCR for preview validation
+        if: steps.git.outputs.preview_eligible == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "${GITHUB_TOKEN}" | "${RUNNER_TEMP}/regctl" registry login ghcr.io -u "${GITHUB_ACTOR}" --pass-stdin
+
+      - name: Validate preview receipt for reuse
+        id: image
+        if: steps.git.outputs.preview_eligible == 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          PREVIEW_HEAD: ${{ steps.preview.outputs.preview_head }}
+          PREVIEW_PR: ${{ steps.preview.outputs.preview_pr }}
+          PREVIEW_RUN_ATTEMPT: ${{ steps.preview.outputs.preview_run_attempt }}
+          PREVIEW_RUN_ID: ${{ steps.preview.outputs.preview_run_id }}
+          REGCTL_BIN: ${{ runner.temp }}/regctl
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY,,}:test-${PREVIEW_PR}"
+          IFS=$'\t' read -r preview_digest preview_base < <(
+            .github/scripts/oci-image.sh preview-receipt \
+              "${image}" \
+              "${PREVIEW_PR}" \
+              "${PREVIEW_HEAD}" \
+              "${PREVIEW_RUN_ID}" \
+              "${PREVIEW_RUN_ATTEMPT}"
+          )
+          echo "preview_base=${preview_base}" >> "${GITHUB_OUTPUT}"
+          echo "preview_digest=${preview_digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check tested main ancestry
+        id: base
+        if: steps.image.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        env:
+          MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PREVIEW_BASE: ${{ steps.image.outputs.preview_base }}
+        run: |
+          set -euo pipefail
+          previous_main="$(git rev-parse "${MAIN_COMMIT}^")"
+          if [[ ! "${PREVIEW_BASE}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "preview_eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          git fetch --no-tags origin "+${PREVIEW_BASE}:refs/remotes/preview/base"
+          if git merge-base --is-ancestor "${PREVIEW_BASE}" "${previous_main}"; then
+            echo "preview_eligible=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "preview_eligible=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Finalize preview decision
+        id: final
+        if: always()
+        shell: bash
+        env:
+          API_ELIGIBLE: ${{ steps.preview.outputs.reuse_preview }}
+          BASE_ELIGIBLE: ${{ steps.base.outputs.preview_eligible }}
+          GIT_ELIGIBLE: ${{ steps.git.outputs.preview_eligible }}
+          IMAGE_ELIGIBLE: ${{ steps.image.outcome }}
+        run: |
+          if [[ \
+            "${API_ELIGIBLE}" == "true" && \
+            "${GIT_ELIGIBLE}" == "true" && \
+            "${IMAGE_ELIGIBLE}" == "success" && \
+            "${BASE_ELIGIBLE}" == "true" \
+          ]]; then
+            echo "reuse_preview=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "reuse_preview=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Export final decision
+        id: export
+        if: always()
+        shell: bash
+        run: |
+          echo "preview_base=${{ steps.image.outputs.preview_base }}" >> "${GITHUB_OUTPUT}"
+          echo "preview_digest=${{ steps.image.outputs.preview_digest }}" >> "${GITHUB_OUTPUT}"
+          echo "reuse_preview=${{ steps.final.outputs.reuse_preview }}" >> "${GITHUB_OUTPUT}"
+
+  publish-image:
+    name: Publish prerelease image
+    needs:
+      - prepare-prerelease
+      - resolve-production-source
+    if: >-
+      ${{
+        needs.prepare-prerelease.outputs.should_publish == 'true' &&
+        needs.resolve-production-source.outputs.reuse_preview != 'true'
+      }}
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/publish-image.yml
     with:
       tag: ${{ needs.prepare-prerelease.outputs.tag }}
+
+  promote-preview-image:
+    name: Promote preview image
+    needs:
+      - prepare-prerelease
+      - resolve-production-source
+    if: >-
+      ${{
+        needs.prepare-prerelease.outputs.should_publish == 'true' &&
+        needs.resolve-production-source.outputs.reuse_preview == 'true'
+      }}
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      pull-requests: read
+      statuses: read
+    runs-on: rootless-docker
+
+    steps:
+      - name: Checkout release helpers
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+          sparse-checkout: .github/scripts
+
+      - name: Revalidate preview receipt
+        uses: actions/github-script@v9
+        env:
+          EXPECTED_HEAD: ${{ needs.resolve-production-source.outputs.preview_head }}
+          EXPECTED_PR: ${{ needs.resolve-production-source.outputs.preview_pr }}
+          EXPECTED_RUN_ATTEMPT: ${{ needs.resolve-production-source.outputs.preview_run_attempt }}
+          EXPECTED_RUN_ID: ${{ needs.resolve-production-source.outputs.preview_run_id }}
+          MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const policy = require("./.github/scripts/image-release-policy.cjs");
+            const resolved = await policy.resolveRcPreview({
+              github,
+              context,
+              mainCommit: process.env.MAIN_COMMIT,
+            });
+            if (
+              !resolved.eligible ||
+              resolved.pullNumber !== Number(process.env.EXPECTED_PR) ||
+              resolved.headSha !== process.env.EXPECTED_HEAD ||
+              resolved.runId !== process.env.EXPECTED_RUN_ID ||
+              resolved.runAttempt !== process.env.EXPECTED_RUN_ATTEMPT
+            ) {
+              core.setFailed(`The preview receipt changed before promotion: ${resolved.reason}.`);
+            }
+
+      - name: Install pinned regctl
+        shell: bash
+        env:
+          REGCTL_SHA256: c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467
+        run: |
+          set -euo pipefail
+          export REGCTL_CONFIG="${RUNNER_TEMP}/regctl-config.json"
+          echo "REGCTL_CONFIG=${REGCTL_CONFIG}" >> "${GITHUB_ENV}"
+          curl -fsSL -o "${RUNNER_TEMP}/regctl" \
+            https://github.com/regclient/regclient/releases/download/v0.11.5/regctl-linux-amd64
+          printf '%s  %s\n' "${REGCTL_SHA256}" "${RUNNER_TEMP}/regctl" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/regctl"
+          "${RUNNER_TEMP}/regctl" config set --docker-cred=false --docker-cert=false
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: echo "${GITHUB_TOKEN}" | "${RUNNER_TEMP}/regctl" registry login ghcr.io -u "${GITHUB_ACTOR}" --pass-stdin
+
+      - name: Validate and promote preview layers
+        shell: bash
+        env:
+          MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          PREVIEW_BASE: ${{ needs.resolve-production-source.outputs.preview_base }}
+          PREVIEW_DIGEST: ${{ needs.resolve-production-source.outputs.preview_digest }}
+          PREVIEW_HEAD: ${{ needs.resolve-production-source.outputs.preview_head }}
+          PREVIEW_PR: ${{ needs.resolve-production-source.outputs.preview_pr }}
+          PREVIEW_RUN_ATTEMPT: ${{ needs.resolve-production-source.outputs.preview_run_attempt }}
+          PREVIEW_RUN_ID: ${{ needs.resolve-production-source.outputs.preview_run_id }}
+          REGCTL_BIN: ${{ runner.temp }}/regctl
+          RC_TAG: ${{ needs.prepare-prerelease.outputs.tag }}
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          source_ref="${image}:test-${PREVIEW_PR}"
+          target_ref="${image}:${RC_TAG}"
+          current_digest="$("${REGCTL_BIN}" manifest head "${source_ref}")"
+          if [[ "${current_digest}" != "${PREVIEW_DIGEST}" ]]; then
+            echo "::error::${source_ref} moved from ${PREVIEW_DIGEST} to ${current_digest}"
+            exit 1
+          fi
+          source_pinned="${source_ref}@${PREVIEW_DIGEST}"
+          .github/scripts/oci-image.sh validate-preview \
+            "${source_pinned}" \
+            "${PREVIEW_PR}" \
+            "${PREVIEW_HEAD}" \
+            "${PREVIEW_BASE}" \
+            "${PREVIEW_RUN_ID}" \
+            "${PREVIEW_RUN_ATTEMPT}"
+          created="$(git show -s --format=%cI "${MAIN_COMMIT}")"
+          .github/scripts/oci-image.sh promote-preview \
+            "${source_pinned}" \
+            "${target_ref}" \
+            "${RC_TAG}" \
+            "${MAIN_COMMIT}" \
+            "${created}"
 
   publish-demo-image:
     name: Publish demo image

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -188,6 +188,8 @@ jobs:
 
     steps:
       - name: Checkout trusted release policy
+        id: policy_checkout
+        continue-on-error: true
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -196,6 +198,8 @@ jobs:
 
       - name: Resolve eligible pull request preview
         id: preview
+        if: steps.policy_checkout.outcome == 'success'
+        continue-on-error: true
         uses: actions/github-script@v9
         env:
           MAIN_COMMIT: ${{ github.event.workflow_run.head_sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,26 @@ FROM runtime-base AS evaluation
 LABEL org.opencontainers.image.variant="evaluation"
 COPY --from=evaluation-builder --chown=densemem:densemem /out/server /app/server
 
-# Keep production last so an unqualified docker build remains production-only.
-FROM runtime-base AS production
+# Preview and production contain the same runtime; only preview carries the
+# trusted receipt that authorizes later release-candidate layer reuse.
+FROM runtime-base AS production-base
 
 LABEL org.opencontainers.image.variant="production"
 COPY --from=production-builder --chown=densemem:densemem /out/server /app/server
+
+FROM production-base AS preview
+
+ARG PREVIEW_PR=""
+ARG PREVIEW_HEAD=""
+ARG PREVIEW_MAIN=""
+ARG PREVIEW_RUN_ID=""
+ARG PREVIEW_RUN_ATTEMPT=""
+
+LABEL io.dense-mem.preview.pr="${PREVIEW_PR}" \
+      io.dense-mem.preview.head="${PREVIEW_HEAD}" \
+      io.dense-mem.preview.main="${PREVIEW_MAIN}" \
+      io.dense-mem.preview.run-id="${PREVIEW_RUN_ID}" \
+      io.dense-mem.preview.run-attempt="${PREVIEW_RUN_ATTEMPT}"
+
+# Keep production last so an unqualified docker build remains production-only.
+FROM production-base AS production

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -8,6 +8,7 @@ npm ci --prefix .lint
 npm run --prefix .lint lint:lines
 scripts/static-analysis.sh
 node --test tests/uat/team_dreaming_schedule.test.mjs
+node --test tests/uat/image_release_policy.test.mjs
 bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 packages="$(scripts/go-packages.sh)"
 

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import policy from "../../.github/scripts/image-release-policy.cjs";
+
+const {
+  compareContainsMain,
+  decidePreviewEvent,
+  decideRcPreview,
+  parseSuccessfulPolicyStatus,
+  selectMergedPull,
+} = policy;
+
+const baseEvent = {
+  action: "synchronize",
+  eventLabel: "",
+  hasPreviewLabel: true,
+  isFork: false,
+  triggerHeadMatches: true,
+  actorPermission: "write",
+};
+
+test("same-repository pushes rebuild while the preview label remains", () => {
+  assert.deepEqual(decidePreviewEvent(baseEvent), {
+    mode: "attempt",
+    reason: "requested",
+  });
+});
+
+test("fork pushes are rejected while runner isolation is unavailable", () => {
+  assert.deepEqual(
+    decidePreviewEvent({ ...baseEvent, isFork: true }),
+    {
+      mode: "skipped",
+      reason: "fork_isolation_unavailable",
+      removeLabel: true,
+    },
+  );
+});
+
+test("unlabeled fork events remain ordinary no-preview requests", () => {
+  assert.deepEqual(
+    decidePreviewEvent({ ...baseEvent, isFork: true, hasPreviewLabel: false }),
+    { mode: "skipped", reason: "label_absent" },
+  );
+});
+
+test("a maintainer-applied fork label starts an attempt", () => {
+  assert.deepEqual(
+    decidePreviewEvent({
+      ...baseEvent,
+      action: "labeled",
+      eventLabel: "deploy-test-image",
+      isFork: true,
+      actorPermission: "maintain",
+      allowForkBuilds: true,
+    }),
+    { mode: "attempt", reason: "requested" },
+  );
+});
+
+test("an untrusted fork label is removed", () => {
+  assert.deepEqual(
+    decidePreviewEvent({
+      ...baseEvent,
+      action: "labeled",
+      eventLabel: "deploy-test-image",
+      isFork: true,
+      actorPermission: "read",
+      allowForkBuilds: true,
+    }),
+    {
+      mode: "skipped",
+      reason: "fork_reapproval_required",
+      removeLabel: true,
+    },
+  );
+});
+
+test("irrelevant label events do not replace an existing policy status", () => {
+  assert.deepEqual(
+    decidePreviewEvent({
+      ...baseEvent,
+      action: "labeled",
+      eventLabel: "documentation",
+    }),
+    { mode: "noop", reason: "irrelevant_label" },
+  );
+});
+
+test("reruns for an obsolete head do not touch the current head", () => {
+  assert.deepEqual(
+    decidePreviewEvent({ ...baseEvent, triggerHeadMatches: false }),
+    { mode: "noop", reason: "stale_event" },
+  );
+});
+
+test("main containment accepts only ahead or identical comparisons", () => {
+  assert.equal(compareContainsMain("ahead"), true);
+  assert.equal(compareContainsMain("identical"), true);
+  assert.equal(compareContainsMain("behind"), false);
+  assert.equal(compareContainsMain("diverged"), false);
+});
+
+test("RC selection requires exactly one PR merged as the main commit", () => {
+  const pull = {
+    number: 42,
+    merged_at: "2026-08-12T00:00:00Z",
+    merge_commit_sha: "main-sha",
+    base: { ref: "main" },
+  };
+  assert.equal(selectMergedPull([pull], "main-sha").pull, pull);
+  assert.equal(selectMergedPull([], "main-sha").pull, null);
+  assert.equal(selectMergedPull([pull, { ...pull, number: 43 }], "main-sha").pull, null);
+});
+
+test("policy receipts bind the PR, run, attempt, and run URL", () => {
+  const receipt = parseSuccessfulPolicyStatus({
+    statuses: [
+      {
+        id: 2,
+        context: "PR test image policy",
+        state: "success",
+        description: "Published test-42 (run 123456, attempt 2).",
+        target_url: "https://github.com/markhuangai/dense-mem/actions/runs/123456",
+      },
+    ],
+    pullNumber: 42,
+    serverUrl: "https://github.com",
+    repository: "markhuangai/dense-mem",
+  });
+
+  assert.deepEqual(receipt.status, {
+    runId: "123456",
+    runAttempt: "2",
+    targetUrl: "https://github.com/markhuangai/dense-mem/actions/runs/123456",
+  });
+});
+
+test("a newer failed policy status invalidates an older success", () => {
+  const receipt = parseSuccessfulPolicyStatus({
+    statuses: [
+      {
+        id: 1,
+        context: "PR test image policy",
+        state: "success",
+        description: "Published test-42 (run 123456, attempt 1).",
+        target_url: "https://github.com/markhuangai/dense-mem/actions/runs/123456",
+      },
+      {
+        id: 2,
+        context: "PR test image policy",
+        state: "failure",
+        description: "Preview publication failed.",
+        target_url: "https://github.com/markhuangai/dense-mem/actions/runs/123457",
+      },
+    ],
+    pullNumber: 42,
+    serverUrl: "https://github.com",
+    repository: "markhuangai/dense-mem",
+  });
+
+  assert.equal(receipt.status, null);
+  assert.match(receipt.reason, /failure/);
+});
+
+test("RC reuse API policy requires the retained label and trusted run", () => {
+  const pull = { number: 42 };
+  const policyStatus = { runId: "123456", runAttempt: "2" };
+  const workflowRun = {
+    id: 123456,
+    run_attempt: 2,
+    event: "pull_request_target",
+    conclusion: "success",
+    path: ".github/workflows/pr-test-image.yml",
+    display_title: "PR test image: PR #42",
+  };
+  const input = {
+    pull,
+    hasPreviewLabel: true,
+    policyStatus,
+    workflowRun,
+  };
+
+  assert.deepEqual(decideRcPreview(input), { eligible: true, reason: "" });
+  assert.equal(decideRcPreview({ ...input, hasPreviewLabel: false }).eligible, false);
+  assert.equal(
+    decideRcPreview({
+      ...input,
+      workflowRun: { ...workflowRun, conclusion: "failure" },
+    }).eligible,
+    false,
+  );
+});

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -163,6 +163,69 @@ test("a newer failed policy status invalidates an older success", () => {
   assert.match(receipt.reason, /failure/);
 });
 
+test("policy receipts reject mismatched PRs, run URLs, and descriptions", () => {
+  const base = {
+    id: 2,
+    context: "PR test image policy",
+    state: "success",
+    description: "Published test-42 (run 123456, attempt 2).",
+    target_url: "https://github.com/markhuangai/dense-mem/actions/runs/123456",
+  };
+  const input = {
+    statuses: [base],
+    pullNumber: 42,
+    serverUrl: "https://github.com",
+    repository: "markhuangai/dense-mem",
+  };
+
+  assert.equal(
+    parseSuccessfulPolicyStatus({
+      ...input,
+      statuses: [{ ...base, description: base.description.replace("test-42", "test-43") }],
+    }).status,
+    null,
+  );
+  assert.match(
+    parseSuccessfulPolicyStatus({
+      ...input,
+      statuses: [{ ...base, target_url: "https://example.invalid/run/123456" }],
+    }).reason,
+    /run URL is invalid/,
+  );
+  assert.equal(
+    parseSuccessfulPolicyStatus({
+      ...input,
+      statuses: [{ ...base, description: "Published test-42." }],
+    }).status,
+    null,
+  );
+});
+
+test("deleted fork repositories resolve as unbuildable fork events", () => {
+  const headSha = "a".repeat(40);
+  assert.deepEqual(
+    policy.resolvePullRequestEvent(
+      {
+        action: "synchronize",
+        pull_request: {
+          number: 42,
+          head: { sha: headSha, repo: null },
+          base: { repo: { full_name: "markhuangai/dense-mem" } },
+        },
+      },
+      "write",
+    ),
+    {
+      action: "synchronize",
+      eventLabel: "",
+      triggerHead: headSha,
+      pullNumber: 42,
+      isFork: true,
+      actorPermission: "write",
+    },
+  );
+});
+
 test("RC reuse API policy requires the retained label and trusted run", () => {
   const pull = { number: 42 };
   const policyStatus = { runId: "123456", runAttempt: "2" };


### PR DESCRIPTION
## Summary

- replace automatic main-branch preview publishing with a `deploy-test-image` label workflow for pull requests
- publish `ghcr.io/markhuangai/dense-mem:test-<PR number>` only after the PR head contains the latest `main` and has no merge conflict
- rebuild the same mutable tag on same-repository branch pushes while the label remains, and post one result comment per attempt
- keep untrusted image construction separate from trusted GHCR publication; fail closed for forks until isolated ephemeral build runners are available
- let RC automation reuse eligible preview production layers with strict receipt and metadata validation, otherwise rebuild from merged `main`; demo RC images still rebuild

## Validation

- `./scripts/ci-check.sh` (coverage: 90.1%)
- `actionlint` v1.7.12 across all workflows
- `node --test tests/uat/image_release_policy.test.mjs` (12/12)
- `bash -n .github/scripts/oci-image.sh`
- production and preview Docker target builds
- disposable-registry tests for multi-platform publication, receipt validation, digest pinning, metadata-only RC promotion, and layer-descriptor preservation
- `git diff --check`

## Activation notes

The new `pull_request_target` workflow cannot run until this change reaches the default branch. Do not apply `deploy-test-image` to this implementation PR. After merge, create the label and smoke-test the workflow before making `PR test image policy` a required status check.

Fork PRs intentionally fail closed: current persistent runners do not establish the isolation needed to build untrusted fork code safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated preview image builds for labeled pull requests.
  * Preview images now include metadata and are published only after validation.
  * Eligible preview images can be reused when creating prereleases.
  * Added support for promoting validated previews to prerelease images.
  * Added shared image build stages for consistent preview and production images.
  * Added safeguards for fork-based changes, stale requests, and outdated results.
* **Bug Fixes**
  * Improved image verification to preserve platform compatibility and integrity.
* **Tests**
  * Added automated coverage for preview-image and prerelease eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->