### PR TITLE
feat: add manual prerelease line initialization

### DIFF
--- a/.github/scripts/prerelease-version.sh
+++ b/.github/scripts/prerelease-version.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+SEMVER_REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+RC_REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.(0|[1-9][0-9]*)$'
+
+fail() {
+	printf 'prerelease version error: %s\n' "$*" >&2
+	exit 1
+}
+
+version_is_greater() {
+	local candidate="$1"
+	local baseline="$2"
+	local highest
+
+	[[ "${candidate}" != "${baseline}" ]] || return 1
+	highest="$(printf '%s\n%s\n' "${candidate}" "${baseline}" | sort -V | tail -n 1)"
+	[[ "${highest}" == "${candidate}" ]]
+}
+
+latest_stable() {
+	local latest=""
+	local tag
+
+	while IFS= read -r tag; do
+		if [[ "${tag}" =~ ${SEMVER_REGEX} ]] &&
+			{ [[ -z "${latest}" ]] || version_is_greater "${tag}" "${latest}"; }; then
+			latest="${tag}"
+		fi
+	done < <(git tag -l 'v*.*.*')
+
+	printf '%s\n' "${latest:-v0.0.0}"
+}
+
+latest_active_base() {
+	local stable="$1"
+	local active=""
+	local base
+	local tag
+
+	while IFS= read -r tag; do
+		[[ "${tag}" =~ ${RC_REGEX} ]] || continue
+		base="${tag%-rc.*}"
+		version_is_greater "${base}" "${stable}" || continue
+		if [[ -z "${active}" ]] || version_is_greater "${base}" "${active}"; then
+			active="${base}"
+		fi
+	done < <(git tag -l 'v*.*.*-rc.*')
+
+	printf '%s\n' "${active}"
+}
+
+latest_rc() {
+	local base="$1"
+	local latest=""
+	local tag
+
+	while IFS= read -r tag; do
+		[[ "${tag}" =~ ${RC_REGEX} ]] || continue
+		[[ "${tag%-rc.*}" == "${base}" ]] || continue
+		if [[ -z "${latest}" ]] || [[ "$(printf '%s\n%s\n' "${tag}" "${latest}" | sort -V | tail -n 1)" == "${tag}" ]]; then
+			latest="${tag}"
+		fi
+	done < <(git tag -l "${base}-rc.*")
+
+	printf '%s\n' "${latest}"
+}
+
+resolve_next() {
+	local stable
+	local base
+	local latest
+	local rc_number
+
+	stable="$(latest_stable)"
+	base="$(latest_active_base "${stable}")"
+	if [[ -z "${base}" ]]; then
+		[[ "${stable}" =~ ${SEMVER_REGEX} ]] || fail "latest stable tag is invalid: ${stable}"
+		base="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+	fi
+
+	latest="$(latest_rc "${base}")"
+	if [[ -z "${latest}" ]]; then
+		rc_number=0
+	elif [[ "${latest}" =~ ${RC_REGEX} ]]; then
+		rc_number="$((BASH_REMATCH[4] + 1))"
+	else
+		fail "latest RC tag is invalid: ${latest}"
+	fi
+
+	printf '%s-rc.%s\n' "${base}" "${rc_number}"
+}
+
+resolve_start() {
+	local base="${1:-}"
+	local target="${2:-}"
+	local stable
+	local active
+	local seed
+	local latest
+	local tagged_commit
+
+	[[ "${base}" =~ ${SEMVER_REGEX} ]] ||
+		fail "release base must be a canonical semantic version like v2.5.0"
+	[[ "${target}" =~ ^[0-9a-f]{40}$ ]] || fail "target must be a 40-character commit SHA"
+	git rev-parse --verify "${target}^{commit}" >/dev/null 2>&1 || fail "target commit does not exist: ${target}"
+
+	stable="$(latest_stable)"
+	version_is_greater "${base}" "${stable}" ||
+		fail "release base ${base} must be newer than latest stable ${stable}"
+
+	active="$(latest_active_base "${stable}")"
+	seed="${base}-rc.0"
+	if [[ -n "${active}" && "${base}" == "${active}" ]]; then
+		latest="$(latest_rc "${base}")"
+		[[ "${latest}" == "${seed}" ]] ||
+			fail "prerelease line ${base} already advanced to ${latest}"
+		tagged_commit="$(git rev-list -n 1 "refs/tags/${seed}")"
+		[[ "${tagged_commit}" == "${target}" ]] ||
+			fail "${seed} already exists at ${tagged_commit}; expected ${target}"
+		printf '%s\n' "${seed}"
+		return
+	fi
+
+	if [[ -n "${active}" ]]; then
+		version_is_greater "${base}" "${active}" ||
+			fail "release base ${base} must be newer than active prerelease base ${active}"
+	fi
+	[[ -z "$(latest_rc "${base}")" ]] || fail "prerelease line ${base} already exists"
+
+	printf '%s\n' "${seed}"
+}
+
+usage() {
+	printf '%s\n' \
+		"usage:" \
+		"  $0 next" \
+		"  $0 start RELEASE_BASE TARGET_SHA" >&2
+	exit 2
+}
+
+case "${1:-}" in
+next)
+	[[ "$#" -eq 1 ]] || usage
+	resolve_next
+	;;
+start)
+	[[ "$#" -eq 3 ]] || usage
+	resolve_start "$2" "$3"
+	;;
+*)
+	usage
+	;;
+esac

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -244,7 +244,7 @@ jobs:
           ai-auth-mode: auth-token
           model: auto
           parallel-count: "5"
-          max-turns: "50"
+          max-turns: "100"
           auto-approve: "false"
           review-prompts: |
             [

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run image release policy tests
         run: node --test tests/uat/image_release_policy.test.mjs
 
+      - name: Run prerelease version tests
+        run: node --test tests/uat/prerelease_version.test.mjs
+
       - name: Run evaluation monitor shell test
         run: bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: false
 
       - name: Set up Node.js

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -13,8 +13,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-prerelease-main
+  group: release-version-tags
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare-prerelease:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -76,43 +76,7 @@ jobs:
             exit 0
           fi
 
-          latest_stable="$(
-            git tag -l 'v[0-9]*.[0-9]*.[0-9]*' |
-              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
-              sort -V |
-              tail -n 1 || true
-          )"
-          if [[ -z "${latest_stable}" ]]; then
-            latest_stable="v0.0.0"
-          fi
-
-          if [[ ! "${latest_stable}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "::error::latest stable tag is not a semantic version: ${latest_stable}"
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          base="v${major}.${minor}.$((patch + 1))"
-          base_pattern="${base//./\\.}"
-
-          latest_rc="$(
-            git tag -l "${base}-rc.*" |
-              grep -E "^${base_pattern}-rc\.[0-9]+$" |
-              sort -V |
-              tail -n 1 || true
-          )"
-          if [[ -z "${latest_rc}" ]]; then
-            rc_number=0
-          elif [[ "${latest_rc}" =~ -rc\.([0-9]+)$ ]]; then
-            rc_number="$((BASH_REMATCH[1] + 1))"
-          else
-            echo "::error::latest RC tag is not valid: ${latest_rc}"
-            exit 1
-          fi
-
-          next_tag="${base}-rc.${rc_number}"
+          next_tag="$(.github/scripts/prerelease-version.sh next)"
           git tag "${next_tag}" "${HEAD_SHA}"
           git push origin "refs/tags/${next_tag}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-${{ inputs.release_tag }}
+  group: release-version-tags
   cancel-in-progress: false
+  queue: max
 
 jobs:
   prepare-release:

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -13,8 +13,9 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-prerelease-main
+  group: release-version-tags
   cancel-in-progress: false
+  queue: max
 
 jobs:
   start-prerelease:
@@ -63,26 +64,45 @@ jobs:
           echo "tag_exists=${tag_exists}" >> "$GITHUB_OUTPUT"
           echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
 
-      - name: Require completed automatic release
+      - name: Require quiescent release state
         uses: actions/github-script@v9
         env:
           TARGET_SHA: ${{ steps.version.outputs.target_sha }}
         with:
           script: |
             const targetSha = process.env.TARGET_SHA;
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "release-rc.yml",
-              event: "workflow_run",
-              head_sha: targetSha,
-              per_page: 10,
-            });
-            const latest = data.workflow_runs.sort((left, right) => right.id - left.id)[0];
+            const [automaticResponse, stableResponse] = await Promise.all([
+              github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "release-rc.yml",
+                event: "workflow_run",
+                head_sha: targetSha,
+                per_page: 10,
+              }),
+              github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "release.yml",
+                per_page: 100,
+              }),
+            ]);
+            const latest = automaticResponse.data.workflow_runs.sort(
+              (left, right) => right.id - left.id,
+            )[0];
 
             if (!latest || latest.status !== "completed" || latest.conclusion !== "success") {
               core.setFailed(
                 `main ${targetSha} does not have a completed successful automatic prerelease run`,
+              );
+            }
+
+            const activeStable = stableResponse.data.workflow_runs.find(
+              (run) => run.status !== "completed",
+            );
+            if (activeStable) {
+              core.setFailed(
+                `stable release run ${activeStable.id} is ${activeStable.status}; retry after it completes`,
               );
             }
 

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -1,0 +1,157 @@
+name: Start prerelease line
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_base:
+        description: "New prerelease base (example: v2.5.0)"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: release-prerelease-main
+  cancel-in-progress: false
+
+jobs:
+  start-prerelease:
+    name: Start prerelease line
+    runs-on: docker-runner
+
+    steps:
+      - name: Checkout current main
+        uses: actions/checkout@v7
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+
+      - name: Resolve and fence prerelease seed
+        id: version
+        shell: bash
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          RELEASE_BASE: ${{ inputs.release_base }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${DISPATCH_REF}" != "refs/heads/main" ]]; then
+            echo "::error::start-prerelease must be dispatched from main"
+            exit 1
+          fi
+
+          git fetch --tags --force origin \
+            '+refs/tags/*:refs/tags/*' \
+            '+refs/heads/main:refs/remotes/origin/main'
+
+          target_sha="$(git rev-parse refs/remotes/origin/main)"
+          checkout_sha="$(git rev-parse HEAD)"
+          if [[ "${checkout_sha}" != "${target_sha}" ]]; then
+            echo "::error::checkout HEAD ${checkout_sha} does not match main ${target_sha}"
+            exit 1
+          fi
+
+          tag="$(.github/scripts/prerelease-version.sh start "${RELEASE_BASE}" "${target_sha}")"
+          tag_exists=false
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            tag_exists=true
+          fi
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "tag_exists=${tag_exists}" >> "$GITHUB_OUTPUT"
+          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Require completed automatic release
+        uses: actions/github-script@v9
+        env:
+          TARGET_SHA: ${{ steps.version.outputs.target_sha }}
+        with:
+          script: |
+            const targetSha = process.env.TARGET_SHA;
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "release-rc.yml",
+              event: "workflow_run",
+              head_sha: targetSha,
+              per_page: 10,
+            });
+            const latest = data.workflow_runs.sort((left, right) => right.id - left.id)[0];
+
+            if (!latest || latest.status !== "completed" || latest.conclusion !== "success") {
+              core.setFailed(
+                `main ${targetSha} does not have a completed successful automatic prerelease run`,
+              );
+            }
+
+      - name: Create prerelease seed tag
+        if: steps.version.outputs.tag_exists != 'true'
+        shell: bash
+        env:
+          RELEASE_BASE: ${{ inputs.release_base }}
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force origin \
+            '+refs/tags/*:refs/tags/*' \
+            '+refs/heads/main:refs/remotes/origin/main'
+          current_main="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "${current_main}" != "${TARGET_SHA}" ]]; then
+            echo "::error::main advanced to ${current_main}; expected ${TARGET_SHA}"
+            exit 1
+          fi
+
+          resolved_tag="$(.github/scripts/prerelease-version.sh start "${RELEASE_BASE}" "${TARGET_SHA}")"
+          if [[ "${resolved_tag}" != "${TAG}" ]]; then
+            echo "::error::prerelease seed changed from ${TAG} to ${resolved_tag}"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "${TAG} already points to ${TARGET_SHA}."
+            exit 0
+          fi
+
+          git tag "${TAG}" "${TARGET_SHA}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Ensure blank GitHub prerelease
+        uses: actions/github-script@v9
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ steps.version.outputs.target_sha }}
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag,
+            };
+
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag(request);
+              if (!data.prerelease) {
+                core.setFailed(`${tag} exists as a non-prerelease GitHub Release`);
+              } else {
+                core.info(`${tag} prerelease already exists`);
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                target_commitish: process.env.TARGET_SHA,
+                name: tag,
+                body: "",
+                prerelease: true,
+              });
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 # ============================================================================
 # Build stage
 # ============================================================================
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder-base
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder-base
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -16,7 +16,7 @@ RUN npm run build
 # ============================================================================
 # Build stage
 # ============================================================================
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/markhuangai/dense-mem
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/http/user_portal_session_test.go
+++ b/internal/http/user_portal_session_test.go
@@ -47,7 +47,7 @@ func (s *portalSessionManagerStub) Logout(_ context.Context, token string) error
 
 func TestCreatePortalSessionSetsHostOnlyUiCookies(t *testing.T) {
 	keyID := uuid.New()
-	expires := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	expires := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
 	manager := &portalSessionManagerStub{result: &service.UserPortalSessionResult{
 		SessionToken: "opaque-session",
 		CSRFToken:    "csrf-token",

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -9,6 +9,7 @@ npm run --prefix .lint lint:lines
 scripts/static-analysis.sh
 node --test tests/uat/team_dreaming_schedule.test.mjs
 node --test tests/uat/image_release_policy.test.mjs
+node --test tests/uat/prerelease_version.test.mjs
 bash tests/eval/scripts/run_full_public_rag_eval_until_done_test.sh
 packages="$(scripts/go-packages.sh)"
 

--- a/tests/uat/prerelease_version.test.mjs
+++ b/tests/uat/prerelease_version.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const resolver = fileURLToPath(
+  new URL("../../.github/scripts/prerelease-version.sh", import.meta.url),
+);
+
+function git(repository, ...args) {
+  const result = spawnSync("git", args, {
+    cwd: repository,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function createRepository(t) {
+  const repository = mkdtempSync(join(tmpdir(), "dense-mem-prerelease-"));
+  t.after(() => rmSync(repository, { recursive: true, force: true }));
+
+  git(repository, "init", "--quiet");
+  git(repository, "config", "user.email", "prerelease-test@example.invalid");
+  git(repository, "config", "user.name", "Prerelease Test");
+  git(repository, "commit", "--quiet", "--allow-empty", "-m", "initial");
+  return repository;
+}
+
+function resolve(repository, ...args) {
+  return spawnSync("bash", [resolver, ...args], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+}
+
+function tag(repository, ...tags) {
+  for (const name of tags) {
+    git(repository, "tag", name);
+  }
+}
+
+test("next defaults to a patch RC when no newer prerelease line exists", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.4.8", "v2.4.8-rc.4", "v2.4.7-rc.6");
+
+  const result = resolve(repository, "next");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "v2.4.9-rc.0");
+});
+
+test("next advances the highest prerelease base newer than stable", (t) => {
+  const repository = createRepository(t);
+  tag(
+    repository,
+    "v2.4.8",
+    "v2.4.9-rc.0",
+    "v2.5.0-rc.0",
+    "v2.5.0-rc.9",
+    "v2.5.0-rc.10",
+  );
+
+  const result = resolve(repository, "next");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "v2.5.0-rc.11");
+});
+
+test("next returns to patch allocation after the active line becomes stable", (t) => {
+  const repository = createRepository(t);
+  tag(
+    repository,
+    "v2.4.8",
+    "v2.4.9-rc.0",
+    "v2.5.0-rc.3",
+    "v2.5.0",
+  );
+
+  const result = resolve(repository, "next");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "v2.5.1-rc.0");
+});
+
+test("start accepts any canonical SemVer base newer than known lines", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.4.8", "v2.4.9-rc.0");
+  const head = git(repository, "rev-parse", "HEAD");
+
+  const result = resolve(repository, "start", "v3.0.0", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "v3.0.0-rc.0");
+});
+
+test("start is idempotent only for rc.0 on the requested target", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.4.8", "v2.5.0-rc.0");
+  const taggedHead = git(repository, "rev-parse", "HEAD");
+
+  const repeated = resolve(repository, "start", "v2.5.0", taggedHead);
+  assert.equal(repeated.status, 0, repeated.stderr);
+  assert.equal(repeated.stdout.trim(), "v2.5.0-rc.0");
+
+  git(repository, "commit", "--quiet", "--allow-empty", "-m", "advance main");
+  const advancedHead = git(repository, "rev-parse", "HEAD");
+  const moved = resolve(repository, "start", "v2.5.0", advancedHead);
+  assert.notEqual(moved.status, 0);
+  assert.match(moved.stderr, /already exists at .* expected/);
+});
+
+test("start rejects malformed, stale, and already-advanced bases", async (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.4.8", "v2.5.0-rc.1");
+  const head = git(repository, "rev-parse", "HEAD");
+
+  for (const releaseBase of ["2.6.0", "v02.6.0", "v2.4.8", "v2.4.9", "v2.5.0"]) {
+    await t.test(releaseBase, () => {
+      const result = resolve(repository, "start", releaseBase, head);
+      assert.notEqual(result.status, 0);
+    });
+  }
+});

--- a/tests/uat/prerelease_version.test.mjs
+++ b/tests/uat/prerelease_version.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { devNull, tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -12,25 +12,37 @@ const resolver = fileURLToPath(
 const isolatedGitEnvironment = Object.fromEntries(
   Object.entries(process.env).filter(([name]) => !name.startsWith("GIT_")),
 );
+isolatedGitEnvironment.GIT_CONFIG_GLOBAL = devNull;
+isolatedGitEnvironment.GIT_CONFIG_NOSYSTEM = "1";
 
-function git(repository, ...args) {
+function gitWithEnvironment(repository, environment, ...args) {
   const result = spawnSync("git", args, {
     cwd: repository,
     encoding: "utf8",
-    env: isolatedGitEnvironment,
+    env: environment,
   });
   assert.equal(result.status, 0, result.stderr);
   return result.stdout.trim();
 }
 
-function createRepository(t) {
+function git(repository, ...args) {
+  return gitWithEnvironment(repository, isolatedGitEnvironment, ...args);
+}
+
+function createRepository(t, environment = isolatedGitEnvironment) {
   const repository = mkdtempSync(join(tmpdir(), "dense-mem-prerelease-"));
   t.after(() => rmSync(repository, { recursive: true, force: true }));
 
-  git(repository, "init", "--quiet");
-  git(repository, "config", "user.email", "prerelease-test@example.invalid");
-  git(repository, "config", "user.name", "Prerelease Test");
-  git(repository, "commit", "--quiet", "--allow-empty", "-m", "initial");
+  gitWithEnvironment(repository, environment, "init", "--quiet");
+  gitWithEnvironment(
+    repository,
+    environment,
+    "config",
+    "user.email",
+    "prerelease-test@example.invalid",
+  );
+  gitWithEnvironment(repository, environment, "config", "user.name", "Prerelease Test");
+  gitWithEnvironment(repository, environment, "commit", "--quiet", "--allow-empty", "-m", "initial");
   return repository;
 }
 
@@ -47,6 +59,20 @@ function tag(repository, ...tags) {
     git(repository, "tag", name);
   }
 }
+
+test("temporary repositories ignore configured global hooks", (t) => {
+  const home = mkdtempSync(join(tmpdir(), "dense-mem-prerelease-home-"));
+  const hooks = join(home, "hooks");
+  t.after(() => rmSync(home, { recursive: true, force: true }));
+  mkdirSync(hooks);
+  writeFileSync(join(home, ".gitconfig"), `[core]\n\thooksPath = ${hooks}\n`);
+  writeFileSync(join(hooks, "pre-commit"), "#!/bin/sh\nexit 97\n");
+  chmodSync(join(hooks, "pre-commit"), 0o755);
+
+  const repository = createRepository(t, { ...isolatedGitEnvironment, HOME: home });
+
+  assert.equal(git(repository, "log", "-1", "--format=%s"), "initial");
+});
 
 test("next defaults to a patch RC when no newer prerelease line exists", (t) => {
   const repository = createRepository(t);

--- a/tests/uat/prerelease_version.test.mjs
+++ b/tests/uat/prerelease_version.test.mjs
@@ -9,11 +9,15 @@ import test from "node:test";
 const resolver = fileURLToPath(
   new URL("../../.github/scripts/prerelease-version.sh", import.meta.url),
 );
+const isolatedGitEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => !name.startsWith("GIT_")),
+);
 
 function git(repository, ...args) {
   const result = spawnSync("git", args, {
     cwd: repository,
     encoding: "utf8",
+    env: isolatedGitEnvironment,
   });
   assert.equal(result.status, 0, result.stderr);
   return result.stdout.trim();
@@ -34,6 +38,7 @@ function resolve(repository, ...args) {
   return spawnSync("bash", [resolver, ...args], {
     cwd: repository,
     encoding: "utf8",
+    env: isolatedGitEnvironment,
   });
 }
 


### PR DESCRIPTION
## What

- add a manual **Start prerelease line** workflow that accepts a base such as `v2.5.0` and creates an empty `v2.5.0-rc.0` prerelease on the current `main`
- make automatic prereleases advance the highest RC base newer than the latest stable release, while preserving patch allocation when no newer line exists
- increase `ai-pr-reviewer@v1-prerelease` from `max-turns: "50"` to `max-turns: "100"`
- keep the portal cookie test expiry in the future and isolate temporary Git repositories from inherited hook state

## Why

The existing allocator always derives its base from the latest stable patch, so a manually seeded minor prerelease does not affect the next merge. The shared resolver makes the seeded line authoritative without requiring a version input on every merge.

## Safety

The initializer runs only from `main`, shares the automatic release concurrency group, requires a successful automatic prerelease run for the captured main SHA, re-fences main before tag creation, rejects tag moves or older versions, and repairs only an exact same-SHA `rc.0` partial run. It creates no images or release assets.

No tag or GitHub Release is created by this PR. After merge and the automatic prerelease run complete, dispatch **Start prerelease line** with `v2.5.0`.

## Validation

- `node --test tests/uat/prerelease_version.test.mjs`
- `go test ./internal/http -run '^TestCreatePortalSessionSetsHostOnlyUiCookies$' -count=1`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/start-prerelease.yml .github/workflows/release-rc.yml .github/workflows/ai-pr-review.yml .github/workflows/ci-shared.yml`\n- `./scripts/ci-check.sh` (90.1% coverage)\n\nThe deterministic 1k semantic evaluation is not applicable because this changes release and PR-review automation, not Dense-Mem retrieval, placement, or semantic verifier/reviewer behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated support for starting and managing prerelease release lines.
  * Improved prerelease version calculation, including release candidate numbering and validation of release targets.

* **Bug Fixes**
  * Improved release workflow handling for invalid, stale, or mismatched release information.
  * Stabilized session cookie expiry testing by using dynamically calculated expiry times.

* **Tests**
  * Added comprehensive automated coverage for prerelease versioning and release-start scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->