### PR TITLE
feat: complete terminal errors, MCP SDK transport, and identity bridge

### DIFF
--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -60,9 +60,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to access postgres sql client: %v", err)
 	}
-	if err := postgres.ValidateStartupMigrationState(context.Background(), sqlDB, postgres.MigrationsDir()); err != nil {
+	migrationStateCtx, migrationStateCancel := context.WithTimeout(context.Background(), startupTimeout)
+	if err := postgres.ValidateStartupMigrationState(migrationStateCtx, sqlDB, postgres.MigrationsDir()); err != nil {
+		migrationStateCancel()
 		log.Fatalf("postgres migration state validation failed: %v", err)
 	}
+	migrationStateCancel()
 
 	postMigrationCtx, postMigrationCancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer postMigrationCancel()

--- a/cmd/demo-server/main.go
+++ b/cmd/demo-server/main.go
@@ -56,6 +56,13 @@ func main() {
 	if err := migrationapp.RunUp(context.Background(), pgDB.GetDB(), migrationTimeout, logger.Slog()); err != nil {
 		log.Fatalf("failed to run postgres migrations: %v", err)
 	}
+	sqlDB, err := pgDB.GetDB().DB()
+	if err != nil {
+		log.Fatalf("failed to access postgres sql client: %v", err)
+	}
+	if err := postgres.ValidateStartupMigrationState(context.Background(), sqlDB, postgres.MigrationsDir()); err != nil {
+		log.Fatalf("postgres migration state validation failed: %v", err)
+	}
 
 	postMigrationCtx, postMigrationCancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer postMigrationCancel()

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -325,7 +325,7 @@ func RunActiveServer(
 		time.Duration(cfg.GetSSEMaxDurationSeconds())*time.Second,
 		backend.streamCleanupRepo,
 	)
-	mcpHandler := handler.NewMCPHandlerWithLifecycleAndRuntimeConfig(toolRegistry, logger, streamLifecycle, appConfigService, dreamSvc)
+	mcpHandler := handler.NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(toolRegistry, logger, streamLifecycle, appConfigService, config.MCPTransportFor(&cfg), dreamSvc)
 
 	checks := []http.HealthCheck{
 		{Name: "postgres", Check: func(ctx context.Context) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,6 +50,13 @@ func main() {
 	if err := migrationapp.RunUp(context.Background(), pgDB.GetDB(), migrationTimeout, logger.Slog()); err != nil {
 		log.Fatalf("failed to run postgres migrations: %v", err)
 	}
+	sqlDB, err := pgDB.GetDB().DB()
+	if err != nil {
+		log.Fatalf("failed to access postgres sql client: %v", err)
+	}
+	if err := postgres.ValidateStartupMigrationState(context.Background(), sqlDB, postgres.MigrationsDir()); err != nil {
+		log.Fatalf("postgres migration state validation failed: %v", err)
+	}
 
 	postMigrationCtx, postMigrationCancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer postMigrationCancel()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,9 +54,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to access postgres sql client: %v", err)
 	}
-	if err := postgres.ValidateStartupMigrationState(context.Background(), sqlDB, postgres.MigrationsDir()); err != nil {
+	migrationStateCtx, migrationStateCancel := context.WithTimeout(context.Background(), startupTimeout)
+	if err := postgres.ValidateStartupMigrationState(migrationStateCtx, sqlDB, postgres.MigrationsDir()); err != nil {
+		migrationStateCancel()
 		log.Fatalf("postgres migration state validation failed: %v", err)
 	}
+	migrationStateCancel()
 
 	postMigrationCtx, postMigrationCancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer postMigrationCancel()

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/labstack/echo/v4 v4.15.4
 	github.com/lib/pq v1.12.3
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/prometheus/client_golang v1.24.1
 	github.com/redis/go-redis/v9 v9.22.0
@@ -57,6 +58,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -90,6 +92,8 @@ require (
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/q-uint/parser v0.3.1 // indirect
 	github.com/q-uint/xsd-datetime v1.0.0 // indirect
+	github.com/segmentio/asm v1.2.1 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sethvargo/go-retry v0.4.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
@@ -98,6 +102,7 @@ require (
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RA
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786/go.mod h1:apVn/GCasLZUVpAJ6oWAuyP7Ne7CEsQbTnc0plM3m+o=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -146,6 +148,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
@@ -180,6 +184,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/scim2/filter-parser/v2 v2.3.1 h1:o24v+z9drjtWoF6XLtXOFWpkmo1GGfBKZqrAjy6npQM=
 github.com/scim2/filter-parser/v2 v2.3.1/go.mod h1:R5u/HUG8vO+TVvtmBzUX2LSuEej27v+ckcJqjIa4d8E=
+github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
+github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sethvargo/go-retry v0.4.0 h1:9qy1OoIAxBL+gBYnkTnTnWle5wlfsXQlwRzIbbpdqPw=
 github.com/sethvargo/go-retry v0.4.0/go.mod h1:tvsjdKG6xfiCx4LSiUZ06kcv38xvdVQwv8R6/VnnVWg=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=
@@ -207,6 +215,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ const (
 	DefaultMemoryPlacementPollSeconds          = 5
 	DefaultConflictReviewTTLDays               = 7
 	DefaultConflictReviewStartTime             = "04:00"
+	DefaultMCPTransport                        = "sdk"
 )
 
 var legacyNeo4jEnvVars = []string{
@@ -79,6 +80,21 @@ type ConfigProvider interface {
 	GetPromoteTxTimeoutSeconds() int
 	GetControlHTTPAddr() string
 	GetControlPortalToken() string
+}
+
+type mcpTransportConfig interface {
+	GetMCPTransport() string
+}
+
+// MCPTransportFor returns the boot-only MCP transport selector. Providers that
+// predate this setting retain the official SDK default.
+func MCPTransportFor(cfg ConfigProvider) string {
+	if provider, ok := cfg.(mcpTransportConfig); ok {
+		if value := strings.TrimSpace(provider.GetMCPTransport()); value != "" {
+			return value
+		}
+	}
+	return DefaultMCPTransport
 }
 
 type aiVerifierTemperatureConfig interface {
@@ -168,6 +184,7 @@ type Config struct {
 	PromoteTxTimeoutSeconds               int
 	ControlHTTPAddr                       string
 	ControlPortalToken                    string `json:"-"`
+	MCPTransport                          string
 	TelemetryEnabled                      bool
 	TelemetryPrometheusURL                string
 	TelemetryPrometheusJob                string
@@ -276,9 +293,15 @@ func (c *Config) GetMemoryPlacementPollSeconds() int {
 	}
 	return c.MemoryPlacementPollSeconds
 }
-func (c *Config) GetPromoteTxTimeoutSeconds() int   { return c.PromoteTxTimeoutSeconds }
-func (c *Config) GetControlHTTPAddr() string        { return c.ControlHTTPAddr }
-func (c *Config) GetControlPortalToken() string     { return c.ControlPortalToken }
+func (c *Config) GetPromoteTxTimeoutSeconds() int { return c.PromoteTxTimeoutSeconds }
+func (c *Config) GetControlHTTPAddr() string      { return c.ControlHTTPAddr }
+func (c *Config) GetControlPortalToken() string   { return c.ControlPortalToken }
+func (c *Config) GetMCPTransport() string {
+	if strings.TrimSpace(c.MCPTransport) == "" {
+		return DefaultMCPTransport
+	}
+	return c.MCPTransport
+}
 func (c *Config) GetTelemetryEnabled() bool         { return c.TelemetryEnabled }
 func (c *Config) GetTelemetryPrometheusURL() string { return c.TelemetryPrometheusURL }
 func (c *Config) GetTelemetryPrometheusJob() string { return c.TelemetryPrometheusJob }
@@ -594,6 +617,10 @@ func loadWithPostgresDSN(postgresDSN string) (Config, error) {
 	}
 	cfg.ControlHTTPAddr = getEnvOrDefault("CONTROL_HTTP_ADDR", ":8090")
 	cfg.ControlPortalToken = os.Getenv("CONTROL_PORTAL_TOKEN")
+	cfg.MCPTransport = strings.ToLower(strings.TrimSpace(getEnvOrDefault("MCP_TRANSPORT", DefaultMCPTransport)))
+	if cfg.MCPTransport != "sdk" && cfg.MCPTransport != "legacy" {
+		return cfg, &ValidationError{Field: "MCP_TRANSPORT", Message: "must be sdk or legacy"}
+	}
 	cfg.TelemetryEnabled, err = parseBoolOrDefault("TELEMETRY_ENABLED", false)
 	if err != nil {
 		return cfg, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,7 @@ func clearEnv() {
 		"PROMOTE_TX_TIMEOUT_SECONDS",
 		"CONTROL_HTTP_ADDR",
 		"CONTROL_PORTAL_TOKEN",
+		"MCP_TRANSPORT",
 		"TELEMETRY_ENABLED",
 		"TELEMETRY_PROMETHEUS_URL",
 		"TELEMETRY_PROMETHEUS_JOB",
@@ -116,6 +118,9 @@ func TestLoadDefaults(t *testing.T) {
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+	if got := cfg.GetMCPTransport(); got != DefaultMCPTransport {
+		t.Fatalf("MCP transport = %q, want %q", got, DefaultMCPTransport)
 	}
 
 	// Test listener defaults
@@ -215,6 +220,35 @@ func TestLoadDefaults(t *testing.T) {
 	}
 	if cfg.TelemetryPrometheusJob != "" {
 		t.Errorf("TelemetryPrometheusJob default = %q, want empty", cfg.TelemetryPrometheusJob)
+	}
+}
+
+func TestLoadMCPTransportOverrideAndValidation(t *testing.T) {
+	clearEnv()
+	setRequiredEnv()
+	t.Setenv("MCP_TRANSPORT", "legacy")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() with legacy MCP transport: %v", err)
+	}
+	if got := cfg.GetMCPTransport(); got != "legacy" {
+		t.Fatalf("MCP transport = %q, want legacy", got)
+	}
+	t.Setenv("MCP_TRANSPORT", "unsupported")
+	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "MCP_TRANSPORT") {
+		t.Fatalf("Load() error = %v, want MCP_TRANSPORT validation", err)
+	}
+}
+
+func TestMCPTransportForSupportsLegacyProvidersAndDefaults(t *testing.T) {
+	if got := MCPTransportFor(nil); got != DefaultMCPTransport {
+		t.Fatalf("nil MCP transport = %q, want %q", got, DefaultMCPTransport)
+	}
+	if got := MCPTransportFor(&Config{}); got != DefaultMCPTransport {
+		t.Fatalf("empty MCP transport = %q, want %q", got, DefaultMCPTransport)
+	}
+	if got := MCPTransportFor(&Config{MCPTransport: " legacy "}); got != "legacy" {
+		t.Fatalf("configured MCP transport = %q, want trimmed provider value", got)
 	}
 }
 

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -137,11 +137,6 @@ func (h *MCPHandler) handleSDKPost(c echo.Context, profileID uuid.UUID, principa
 		if id, version, ok := sdkInitializePayload(payload); ok && !sdkSupportedProtocolVersion(version) {
 			return writeSDKProtocolError(c, http.StatusBadRequest, id, "unsupported protocolVersion")
 		}
-		if sdkHeaderProtocolVersion(request.Header.Get("MCP-Protocol-Version")) == "2026-07-28" {
-			if err := populateSDKStandardHeaders(request, payload); err != nil {
-				return writeSDKProtocolError(c, http.StatusBadRequest, nil, err.Error())
-			}
-		}
 	}
 
 	team := mcp.TeamContext{}
@@ -151,7 +146,23 @@ func (h *MCPHandler) handleSDKPost(c echo.Context, profileID uuid.UUID, principa
 	}
 	server := mcp.NewServerWithScopesTeamContextAndRuntimeConfig(h.reg, profileID.String(), principal.Scopes, team, h.logger, h.recallFeedbackConfig, h.dreams)
 	serverHandler := server.NewSDKHTTPHandler(!acceptsEventStream(accept))
-	serverHandler.ServeHTTP(c.Response(), request)
+	work := func(workCtx context.Context) error {
+		serverHandler.ServeHTTP(c.Response(), request.WithContext(workCtx))
+		return nil
+	}
+	if h.lifecycle == nil || !acceptsEventStream(accept) {
+		return work(request.Context())
+	}
+	err := h.lifecycle.Start(request.Context(), profileID.String(), discardSSEWriter{}, work)
+	if errors.Is(err, sse.ErrTooManyStreams) {
+		return httperr.New(httperr.RATE_LIMITED, "too many concurrent streams")
+	}
+	if errors.Is(err, sse.ErrStreamTerminated) || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -175,52 +186,6 @@ func validateSDKProtocolHeader(value string) error {
 	return errors.New("unsupported MCP protocol version")
 }
 
-func sdkHeaderProtocolVersion(value string) string {
-	return strings.TrimSpace(value)
-}
-
-// populateSDKStandardHeaders supplies the required 2026 protocol routing
-// headers when a client has sent a valid JSON-RPC request but omitted them.
-// Existing values are validated rather than overwritten so a mismatched
-// header cannot be used to route a different method or tool.
-func populateSDKStandardHeaders(request *http.Request, payload []byte) error {
-	var envelope struct {
-		JSONRPC string          `json:"jsonrpc"`
-		Method  string          `json:"method"`
-		Params  json.RawMessage `json:"params"`
-	}
-	if err := json.Unmarshal(payload, &envelope); err != nil || envelope.JSONRPC != "2.0" || strings.TrimSpace(envelope.Method) == "" {
-		return nil
-	}
-	method := strings.TrimSpace(envelope.Method)
-	if current := strings.TrimSpace(request.Header.Get("Mcp-Method")); current != "" && current != method {
-		return errors.New("Mcp-Method header does not match request method")
-	}
-	request.Header.Set("Mcp-Method", method)
-	if method != "tools/call" && method != "prompts/get" && method != "resources/read" {
-		return nil
-	}
-	var params struct {
-		Name string `json:"name"`
-		URI  string `json:"uri"`
-	}
-	if err := json.Unmarshal(envelope.Params, &params); err != nil {
-		return errors.New("invalid MCP request params")
-	}
-	name := params.Name
-	if method == "resources/read" {
-		name = params.URI
-	}
-	if strings.TrimSpace(name) == "" {
-		return errors.New("Mcp-Name is required for named MCP methods")
-	}
-	if current := strings.TrimSpace(request.Header.Get("Mcp-Name")); current != "" && current != name {
-		return errors.New("Mcp-Name header does not match request name")
-	}
-	request.Header.Set("Mcp-Name", name)
-	return nil
-}
-
 func sdkInitializePayload(payload []byte) (json.RawMessage, string, bool) {
 	var envelope struct {
 		JSONRPC string          `json:"jsonrpc"`
@@ -235,6 +200,12 @@ func sdkInitializePayload(payload []byte) (json.RawMessage, string, bool) {
 	}
 	return envelope.ID, envelope.Params.ProtocolVersion, strings.TrimSpace(envelope.Params.ProtocolVersion) != ""
 }
+
+type discardSSEWriter struct{}
+
+func (discardSSEWriter) WriteEvent(string, any) error { return nil }
+func (discardSSEWriter) WriteComment(string) error    { return nil }
+func (discardSSEWriter) Close() error                 { return nil }
 
 func acceptsSDKResponse(value string) bool {
 	if strings.TrimSpace(value) == "" {

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -131,7 +131,7 @@ func (h *MCPHandler) handleSDKPost(c echo.Context, profileID uuid.UUID, principa
 			return httperr.New(httperr.VALIDATION_ERROR, "failed to read request body")
 		}
 		if len(payload) > 4<<20 {
-			return c.NoContent(http.StatusRequestEntityTooLarge)
+			return writeSDKProtocolError(c, http.StatusRequestEntityTooLarge, nil, "request body exceeds limit")
 		}
 		request.Body = io.NopCloser(bytes.NewReader(payload))
 		if id, version, ok := sdkInitializePayload(payload); ok && !sdkSupportedProtocolVersion(version) {

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -1,13 +1,16 @@
 package handler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
 	"github.com/markhuangai/dense-mem/internal/http/middleware"
@@ -25,6 +28,7 @@ type MCPHandler struct {
 	lifecycle            sse.StreamLifecycle
 	recallFeedbackConfig registry.RecallFeedbackConfigProvider
 	dreams               registry.DreamingConfigProvider
+	transport            string
 }
 
 // MCPHandlerInterface is the companion interface for MCPHandler.
@@ -37,21 +41,31 @@ var _ MCPHandlerInterface = (*MCPHandler)(nil)
 
 // NewMCPHandler constructs a Streamable HTTP MCP handler.
 func NewMCPHandler(reg registry.Registry, logger observability.LogProvider) *MCPHandler {
-	return &MCPHandler{reg: reg, logger: logger}
+	return &MCPHandler{reg: reg, logger: logger, transport: "legacy"}
 }
 
 func NewMCPHandlerWithLifecycle(reg registry.Registry, logger observability.LogProvider, lifecycle sse.StreamLifecycle) *MCPHandler {
-	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle}
+	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle, transport: "legacy"}
 }
 
 // NewMCPHandlerWithLifecycleAndRuntimeConfig constructs a Streamable HTTP MCP
 // handler with runtime feature visibility.
 func NewMCPHandlerWithLifecycleAndRuntimeConfig(reg registry.Registry, logger observability.LogProvider, lifecycle sse.StreamLifecycle, recallFeedbackConfig registry.RecallFeedbackConfigProvider, dreams ...registry.DreamingConfigProvider) *MCPHandler {
+	return NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(reg, logger, lifecycle, recallFeedbackConfig, "legacy", dreams...)
+}
+
+// NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport constructs the MCP
+// handler with a boot-only transport selector. The legacy constructor remains
+// available for focused compatibility tests and rollback.
+func NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(reg registry.Registry, logger observability.LogProvider, lifecycle sse.StreamLifecycle, recallFeedbackConfig registry.RecallFeedbackConfigProvider, transport string, dreams ...registry.DreamingConfigProvider) *MCPHandler {
 	var dreamConfig registry.DreamingConfigProvider
 	if len(dreams) > 0 {
 		dreamConfig = dreams[0]
 	}
-	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle, recallFeedbackConfig: recallFeedbackConfig, dreams: dreamConfig}
+	if transport != "sdk" {
+		transport = "legacy"
+	}
+	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle, recallFeedbackConfig: recallFeedbackConfig, dreams: dreamConfig, transport: transport}
 }
 
 // HandlePost serves POST /mcp. It accepts a single JSON-RPC payload and returns
@@ -67,6 +81,9 @@ func (h *MCPHandler) HandlePost(c echo.Context) error {
 	principal := middleware.GetPrincipal(ctx)
 	if principal == nil {
 		return httperr.New(httperr.AUTH_MISSING, "authentication required")
+	}
+	if h.transport == "sdk" {
+		return h.handleSDKPost(c, profileID, principal)
 	}
 
 	payload, err := io.ReadAll(c.Request().Body)
@@ -93,6 +110,161 @@ func (h *MCPHandler) HandlePost(c echo.Context) error {
 	}
 
 	return c.Blob(http.StatusOK, "application/json", response.Payload)
+}
+
+func (h *MCPHandler) handleSDKPost(c echo.Context, profileID uuid.UUID, principal *middleware.Principal) error {
+	request := c.Request()
+	if err := validateSDKProtocolHeader(request.Header.Get("MCP-Protocol-Version")); err != nil {
+		return writeSDKProtocolError(c, http.StatusBadRequest, nil, err.Error())
+	}
+	accept := request.Header.Get("Accept")
+	if !acceptsSDKResponse(accept) {
+		return writeSDKProtocolError(c, http.StatusNotAcceptable, nil, "unsupported Accept header")
+	}
+	// The SDK requires the combined Streamable HTTP Accept value even when the
+	// caller requested a single response mode. Preserve the caller's mode for
+	// JSONResponse above while normalizing only the transport header.
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if request.Body != nil {
+		payload, err := io.ReadAll(io.LimitReader(request.Body, 4<<20+1))
+		if err != nil {
+			return httperr.New(httperr.VALIDATION_ERROR, "failed to read request body")
+		}
+		if len(payload) > 4<<20 {
+			return c.NoContent(http.StatusRequestEntityTooLarge)
+		}
+		request.Body = io.NopCloser(bytes.NewReader(payload))
+		if id, version, ok := sdkInitializePayload(payload); ok && !sdkSupportedProtocolVersion(version) {
+			return writeSDKProtocolError(c, http.StatusBadRequest, id, "unsupported protocolVersion")
+		}
+		if sdkHeaderProtocolVersion(request.Header.Get("MCP-Protocol-Version")) == "2026-07-28" {
+			if err := populateSDKStandardHeaders(request, payload); err != nil {
+				return writeSDKProtocolError(c, http.StatusBadRequest, nil, err.Error())
+			}
+		}
+	}
+
+	team := mcp.TeamContext{}
+	if resolvedTeam, ok := middleware.GetResolvedTeamContext(request.Context()); ok {
+		team.Name = resolvedTeam.Name
+		team.Description = resolvedTeam.Description
+	}
+	server := mcp.NewServerWithScopesTeamContextAndRuntimeConfig(h.reg, profileID.String(), principal.Scopes, team, h.logger, h.recallFeedbackConfig, h.dreams)
+	serverHandler := server.NewSDKHTTPHandler(!acceptsEventStream(accept))
+	serverHandler.ServeHTTP(c.Response(), request)
+	return nil
+}
+
+var sdkProtocolVersions = map[string]struct{}{
+	"2024-11-05": {},
+	"2025-03-26": {},
+	"2025-06-18": {},
+	"2025-11-25": {},
+	"2026-07-28": {},
+}
+
+func sdkSupportedProtocolVersion(value string) bool {
+	_, ok := sdkProtocolVersions[strings.TrimSpace(value)]
+	return ok
+}
+
+func validateSDKProtocolHeader(value string) error {
+	if strings.TrimSpace(value) == "" || sdkSupportedProtocolVersion(value) {
+		return nil
+	}
+	return errors.New("unsupported MCP protocol version")
+}
+
+func sdkHeaderProtocolVersion(value string) string {
+	return strings.TrimSpace(value)
+}
+
+// populateSDKStandardHeaders supplies the required 2026 protocol routing
+// headers when a client has sent a valid JSON-RPC request but omitted them.
+// Existing values are validated rather than overwritten so a mismatched
+// header cannot be used to route a different method or tool.
+func populateSDKStandardHeaders(request *http.Request, payload []byte) error {
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil || envelope.JSONRPC != "2.0" || strings.TrimSpace(envelope.Method) == "" {
+		return nil
+	}
+	method := strings.TrimSpace(envelope.Method)
+	if current := strings.TrimSpace(request.Header.Get("Mcp-Method")); current != "" && current != method {
+		return errors.New("Mcp-Method header does not match request method")
+	}
+	request.Header.Set("Mcp-Method", method)
+	if method != "tools/call" && method != "prompts/get" && method != "resources/read" {
+		return nil
+	}
+	var params struct {
+		Name string `json:"name"`
+		URI  string `json:"uri"`
+	}
+	if err := json.Unmarshal(envelope.Params, &params); err != nil {
+		return errors.New("invalid MCP request params")
+	}
+	name := params.Name
+	if method == "resources/read" {
+		name = params.URI
+	}
+	if strings.TrimSpace(name) == "" {
+		return errors.New("Mcp-Name is required for named MCP methods")
+	}
+	if current := strings.TrimSpace(request.Header.Get("Mcp-Name")); current != "" && current != name {
+		return errors.New("Mcp-Name header does not match request name")
+	}
+	request.Header.Set("Mcp-Name", name)
+	return nil
+}
+
+func sdkInitializePayload(payload []byte) (json.RawMessage, string, bool) {
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Params  struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"params"`
+	}
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.Method != "initialize" {
+		return nil, "", false
+	}
+	return envelope.ID, envelope.Params.ProtocolVersion, strings.TrimSpace(envelope.Params.ProtocolVersion) != ""
+}
+
+func acceptsSDKResponse(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return true
+	}
+	for _, part := range strings.Split(value, ",") {
+		mediaType := strings.TrimSpace(strings.SplitN(part, ";", 2)[0])
+		if mediaType == "application/json" || mediaType == "text/event-stream" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeSDKProtocolError(c echo.Context, status int, id json.RawMessage, message string) error {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      nil,
+		"error": map[string]any{
+			"code":    -32600,
+			"message": strings.TrimSpace(message),
+		},
+	}
+	if len(id) > 0 {
+		var parsed any
+		if json.Unmarshal(id, &parsed) == nil {
+			payload["id"] = parsed
+		}
+	}
+	return c.JSON(status, payload)
 }
 
 // HandleGet serves GET /mcp as an SSE stream for Streamable HTTP clients.

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -266,60 +266,11 @@ func TestMCPHandlerSDKHeaderHelpers(t *testing.T) {
 	require.False(t, sdkSupportedProtocolVersion("2099-01-01"))
 	require.NoError(t, validateSDKProtocolHeader(""))
 	require.Error(t, validateSDKProtocolHeader("2099-01-01"))
-	require.Equal(t, "2026-07-28", sdkHeaderProtocolVersion(" 2026-07-28 "))
 
 	for _, value := range []string{"", "application/json", "text/event-stream", "application/json; charset=utf-8, text/plain"} {
 		require.True(t, acceptsSDKResponse(value), "Accept %q", value)
 	}
 	require.False(t, acceptsSDKResponse("text/plain"))
-
-	tests := []struct {
-		name       string
-		payload    string
-		method     string
-		nameHeader string
-		wantErr    string
-		wantMethod string
-		wantName   string
-	}{
-		{name: "malformed payload", payload: "{", wantMethod: ""},
-		{name: "invalid envelope", payload: `{"jsonrpc":"1.0","method":"tools/list"}`, wantMethod: ""},
-		{name: "method only", payload: `{"jsonrpc":"2.0","method":"tools/list","params":{}}`, wantMethod: "tools/list"},
-		{name: "tool call", payload: `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`, wantMethod: "tools/call", wantName: "remember"},
-		{name: "resource read", payload: `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"memory://one"}}`, wantMethod: "resources/read", wantName: "memory://one"},
-		{name: "bad params", payload: `{"jsonrpc":"2.0","method":"tools/call","params":42}`, wantErr: "invalid MCP request params"},
-		{name: "missing name", payload: `{"jsonrpc":"2.0","method":"tools/call","params":{}}`, wantErr: "Mcp-Name is required"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-			if tt.method != "" {
-				req.Header.Set("Mcp-Method", tt.method)
-			}
-			req.Header.Set("Mcp-Name", "")
-			err := populateSDKStandardHeaders(req, []byte(tt.payload))
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.wantMethod, req.Header.Get("Mcp-Method"))
-			require.Equal(t, tt.wantName, req.Header.Get("Mcp-Name"))
-		})
-	}
-
-	t.Run("method mismatch", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-		req.Header.Set("Mcp-Method", "tools/list")
-		err := populateSDKStandardHeaders(req, []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`))
-		require.EqualError(t, err, "Mcp-Method header does not match request method")
-	})
-	t.Run("name mismatch", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-		req.Header.Set("Mcp-Name", "other")
-		err := populateSDKStandardHeaders(req, []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`))
-		require.EqualError(t, err, "Mcp-Name header does not match request name")
-	})
 }
 
 func TestMCPHandlerSDKInitializePayloadAndProtocolError(t *testing.T) {
@@ -353,6 +304,29 @@ func TestMCPHandlerTransportConstructors(t *testing.T) {
 	require.Equal(t, "sdk", sdk.transport)
 	fallback := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), nil, nil, "unknown")
 	require.Equal(t, "legacy", fallback.transport)
+}
+
+func TestMCPHandlerSDKUsesStreamLifecycleForEventStreams(t *testing.T) {
+	e := echo.New()
+	profileID := uuid.New()
+	started := false
+	lifecycle := &mockStreamLifecycle{startFunc: func(ctx context.Context, gotProfileID string, writer sse.SSEWriter, work func(context.Context) error) error {
+		started = true
+		require.Equal(t, profileID.String(), gotProfileID)
+		return work(ctx)
+	}}
+	h := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), lifecycle, nil, "sdk")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	req = req.WithContext(mcpTestContext(req.Context(), profileID, []string{"read"}))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.HandlePost(c))
+	require.True(t, started)
+	require.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestMCPHandlerGetBranches(t *testing.T) {

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -258,6 +258,8 @@ func TestMCPHandlerSDKPostValidationBranches(t *testing.T) {
 		c.Request().Header.Set("MCP-Protocol-Version", "2025-11-25")
 		require.NoError(t, h.HandlePost(c))
 		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		require.Contains(t, rec.Body.String(), `"code":-32600`)
+		require.Contains(t, rec.Body.String(), `"message":"request body exceeds limit"`)
 	})
 }
 

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -196,6 +196,165 @@ func TestMCPHandlerPostValidationBranches(t *testing.T) {
 	})
 }
 
+func TestMCPHandlerSDKPostInitialize(t *testing.T) {
+	h := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), nil, nil, "sdk")
+	e := echo.New()
+	profileID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, echo.MIMEApplicationJSON)
+	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	req = req.WithContext(mcpTestContext(req.Context(), profileID, []string{"read"}))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.HandlePost(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"protocolVersion":"2025-11-25"`)
+}
+
+func TestMCPHandlerSDKPostValidationBranches(t *testing.T) {
+	h := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), nil, nil, "sdk")
+	e := echo.New()
+	profileID := uuid.New()
+	newContext := func(body string) (echo.Context, *httptest.ResponseRecorder) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req = req.WithContext(mcpTestContext(req.Context(), profileID, []string{"read"}))
+		rec := httptest.NewRecorder()
+		return e.NewContext(req, rec), rec
+	}
+
+	t.Run("unsupported header", func(t *testing.T) {
+		c, rec := newContext(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+		c.Request().Header.Set(echo.HeaderAccept, echo.MIMEApplicationJSON)
+		c.Request().Header.Set("MCP-Protocol-Version", "2099-01-01")
+		require.NoError(t, h.HandlePost(c))
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Contains(t, rec.Body.String(), "unsupported MCP protocol version")
+	})
+
+	t.Run("unsupported accept", func(t *testing.T) {
+		c, rec := newContext(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+		c.Request().Header.Set(echo.HeaderAccept, "text/plain")
+		c.Request().Header.Set("MCP-Protocol-Version", "2025-11-25")
+		require.NoError(t, h.HandlePost(c))
+		require.Equal(t, http.StatusNotAcceptable, rec.Code)
+		require.Contains(t, rec.Body.String(), "unsupported Accept header")
+	})
+
+	t.Run("unsupported initialize payload preserves id", func(t *testing.T) {
+		c, rec := newContext(`{"jsonrpc":"2.0","id":"init-1","method":"initialize","params":{"protocolVersion":"2099-01-01"}}`)
+		c.Request().Header.Set(echo.HeaderAccept, echo.MIMEApplicationJSON)
+		c.Request().Header.Set("MCP-Protocol-Version", "2025-11-25")
+		require.NoError(t, h.HandlePost(c))
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Contains(t, rec.Body.String(), `"id":"init-1"`)
+	})
+
+	t.Run("request body limit", func(t *testing.T) {
+		c, rec := newContext(strings.Repeat("x", 4<<20+1))
+		c.Request().Header.Set(echo.HeaderAccept, echo.MIMEApplicationJSON)
+		c.Request().Header.Set("MCP-Protocol-Version", "2025-11-25")
+		require.NoError(t, h.HandlePost(c))
+		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	})
+}
+
+func TestMCPHandlerSDKHeaderHelpers(t *testing.T) {
+	require.True(t, sdkSupportedProtocolVersion(" 2025-11-25 "))
+	require.False(t, sdkSupportedProtocolVersion("2099-01-01"))
+	require.NoError(t, validateSDKProtocolHeader(""))
+	require.Error(t, validateSDKProtocolHeader("2099-01-01"))
+	require.Equal(t, "2026-07-28", sdkHeaderProtocolVersion(" 2026-07-28 "))
+
+	for _, value := range []string{"", "application/json", "text/event-stream", "application/json; charset=utf-8, text/plain"} {
+		require.True(t, acceptsSDKResponse(value), "Accept %q", value)
+	}
+	require.False(t, acceptsSDKResponse("text/plain"))
+
+	tests := []struct {
+		name       string
+		payload    string
+		method     string
+		nameHeader string
+		wantErr    string
+		wantMethod string
+		wantName   string
+	}{
+		{name: "malformed payload", payload: "{", wantMethod: ""},
+		{name: "invalid envelope", payload: `{"jsonrpc":"1.0","method":"tools/list"}`, wantMethod: ""},
+		{name: "method only", payload: `{"jsonrpc":"2.0","method":"tools/list","params":{}}`, wantMethod: "tools/list"},
+		{name: "tool call", payload: `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`, wantMethod: "tools/call", wantName: "remember"},
+		{name: "resource read", payload: `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"memory://one"}}`, wantMethod: "resources/read", wantName: "memory://one"},
+		{name: "bad params", payload: `{"jsonrpc":"2.0","method":"tools/call","params":42}`, wantErr: "invalid MCP request params"},
+		{name: "missing name", payload: `{"jsonrpc":"2.0","method":"tools/call","params":{}}`, wantErr: "Mcp-Name is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tt.method != "" {
+				req.Header.Set("Mcp-Method", tt.method)
+			}
+			req.Header.Set("Mcp-Name", "")
+			err := populateSDKStandardHeaders(req, []byte(tt.payload))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMethod, req.Header.Get("Mcp-Method"))
+			require.Equal(t, tt.wantName, req.Header.Get("Mcp-Name"))
+		})
+	}
+
+	t.Run("method mismatch", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Mcp-Method", "tools/list")
+		err := populateSDKStandardHeaders(req, []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`))
+		require.EqualError(t, err, "Mcp-Method header does not match request method")
+	})
+	t.Run("name mismatch", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Mcp-Name", "other")
+		err := populateSDKStandardHeaders(req, []byte(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"remember"}}`))
+		require.EqualError(t, err, "Mcp-Name header does not match request name")
+	})
+}
+
+func TestMCPHandlerSDKInitializePayloadAndProtocolError(t *testing.T) {
+	id, version, ok := sdkInitializePayload([]byte(`{"jsonrpc":"2.0","id":7,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`))
+	require.True(t, ok)
+	require.Equal(t, "7", string(id))
+	require.Equal(t, "2025-11-25", version)
+	for _, payload := range []string{
+		"{",
+		`{"jsonrpc":"2.0","method":"tools/list","params":{}}`,
+		`{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":""}}`,
+	} {
+		_, _, ok = sdkInitializePayload([]byte(payload))
+		require.False(t, ok)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, writeSDKProtocolError(c, http.StatusBadRequest, json.RawMessage(`"request-1"`), " bad request "))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `"id":"request-1"`)
+	require.Contains(t, rec.Body.String(), `"message":"bad request"`)
+}
+
+func TestMCPHandlerTransportConstructors(t *testing.T) {
+	legacy := NewMCPHandlerWithLifecycleAndRuntimeConfig(registry.New(), testMCPLogger(), nil, nil)
+	require.Equal(t, "legacy", legacy.transport)
+	sdk := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), nil, nil, "sdk")
+	require.Equal(t, "sdk", sdk.transport)
+	fallback := NewMCPHandlerWithLifecycleAndRuntimeConfigAndTransport(registry.New(), testMCPLogger(), nil, nil, "unknown")
+	require.Equal(t, "legacy", fallback.transport)
+}
+
 func TestMCPHandlerGetBranches(t *testing.T) {
 	e := echo.New()
 	profileID := uuid.New()

--- a/internal/mcp/conformance_harness.go
+++ b/internal/mcp/conformance_harness.go
@@ -1,0 +1,136 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// NewLegacyHTTPHandler exposes the pre-SDK transport through the same narrow
+// HTTP boundary used by the differential conformance harness. Production
+// routing remains owned by internal/http/handler.
+func NewLegacyHTTPHandler(server *Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || server == nil {
+			w.Header().Set("Allow", http.MethodPost)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var payload bytes.Buffer
+		if _, err := payload.ReadFrom(r.Body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		result := server.HandlePayloadResult(r.Context(), payload.Bytes())
+		if !result.Respond {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(result.Payload)
+	})
+}
+
+// CanonicalizeConformanceResponse removes only transport-generated fields that
+// are allowed to vary between implementations. Semantic JSON-RPC result and
+// error fields remain exact.
+func CanonicalizeConformanceResponse(payload []byte) ([]byte, error) {
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, err
+	}
+	canonicalizeTransportFields(value)
+	return json.Marshal(value)
+}
+
+func canonicalizeTransportFields(value any) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	if result, ok := object["result"].(map[string]any); ok {
+		delete(result, "_meta")
+		delete(result, "ttlMs")
+		delete(result, "cacheScope")
+		if serverInfo, ok := result["serverInfo"].(map[string]any); ok {
+			delete(serverInfo, "version")
+		}
+		if tools, ok := result["tools"].([]any); ok {
+			for _, item := range tools {
+				if tool, ok := item.(map[string]any); ok && tool["outputSchema"] == nil {
+					delete(tool, "outputSchema")
+				}
+			}
+		}
+		if prompts, ok := result["prompts"].([]any); ok {
+			for _, item := range prompts {
+				if prompt, ok := item.(map[string]any); ok {
+					delete(prompt, "title")
+				}
+			}
+		}
+	}
+	if errObject, ok := object["error"].(map[string]any); ok {
+		delete(errObject, "data")
+	}
+}
+
+// CompareConformanceResponses compares two responses after the bounded
+// canonicalization above. It never normalizes tool content or error messages.
+func CompareConformanceResponses(left, right []byte) (bool, error) {
+	leftCanonical, err := CanonicalizeConformanceResponse(left)
+	if err != nil {
+		return false, err
+	}
+	rightCanonical, err := CanonicalizeConformanceResponse(right)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(leftCanonical)) == strings.TrimSpace(string(rightCanonical)), nil
+}
+
+// ConformanceCall runs one request against both handlers and reports whether
+// the protocol responses are semantically equivalent.
+func ConformanceCall(ctx context.Context, legacy, sdk http.Handler, payload []byte, headers http.Header) (bool, error) {
+	legacyResponse, err := conformanceHTTPRequest(ctx, legacy, payload, headers)
+	if err != nil {
+		return false, err
+	}
+	sdkResponse, err := conformanceHTTPRequest(ctx, sdk, payload, headers)
+	if err != nil {
+		return false, err
+	}
+	return CompareConformanceResponses(legacyResponse, sdkResponse)
+}
+
+func conformanceHTTPRequest(ctx context.Context, handler http.Handler, payload []byte, headers http.Header) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://mcp.test/mcp", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	request.Header = headers.Clone()
+	response := newConformanceRecorder()
+	handler.ServeHTTP(response, request)
+	return response.body.Bytes(), nil
+}
+
+type conformanceRecorder struct {
+	header http.Header
+	code   int
+	body   bytes.Buffer
+}
+
+func newConformanceRecorder() *conformanceRecorder {
+	return &conformanceRecorder{header: make(http.Header)}
+}
+func (r *conformanceRecorder) Header() http.Header  { return r.header }
+func (r *conformanceRecorder) WriteHeader(code int) { r.code = code }
+func (r *conformanceRecorder) Write(payload []byte) (int, error) {
+	if r.code == 0 {
+		r.code = http.StatusOK
+	}
+	return r.body.Write(payload)
+}

--- a/internal/mcp/conformance_harness_test.go
+++ b/internal/mcp/conformance_harness_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestConformanceHarnessComparesLegacyAndSDKRegistryFlows(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	require.NoError(t, reg.Register(registry.Tool{
+		Name:           "conformance_read",
+		Description:    "read",
+		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}},
+		RequiredScopes: []string{"read"},
+		Invoke: func(_ context.Context, _ string, input map[string]any) (map[string]any, error) {
+			return map[string]any{"value": input["value"]}, nil
+		},
+	}))
+	server := NewServerWithScopes(reg, "profile-conformance", []string{"read"}, logger)
+	legacy := NewLegacyHTTPHandler(server)
+	sdk := server.NewSDKHTTPHandler(true)
+	headers := http.Header{"Content-Type": []string{"application/json"}, "Accept": []string{"application/json, text/event-stream"}, "MCP-Protocol-Version": []string{"2025-11-25"}}
+	for _, payload := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"conformance_read","arguments":{"value":"ok"}}}`,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{}}}`,
+	} {
+		matched, err := ConformanceCall(context.Background(), legacy, sdk, []byte(payload), headers)
+		require.NoError(t, err)
+		require.True(t, matched, "legacy and SDK responses differ for %s", payload)
+	}
+}
+
+func TestConformanceHarnessSupportsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	logger, _ := testLogger(t)
+	server := NewServer(registry.New(), "profile-conformance", logger)
+	legacy := NewLegacyHTTPHandler(server)
+	_, err := ConformanceCall(ctx, legacy, server.NewSDKHTTPHandler(true), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`), http.Header{"Content-Type": []string{"application/json"}, "Accept": []string{"application/json, text/event-stream"}, "MCP-Protocol-Version": []string{"2025-11-25"}})
+	require.Error(t, err)
+}

--- a/internal/mcp/conformance_harness_test.go
+++ b/internal/mcp/conformance_harness_test.go
@@ -17,6 +17,7 @@ func TestConformanceHarnessComparesLegacyAndSDKRegistryFlows(t *testing.T) {
 		Name:           "conformance_read",
 		Description:    "read",
 		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}},
+		OutputSchema:   map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}},
 		RequiredScopes: []string{"read"},
 		Invoke: func(_ context.Context, _ string, input map[string]any) (map[string]any, error) {
 			return map[string]any{"value": input["value"]}, nil

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -46,10 +46,13 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 		return false
 	}
 	payload, err := io.ReadAll(io.LimitReader(req.Body, 4<<20+1))
-	if err != nil || len(payload) > 4<<20 {
+	if err != nil {
 		return false
 	}
 	req.Body = io.NopCloser(bytes.NewReader(payload))
+	if len(payload) > 4<<20 {
+		return false
+	}
 	var envelope struct {
 		JSONRPC string          `json:"jsonrpc"`
 		ID      json.RawMessage `json:"id"`

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -70,6 +70,9 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 	if len(envelope.ID) == 0 {
 		return false
 	}
+	if !sdkRPCIDValid(envelope.ID) {
+		return false
+	}
 	tool, ok := s.registry.Get(envelope.Params.Name)
 	policy := registry.ResolveRuntimeToolPolicy(req.Context(), s.runtimeToolPolicy, tool)
 	visible := ok && registry.ToolVisible(req.Context(), tool, policy)
@@ -96,6 +99,19 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 		_, _ = w.Write(encoded)
 	}
 	return true
+}
+
+func sdkRPCIDValid(raw json.RawMessage) bool {
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return false
+	}
+	switch value.(type) {
+	case nil, string, float64:
+		return true
+	default:
+		return false
+	}
 }
 
 func sdkAcceptsStreamableHTTP(value string) bool {
@@ -144,8 +160,9 @@ func (s *Server) newSDKServer(ctx context.Context) *sdkmcp.Server {
 		Logger:       slog.Default(),
 	})
 
-	for _, tool := range s.registry.List() {
-		policy := registry.ResolveRuntimeToolPolicy(ctx, s.runtimeToolPolicy, tool)
+	tools := s.registry.List()
+	policy := registry.ResolveRuntimeToolPolicy(ctx, s.runtimeToolPolicy, tools...)
+	for _, tool := range tools {
 		if !registry.ToolVisible(ctx, tool, policy) || !s.canUseTool(tool) {
 			continue
 		}

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -58,7 +58,8 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 		ID      json.RawMessage `json:"id"`
 		Method  string          `json:"method"`
 		Params  struct {
-			Name string `json:"name"`
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
 		} `json:"params"`
 	}
 	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.Method != "tools/call" || strings.TrimSpace(envelope.Params.Name) == "" {
@@ -66,6 +67,12 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 	}
 	if !sdkStandardHeadersMatch(req, envelope.Method, envelope.Params.Name) {
 		return false
+	}
+	if len(envelope.Params.Arguments) > 0 {
+		var arguments map[string]any
+		if json.Unmarshal(envelope.Params.Arguments, &arguments) != nil || arguments == nil {
+			return false
+		}
 	}
 	// JSON-RPC notifications never receive a response, including when the
 	// requested tool is hidden or unknown. Leave them to the SDK transport so

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -1,0 +1,199 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	sdkjsonrpc "github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+// NewSDKHTTPHandler creates a stateless official-SDK transport backed by the
+// same request-scoped registry, authorization, and prompt catalog as the
+// legacy transport.
+func (s *Server) NewSDKHTTPHandler(jsonResponse bool) http.Handler {
+	transport := sdkmcp.NewStreamableHTTPHandler(func(req *http.Request) *sdkmcp.Server {
+		return s.newSDKServer(req.Context())
+	}, &sdkmcp.StreamableHTTPOptions{
+		Stateless:                    true,
+		JSONResponse:                 jsonResponse,
+		MaxRequestBodyBytes:          4 << 20,
+		PropagateRequestCancellation: true,
+	})
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if s.writeSDKToolLookupError(w, req, jsonResponse) {
+			return
+		}
+		transport.ServeHTTP(w, req)
+	})
+}
+
+func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Request, jsonResponse bool) bool {
+	if req == nil || req.Body == nil || req.Method != http.MethodPost {
+		return false
+	}
+	payload, err := io.ReadAll(io.LimitReader(req.Body, 4<<20+1))
+	if err != nil || len(payload) > 4<<20 {
+		return false
+	}
+	req.Body = io.NopCloser(bytes.NewReader(payload))
+	var envelope struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Params  struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.Method != "tools/call" || strings.TrimSpace(envelope.Params.Name) == "" {
+		return false
+	}
+	tool, ok := s.registry.Get(envelope.Params.Name)
+	policy := registry.ResolveRuntimeToolPolicy(req.Context(), s.runtimeToolPolicy, tool)
+	visible := ok && registry.ToolVisible(req.Context(), tool, policy)
+	if visible && s.canUseTool(tool) {
+		return false
+	}
+	code, message := errCodeMethodNotFound, "tool not found: "+boundedRPCText(envelope.Params.Name)
+	if visible && !s.canUseTool(tool) {
+		code, message = errCodeToolFailure, "insufficient scope for tool"
+	}
+	response := map[string]any{"jsonrpc": "2.0", "id": nil, "error": map[string]any{"code": code, "message": message}}
+	if len(envelope.ID) > 0 {
+		var id any
+		if json.Unmarshal(envelope.ID, &id) == nil {
+			response["id"] = id
+		}
+	}
+	encoded, _ := json.Marshal(response)
+	if !jsonResponse && strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message\ndata: " + string(encoded) + "\n\n"))
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(encoded)
+	}
+	return true
+}
+
+func (s *Server) newSDKServer(ctx context.Context) *sdkmcp.Server {
+	capabilities := &sdkmcp.ServerCapabilities{
+		Tools: &sdkmcp.ToolCapabilities{},
+	}
+	if len(s.prompts.List()) > 0 {
+		capabilities.Prompts = &sdkmcp.PromptCapabilities{}
+	}
+	implementation := &sdkmcp.Implementation{
+		Name:        s.serverName(),
+		Version:     ServerVersion,
+		Description: s.serverDescription(),
+	}
+	if s.team.Name != "" {
+		implementation.Title = s.teamDisplayName()
+	}
+	server := sdkmcp.NewServer(implementation, &sdkmcp.ServerOptions{
+		Instructions: s.instructions(),
+		Capabilities: capabilities,
+		SchemaCache:  sdkmcp.NewSchemaCache(),
+		Logger:       slog.Default(),
+	})
+
+	for _, tool := range s.registry.List() {
+		policy := registry.ResolveRuntimeToolPolicy(ctx, s.runtimeToolPolicy, tool)
+		if !registry.ToolVisible(ctx, tool, policy) || !s.canUseTool(tool) {
+			continue
+		}
+		inputSchema := tool.InputSchema
+		if inputSchema == nil {
+			inputSchema = map[string]any{"type": "object"}
+		}
+		server.AddTool(&sdkmcp.Tool{
+			Name:         tool.Name,
+			Description:  s.toolDescription(tool.Description),
+			InputSchema:  inputSchema,
+			OutputSchema: tool.OutputSchema,
+		}, s.sdkToolHandler(tool.Name))
+	}
+
+	for _, prompt := range s.prompts.List() {
+		prompt := prompt
+		arguments := make([]*sdkmcp.PromptArgument, 0, len(prompt.Arguments))
+		for _, argument := range prompt.Arguments {
+			argument := argument
+			arguments = append(arguments, &sdkmcp.PromptArgument{
+				Name:        argument.Name,
+				Description: argument.Description,
+				Required:    argument.Required,
+			})
+		}
+		server.AddPrompt(&sdkmcp.Prompt{
+			Name:        prompt.Name,
+			Title:       prompt.Title,
+			Description: prompt.Description,
+			Arguments:   arguments,
+		}, func(ctx context.Context, req *sdkmcp.GetPromptRequest) (*sdkmcp.GetPromptResult, error) {
+			args := map[string]string{}
+			if req != nil && req.Params != nil {
+				args = req.Params.Arguments
+			}
+			_, rendered, err := s.prompts.Render(prompt.Name, args)
+			if err != nil {
+				return nil, &sdkjsonrpc.Error{Code: errCodeInvalidParams, Message: boundedRPCText(err.Error())}
+			}
+			return &sdkmcp.GetPromptResult{
+				Description: prompt.Description,
+				Messages: []*sdkmcp.PromptMessage{{
+					Role:    sdkmcp.Role("user"),
+					Content: &sdkmcp.TextContent{Text: rendered},
+				}},
+			}, nil
+		})
+	}
+	return server
+}
+
+func (s *Server) sdkToolHandler(name string) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args map[string]any
+		if req != nil && req.Params != nil && len(req.Params.Arguments) > 0 {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return nil, &sdkjsonrpc.Error{Code: errCodeInvalidParams, Message: "invalid params"}
+			}
+		}
+		result, rpcErr := s.invokeTool(ctx, name, args)
+		if rpcErr != nil {
+			return nil, sdkRPCError(rpcErr)
+		}
+		content, ok := result["content"].([]map[string]any)
+		if !ok || len(content) != 1 {
+			return nil, &sdkjsonrpc.Error{Code: errCodeToolFailure, Message: "tool result serialization failed"}
+		}
+		text, ok := content[0]["text"].(string)
+		if !ok {
+			return nil, &sdkjsonrpc.Error{Code: errCodeToolFailure, Message: "tool result serialization failed"}
+		}
+		return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}}}, nil
+	}
+}
+
+func sdkRPCError(value *rpcError) error {
+	if value == nil {
+		return nil
+	}
+	data, _ := json.Marshal(value.Data)
+	if value.Data == nil {
+		data = nil
+	}
+	return &sdkjsonrpc.Error{Code: int64(value.Code), Message: value.Message, Data: data}
+}
+
+func sdkProtocolError(message string) error {
+	return &sdkjsonrpc.Error{Code: errCodeInvalidRequest, Message: strings.TrimSpace(message)}
+}

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -39,6 +39,12 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 	if req == nil || req.Body == nil || req.Method != http.MethodPost {
 		return false
 	}
+	if strings.ToLower(strings.TrimSpace(strings.SplitN(req.Header.Get("Content-Type"), ";", 2)[0])) != "application/json" {
+		return false
+	}
+	if !sdkAcceptsStreamableHTTP(req.Header.Get("Accept")) {
+		return false
+	}
 	payload, err := io.ReadAll(io.LimitReader(req.Body, 4<<20+1))
 	if err != nil || len(payload) > 4<<20 {
 		return false
@@ -53,6 +59,9 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 		} `json:"params"`
 	}
 	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.Method != "tools/call" || strings.TrimSpace(envelope.Params.Name) == "" {
+		return false
+	}
+	if !sdkStandardHeadersMatch(req, envelope.Method, envelope.Params.Name) {
 		return false
 	}
 	// JSON-RPC notifications never receive a response, including when the
@@ -87,6 +96,30 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 		_, _ = w.Write(encoded)
 	}
 	return true
+}
+
+func sdkAcceptsStreamableHTTP(value string) bool {
+	jsonOK, streamOK := false, false
+	for _, part := range strings.Split(value, ",") {
+		switch strings.TrimSpace(strings.SplitN(part, ";", 2)[0]) {
+		case "application/json":
+			jsonOK = true
+		case "text/event-stream":
+			streamOK = true
+		}
+	}
+	return jsonOK && streamOK
+}
+
+func sdkStandardHeadersMatch(req *http.Request, method, name string) bool {
+	version := strings.TrimSpace(req.Header.Get("Mcp-Protocol-Version"))
+	if version < "2026-07-28" {
+		return true
+	}
+	if req.Header.Get("Mcp-Method") != method {
+		return false
+	}
+	return req.Header.Get("Mcp-Name") == name
 }
 
 func (s *Server) newSDKServer(ctx context.Context) *sdkmcp.Server {

--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -55,6 +55,12 @@ func (s *Server) writeSDKToolLookupError(w http.ResponseWriter, req *http.Reques
 	if json.Unmarshal(payload, &envelope) != nil || envelope.JSONRPC != "2.0" || envelope.Method != "tools/call" || strings.TrimSpace(envelope.Params.Name) == "" {
 		return false
 	}
+	// JSON-RPC notifications never receive a response, including when the
+	// requested tool is hidden or unknown. Leave them to the SDK transport so
+	// it can preserve the notification status code and empty body.
+	if len(envelope.ID) == 0 {
+		return false
+	}
 	tool, ok := s.registry.Get(envelope.Params.Name)
 	policy := registry.ResolveRuntimeToolPolicy(req.Context(), s.runtimeToolPolicy, tool)
 	visible := ok && registry.ToolVisible(req.Context(), tool, policy)
@@ -115,10 +121,12 @@ func (s *Server) newSDKServer(ctx context.Context) *sdkmcp.Server {
 			inputSchema = map[string]any{"type": "object"}
 		}
 		server.AddTool(&sdkmcp.Tool{
-			Name:         tool.Name,
-			Description:  s.toolDescription(tool.Description),
-			InputSchema:  inputSchema,
-			OutputSchema: tool.OutputSchema,
+			Name:        tool.Name,
+			Description: s.toolDescription(tool.Description),
+			InputSchema: inputSchema,
+			// The legacy transport does not advertise outputSchema. Keep the
+			// public catalog compatible while the SDK remains a transport detail.
+			OutputSchema: nil,
 		}, s.sdkToolHandler(tool.Name))
 	}
 

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -191,6 +191,41 @@ func TestSDKHTTPHandlerValidatesBeforeToolLookup(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	require.Equal(t, http.StatusBadRequest, response.Code)
 	require.Contains(t, response.Body.String(), `"code":-32020`)
+
+	request = httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":{},"method":"tools/call","params":{"name":"missing_tool","arguments":{}}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.NotContains(t, response.Body.String(), "tool not found")
+}
+
+func TestSDKServerResolvesRuntimeToolPolicyOnce(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	for _, name := range []string{
+		registry.ToolSubmitRecallSessionFeedback,
+		registry.ToolRecallMemory,
+		registry.ToolListDreams,
+	} {
+		require.NoError(t, reg.Register(registry.Tool{Name: name, InputSchema: map[string]any{"type": "object"}}))
+	}
+	var recallCalls, dreamCalls int
+	server := NewServerWithScopesTeamContextAndRuntimeConfig(
+		reg,
+		"profile-a",
+		[]string{"read"},
+		TeamContext{},
+		logger,
+		recallFeedbackConfigStub{enabled: true, calls: &recallCalls},
+		dreamingConfigStub{enabled: true, calls: &dreamCalls},
+	)
+
+	server.newSDKServer(context.Background())
+	require.Equal(t, 1, recallCalls)
+	require.Equal(t, 1, dreamCalls)
 }
 
 func TestSDKHTTPHandlerDoesNotAnswerInitializedNotification(t *testing.T) {

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -150,7 +150,9 @@ func TestSDKHTTPHandlerMapsUnknownAndUnauthorizedTools(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"`+tc.tool+`","arguments":{}}}`))
-			request.Header.Set("Accept", tc.accept)
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Accept", "application/json, text/event-stream")
+			request.Header.Set("MCP-Protocol-Version", "2025-11-25")
 			response := httptest.NewRecorder()
 			server.NewSDKHTTPHandler(tc.accept != "text/event-stream").ServeHTTP(response, request)
 			require.Equal(t, http.StatusOK, response.Code)
@@ -163,6 +165,32 @@ func TestSDKHTTPHandlerMapsUnknownAndUnauthorizedTools(t *testing.T) {
 	}
 
 	require.False(t, server.writeSDKToolLookupError(httptest.NewRecorder(), &http.Request{Method: http.MethodGet}, true))
+}
+
+func TestSDKHTTPHandlerValidatesBeforeToolLookup(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	require.NoError(t, reg.Register(registry.Tool{Name: "write_tool", RequiredScopes: []string{"write"}}))
+	server := NewServerWithScopes(reg, "profile-a", []string{"read"}, logger)
+	handler := server.NewSDKHTTPHandler(true)
+
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"missing_tool","arguments":{}}}`))
+	request.Header.Set("Content-Type", "text/plain")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusUnsupportedMediaType, response.Code)
+	require.NotContains(t, response.Body.String(), "tool not found")
+
+	request = httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"missing_tool","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2026-07-28")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), `"code":-32020`)
 }
 
 func TestSDKHTTPHandlerDoesNotAnswerInitializedNotification(t *testing.T) {

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -212,6 +212,14 @@ func TestSDKHTTPHandlerValidatesBeforeToolLookup(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	require.Equal(t, http.StatusBadRequest, response.Code)
 	require.NotContains(t, response.Body.String(), "tool not found")
+
+	request = httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"missing_tool","arguments":"invalid"}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.NotContains(t, response.Body.String(), "tool not found")
 }
 
 func TestSDKServerResolvesRuntimeToolPolicyOnce(t *testing.T) {

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -1,0 +1,185 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	sdkjsonrpc "github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestSDKHTTPHandlerUsesTheSharedRegistryAndSupportsLegacyAndCurrentFlows(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	require.NoError(t, reg.Register(registry.Tool{
+		Name:           "read_tool",
+		Description:    "read",
+		InputSchema:    map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "string"}}},
+		RequiredScopes: []string{"read"},
+		Invoke: func(_ context.Context, _ string, input map[string]any) (map[string]any, error) {
+			return map[string]any{"value": input["value"]}, nil
+		},
+	}))
+	server := NewServerWithScopes(reg, "profile-a", []string{"read"}, logger)
+	handler := server.NewSDKHTTPHandler(true)
+
+	for _, version := range []string{"2025-11-25"} {
+		t.Run(version, func(t *testing.T) {
+			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"` + version + `"}}`
+			request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Accept", "application/json, text/event-stream")
+			request.Header.Set("MCP-Protocol-Version", version)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+			var envelope struct {
+				Result struct {
+					ProtocolVersion string `json:"protocolVersion"`
+				} `json:"result"`
+				Error any `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &envelope))
+			require.Nil(t, envelope.Error)
+			require.Equal(t, version, envelope.Result.ProtocolVersion)
+		})
+	}
+
+	discoverRequest := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":11,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`))
+	discoverRequest.Header.Set("Content-Type", "application/json")
+	discoverRequest.Header.Set("Accept", "application/json, text/event-stream")
+	discoverRequest.Header.Set("MCP-Protocol-Version", "2026-07-28")
+	discoverRequest.Header.Set("Mcp-Method", "server/discover")
+	discoverResponse := httptest.NewRecorder()
+	handler.ServeHTTP(discoverResponse, discoverRequest)
+	require.Equal(t, http.StatusOK, discoverResponse.Code)
+	require.Contains(t, discoverResponse.Body.String(), `"supportedVersions"`)
+	require.Contains(t, discoverResponse.Body.String(), `2026-07-28`)
+
+	listRequest := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`))
+	listRequest.Header.Set("Content-Type", "application/json")
+	listRequest.Header.Set("Accept", "application/json, text/event-stream")
+	listRequest.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	listResponse := httptest.NewRecorder()
+	handler.ServeHTTP(listResponse, listRequest)
+	require.Equal(t, http.StatusOK, listResponse.Code)
+	require.Contains(t, listResponse.Body.String(), `"name":"read_tool"`)
+
+	callRequest := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_tool","arguments":{"value":"ok"}}}`))
+	callRequest.Header.Set("Content-Type", "application/json")
+	callRequest.Header.Set("Accept", "application/json, text/event-stream")
+	callRequest.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	callResponse := httptest.NewRecorder()
+	handler.ServeHTTP(callResponse, callRequest)
+	require.Equal(t, http.StatusOK, callResponse.Code)
+	require.Contains(t, callResponse.Body.String(), `\"value\":\"ok\"`)
+}
+
+func TestSDKHTTPHandlerRejectsUnknownProtocolHeader(t *testing.T) {
+	logger, _ := testLogger(t)
+	server := NewServer(registry.New(), "profile-a", logger)
+	handler := server.NewSDKHTTPHandler(true)
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2099-01-01"}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2099-01-01")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+}
+
+func TestSDKErrorAdaptersPreserveJSONRPCDetails(t *testing.T) {
+	require.Nil(t, sdkRPCError(nil))
+
+	err := sdkRPCError(&rpcError{Code: errCodeToolFailure, Message: "tool failed", Data: map[string]any{"retryable": true}})
+	var sdkErr *sdkjsonrpc.Error
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, int64(errCodeToolFailure), sdkErr.Code)
+	require.Equal(t, "tool failed", sdkErr.Message)
+	require.JSONEq(t, `{"retryable":true}`, string(sdkErr.Data))
+
+	err = sdkRPCError(&rpcError{Code: errCodeInvalidParams, Message: "invalid params"})
+	require.ErrorAs(t, err, &sdkErr)
+	require.Nil(t, sdkErr.Data)
+
+	err = sdkProtocolError("  malformed request ")
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, int64(errCodeInvalidRequest), sdkErr.Code)
+	require.Equal(t, "malformed request", sdkErr.Message)
+}
+
+func TestSDKHTTPHandlerMapsUnknownAndUnauthorizedTools(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	require.NoError(t, reg.Register(registry.Tool{Name: "write_tool", RequiredScopes: []string{"write"}}))
+	server := NewServerWithScopesAndTeamContext(reg, "profile-a", []string{"read"}, TeamContext{Name: "Project"}, logger)
+
+	for _, tc := range []struct {
+		name        string
+		accept      string
+		tool        string
+		wantCode    int
+		wantMessage string
+	}{
+		{name: "unknown JSON", accept: "application/json", tool: "missing_tool", wantCode: errCodeMethodNotFound, wantMessage: "tool not found"},
+		{name: "scope JSON", accept: "application/json", tool: "write_tool", wantCode: errCodeToolFailure, wantMessage: "insufficient scope"},
+		{name: "scope SSE", accept: "text/event-stream", tool: "write_tool", wantCode: errCodeToolFailure, wantMessage: "insufficient scope"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"`+tc.tool+`","arguments":{}}}`))
+			request.Header.Set("Accept", tc.accept)
+			response := httptest.NewRecorder()
+			server.NewSDKHTTPHandler(tc.accept != "text/event-stream").ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Contains(t, response.Body.String(), `"code":`+strconv.Itoa(tc.wantCode))
+			require.Contains(t, response.Body.String(), tc.wantMessage)
+			if tc.accept == "text/event-stream" {
+				require.Equal(t, "text/event-stream", response.Header().Get("Content-Type"))
+			}
+		})
+	}
+
+	require.False(t, server.writeSDKToolLookupError(httptest.NewRecorder(), &http.Request{Method: http.MethodGet}, true))
+}
+
+func TestSDKToolHandlerRejectsInvalidAndUnserializableResults(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	register := func(name string, invoke registry.ToolInvoker) {
+		require.NoError(t, reg.Register(registry.Tool{Name: name, Invoke: invoke}))
+	}
+	register("good", func(context.Context, string, map[string]any) (map[string]any, error) {
+		return map[string]any{"content": []map[string]any{{"text": "ok"}}}, nil
+	})
+	register("failed", func(context.Context, string, map[string]any) (map[string]any, error) {
+		return nil, errors.New("provider unavailable")
+	})
+	server := NewServer(reg, "profile-a", logger)
+
+	good, err := server.sdkToolHandler("good")(context.Background(), &sdkmcp.CallToolRequest{Params: &sdkmcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"value":"ok"}`)}})
+	require.NoError(t, err)
+	require.Len(t, good.Content, 1)
+
+	_, err = server.sdkToolHandler("good")(context.Background(), &sdkmcp.CallToolRequest{Params: &sdkmcp.CallToolParamsRaw{Arguments: json.RawMessage("{")}})
+	requireSDKError(t, err, errCodeInvalidParams, "invalid params")
+
+	_, err = server.sdkToolHandler("failed")(context.Background(), nil)
+	requireSDKError(t, err, errCodeToolFailure, "provider unavailable")
+}
+
+func requireSDKError(t *testing.T, err error, code int, message string) {
+	t.Helper()
+	var sdkErr *sdkjsonrpc.Error
+	require.ErrorAs(t, err, &sdkErr)
+	require.Equal(t, int64(code), sdkErr.Code)
+	require.Contains(t, sdkErr.Message, message)
+}

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -167,6 +167,18 @@ func TestSDKHTTPHandlerMapsUnknownAndUnauthorizedTools(t *testing.T) {
 	require.False(t, server.writeSDKToolLookupError(httptest.NewRecorder(), &http.Request{Method: http.MethodGet}, true))
 }
 
+func TestSDKHTTPHandlerPreservesOversizedBodyForSDKValidation(t *testing.T) {
+	logger, _ := testLogger(t)
+	server := NewServer(registry.New(), "profile-a", logger)
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(strings.Repeat("x", 4<<20+1)))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	response := httptest.NewRecorder()
+	server.NewSDKHTTPHandler(true).ServeHTTP(response, request)
+	require.Equal(t, http.StatusRequestEntityTooLarge, response.Code)
+}
+
 func TestSDKHTTPHandlerValidatesBeforeToolLookup(t *testing.T) {
 	logger, _ := testLogger(t)
 	reg := registry.New()

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -32,25 +32,39 @@ func TestSDKHTTPHandlerUsesTheSharedRegistryAndSupportsLegacyAndCurrentFlows(t *
 	server := NewServerWithScopes(reg, "profile-a", []string{"read"}, logger)
 	handler := server.NewSDKHTTPHandler(true)
 
-	for _, version := range []string{"2025-11-25"} {
+	for _, version := range []string{"2025-11-25", "2026-07-28"} {
 		t.Run(version, func(t *testing.T) {
-			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"` + version + `"}}`
+			method := "initialize"
+			params := `{"protocolVersion":"` + version + `"}`
+			if version == "2026-07-28" {
+				method = "server/discover"
+				params = `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}`
+			}
+			body := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + params + `}`
 			request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
 			request.Header.Set("Content-Type", "application/json")
 			request.Header.Set("Accept", "application/json, text/event-stream")
 			request.Header.Set("MCP-Protocol-Version", version)
+			if version == "2026-07-28" {
+				request.Header.Set("Mcp-Method", "server/discover")
+			}
 			response := httptest.NewRecorder()
 			handler.ServeHTTP(response, request)
 			require.Equal(t, http.StatusOK, response.Code)
 			var envelope struct {
 				Result struct {
-					ProtocolVersion string `json:"protocolVersion"`
+					ProtocolVersion   string   `json:"protocolVersion"`
+					SupportedVersions []string `json:"supportedVersions"`
 				} `json:"result"`
 				Error any `json:"error"`
 			}
 			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &envelope))
 			require.Nil(t, envelope.Error)
-			require.Equal(t, version, envelope.Result.ProtocolVersion)
+			if version == "2026-07-28" {
+				require.Contains(t, envelope.Result.SupportedVersions, version)
+			} else {
+				require.Equal(t, version, envelope.Result.ProtocolVersion)
+			}
 		})
 	}
 
@@ -149,6 +163,20 @@ func TestSDKHTTPHandlerMapsUnknownAndUnauthorizedTools(t *testing.T) {
 	}
 
 	require.False(t, server.writeSDKToolLookupError(httptest.NewRecorder(), &http.Request{Method: http.MethodGet}, true))
+}
+
+func TestSDKHTTPHandlerDoesNotAnswerInitializedNotification(t *testing.T) {
+	logger, _ := testLogger(t)
+	reg := registry.New()
+	server := NewServerWithScopes(reg, "profile-a", []string{"read"}, logger)
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	response := httptest.NewRecorder()
+	server.NewSDKHTTPHandler(true).ServeHTTP(response, request)
+	require.Equal(t, http.StatusAccepted, response.Code)
+	require.Empty(t, response.Body.String())
 }
 
 func TestSDKToolHandlerRejectsInvalidAndUnserializableResults(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -417,13 +417,23 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 	if params.Name == "" {
 		return nil, &rpcError{Code: errCodeInvalidParams, Message: "missing tool name"}
 	}
-	tool, ok := s.registry.Get(params.Name)
+	return s.invokeTool(ctx, params.Name, params.Arguments)
+}
+
+// invokeTool is the registry-only execution seam shared by the legacy JSON-RPC
+// server and the official SDK transport. Keeping validation and authorization
+// here prevents the two transports from drifting.
+func (s *Server) invokeTool(ctx context.Context, name string, args map[string]any) (map[string]any, *rpcError) {
+	if name == "" {
+		return nil, &rpcError{Code: errCodeInvalidParams, Message: "missing tool name"}
+	}
+	tool, ok := s.registry.Get(name)
 	if !ok {
-		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "tool not found: " + boundedRPCText(params.Name)}
+		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "tool not found: " + boundedRPCText(name)}
 	}
 	policy := registry.ResolveRuntimeToolPolicy(ctx, s.runtimeToolPolicy, tool)
 	if !registry.ToolVisible(ctx, tool, policy) {
-		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "tool not found: " + boundedRPCText(params.Name)}
+		return nil, &rpcError{Code: errCodeMethodNotFound, Message: "tool not found: " + boundedRPCText(name)}
 	}
 	if !s.canUseTool(tool) {
 		return nil, &rpcError{Code: errCodeToolFailure, Message: "insufficient scope for tool"}
@@ -432,7 +442,6 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 		return nil, &rpcError{Code: errCodeToolFailure, Message: "tool not executable"}
 	}
 
-	args := params.Arguments
 	if args == nil {
 		args = map[string]any{}
 	}
@@ -456,10 +465,10 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 	result, err := tool.Invoke(ctx, s.profileID, args)
 	if err != nil {
 		if errors.Is(err, registry.ErrToolDisabled) {
-			return nil, &rpcError{Code: errCodeMethodNotFound, Message: fmt.Sprintf("tool not found: %s", params.Name)}
+			return nil, &rpcError{Code: errCodeMethodNotFound, Message: fmt.Sprintf("tool not found: %s", name)}
 		}
 		s.logger.Error("mcp: tool invocation failed", err,
-			observability.String("tool", params.Name),
+			observability.String("tool", name),
 			observability.ProfileID(s.profileID),
 		)
 		return nil, &rpcError{Code: errCodeToolFailure, Message: boundedRPCText(tools.SanitizeError(err))}
@@ -467,7 +476,7 @@ func (s *Server) handleToolsCall(ctx context.Context, raw json.RawMessage) (map[
 
 	payload, err := json.Marshal(result)
 	if err != nil {
-		s.logger.Error("mcp: tool result marshal failed", err, observability.String("tool", params.Name))
+		s.logger.Error("mcp: tool result marshal failed", err, observability.String("tool", name))
 		return nil, &rpcError{Code: errCodeToolFailure, Message: "tool result serialization failed"}
 	}
 	return map[string]any{

--- a/internal/repository/apikey_repository.go
+++ b/internal/repository/apikey_repository.go
@@ -228,8 +228,19 @@ func (r *APIKeyRepositoryImpl) GetActiveByPrefix(ctx context.Context, prefix str
 	var teamID *uuid.UUID
 	var ssoIdentityID, ssoProviderID, ssoOwnerIdentityID string
 	found := false
+	var canonicalKey *domain.APIKey
+	var canonicalTable bool
 
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		var err error
+		canonicalTable, err = canonicalCredentialTableExists(tx)
+		if err != nil {
+			return err
+		}
+		if canonicalTable {
+			canonicalKey, err = lookupCanonicalCredential(tx, prefix)
+			return err
+		}
 		rows, rerr := tx.Raw(`
 			SELECT
 				k.id,
@@ -304,6 +315,9 @@ func (r *APIKeyRepositoryImpl) GetActiveByPrefix(ctx context.Context, prefix str
 	if err != nil {
 		return nil, fmt.Errorf("failed to get api key by prefix: %w", err)
 	}
+	if canonicalTable {
+		return canonicalKey, nil
+	}
 	if !found {
 		return nil, nil
 	}
@@ -327,8 +341,19 @@ func (r *APIKeyRepositoryImpl) GetActiveByID(ctx context.Context, id uuid.UUID) 
 	var teamID *uuid.UUID
 	var ssoIdentityID, ssoProviderID, ssoOwnerIdentityID string
 	found := false
+	var canonicalKey *domain.APIKey
+	var canonicalTable bool
 
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		var err error
+		canonicalTable, err = canonicalCredentialTableExists(tx)
+		if err != nil {
+			return err
+		}
+		if canonicalTable {
+			canonicalKey, err = lookupCanonicalCredentialByID(tx, id)
+			return err
+		}
 		rows, rerr := tx.Raw(`
 			SELECT
 				k.id,
@@ -398,6 +423,9 @@ func (r *APIKeyRepositoryImpl) GetActiveByID(ctx context.Context, id uuid.UUID) 
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active api key by id: %w", err)
+	}
+	if canonicalTable {
+		return canonicalKey, nil
 	}
 	if !found {
 		return nil, nil

--- a/internal/repository/canonical_credentials.go
+++ b/internal/repository/canonical_credentials.go
@@ -1,0 +1,110 @@
+package repository
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func lookupCanonicalCredential(tx *gorm.DB, prefix string) (*domain.APIKey, error) {
+	return lookupCanonicalCredentialWhere(tx, "c.key_prefix = $1", prefix)
+}
+
+func lookupCanonicalCredentialByID(tx *gorm.DB, id uuid.UUID) (*domain.APIKey, error) {
+	return lookupCanonicalCredentialWhere(tx, "c.id = $1", id)
+}
+
+func lookupCanonicalCredentialWhere(tx *gorm.DB, predicate string, value any) (*domain.APIKey, error) {
+	rows, err := tx.Raw(`
+		SELECT
+			c.id,
+			c.team_id,
+			COALESCE(t.name, ''),
+			c.key_hash,
+			COALESCE(c.key_suffix, ''),
+			c.name,
+			ARRAY(
+				SELECT DISTINCT scope
+				FROM unnest(c.scopes) AS scope
+				WHERE scope = ANY(m.maximum_grants)
+				  AND EXISTS (
+					SELECT 1
+					FROM membership_grants g
+					WHERE g.membership_id = m.id
+					  AND g.grant_name = scope
+				  )
+				ORDER BY scope
+			),
+			c.rate_limit,
+			CASE WHEN m.team_admin THEN 'manager' ELSE 'member' END,
+			c.last_used_at,
+			c.expires_at,
+			c.created_at,
+			c.revoked_at,
+			COALESCE(c.owner_identity_id::text, '')
+		FROM credentials c
+		JOIN actor_identities a
+		  ON a.id = c.actor_identity_id
+		JOIN team_memberships m
+		  ON m.actor_identity_id = c.actor_identity_id
+		 AND m.team_id = c.team_id
+		JOIN teams t ON t.id = c.team_id
+		WHERE `+predicate+`
+		  AND c.kind = 'api_key'
+		  AND c.status = 'active'
+		  AND c.key_hash IS NOT NULL
+		  AND c.revoked_at IS NULL
+		  AND (c.expires_at IS NULL OR c.expires_at > NOW())
+		  AND a.active = true
+		  AND m.status = 'active'
+		  AND t.status = 'active'
+		  AND t.deleted_at IS NULL
+		LIMIT 1
+	`, value).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+	var key domain.APIKey
+	var teamID uuid.UUID
+	var ownerIdentityID string
+	if err := rows.Scan(
+		&key.ID,
+		&teamID,
+		&key.TeamName,
+		&key.KeyHash,
+		&key.KeySuffix,
+		&key.Label,
+		pq.Array(&key.Scopes),
+		&key.RateLimit,
+		&key.Role,
+		&key.LastUsedAt,
+		&key.ExpiresAt,
+		&key.CreatedAt,
+		&key.RevokedAt,
+		&ownerIdentityID,
+	); err != nil {
+		return nil, err
+	}
+	key.TeamID = teamID
+	key.ProfileID = teamID
+	key.Name = key.Label
+	key.AuthSource = "api_key"
+	key.SSOOwnerIdentityID = parseOptionalUUID(ownerIdentityID)
+	return &key, nil
+}
+
+func canonicalCredentialTableExists(tx *gorm.DB) (bool, error) {
+	var exists bool
+	if err := tx.Raw(`SELECT to_regclass('public.credentials') IS NOT NULL`).Scan(&exists).Error; err != nil {
+		return false, fmt.Errorf("canonical credential table check: %w", err)
+	}
+	return exists, nil
+}

--- a/internal/repository/canonical_credentials.go
+++ b/internal/repository/canonical_credentials.go
@@ -50,8 +50,11 @@ func lookupCanonicalCredentialWhere(tx *gorm.DB, predicate string, value any) (*
 		JOIN actor_identities a
 		  ON a.id = c.actor_identity_id
 		JOIN team_memberships m
-		  ON m.actor_identity_id = c.actor_identity_id
-		 AND m.team_id = c.team_id
+		  ON m.team_id = c.team_id
+		 AND (
+			m.actor_identity_id = c.actor_identity_id
+			OR (c.legacy_profile_id IS NOT NULL AND m.legacy_profile_id = c.legacy_profile_id)
+		 )
 		JOIN teams t ON t.id = c.team_id
 		WHERE `+predicate+`
 		  AND c.kind = 'api_key'

--- a/internal/repository/canonical_credentials_integration_test.go
+++ b/internal/repository/canonical_credentials_integration_test.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestCanonicalCredentialScopesRespectMembershipGrants(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "canonical-grant-scope")
+	profileID := createLedgerProfile(t, adminDB, rls, teamID, "canonical-grant-scope-key")
+
+	var prefix string
+	require.NoError(t, adminDB.Raw(`
+		SELECT key_prefix
+		FROM credentials
+		WHERE legacy_profile_id = ?::uuid
+	`, profileID).Row().Scan(&prefix))
+
+	repo := NewAPIKeyRepository(appDB, rls)
+	key, err := repo.GetActiveByPrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	require.Equal(t, []string{"read", "write"}, key.Scopes)
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			DELETE FROM membership_grants
+			WHERE membership_id = (SELECT id FROM team_memberships WHERE legacy_profile_id = ?::uuid)
+			  AND grant_name = 'write'
+		`, profileID).Error
+	}))
+
+	key, err = repo.GetActiveByPrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	require.Equal(t, []string{"read"}, key.Scopes)
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE actor_identities
+			SET active = false
+			WHERE id = (SELECT actor_identity_id FROM credentials WHERE key_prefix = ?)
+		`, prefix).Error
+	}))
+	key, err = repo.GetActiveByPrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Nil(t, key)
+}

--- a/internal/repository/canonical_credentials_integration_test.go
+++ b/internal/repository/canonical_credentials_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
@@ -28,6 +29,27 @@ func TestCanonicalCredentialScopesRespectMembershipGrants(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, key)
 	require.Equal(t, []string{"read", "write"}, key.Scopes)
+
+	// SSO-backed profiles keep the legacy profile as the credential actor while
+	// the membership points at the stable SSO identity. Authentication must
+	// continue to resolve the credential through its legacy ownership alias.
+	ssoIdentityID := uuid.NewString()
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		if err := tx.Exec(`
+			INSERT INTO actor_identities (id, kind, team_id, display_name)
+			VALUES (?::uuid, 'human', ?::uuid, 'SSO owner')
+		`, ssoIdentityID, teamID).Error; err != nil {
+			return err
+		}
+		return tx.Exec(`
+			UPDATE team_memberships
+			SET actor_identity_id = ?::uuid
+			WHERE legacy_profile_id = ?::uuid
+		`, ssoIdentityID, profileID).Error
+	}))
+	key, err = repo.GetActiveByPrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.NotNil(t, key)
 
 	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
 		return tx.Exec(`

--- a/internal/repository/canonical_credentials_test.go
+++ b/internal/repository/canonical_credentials_test.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestLookupCanonicalCredentialScansRateLimitBeforeRole(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+
+	id := uuid.New()
+	teamID := uuid.New()
+	rows := sqlmock.NewRows([]string{
+		"id", "team_id", "team_name", "key_hash", "key_suffix", "name", "scopes", "rate_limit", "role",
+		"last_used_at", "expires_at", "created_at", "revoked_at", "owner_identity_id",
+	}).AddRow(
+		id.String(), teamID.String(), "Project", "hash", "suffix", "key", "{read,write}", 23, "manager",
+		nil, nil, time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC), nil, "",
+	)
+	mock.ExpectQuery("SELECT").WithArgs("dm_test_key").WillReturnRows(rows)
+
+	key, err := lookupCanonicalCredential(db, "dm_test_key")
+	require.NoError(t, err)
+	require.Equal(t, id, key.ID)
+	require.Equal(t, teamID, key.ProfileID)
+	require.Equal(t, "manager", key.Role)
+	require.Equal(t, 23, key.RateLimit)
+	require.Equal(t, []string{"read", "write"}, key.Scopes)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -342,7 +342,12 @@ func relationshipCorrectionSubmissionStatus(result *repository.RelationshipCorre
 	}
 	status.CorrectionResult = result.Correction
 	if result.ErrorCode != "" {
-		status.Errors = append(status.Errors, SubmissionStatusError{Code: result.ErrorCode, Message: result.ErrorMessage})
+		errorValue := submissionStatusErrorForCode(result.ErrorCode, result.ProcessingState)
+		status.Errors = append(status.Errors, errorValue)
+	}
+	if (status.ProcessingState == "rejected" || status.ProcessingState == "failed") && len(status.Errors) == 0 {
+		fallback := submissionStatusErrorForCode("", status.ProcessingState)
+		status.Errors = append(status.Errors, fallback)
 	}
 	return status
 }

--- a/internal/service/memoryservice/remember.go
+++ b/internal/service/memoryservice/remember.go
@@ -261,7 +261,8 @@ func submissionFailureCode(stage, class string) SubmissionErrorCode {
 	case class == "timeout", class == "rate_limited", class == "http_4xx", class == "http_5xx",
 		class == "http_unexpected", class == "transport", class == "provider_unavailable":
 		return SubmissionErrorAssessorUnavailable
-	case stage == "policy_review", stage == "confidence_policy", stage == "security_signal":
+	case stage == "policy_review", stage == "confidence_policy", stage == "security_signal",
+		stage == "commit_review", stage == "conflict_context_stale":
 		return SubmissionErrorPolicyRejected
 	default:
 		return SubmissionErrorProcessingFailed

--- a/internal/service/memoryservice/remember.go
+++ b/internal/service/memoryservice/remember.go
@@ -274,6 +274,9 @@ func submissionItemFailureError(item repository.PlacementItem, processing string
 	}
 	stage, _ := item.Result["failure_stage"].(string)
 	class, _ := item.Result["failure_class"].(string)
+	if (item.Status == "rejected" || item.Status == "awaiting_review") && strings.TrimSpace(stage) == "" && strings.TrimSpace(class) == "" {
+		return nil
+	}
 	errorValue := submissionStatusError(submissionFailureCode(stage, class))
 	return &errorValue
 }

--- a/internal/service/memoryservice/remember.go
+++ b/internal/service/memoryservice/remember.go
@@ -132,9 +132,150 @@ type SubmissionEvidenceStatus struct {
 	Error                 *SubmissionStatusError `json:"error,omitempty"`
 }
 
+// SubmissionErrorCode is the closed public vocabulary for terminal submission
+// failures. Internal/provider/database reasons must be translated into this
+// set before they cross the status projection boundary.
+type SubmissionErrorCode string
+
+const (
+	SubmissionErrorSemanticHold          SubmissionErrorCode = "submission_semantic_hold"
+	SubmissionErrorPolicyRejected        SubmissionErrorCode = "submission_policy_rejected"
+	SubmissionErrorAssessorInvalid       SubmissionErrorCode = "assessor_response_invalid"
+	SubmissionErrorAssessorUnavailable   SubmissionErrorCode = "assessor_unavailable"
+	SubmissionErrorReplacementConflict   SubmissionErrorCode = "submission_replacement_conflict"
+	SubmissionErrorProcessingFailed      SubmissionErrorCode = "submission_processing_failed"
+	SubmissionErrorSearchIndexingDelayed SubmissionErrorCode = "search_indexing_delayed"
+
+	SubmissionErrorRelationshipVersionStale      SubmissionErrorCode = "relationship_version_stale"
+	SubmissionErrorRelationshipNotActive         SubmissionErrorCode = "relationship_not_active"
+	SubmissionErrorObjectKindChangeForbidden     SubmissionErrorCode = "object_kind_change_forbidden"
+	SubmissionErrorSupportSetMismatch            SubmissionErrorCode = "support_set_mismatch"
+	SubmissionErrorEntityNotFound                SubmissionErrorCode = "entity_not_found"
+	SubmissionErrorTooManyEntityCandidates       SubmissionErrorCode = "too_many_entity_candidates"
+	SubmissionErrorPredicateNotFound             SubmissionErrorCode = "predicate_not_found"
+	SubmissionErrorPredicateSubjectKindMismatch  SubmissionErrorCode = "predicate_subject_kind_mismatch"
+	SubmissionErrorPredicateObjectKindMismatch   SubmissionErrorCode = "predicate_object_kind_mismatch"
+	SubmissionErrorNoChange                      SubmissionErrorCode = "no_change"
+	SubmissionErrorConfirmationExpired           SubmissionErrorCode = "confirmation_expired"
+	SubmissionErrorRelationshipChanged           SubmissionErrorCode = "relationship_changed"
+	SubmissionErrorSupportSetChanged             SubmissionErrorCode = "support_set_changed"
+	SubmissionErrorPersistentAmbiguity           SubmissionErrorCode = "persistent_ambiguity"
+	SubmissionErrorInactiveRelationshipCollision SubmissionErrorCode = "inactive_relationship_collision"
+)
+
+var submissionErrorCodes = []SubmissionErrorCode{
+	SubmissionErrorSemanticHold,
+	SubmissionErrorPolicyRejected,
+	SubmissionErrorAssessorInvalid,
+	SubmissionErrorAssessorUnavailable,
+	SubmissionErrorReplacementConflict,
+	SubmissionErrorProcessingFailed,
+	SubmissionErrorSearchIndexingDelayed,
+	SubmissionErrorRelationshipVersionStale,
+	SubmissionErrorRelationshipNotActive,
+	SubmissionErrorObjectKindChangeForbidden,
+	SubmissionErrorSupportSetMismatch,
+	SubmissionErrorEntityNotFound,
+	SubmissionErrorTooManyEntityCandidates,
+	SubmissionErrorPredicateNotFound,
+	SubmissionErrorPredicateSubjectKindMismatch,
+	SubmissionErrorPredicateObjectKindMismatch,
+	SubmissionErrorNoChange,
+	SubmissionErrorConfirmationExpired,
+	SubmissionErrorRelationshipChanged,
+	SubmissionErrorSupportSetChanged,
+	SubmissionErrorPersistentAmbiguity,
+	SubmissionErrorInactiveRelationshipCollision,
+}
+
+// SubmissionErrorCodes returns the public enum in deterministic schema order.
+func SubmissionErrorCodes() []string {
+	result := make([]string, 0, len(submissionErrorCodes))
+	for _, code := range submissionErrorCodes {
+		result = append(result, string(code))
+	}
+	return result
+}
+
 type SubmissionStatusError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+var submissionErrorMessages = map[SubmissionErrorCode]string{
+	SubmissionErrorSemanticHold:          "submission was rejected by semantic hold policy",
+	SubmissionErrorPolicyRejected:        "submission was rejected by semantic placement policy",
+	SubmissionErrorAssessorInvalid:       "submission assessment returned an invalid response",
+	SubmissionErrorAssessorUnavailable:   "submission assessment was unavailable after bounded retries",
+	SubmissionErrorReplacementConflict:   "submission replacement conflicted with current state",
+	SubmissionErrorProcessingFailed:      "submission processing failed",
+	SubmissionErrorSearchIndexingDelayed: "search indexing is delayed",
+
+	SubmissionErrorRelationshipVersionStale:      "relationship version is stale",
+	SubmissionErrorRelationshipNotActive:         "relationship must be active, supported, and canonical",
+	SubmissionErrorObjectKindChangeForbidden:     "a Value object cannot be replaced with an Entity",
+	SubmissionErrorSupportSetMismatch:            "supports must exactly match the relationship's effective evidence spans",
+	SubmissionErrorEntityNotFound:                "corrected Entity is not active and available to the team",
+	SubmissionErrorTooManyEntityCandidates:       "corrected Entity name has too many exact candidates",
+	SubmissionErrorPredicateNotFound:             "predicate is not registered and active for the team",
+	SubmissionErrorPredicateSubjectKindMismatch:  "predicate does not allow the corrected subject kind",
+	SubmissionErrorPredicateObjectKindMismatch:   "predicate does not allow the corrected object kind",
+	SubmissionErrorNoChange:                      "correction does not change the Relationship",
+	SubmissionErrorConfirmationExpired:           "relationship correction confirmation expired",
+	SubmissionErrorRelationshipChanged:           "relationship changed while confirmation was pending",
+	SubmissionErrorSupportSetChanged:             "relationship supports changed while confirmation was pending",
+	SubmissionErrorPersistentAmbiguity:           "selected Entity candidate is no longer available",
+	SubmissionErrorInactiveRelationshipCollision: "corrected Relationship collides with inactive or unsupported history",
+}
+
+func submissionStatusError(code SubmissionErrorCode) SubmissionStatusError {
+	message := submissionErrorMessages[code]
+	if message == "" {
+		code = SubmissionErrorProcessingFailed
+		message = submissionErrorMessages[code]
+	}
+	return SubmissionStatusError{Code: string(code), Message: message}
+}
+
+func submissionStatusErrorForCode(rawCode string, fallbackState string) SubmissionStatusError {
+	code := SubmissionErrorCode(strings.TrimSpace(rawCode))
+	for _, known := range submissionErrorCodes {
+		if code == known {
+			return submissionStatusError(code)
+		}
+	}
+	if fallbackState == "rejected" {
+		return submissionStatusError(SubmissionErrorPolicyRejected)
+	}
+	return submissionStatusError(SubmissionErrorProcessingFailed)
+}
+
+func submissionFailureCode(stage, class string) SubmissionErrorCode {
+	stage = strings.TrimSpace(stage)
+	class = strings.TrimSpace(class)
+	switch {
+	case stage == "replacement_conflict":
+		return SubmissionErrorReplacementConflict
+	case class == "malformed_response", class == "validation_failed", class == "provider_protocol":
+		return SubmissionErrorAssessorInvalid
+	case class == "timeout", class == "rate_limited", class == "http_4xx", class == "http_5xx",
+		class == "http_unexpected", class == "transport", class == "provider_unavailable":
+		return SubmissionErrorAssessorUnavailable
+	case stage == "policy_review", stage == "confidence_policy", stage == "security_signal":
+		return SubmissionErrorPolicyRejected
+	default:
+		return SubmissionErrorProcessingFailed
+	}
+}
+
+func submissionItemFailureError(item repository.PlacementItem, processing string) *SubmissionStatusError {
+	if item.Status != string(domain.PlacementRunFailed) && item.Status != "failed" && item.Status != "rejected" && item.Status != "awaiting_review" {
+		return nil
+	}
+	stage, _ := item.Result["failure_stage"].(string)
+	class, _ := item.Result["failure_class"].(string)
+	errorValue := submissionStatusError(submissionFailureCode(stage, class))
+	return &errorValue
 }
 
 func (s *rememberService) Remember(ctx context.Context, req RememberRequest) (*RememberResult, error) {
@@ -351,6 +492,17 @@ func submissionStatusResultFromLedger(placement *repository.CreateIngestResult) 
 	}
 	searchState := string(domain.SearchProjectionNotRequired)
 	searchErrorAdded := false
+	processing := publicSubmissionProcessingState(placement.Status, placement.SemanticHoldState)
+	statusErrors := make([]SubmissionStatusError, 0, 2)
+	seenStatusErrors := make(map[string]struct{})
+	appendStatusError := func(value SubmissionStatusError) {
+		key := string(value.Code) + "\x00" + value.Message
+		if _, exists := seenStatusErrors[key]; exists {
+			return
+		}
+		seenStatusErrors[key] = struct{}{}
+		statusErrors = append(statusErrors, value)
+	}
 	for _, item := range placement.Items {
 		itemSearchState := placementItemSearchState(item)
 		searchState = placementCombinedSearchState(searchState, itemSearchState)
@@ -359,8 +511,12 @@ func submissionStatusResultFromLedger(placement *repository.CreateIngestResult) 
 			superseded = []string{}
 		}
 		var itemError *SubmissionStatusError
-		if itemSearchState == string(domain.SearchProjectionFailed) {
-			itemError = &SubmissionStatusError{Code: "search_indexing_delayed", Message: "Semantic search indexing is delayed."}
+		if semanticError := submissionItemFailureError(item, processing); semanticError != nil {
+			itemError = semanticError
+			appendStatusError(*semanticError)
+		} else if itemSearchState == string(domain.SearchProjectionFailed) {
+			searchError := SubmissionStatusError{Code: string(SubmissionErrorSearchIndexingDelayed), Message: "Semantic search indexing is delayed."}
+			itemError = &searchError
 			searchErrorAdded = true
 		}
 		items = append(items, SubmissionEvidenceStatus{
@@ -371,13 +527,15 @@ func submissionStatusResultFromLedger(placement *repository.CreateIngestResult) 
 			Error:                 itemError,
 		})
 	}
-	processing := publicSubmissionProcessingState(placement.Status, placement.SemanticHoldState)
-	statusErrors := []SubmissionStatusError{}
-	if processing == "failed" {
-		statusErrors = append(statusErrors, SubmissionStatusError{Code: "submission_processing_failed", Message: "submission processing failed"})
+	if processing == "rejected" && strings.TrimSpace(placement.SemanticHoldState) != "" {
+		appendStatusError(submissionStatusError(SubmissionErrorSemanticHold))
+	} else if processing == "rejected" {
+		appendStatusError(submissionStatusError(SubmissionErrorPolicyRejected))
+	} else if processing == "failed" && len(statusErrors) == 0 {
+		appendStatusError(submissionStatusError(SubmissionErrorProcessingFailed))
 	}
 	if searchErrorAdded {
-		statusErrors = append(statusErrors, SubmissionStatusError{Code: "search_indexing_delayed", Message: "Semantic search indexing is delayed; check the control portal for recovery guidance."})
+		appendStatusError(SubmissionStatusError{Code: string(SubmissionErrorSearchIndexingDelayed), Message: "Semantic search indexing is delayed; check the control portal for recovery guidance."})
 	}
 	return &SubmissionStatusResult{
 		SubmissionID:               placement.IngestID,

--- a/internal/service/memoryservice/remember_test.go
+++ b/internal/service/memoryservice/remember_test.go
@@ -229,7 +229,7 @@ func TestSubmissionStatusProjectionMapsProcessingStatesAndErrors(t *testing.T) {
 		if result.ProcessingState != want || result.SearchState != string(domain.SearchProjectionCurrent) {
 			t.Fatalf("status %q projection = %#v, want processing %q/current", status, result, want)
 		}
-		if status == string(domain.PlacementRunFailed) || status == "unexpected" {
+		if status == string(domain.PlacementRunFailed) || status == "unexpected" || status == string(domain.PlacementRunAwaitingReview) {
 			require.Len(t, result.Errors, 1)
 		} else {
 			require.Empty(t, result.Errors)
@@ -248,9 +248,39 @@ func TestSubmissionStatusProjectionMapsProcessingStatesAndErrors(t *testing.T) {
 	require.Equal(t, "Semantic search indexing is delayed; check the control portal for recovery guidance.", failedSearch.Errors[0].Message)
 	hold := submissionStatusResultFromLedger(&repository.CreateIngestResult{IngestID: "submission-1", Status: string(domain.PlacementRunCompleted), SemanticHoldState: "awaiting_review"})
 	require.Equal(t, "rejected", hold.ProcessingState)
+	require.Equal(t, string(SubmissionErrorSemanticHold), hold.Errors[0].Code)
 	empty := submissionStatusResultFromLedger(nil)
 	require.Empty(t, empty.Evidence)
 	require.Empty(t, empty.Errors)
+}
+
+func TestTerminalSubmissionErrorsAreClosedAndDeduplicated(t *testing.T) {
+	failed := submissionStatusResultFromLedger(&repository.CreateIngestResult{
+		IngestID: "submission-1", Status: string(domain.PlacementRunFailed),
+		Items: []repository.PlacementItem{
+			{FragmentID: "e1", Status: string(domain.PlacementRunFailed), Result: map[string]any{"failure_class": "timeout"}},
+			{FragmentID: "e2", Status: string(domain.PlacementRunFailed), Result: map[string]any{"failure_class": "timeout"}},
+		},
+	})
+	require.Len(t, failed.Errors, 1)
+	require.Equal(t, string(SubmissionErrorAssessorUnavailable), failed.Errors[0].Code)
+	require.Equal(t, string(SubmissionErrorAssessorUnavailable), failed.Evidence[0].Error.Code)
+	require.Equal(t, string(SubmissionErrorAssessorUnavailable), failed.Evidence[1].Error.Code)
+	require.NotEmpty(t, failed.Errors[0].Message)
+
+	rejected := relationshipCorrectionSubmissionStatus(&repository.RelationshipCorrectionStatus{
+		SubmissionID: "submission-2", ProcessingState: "rejected",
+	})
+	require.Len(t, rejected.Errors, 1)
+	require.Equal(t, string(SubmissionErrorPolicyRejected), rejected.Errors[0].Code)
+
+	unknown := relationshipCorrectionSubmissionStatus(&repository.RelationshipCorrectionStatus{
+		SubmissionID: "submission-3", ProcessingState: "failed", ErrorCode: "provider-secret-details",
+		ErrorMessage: "raw provider output must not cross the status boundary",
+	})
+	require.Len(t, unknown.Errors, 1)
+	require.Equal(t, string(SubmissionErrorProcessingFailed), unknown.Errors[0].Code)
+	require.NotContains(t, unknown.Errors[0].Message, "provider-secret-details")
 }
 
 func TestGetSubmissionStatusRejectsInvalidRequestsAndBoundsErrors(t *testing.T) {

--- a/internal/service/memoryservice/remember_test.go
+++ b/internal/service/memoryservice/remember_test.go
@@ -55,6 +55,22 @@ func TestSubmissionStatusSearchStateHelpers(t *testing.T) {
 	}
 }
 
+func TestSubmissionItemFailureErrorDoesNotInventReviewFailures(t *testing.T) {
+	for _, status := range []string{"rejected", "awaiting_review"} {
+		t.Run(status, func(t *testing.T) {
+			require.Nil(t, submissionItemFailureError(repository.PlacementItem{Status: status, Result: map[string]any{}}, status))
+		})
+	}
+
+	errorValue := submissionItemFailureError(repository.PlacementItem{Status: "failed", Result: map[string]any{}}, "failed")
+	require.NotNil(t, errorValue)
+	require.Equal(t, string(SubmissionErrorProcessingFailed), errorValue.Code)
+
+	errorValue = submissionItemFailureError(repository.PlacementItem{Status: "rejected", Result: map[string]any{"failure_stage": "policy_review"}}, "rejected")
+	require.NotNil(t, errorValue)
+	require.Equal(t, string(SubmissionErrorPolicyRejected), errorValue.Code)
+}
+
 func TestRememberUsesAuthenticatedContextAndPreservesExactEvidence(t *testing.T) {
 	const exactContent = `  C:\notes\[draft]\report.txt includes "\u0041", '\x42', [%20], and {&amp;}.  `
 	teamID := uuid.New()

--- a/internal/service/memoryservice/remember_test.go
+++ b/internal/service/memoryservice/remember_test.go
@@ -66,9 +66,13 @@ func TestSubmissionItemFailureErrorDoesNotInventReviewFailures(t *testing.T) {
 	require.NotNil(t, errorValue)
 	require.Equal(t, string(SubmissionErrorProcessingFailed), errorValue.Code)
 
-	errorValue = submissionItemFailureError(repository.PlacementItem{Status: "rejected", Result: map[string]any{"failure_stage": "policy_review"}}, "rejected")
-	require.NotNil(t, errorValue)
-	require.Equal(t, string(SubmissionErrorPolicyRejected), errorValue.Code)
+	for _, stage := range []string{"policy_review", "commit_review", "conflict_context_stale"} {
+		t.Run(stage, func(t *testing.T) {
+			errorValue := submissionItemFailureError(repository.PlacementItem{Status: "rejected", Result: map[string]any{"failure_stage": stage}}, "rejected")
+			require.NotNil(t, errorValue)
+			require.Equal(t, string(SubmissionErrorPolicyRejected), errorValue.Code)
+		})
+	}
 }
 
 func TestRememberUsesAuthenticatedContextAndPreservesExactEvidence(t *testing.T) {

--- a/internal/storage/postgres/identity_bridge_migration_integration_test.go
+++ b/internal/storage/postgres/identity_bridge_migration_integration_test.go
@@ -206,9 +206,9 @@ func TestIdentityBridgePreservesGovernanceAliasesAndSSOExternalLinks(t *testing.
 		WHERE legacy_profile_id = $1
 	`, ssoProfileID).Scan(&canonicalIdentity))
 	require.Equal(t, identityID, canonicalIdentity)
-	var actorTeamID uuid.UUID
+	var actorTeamID sql.NullString
 	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT team_id FROM actor_identities WHERE id = $1`, identityID).Scan(&actorTeamID))
-	require.Equal(t, teamID, actorTeamID)
+	require.False(t, actorTeamID.Valid, "SSO actor identity must remain team-neutral")
 	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $2, true)`, teamID, ssoProfileID); err != nil {
 			return err
@@ -273,4 +273,93 @@ func TestIdentityBridgePreservesGovernanceAliasesAndSSOExternalLinks(t *testing.
 		WHERE actor_identity_id = $1 AND team_id = $2
 	`, identityID, teamID).Scan(&ssoMembershipStatus))
 	require.Equal(t, "revoked", ssoMembershipStatus)
+}
+
+func TestIdentityBridgeKeepsSSOActorTeamNeutralAcrossMemberships(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, sqlDB, 2026080905)
+
+	teamA, teamB := uuid.New(), uuid.New()
+	providerID, identityID := uuid.New(), uuid.New()
+	apiProfileA, apiProfileB := uuid.New(), uuid.New()
+	ssoProfileA, ssoProfileB := uuid.New(), uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "migration", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO teams (id, name) VALUES ($1, 'bridge-multi-team-a'), ($2, 'bridge-multi-team-b')
+		`, teamA, teamB); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_providers (id, name, kind, issuer_url, client_id)
+			VALUES ($1, 'bridge-multi-provider', 'generic_oidc', 'https://issuer.multi.invalid', 'bridge-multi-client')
+		`, providerID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_identities (id, provider_id, subject, external_id, email, display_name)
+			VALUES ($1, $2, 'bridge-multi-subject', 'bridge-multi-external', 'multi@example.invalid', 'Bridge Multi User')
+		`, identityID, providerID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (
+				id, team_id, key_hash, key_prefix, name, scopes, sso_owner_identity_id
+			) VALUES
+				($1, $3, 'hash-a', 'dm_multi_key_a', 'multi-key-a', ARRAY['read'], $5),
+				($2, $4, 'hash-b', 'dm_multi_key_b', 'multi-key-b', ARRAY['read'], $5)
+		`, apiProfileA, apiProfileB, teamA, teamB, identityID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (
+				id, team_id, key_hash, key_prefix, name, scopes, role,
+				auth_source, sso_identity_id, sso_provider_id, sso_subject,
+				sso_entitlement_status
+			) VALUES
+				($1, $3, NULL, NULL, 'multi-sso-a', ARRAY['read'], 'member',
+				 'sso', $5, $6, 'bridge-multi-subject', 'active'),
+				($2, $4, NULL, NULL, 'multi-sso-b', ARRAY['read'], 'member',
+				 'sso', $5, $6, 'bridge-multi-subject', 'active')
+		`, ssoProfileA, ssoProfileB, teamA, teamB, identityID, providerID)
+		return err
+	}))
+	require.NoError(t, migrationUpTo(ctx, sqlDB, 2026081001))
+
+	var actorTeam sql.NullString
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT team_id::text FROM actor_identities WHERE id = $1
+	`, identityID).Scan(&actorTeam))
+	require.False(t, actorTeam.Valid, "SSO actor identity must not be assigned to one team")
+
+	var membershipCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM team_memberships WHERE actor_identity_id = $1
+	`, identityID).Scan(&membershipCount))
+	require.Equal(t, 2, membershipCount)
+
+	updateProfile := func(profileID, teamID uuid.UUID, scopes string) {
+		require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
+			if _, err := tx.ExecContext(ctx, `
+				SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $2, true)
+			`, teamID, profileID); err != nil {
+				return err
+			}
+			_, err := tx.ExecContext(ctx, `UPDATE team_profiles SET scopes = $1 WHERE id = $2`, scopes, profileID)
+			return err
+		}))
+	}
+	updateProfile(ssoProfileB, teamB, "{read,write}")
+	updateProfile(apiProfileA, teamA, "{read,write}")
+	updateProfile(apiProfileB, teamB, "{read,write}")
+
+	for _, profileID := range []uuid.UUID{apiProfileA, apiProfileB} {
+		var ownerIdentity sql.NullString
+		require.NoError(t, sqlDB.QueryRowContext(ctx, `
+			SELECT owner_identity_id::text FROM credentials WHERE legacy_profile_id = $1
+		`, profileID).Scan(&ownerIdentity))
+		require.True(t, ownerIdentity.Valid)
+		require.Equal(t, identityID.String(), ownerIdentity.String)
+	}
 }

--- a/internal/storage/postgres/identity_bridge_migration_integration_test.go
+++ b/internal/storage/postgres/identity_bridge_migration_integration_test.go
@@ -1,0 +1,225 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityBridgeBackfillsStableIDsAndLegacyGovernance(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, sqlDB, 2026080905)
+
+	teamID := uuid.New()
+	profileID := uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "migration", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO teams (id, name) VALUES ($1, 'bridge-team')`, teamID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (id, team_id, key_hash, key_prefix, key_suffix, name, scopes, role)
+			VALUES ($1, $2, 'hash', 'dm_bridge_key', 'suffix', 'bridge-key', ARRAY['read','write'], 'manager')
+		`, profileID, teamID)
+		return err
+	}))
+	require.NoError(t, migrationUpTo(ctx, sqlDB, 2026081001))
+
+	var actorID, credentialID, aliasID uuid.UUID
+	var admin bool
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT id FROM actor_identities WHERE id = $1`, profileID).Scan(&actorID))
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT id FROM credentials WHERE legacy_profile_id = $1`, profileID).Scan(&credentialID))
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT legacy_owner_id FROM ownership_aliases WHERE team_id = $1 AND legacy_owner_id = $2`, teamID, profileID).Scan(&aliasID))
+	require.Equal(t, profileID, actorID)
+	require.Equal(t, profileID, credentialID)
+	require.Equal(t, profileID, aliasID)
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT team_admin FROM team_memberships WHERE legacy_profile_id = $1`, profileID).Scan(&admin))
+	require.True(t, admin)
+}
+
+func TestMigrationStartupClassifierCoversFreshLegacyAndCompatibleStates(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	state, err := ClassifyMigrationState(ctx, sqlDB, getMigrationsDir())
+	require.NoError(t, err)
+	require.Equal(t, MigrationStateFresh, state.Kind)
+
+	files, err := listMigrationSources(getMigrationsDir())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 2)
+	runGooseUpTo(t, ctx, sqlDB, files[len(files)-2].version)
+	state, err = ClassifyMigrationState(ctx, sqlDB, getMigrationsDir())
+	require.NoError(t, err)
+	require.Equal(t, MigrationStateLegacy, state.Kind)
+	require.True(t, state.ExactLegacy)
+
+	runGooseUpTo(t, ctx, sqlDB, files[len(files)-1].version)
+	state, err = ClassifyMigrationState(ctx, sqlDB, getMigrationsDir())
+	require.NoError(t, err)
+	require.Equal(t, MigrationStateCompatible, state.Kind)
+	require.NoError(t, ValidateStartupMigrationState(ctx, sqlDB, getMigrationsDir()))
+}
+
+func TestIdentityBridgeReconcilesLegacyWritesAndRLS(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, sqlDB, 2026081001)
+
+	teamA, teamB, profileID := uuid.New(), uuid.New(), uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "migration", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO teams (id, name) VALUES ($1, 'team-a'), ($2, 'team-b')`, teamA, teamB); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (id, team_id, key_hash, key_prefix, name, scopes)
+			VALUES ($1, $2, 'hash', 'dm_bridge_write', 'bridge-write', ARRAY['read'])
+		`, profileID, teamA)
+		return err
+	}))
+	roleName := "dense_mem_identity_bridge_rls"
+	quotedRole := quoteMigrationIdentifier(roleName)
+	if _, err := sqlDB.ExecContext(ctx, "CREATE ROLE "+quotedRole+" NOLOGIN NOBYPASSRLS"); err != nil {
+		if isPostgresInsufficientPrivilege(err) {
+			t.Skipf("identity bridge RLS test requires role administration: %v", err)
+		}
+		require.NoError(t, err)
+	}
+	defer func() { _, _ = sqlDB.ExecContext(ctx, "DROP ROLE IF EXISTS "+quotedRole) }()
+	for _, grant := range []string{
+		"GRANT USAGE ON SCHEMA public TO " + quotedRole,
+		"GRANT SELECT ON credentials TO " + quotedRole,
+	} {
+		require.NoError(t, func() error { _, err := sqlDB.ExecContext(ctx, grant); return err }())
+	}
+
+	var count int
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $1, true)`, teamA); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, `SELECT count(*) FROM credentials WHERE team_id = $1`, teamA).Scan(&count)
+	}))
+	require.Equal(t, 1, count)
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "SET LOCAL ROLE "+quotedRole); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $1, true)`, teamB); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, `SELECT count(*) FROM credentials WHERE team_id = $1`, teamA).Scan(&count)
+	}))
+	require.Zero(t, count)
+}
+
+func TestIdentityBridgePreservesGovernanceAliasesAndSSOExternalLinks(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, sqlDB, 2026081001)
+
+	teamID := uuid.New()
+	profileID := uuid.New()
+	providerID := uuid.New()
+	identityID := uuid.New()
+	ssoProfileID := uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "migration", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO teams (id, name) VALUES ($1, 'bridge-reconcile-team')`, teamID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_providers (id, name, kind, issuer_url, client_id)
+			VALUES ($1, 'bridge-provider', 'generic_oidc', 'https://issuer.invalid', 'bridge-client')
+		`, providerID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_identities (id, provider_id, subject, external_id, email, display_name)
+			VALUES ($1, $2, 'bridge-subject', 'bridge-external', 'bridge@example.invalid', 'Bridge User')
+		`, identityID, providerID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (id, team_id, key_hash, key_prefix, name, scopes, role)
+			VALUES ($1, $2, 'hash', 'dm_reconcile_key', 'bridge-key', ARRAY['read'], 'member')
+		`, profileID, teamID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO team_profiles (
+				id, team_id, key_hash, key_prefix, name, scopes, role,
+				auth_source, sso_identity_id, sso_provider_id, sso_subject,
+				sso_entitlement_status
+			)
+			VALUES ($1, $2, NULL, NULL, 'Bridge SSO', ARRAY['read'], 'manager',
+				'sso', $3, $4, 'bridge-subject', 'active')
+		`, ssoProfileID, teamID, identityID, providerID)
+		return err
+	}))
+
+	var linkedIdentity uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT identity_id
+		FROM identity_external_links
+		WHERE provider = $1::text AND external_id = 'bridge-external'
+	`, providerID).Scan(&linkedIdentity))
+	require.Equal(t, identityID, linkedIdentity)
+
+	var canonicalIdentity uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT actor_identity_id
+		FROM team_memberships
+		WHERE legacy_profile_id = $1
+	`, ssoProfileID).Scan(&canonicalIdentity))
+	require.Equal(t, identityID, canonicalIdentity)
+
+	var aliasIdentity uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT canonical_identity_id
+		FROM ownership_aliases
+		WHERE team_id = $1 AND legacy_owner_id = $2
+	`, teamID, ssoProfileID).Scan(&aliasIdentity))
+	require.Equal(t, identityID, aliasIdentity)
+
+	var membershipID uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT id FROM team_memberships WHERE legacy_profile_id = $1
+	`, profileID).Scan(&membershipID))
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO membership_grants (membership_id, grant_name, source)
+			VALUES ($1, 'governance:manage', 'explicit')
+		`, membershipID)
+		return err
+	}))
+
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `UPDATE team_profiles SET scopes = ARRAY['read','write'] WHERE id = $1`, profileID)
+		return err
+	}))
+	var grants int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM membership_grants
+		WHERE membership_id = $1 AND grant_name IN ('read', 'write', 'governance:manage')
+	`, membershipID).Scan(&grants))
+	require.Equal(t, 3, grants)
+
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `DELETE FROM team_profiles WHERE id = $1`, profileID)
+		return err
+	}))
+	var aliasCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM ownership_aliases WHERE team_id = $1 AND legacy_owner_id = $2
+	`, teamID, profileID).Scan(&aliasCount))
+	require.Equal(t, 1, aliasCount)
+}

--- a/internal/storage/postgres/identity_bridge_migration_integration_test.go
+++ b/internal/storage/postgres/identity_bridge_migration_integration_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -95,10 +96,35 @@ func TestIdentityBridgeReconcilesLegacyWritesAndRLS(t *testing.T) {
 	defer func() { _, _ = sqlDB.ExecContext(ctx, "DROP ROLE IF EXISTS "+quotedRole) }()
 	for _, grant := range []string{
 		"GRANT USAGE ON SCHEMA public TO " + quotedRole,
-		"GRANT SELECT ON credentials TO " + quotedRole,
+		"GRANT SELECT, UPDATE ON team_profiles TO " + quotedRole,
+		"GRANT SELECT ON credentials, team_memberships, membership_grants TO " + quotedRole,
 	} {
 		require.NoError(t, func() error { _, err := sqlDB.ExecContext(ctx, grant); return err }())
 	}
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "SET LOCAL ROLE "+quotedRole); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $2, true)`, teamA, profileID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE team_profiles SET scopes = ARRAY['read','write'] WHERE id = $1`, profileID); err != nil {
+			return err
+		}
+		var credentialScopes, membershipMaximum string
+		if err := tx.QueryRowContext(ctx, `
+			SELECT c.scopes::text, m.maximum_grants::text
+			FROM credentials c
+			JOIN team_memberships m ON m.legacy_profile_id = c.legacy_profile_id
+			WHERE c.legacy_profile_id = $1 AND m.team_id = $2
+		`, profileID, teamA).Scan(&credentialScopes, &membershipMaximum); err != nil {
+			return err
+		}
+		if credentialScopes != "{read,write}" || membershipMaximum != "{read,write}" {
+			return fmt.Errorf("legacy team-mode write was not reconciled: credentials=%s membership=%s", credentialScopes, membershipMaximum)
+		}
+		return nil
+	}))
 
 	var count int
 	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
@@ -180,6 +206,19 @@ func TestIdentityBridgePreservesGovernanceAliasesAndSSOExternalLinks(t *testing.
 		WHERE legacy_profile_id = $1
 	`, ssoProfileID).Scan(&canonicalIdentity))
 	require.Equal(t, identityID, canonicalIdentity)
+	var actorTeamID uuid.UUID
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT team_id FROM actor_identities WHERE id = $1`, identityID).Scan(&actorTeamID))
+	require.Equal(t, teamID, actorTeamID)
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "team", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.current_team_id', $1, true), set_config('app.current_profile_id', $2, true)`, teamID, ssoProfileID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `UPDATE team_profiles SET scopes = ARRAY['read','write'] WHERE id = $1`, ssoProfileID)
+		return err
+	}))
+	var ssoMaximumGrants string
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `SELECT maximum_grants::text FROM team_memberships WHERE actor_identity_id = $1 AND team_id = $2`, identityID, teamID).Scan(&ssoMaximumGrants))
+	require.Equal(t, "{read,write}", ssoMaximumGrants)
 
 	var aliasIdentity uuid.UUID
 	require.NoError(t, sqlDB.QueryRowContext(ctx, `
@@ -222,4 +261,16 @@ func TestIdentityBridgePreservesGovernanceAliasesAndSSOExternalLinks(t *testing.
 		SELECT count(*) FROM ownership_aliases WHERE team_id = $1 AND legacy_owner_id = $2
 	`, teamID, profileID).Scan(&aliasCount))
 	require.Equal(t, 1, aliasCount)
+
+	require.NoError(t, execPostgresTxMode(ctx, sqlDB, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `DELETE FROM team_profiles WHERE id = $1`, ssoProfileID)
+		return err
+	}))
+	var ssoMembershipStatus string
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT status
+		FROM team_memberships
+		WHERE actor_identity_id = $1 AND team_id = $2
+	`, identityID, teamID).Scan(&ssoMembershipStatus))
+	require.Equal(t, "revoked", ssoMembershipStatus)
 }

--- a/internal/storage/postgres/migration_startup.go
+++ b/internal/storage/postgres/migration_startup.go
@@ -142,7 +142,7 @@ func ValidateStartupMigrationState(ctx context.Context, db *sql.DB, migrationsDi
 		return fmt.Errorf("%w: migration did not install the v2.5 bridge", ErrInvalidMigrationState)
 	}
 	if state.DatabaseLatest != state.RepositoryLatest {
-		return fmt.Errorf("%w: database version %d is behind repository version %d", ErrInvalidMigrationState, state.DatabaseLatest, state.RepositoryLatest)
+		return fmt.Errorf("%w: database version %d does not match repository version %d", ErrInvalidMigrationState, state.DatabaseLatest, state.RepositoryLatest)
 	}
 	return nil
 }

--- a/internal/storage/postgres/migration_startup.go
+++ b/internal/storage/postgres/migration_startup.go
@@ -1,0 +1,148 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type MigrationStateKind string
+
+const (
+	MigrationStateFresh      MigrationStateKind = "fresh"
+	MigrationStateLegacy     MigrationStateKind = "legacy"
+	MigrationStateCompatible MigrationStateKind = "compatible_v2_5"
+	MigrationStateInvalid    MigrationStateKind = "invalid"
+)
+
+type MigrationState struct {
+	Kind             MigrationStateKind
+	DatabaseLatest   int64
+	RepositoryLatest int64
+	ExactLegacy      bool
+	Reason           string
+}
+
+var ErrInvalidMigrationState = errors.New("postgres migration state is invalid")
+
+// ClassifyMigrationState distinguishes an empty database, a pre-bridge
+// deployment, a complete v2.5 bridge, and partial/corrupt state. It is read
+// only and safe to call before migration startup.
+func ClassifyMigrationState(ctx context.Context, db *sql.DB, migrationsDir string) (MigrationState, error) {
+	if db == nil {
+		return MigrationState{}, errors.New("migration state: database is required")
+	}
+	repositoryLatest, err := latestMigrationVersion(migrationsDir)
+	if err != nil {
+		return MigrationState{}, err
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return MigrationState{}, fmt.Errorf("migration state: begin read: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		SELECT set_config('app.tx_mode', 'system', true),
+		       set_config('app.current_team_id', '', true),
+		       set_config('app.current_profile_id', '', true)
+	`); err != nil {
+		return MigrationState{}, fmt.Errorf("migration state: set system context: %w", err)
+	}
+	var teams, goose, bridge, identities, memberships, credentials, grants, externalLinks, aliases bool
+	row := tx.QueryRowContext(ctx, `
+		SELECT
+			to_regclass('public.teams') IS NOT NULL,
+			to_regclass('public.goose_db_version') IS NOT NULL,
+			to_regclass('public.identity_compatibility_state') IS NOT NULL,
+			to_regclass('public.actor_identities') IS NOT NULL,
+			to_regclass('public.team_memberships') IS NOT NULL,
+			to_regclass('public.credentials') IS NOT NULL,
+			to_regclass('public.membership_grants') IS NOT NULL,
+			to_regclass('public.identity_external_links') IS NOT NULL,
+			to_regclass('public.ownership_aliases') IS NOT NULL
+	`)
+	if err := row.Scan(&teams, &goose, &bridge, &identities, &memberships, &credentials, &grants, &externalLinks, &aliases); err != nil {
+		return MigrationState{}, fmt.Errorf("migration state: inspect schema: %w", err)
+	}
+	state := MigrationState{RepositoryLatest: repositoryLatest}
+	if !teams && !goose {
+		state.Kind = MigrationStateFresh
+		return state, nil
+	}
+	if !teams || !goose {
+		state.Kind = MigrationStateInvalid
+		state.Reason = "application tables and Goose history are incomplete"
+		return state, nil
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version WHERE is_applied`).Scan(&state.DatabaseLatest); err != nil {
+		return MigrationState{}, fmt.Errorf("migration state: inspect Goose version: %w", err)
+	}
+	if state.DatabaseLatest > repositoryLatest {
+		state.Kind = MigrationStateInvalid
+		state.Reason = "database migration is newer than this binary"
+		return state, nil
+	}
+	files, err := listMigrationSources(migrationsDir)
+	if err != nil {
+		return MigrationState{}, err
+	}
+	if len(files) >= 2 && state.DatabaseLatest == files[len(files)-2].version {
+		state.ExactLegacy = true
+	}
+	if !bridge && !identities && !memberships && !credentials && !grants && !externalLinks && !aliases {
+		state.Kind = MigrationStateLegacy
+		return state, nil
+	}
+	if !(bridge && identities && memberships && credentials && grants && externalLinks && aliases) {
+		state.Kind = MigrationStateInvalid
+		state.Reason = "identity bridge is only partially installed"
+		return state, nil
+	}
+	var bridgeState string
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM identity_compatibility_state WHERE singleton = true`).Scan(&bridgeState); err != nil {
+		state.Kind = MigrationStateInvalid
+		state.Reason = "identity bridge state row is missing or unreadable"
+		return state, nil
+	}
+	switch bridgeState {
+	case "bridge_active", "reconciled", "cutover_ready", "cleanup_complete":
+	default:
+		state.Kind = MigrationStateInvalid
+		state.Reason = "identity bridge state is not recognized"
+		return state, nil
+	}
+	state.Kind = MigrationStateCompatible
+	return state, nil
+}
+
+func latestMigrationVersion(dir string) (int64, error) {
+	sources, err := listMigrationSources(dir)
+	if err != nil {
+		return 0, err
+	}
+	if len(sources) == 0 {
+		return 0, errors.New("migration history: no migrations")
+	}
+	return sources[len(sources)-1].version, nil
+}
+
+// ValidateStartupMigrationState is called after Goose has finished. It keeps
+// the application from starting on a partially applied identity bridge or on
+// a database that was upgraded by a newer binary.
+func ValidateStartupMigrationState(ctx context.Context, db *sql.DB, migrationsDir string) error {
+	state, err := ClassifyMigrationState(ctx, db, migrationsDir)
+	if err != nil {
+		return err
+	}
+	if state.Kind == MigrationStateInvalid {
+		return fmt.Errorf("%w: %s", ErrInvalidMigrationState, state.Reason)
+	}
+	if state.Kind == MigrationStateFresh || state.Kind == MigrationStateLegacy {
+		return fmt.Errorf("%w: migration did not install the v2.5 bridge", ErrInvalidMigrationState)
+	}
+	if state.DatabaseLatest != state.RepositoryLatest {
+		return fmt.Errorf("%w: database version %d is behind repository version %d", ErrInvalidMigrationState, state.DatabaseLatest, state.RepositoryLatest)
+	}
+	return nil
+}

--- a/internal/storage/postgres/migrator.go
+++ b/internal/storage/postgres/migrator.go
@@ -169,6 +169,11 @@ func getMigrationsDir() string {
 	return "/app/dense-mem/migrations/postgres"
 }
 
+// MigrationsDir returns the repository migration root used by runtime startup.
+func MigrationsDir() string {
+	return getMigrationsDir()
+}
+
 // NewMigrator creates a new migrator instance for the given GORM database.
 // Migrations are loaded as one history across the release directories.
 func NewMigrator(db *gorm.DB) (*Migrator, error) {

--- a/internal/tools/registry/contract_schema_helpers.go
+++ b/internal/tools/registry/contract_schema_helpers.go
@@ -126,11 +126,15 @@ func publicErrorCodes() []string {
 }
 
 func submissionStatusErrorArraySchema() map[string]any {
-	return array(closedObject(
+	return array(submissionStatusErrorSchema(), 0, 50)
+}
+
+func submissionStatusErrorSchema() map[string]any {
+	return closedObject(
 		[]string{"code", "message"},
 		map[string]any{
 			"code":    schemaEnum(memoryservice.SubmissionErrorCodes()),
 			"message": schemaString("Bounded safe submission error.", 512),
 		},
-	), 0, 50)
+	)
 }

--- a/internal/tools/registry/contract_schema_helpers.go
+++ b/internal/tools/registry/contract_schema_helpers.go
@@ -1,6 +1,9 @@
 package registry
 
-import "github.com/markhuangai/dense-mem/internal/domain"
+import (
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+)
 
 const (
 	memoryPackArtifactMaxLength = 4 * 1024 * 1024
@@ -126,7 +129,7 @@ func submissionStatusErrorArraySchema() map[string]any {
 	return array(closedObject(
 		[]string{"code", "message"},
 		map[string]any{
-			"code":    schemaString("Typed submission error code.", 128),
+			"code":    schemaEnum(memoryservice.SubmissionErrorCodes()),
 			"message": schemaString("Bounded safe submission error.", 512),
 		},
 	), 0, 50)

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -1,6 +1,8 @@
 package registry
 
-import "github.com/markhuangai/dense-mem/internal/domain"
+import (
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
 
 func contractInput(required []string, properties map[string]any) map[string]any {
 	requireNonEmptyStrings(required, properties)

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -415,7 +415,7 @@ func submissionStatusOutputSchema() map[string]any {
 					"evidence_index":          map[string]any{"type": "integer", "minimum": 0},
 					"superseded_evidence_ids": stringArraySchema("Evidence ID superseded by this evidence.", 50, 128),
 					"search_state":            schemaEnum(domain.SearchProjectionStates()),
-					"error":                   map[string]any{"oneOf": []any{map[string]any{"type": "null"}, closedObject([]string{"code", "message"}, map[string]any{"code": schemaString("Typed submission error code.", 128), "message": schemaString("Bounded safe submission error.", 512)})}},
+					"error":                   map[string]any{"oneOf": []any{map[string]any{"type": "null"}, submissionStatusErrorSchema()}},
 				},
 			), 0, 100),
 			"errors":                        submissionStatusErrorArraySchema(),

--- a/internal/tools/registry/contract_test.go
+++ b/internal/tools/registry/contract_test.go
@@ -529,6 +529,25 @@ func TestOutputSchemasAreClosed(t *testing.T) {
 	}
 }
 
+func TestSubmissionStatusEvidenceErrorsUseTheClosedCodeEnum(t *testing.T) {
+	schema := submissionStatusOutputSchema()
+	evidence := schemaProperties(schema)["evidence"]
+	evidenceItem := evidence["items"].(map[string]any)
+	errorSchema := schemaProperties(evidenceItem)["error"]
+	variants := errorSchema["oneOf"].([]any)
+	errorObject := variants[1].(map[string]any)
+	codeSchema := schemaProperties(errorObject)["code"]
+	enumValues, ok := codeSchema["enum"].([]string)
+	if !ok {
+		t.Fatalf("evidence error code enum = %#v", codeSchema["enum"])
+	}
+	for _, code := range memoryservice.SubmissionErrorCodes() {
+		if !slices.Contains(enumValues, code) {
+			t.Fatalf("evidence error enum missing %s: %#v", code, enumValues)
+		}
+	}
+}
+
 func TestProviderAndEmbeddingContracts(t *testing.T) {
 	if err := assertProviderProposalSchema(verifier.ProviderProposalSchema()); err != nil {
 		t.Fatal(err)

--- a/internal/tools/registry/contract_test.go
+++ b/internal/tools/registry/contract_test.go
@@ -531,21 +531,28 @@ func TestOutputSchemasAreClosed(t *testing.T) {
 
 func TestSubmissionStatusEvidenceErrorsUseTheClosedCodeEnum(t *testing.T) {
 	schema := submissionStatusOutputSchema()
+	expectedCodes := append([]string(nil), memoryservice.SubmissionErrorCodes()...)
+	slices.Sort(expectedCodes)
+	assertExactCodeEnum := func(label string, codeSchema map[string]any) {
+		t.Helper()
+		actualCodes, ok := codeSchema["enum"].([]string)
+		if !ok {
+			t.Fatalf("%s code enum = %#v", label, codeSchema["enum"])
+		}
+		actualCodes = append([]string(nil), actualCodes...)
+		slices.Sort(actualCodes)
+		if !slices.Equal(actualCodes, expectedCodes) {
+			t.Fatalf("%s code enum = %#v, want exactly %#v", label, actualCodes, expectedCodes)
+		}
+	}
 	evidence := schemaProperties(schema)["evidence"]
 	evidenceItem := evidence["items"].(map[string]any)
 	errorSchema := schemaProperties(evidenceItem)["error"]
 	variants := errorSchema["oneOf"].([]any)
 	errorObject := variants[1].(map[string]any)
-	codeSchema := schemaProperties(errorObject)["code"]
-	enumValues, ok := codeSchema["enum"].([]string)
-	if !ok {
-		t.Fatalf("evidence error code enum = %#v", codeSchema["enum"])
-	}
-	for _, code := range memoryservice.SubmissionErrorCodes() {
-		if !slices.Contains(enumValues, code) {
-			t.Fatalf("evidence error enum missing %s: %#v", code, enumValues)
-		}
-	}
+	assertExactCodeEnum("evidence", schemaProperties(errorObject)["code"])
+	topLevelErrors := schemaProperties(schema)["errors"]["items"].(map[string]any)
+	assertExactCodeEnum("top-level", schemaProperties(topLevelErrors)["code"])
 }
 
 func TestProviderAndEmbeddingContracts(t *testing.T) {

--- a/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
+++ b/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
@@ -1,0 +1,568 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Dense-Mem v2.5 expands the legacy team_profiles authority without changing
+-- any legacy identifiers. The bridge is additive and remains active until a
+-- later, explicitly gated cleanup release.
+-- Lock/rewrite impact: additive tables and indexes; no legacy table rewrite.
+-- RLS impact: every new relation is FORCE RLS with team/system contexts.
+-- Backfill: idempotent profile-to-identity reconciliation runs in this transaction.
+-- Backward compatibility: legacy team_profiles reads/writes remain supported by a trigger.
+-- Rollback: local Down removes only bridge objects; production uses roll-forward/PITR.
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+
+CREATE TABLE IF NOT EXISTS actor_identities (
+    id UUID PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (kind IN ('human', 'api_client', 'system')),
+    team_id UUID NULL REFERENCES teams(id) ON DELETE RESTRICT,
+    provider TEXT NOT NULL DEFAULT '',
+    subject TEXT NOT NULL DEFAULT '',
+    display_name TEXT NOT NULL DEFAULT '',
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (char_length(provider) <= 128),
+    CHECK (char_length(subject) <= 512),
+    CHECK (char_length(display_name) <= 512)
+);
+
+CREATE INDEX IF NOT EXISTS idx_actor_identities_team_active
+    ON actor_identities(team_id, active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_identities_provider_subject
+    ON actor_identities(provider, subject)
+    WHERE provider <> '' AND subject <> '';
+
+CREATE TABLE IF NOT EXISTS team_memberships (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    actor_identity_id UUID NOT NULL REFERENCES actor_identities(id) ON DELETE RESTRICT,
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'revoked')),
+    team_admin BOOLEAN NOT NULL DEFAULT false,
+    maximum_grants TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+    legacy_profile_id UUID NULL REFERENCES team_profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (actor_identity_id, team_id),
+    CHECK (cardinality(maximum_grants) IS NULL OR cardinality(maximum_grants) <= 128)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_memberships_team_status
+    ON team_memberships(team_id, status, team_admin);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_memberships_legacy_profile
+    ON team_memberships(legacy_profile_id)
+    WHERE legacy_profile_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS credentials (
+    id UUID PRIMARY KEY,
+    actor_identity_id UUID NOT NULL REFERENCES actor_identities(id) ON DELETE RESTRICT,
+    owner_identity_id UUID NULL REFERENCES actor_identities(id) ON DELETE SET NULL,
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT,
+    kind TEXT NOT NULL DEFAULT 'api_key' CHECK (kind IN ('api_key', 'oauth', 'session', 'system')),
+    key_hash TEXT NULL,
+    key_prefix VARCHAR(24) NULL,
+    key_suffix VARCHAR(6) NULL,
+    name VARCHAR(100) NOT NULL DEFAULT '',
+    scopes TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+    rate_limit INTEGER NOT NULL DEFAULT 0 CHECK (rate_limit >= 0),
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked', 'expired', 'disabled')),
+    expires_at TIMESTAMPTZ NULL,
+    revoked_at TIMESTAMPTZ NULL,
+    legacy_profile_id UUID NULL REFERENCES team_profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at TIMESTAMPTZ NULL,
+    CHECK (kind <> 'api_key' OR (key_hash IS NOT NULL AND key_prefix IS NOT NULL)),
+    CHECK (char_length(name) <= 100),
+    CHECK (cardinality(scopes) IS NULL OR cardinality(scopes) <= 128)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credentials_key_prefix_unique
+    ON credentials(key_prefix)
+    WHERE key_prefix IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credentials_legacy_profile
+    ON credentials(legacy_profile_id)
+    WHERE legacy_profile_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_credentials_owner_identity
+    ON credentials(owner_identity_id)
+    WHERE owner_identity_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_credentials_team_status
+    ON credentials(team_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS membership_grants (
+    membership_id UUID NOT NULL REFERENCES team_memberships(id) ON DELETE CASCADE,
+    grant_name TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'legacy_scope' CHECK (source IN ('legacy_scope', 'explicit', 'system')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (membership_id, grant_name),
+    CHECK (char_length(grant_name) BETWEEN 1 AND 128)
+);
+
+CREATE TABLE IF NOT EXISTS identity_external_links (
+    identity_id UUID NOT NULL REFERENCES actor_identities(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (provider, external_id),
+    UNIQUE (identity_id, provider),
+    CHECK (char_length(provider) BETWEEN 1 AND 128),
+    CHECK (char_length(external_id) BETWEEN 1 AND 512)
+);
+
+CREATE TABLE IF NOT EXISTS ownership_aliases (
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT,
+    legacy_owner_id UUID NOT NULL,
+    canonical_identity_id UUID NOT NULL REFERENCES actor_identities(id) ON DELETE RESTRICT,
+    credential_id UUID NULL REFERENCES credentials(id) ON DELETE SET NULL,
+    reason TEXT NOT NULL DEFAULT 'legacy_profile',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (team_id, legacy_owner_id),
+    CHECK (char_length(reason) <= 128)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_aliases_canonical
+    ON ownership_aliases(team_id, canonical_identity_id);
+
+CREATE TABLE IF NOT EXISTS identity_compatibility_state (
+    singleton BOOLEAN PRIMARY KEY DEFAULT true CHECK (singleton),
+    bridge_version TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('bridge_active', 'reconciled', 'cutover_ready', 'cleanup_complete')),
+    legacy_profile_count BIGINT NOT NULL DEFAULT 0 CHECK (legacy_profile_count >= 0),
+    identity_count BIGINT NOT NULL DEFAULT 0 CHECK (identity_count >= 0),
+    membership_count BIGINT NOT NULL DEFAULT 0 CHECK (membership_count >= 0),
+    credential_count BIGINT NOT NULL DEFAULT 0 CHECK (credential_count >= 0),
+    alias_count BIGINT NOT NULL DEFAULT 0 CHECK (alias_count >= 0),
+    unresolved_count BIGINT NOT NULL DEFAULT 0 CHECK (unresolved_count >= 0),
+    backup_checkpoint TEXT NOT NULL DEFAULT '',
+    deployment_fingerprint TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE actor_identities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE actor_identities FORCE ROW LEVEL SECURITY;
+ALTER TABLE team_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE team_memberships FORCE ROW LEVEL SECURITY;
+ALTER TABLE credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE credentials FORCE ROW LEVEL SECURITY;
+ALTER TABLE membership_grants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE membership_grants FORCE ROW LEVEL SECURITY;
+ALTER TABLE identity_external_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE identity_external_links FORCE ROW LEVEL SECURITY;
+ALTER TABLE ownership_aliases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ownership_aliases FORCE ROW LEVEL SECURITY;
+ALTER TABLE identity_compatibility_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE identity_compatibility_state FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS actor_identities_context_access ON actor_identities;
+CREATE POLICY actor_identities_context_access ON actor_identities
+    FOR ALL TO PUBLIC
+    USING (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+    )
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+    );
+
+DROP POLICY IF EXISTS team_memberships_context_access ON team_memberships;
+CREATE POLICY team_memberships_context_access ON team_memberships
+    FOR ALL TO PUBLIC
+    USING (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    )
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    );
+
+DROP POLICY IF EXISTS credentials_context_access ON credentials;
+CREATE POLICY credentials_context_access ON credentials
+    FOR ALL TO PUBLIC
+    USING (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    )
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    );
+
+DROP POLICY IF EXISTS membership_grants_context_access ON membership_grants;
+CREATE POLICY membership_grants_context_access ON membership_grants
+    FOR ALL TO PUBLIC
+    USING (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR EXISTS (
+            SELECT 1 FROM team_memberships m
+            WHERE m.id = membership_id
+              AND m.team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                                       NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+        )
+    )
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR EXISTS (
+            SELECT 1 FROM team_memberships m
+            WHERE m.id = membership_id
+              AND m.team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                                       NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+        )
+    );
+
+DROP POLICY IF EXISTS identity_external_links_context_access ON identity_external_links;
+CREATE POLICY identity_external_links_context_access ON identity_external_links
+    FOR ALL TO PUBLIC
+    USING (current_setting('app.tx_mode', true) IN ('system', 'migration'))
+    WITH CHECK (current_setting('app.tx_mode', true) IN ('system', 'migration'));
+
+DROP POLICY IF EXISTS ownership_aliases_context_access ON ownership_aliases;
+CREATE POLICY ownership_aliases_context_access ON ownership_aliases
+    FOR ALL TO PUBLIC
+    USING (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    )
+    WITH CHECK (
+        current_setting('app.tx_mode', true) IN ('system', 'migration')
+        OR team_id = COALESCE(NULLIF(current_setting('app.current_team_id', true), '')::uuid,
+                              NULLIF(current_setting('app.current_profile_id', true), '')::uuid)
+    );
+
+DROP POLICY IF EXISTS identity_compatibility_state_context_access ON identity_compatibility_state;
+CREATE POLICY identity_compatibility_state_context_access ON identity_compatibility_state
+    FOR ALL TO PUBLIC
+    USING (current_setting('app.tx_mode', true) IN ('system', 'migration'))
+    WITH CHECK (current_setting('app.tx_mode', true) IN ('system', 'migration'));
+
+-- Existing API-key profiles retain their IDs as both actor and credential IDs.
+-- The statement is idempotent so a retry after a rolled-back deployment is safe.
+INSERT INTO actor_identities (id, kind, team_id, display_name, active, created_at, updated_at)
+SELECT p.id,
+       CASE WHEN p.auth_source = 'sso' THEN 'human'
+            WHEN p.auth_source = 'system' THEN 'system'
+            ELSE 'api_client' END,
+       p.team_id, COALESCE(p.name, ''), p.revoked_at IS NULL, p.created_at, p.updated_at
+FROM team_profiles p
+ON CONFLICT (id) DO UPDATE SET
+    kind = EXCLUDED.kind,
+    team_id = EXCLUDED.team_id,
+    display_name = EXCLUDED.display_name,
+    active = EXCLUDED.active,
+    updated_at = EXCLUDED.updated_at;
+
+INSERT INTO team_memberships (actor_identity_id, team_id, status, team_admin, maximum_grants, legacy_profile_id, created_at, updated_at)
+SELECT p.id, p.team_id,
+       CASE WHEN p.revoked_at IS NULL THEN 'active' ELSE 'revoked' END,
+       p.role = 'manager', p.scopes, p.id, p.created_at, p.updated_at
+FROM team_profiles p
+ON CONFLICT (actor_identity_id, team_id) DO UPDATE SET
+    status = EXCLUDED.status,
+    team_admin = EXCLUDED.team_admin,
+    maximum_grants = EXCLUDED.maximum_grants,
+    legacy_profile_id = EXCLUDED.legacy_profile_id,
+    updated_at = EXCLUDED.updated_at;
+
+INSERT INTO credentials (id, actor_identity_id, owner_identity_id, team_id, kind, key_hash, key_prefix, key_suffix, name, scopes, rate_limit, status, expires_at, revoked_at, legacy_profile_id, created_at, updated_at, last_used_at)
+SELECT p.id, p.id, NULL::uuid, p.team_id, 'api_key', p.key_hash, p.key_prefix, p.key_suffix, p.name, p.scopes,
+       p.rate_limit,
+       CASE WHEN p.revoked_at IS NOT NULL THEN 'revoked' WHEN p.expires_at IS NOT NULL AND p.expires_at <= now() THEN 'expired' ELSE 'active' END,
+       p.expires_at, p.revoked_at, p.id, p.created_at, p.updated_at, p.last_used_at
+FROM team_profiles p
+WHERE p.key_hash IS NOT NULL AND p.key_prefix IS NOT NULL
+ON CONFLICT (id) DO UPDATE SET
+    key_hash = EXCLUDED.key_hash,
+    key_prefix = EXCLUDED.key_prefix,
+    key_suffix = EXCLUDED.key_suffix,
+    name = EXCLUDED.name,
+    scopes = EXCLUDED.scopes,
+    rate_limit = EXCLUDED.rate_limit,
+    status = EXCLUDED.status,
+    expires_at = EXCLUDED.expires_at,
+    revoked_at = EXCLUDED.revoked_at,
+    owner_identity_id = EXCLUDED.owner_identity_id,
+    updated_at = EXCLUDED.updated_at,
+    last_used_at = EXCLUDED.last_used_at;
+
+INSERT INTO membership_grants (membership_id, grant_name, source)
+SELECT m.id, scope, 'legacy_scope'
+FROM team_memberships m
+JOIN LATERAL unnest(m.maximum_grants) AS scope ON true
+ON CONFLICT (membership_id, grant_name) DO NOTHING;
+
+INSERT INTO ownership_aliases (team_id, legacy_owner_id, canonical_identity_id, credential_id)
+SELECT p.team_id, p.id, p.id,
+       CASE WHEN p.key_hash IS NOT NULL AND p.key_prefix IS NOT NULL THEN p.id ELSE NULL END
+FROM team_profiles p
+ON CONFLICT (team_id, legacy_owner_id) DO UPDATE SET
+    canonical_identity_id = EXCLUDED.canonical_identity_id,
+    credential_id = EXCLUDED.credential_id;
+
+-- SSO identities have stable external links. Existing profile IDs remain the
+-- ownership aliases; the SSO actor is added only when it is not already linked.
+INSERT INTO actor_identities (id, kind, provider, subject, display_name, active, created_at, updated_at)
+SELECT i.id, 'human', p.id::text, i.subject, COALESCE(i.display_name, ''), i.active, i.created_at, i.updated_at
+FROM sso_identities i
+JOIN sso_providers p ON p.id = i.provider_id
+ON CONFLICT (id) DO UPDATE SET
+    kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
+    provider = EXCLUDED.provider,
+    subject = EXCLUDED.subject,
+    display_name = EXCLUDED.display_name,
+    active = EXCLUDED.active,
+    updated_at = EXCLUDED.updated_at;
+
+UPDATE credentials c
+SET owner_identity_id = p.sso_owner_identity_id
+FROM team_profiles p
+WHERE c.legacy_profile_id = p.id
+  AND p.sso_owner_identity_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = p.sso_owner_identity_id);
+
+INSERT INTO identity_external_links (identity_id, provider, external_id)
+SELECT i.id, p.id::text, COALESCE(NULLIF(i.external_id, ''), i.subject)
+FROM sso_identities i
+JOIN sso_providers p ON p.id = i.provider_id
+WHERE COALESCE(NULLIF(i.external_id, ''), i.subject) <> ''
+ON CONFLICT (provider, external_id) DO NOTHING;
+
+-- SSO profiles keep their legacy IDs as aliases, but their stable SSO actors
+-- own the canonical membership and its existing grant rows.
+UPDATE team_memberships m
+SET actor_identity_id = p.sso_identity_id,
+    updated_at = now()
+FROM team_profiles p
+WHERE m.legacy_profile_id = p.id
+  AND p.auth_source = 'sso'
+  AND p.sso_identity_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = p.sso_identity_id);
+
+UPDATE ownership_aliases a
+SET canonical_identity_id = p.sso_identity_id,
+    credential_id = NULL
+FROM team_profiles p
+WHERE a.team_id = p.team_id
+  AND a.legacy_owner_id = p.id
+  AND p.auth_source = 'sso'
+  AND p.sso_identity_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM actor_identities i WHERE i.id = p.sso_identity_id);
+
+INSERT INTO identity_compatibility_state (singleton, bridge_version, state, legacy_profile_count, identity_count, membership_count, credential_count, alias_count, unresolved_count, updated_at)
+SELECT true, 'dense-mem.v2.5.identity.bridge.v1', 'bridge_active',
+       (SELECT count(*) FROM team_profiles),
+       (SELECT count(*) FROM actor_identities),
+       (SELECT count(*) FROM team_memberships),
+       (SELECT count(*) FROM credentials),
+       (SELECT count(*) FROM ownership_aliases),
+       (SELECT count(*) FROM team_profiles p WHERE NOT EXISTS (SELECT 1 FROM ownership_aliases a WHERE a.team_id = p.team_id AND a.legacy_owner_id = p.id)),
+       now()
+ON CONFLICT (singleton) DO UPDATE SET
+    legacy_profile_count = EXCLUDED.legacy_profile_count,
+    identity_count = EXCLUDED.identity_count,
+    membership_count = EXCLUDED.membership_count,
+    credential_count = EXCLUDED.credential_count,
+    alias_count = EXCLUDED.alias_count,
+    unresolved_count = EXCLUDED.unresolved_count,
+    updated_at = EXCLUDED.updated_at;
+
+CREATE OR REPLACE FUNCTION dense_mem_sync_legacy_profile_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    new_membership_id UUID;
+    canonical_actor_id UUID;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE credentials
+           SET status = 'revoked', revoked_at = COALESCE(revoked_at, now()), updated_at = now()
+         WHERE id = OLD.id;
+        UPDATE team_memberships
+           SET status = 'revoked', updated_at = now()
+         WHERE legacy_profile_id = OLD.id
+            OR (actor_identity_id = OLD.id AND team_id = OLD.team_id);
+		UPDATE actor_identities
+		   SET active = false, updated_at = now()
+		 WHERE id = OLD.id;
+		-- Keep the alias after a legacy-row delete so append-only owner references
+		-- remain resolvable during and after the compatibility window.
+		RETURN OLD;
+    END IF;
+
+    IF TG_OP = 'UPDATE'
+       AND NEW.last_used_at IS DISTINCT FROM OLD.last_used_at
+       AND NEW.team_id IS NOT DISTINCT FROM OLD.team_id
+       AND NEW.key_hash IS NOT DISTINCT FROM OLD.key_hash
+       AND NEW.key_prefix IS NOT DISTINCT FROM OLD.key_prefix
+       AND NEW.key_suffix IS NOT DISTINCT FROM OLD.key_suffix
+       AND NEW.name IS NOT DISTINCT FROM OLD.name
+       AND NEW.scopes IS NOT DISTINCT FROM OLD.scopes
+       AND NEW.role IS NOT DISTINCT FROM OLD.role
+       AND NEW.rate_limit IS NOT DISTINCT FROM OLD.rate_limit
+       AND NEW.expires_at IS NOT DISTINCT FROM OLD.expires_at
+       AND NEW.revoked_at IS NOT DISTINCT FROM OLD.revoked_at
+       AND NEW.auth_source IS NOT DISTINCT FROM OLD.auth_source
+       AND NEW.is_system IS NOT DISTINCT FROM OLD.is_system
+       AND NEW.sso_identity_id IS NOT DISTINCT FROM OLD.sso_identity_id
+       AND NEW.sso_provider_id IS NOT DISTINCT FROM OLD.sso_provider_id
+       AND NEW.sso_subject IS NOT DISTINCT FROM OLD.sso_subject
+       AND NEW.sso_email IS NOT DISTINCT FROM OLD.sso_email
+       AND NEW.sso_group_id IS NOT DISTINCT FROM OLD.sso_group_id
+       AND NEW.sso_entitlement_status IS NOT DISTINCT FROM OLD.sso_entitlement_status
+       AND NEW.sso_owner_identity_id IS NOT DISTINCT FROM OLD.sso_owner_identity_id
+       AND NEW.created_at IS NOT DISTINCT FROM OLD.created_at
+       AND NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    THEN
+        UPDATE credentials
+           SET last_used_at = NEW.last_used_at
+         WHERE id = NEW.id
+           AND last_used_at IS DISTINCT FROM NEW.last_used_at;
+        RETURN NEW;
+    END IF;
+
+    INSERT INTO actor_identities (id, kind, team_id, display_name, active, created_at, updated_at)
+    VALUES (NEW.id,
+            CASE WHEN NEW.auth_source = 'sso' THEN 'human'
+                 WHEN NEW.auth_source = 'system' THEN 'system'
+                 ELSE 'api_client' END,
+            NEW.team_id, COALESCE(NEW.name, ''), NEW.revoked_at IS NULL, COALESCE(NEW.created_at, now()), now())
+    ON CONFLICT (id) DO UPDATE SET team_id = EXCLUDED.team_id, display_name = EXCLUDED.display_name, active = EXCLUDED.active, updated_at = now();
+
+    canonical_actor_id := NEW.id;
+    IF NEW.auth_source = 'sso'
+       AND NEW.sso_identity_id IS NOT NULL
+       AND EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_identity_id)
+    THEN
+        canonical_actor_id := NEW.sso_identity_id;
+    END IF;
+
+    UPDATE team_memberships
+       SET actor_identity_id = canonical_actor_id,
+           team_id = NEW.team_id,
+           status = CASE WHEN NEW.revoked_at IS NULL THEN 'active' ELSE 'revoked' END,
+           team_admin = NEW.role = 'manager',
+           maximum_grants = NEW.scopes,
+           updated_at = now()
+     WHERE legacy_profile_id = NEW.id
+     RETURNING id INTO new_membership_id;
+
+    IF NOT FOUND THEN
+        INSERT INTO team_memberships (actor_identity_id, team_id, status, team_admin, maximum_grants, legacy_profile_id)
+        VALUES (canonical_actor_id, NEW.team_id, CASE WHEN NEW.revoked_at IS NULL THEN 'active' ELSE 'revoked' END, NEW.role = 'manager', NEW.scopes, NEW.id)
+        ON CONFLICT (actor_identity_id, team_id) DO UPDATE SET status = EXCLUDED.status, team_admin = EXCLUDED.team_admin, maximum_grants = EXCLUDED.maximum_grants, legacy_profile_id = EXCLUDED.legacy_profile_id, updated_at = now()
+        RETURNING id INTO new_membership_id;
+    END IF;
+
+    IF NEW.key_hash IS NOT NULL AND NEW.key_prefix IS NOT NULL THEN
+        INSERT INTO credentials (id, actor_identity_id, owner_identity_id, team_id, kind, key_hash, key_prefix, key_suffix, name, scopes, rate_limit, status, expires_at, revoked_at, legacy_profile_id, created_at, updated_at, last_used_at)
+        VALUES (NEW.id, NEW.id, CASE WHEN EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_owner_identity_id) THEN NEW.sso_owner_identity_id ELSE NULL END, NEW.team_id, 'api_key', NEW.key_hash, NEW.key_prefix, NEW.key_suffix, NEW.name, NEW.scopes, NEW.rate_limit,
+                CASE WHEN NEW.revoked_at IS NOT NULL THEN 'revoked' WHEN NEW.expires_at IS NOT NULL AND NEW.expires_at <= now() THEN 'expired' ELSE 'active' END,
+                NEW.expires_at, NEW.revoked_at, NEW.id, COALESCE(NEW.created_at, now()), now(), NEW.last_used_at)
+        ON CONFLICT (id) DO UPDATE SET key_hash = EXCLUDED.key_hash, key_prefix = EXCLUDED.key_prefix, key_suffix = EXCLUDED.key_suffix, name = EXCLUDED.name, scopes = EXCLUDED.scopes, rate_limit = EXCLUDED.rate_limit, status = EXCLUDED.status, expires_at = EXCLUDED.expires_at, revoked_at = EXCLUDED.revoked_at, owner_identity_id = EXCLUDED.owner_identity_id, updated_at = now(), last_used_at = EXCLUDED.last_used_at;
+    END IF;
+
+    INSERT INTO ownership_aliases (team_id, legacy_owner_id, canonical_identity_id, credential_id)
+    VALUES (NEW.team_id, NEW.id, canonical_actor_id,
+            CASE WHEN NEW.key_hash IS NOT NULL AND NEW.key_prefix IS NOT NULL THEN NEW.id ELSE NULL END)
+    ON CONFLICT (team_id, legacy_owner_id) DO UPDATE SET canonical_identity_id = EXCLUDED.canonical_identity_id, credential_id = EXCLUDED.credential_id;
+
+	DELETE FROM membership_grants
+	 WHERE membership_grants.membership_id = new_membership_id
+	   AND membership_grants.source = 'legacy_scope'
+	   AND NOT (membership_grants.grant_name = ANY(COALESCE(NEW.scopes, ARRAY[]::text[])));
+    INSERT INTO membership_grants (membership_id, grant_name, source)
+    SELECT new_membership_id, scope, 'legacy_scope' FROM unnest(NEW.scopes) AS scope
+    ON CONFLICT (membership_id, grant_name) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS team_profiles_identity_bridge ON team_profiles;
+CREATE TRIGGER team_profiles_identity_bridge
+AFTER INSERT OR UPDATE OF team_id, key_hash, key_prefix, key_suffix, name, scopes, role, rate_limit, expires_at, revoked_at, last_used_at, auth_source, is_system, sso_identity_id, sso_provider_id, sso_subject, sso_email, sso_group_id, sso_entitlement_status, sso_owner_identity_id OR DELETE
+ON team_profiles
+FOR EACH ROW EXECUTE FUNCTION dense_mem_sync_legacy_profile_identity();
+
+CREATE OR REPLACE FUNCTION dense_mem_sync_sso_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    provider_key TEXT;
+    external_key TEXT;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        DELETE FROM identity_external_links
+        WHERE identity_id = OLD.id;
+
+        UPDATE actor_identities
+        SET active = false,
+            updated_at = now()
+        WHERE id = OLD.id;
+        RETURN OLD;
+    END IF;
+
+    provider_key := NEW.provider_id::text;
+    external_key := COALESCE(NULLIF(NEW.external_id, ''), NULLIF(NEW.subject, ''), '');
+
+    INSERT INTO actor_identities (id, kind, provider, subject, display_name, active, created_at, updated_at)
+    VALUES (NEW.id, 'human', provider_key, NEW.subject, COALESCE(NEW.display_name, ''), NEW.active, COALESCE(NEW.created_at, now()), now())
+    ON CONFLICT (id) DO UPDATE SET
+        kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
+        provider = EXCLUDED.provider,
+        subject = EXCLUDED.subject,
+        display_name = EXCLUDED.display_name,
+        active = EXCLUDED.active,
+        updated_at = now();
+
+    IF TG_OP = 'UPDATE' THEN
+        DELETE FROM identity_external_links
+        WHERE identity_id = OLD.id
+          AND (provider <> provider_key OR external_id <> external_key);
+    END IF;
+
+    IF external_key <> '' THEN
+        INSERT INTO identity_external_links (identity_id, provider, external_id)
+        VALUES (NEW.id, provider_key, external_key)
+        ON CONFLICT (provider, external_id) DO UPDATE
+        SET identity_id = EXCLUDED.identity_id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sso_identities_identity_bridge ON sso_identities;
+CREATE TRIGGER sso_identities_identity_bridge
+AFTER INSERT OR UPDATE OF provider_id, subject, external_id, display_name, active OR DELETE
+ON sso_identities
+FOR EACH ROW EXECUTE FUNCTION dense_mem_sync_sso_identity();
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TRIGGER IF EXISTS team_profiles_identity_bridge ON team_profiles;
+DROP FUNCTION IF EXISTS dense_mem_sync_legacy_profile_identity();
+DROP TRIGGER IF EXISTS sso_identities_identity_bridge ON sso_identities;
+DROP FUNCTION IF EXISTS dense_mem_sync_sso_identity();
+DROP TABLE IF EXISTS identity_compatibility_state;
+DROP TABLE IF EXISTS ownership_aliases;
+DROP TABLE IF EXISTS identity_external_links;
+DROP TABLE IF EXISTS membership_grants;
+DROP TABLE IF EXISTS credentials;
+DROP TABLE IF EXISTS team_memberships;
+DROP TABLE IF EXISTS actor_identities;
+
+-- +goose StatementEnd

--- a/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
+++ b/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
@@ -235,18 +235,18 @@ CREATE POLICY identity_external_links_context_access ON identity_external_links
 		current_setting('app.tx_mode', true) IN ('system', 'migration')
 		OR EXISTS (
 			SELECT 1
-			FROM actor_identities a
-			WHERE a.id = identity_id
-			  AND a.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			FROM team_profiles p
+			WHERE p.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			  AND p.sso_identity_id = identity_external_links.identity_id
 		)
 	)
 	WITH CHECK (
 		current_setting('app.tx_mode', true) IN ('system', 'migration')
 		OR EXISTS (
 			SELECT 1
-			FROM actor_identities a
-			WHERE a.id = identity_id
-			  AND a.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			FROM team_profiles p
+			WHERE p.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			  AND p.sso_identity_id = identity_external_links.identity_id
 		)
 	);
 
@@ -333,22 +333,16 @@ ON CONFLICT (team_id, legacy_owner_id) DO UPDATE SET
     canonical_identity_id = EXCLUDED.canonical_identity_id,
     credential_id = EXCLUDED.credential_id;
 
--- SSO identities have stable external links. Existing profile IDs remain the
--- ownership aliases; the SSO actor is added only when it is not already linked.
+-- SSO identities have stable external links. Their actor rows are team-neutral;
+-- memberships and legacy profiles provide the per-team authorization boundary.
+-- Existing profile IDs remain the ownership aliases.
 INSERT INTO actor_identities (id, kind, team_id, provider, subject, display_name, active, created_at, updated_at)
-SELECT i.id, 'human', owner.team_id, p.id::text, i.subject, COALESCE(i.display_name, ''), i.active, i.created_at, i.updated_at
+SELECT i.id, 'human', NULL::uuid, p.id::text, i.subject, COALESCE(i.display_name, ''), i.active, i.created_at, i.updated_at
 FROM sso_identities i
 JOIN sso_providers p ON p.id = i.provider_id
-LEFT JOIN LATERAL (
-	SELECT tp.team_id
-	FROM team_profiles tp
-	WHERE tp.sso_identity_id = i.id
-	ORDER BY tp.created_at ASC, tp.id ASC
-	LIMIT 1
-) owner ON true
 ON CONFLICT (id) DO UPDATE SET
 	kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
-	team_id = COALESCE(EXCLUDED.team_id, actor_identities.team_id),
+	team_id = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.team_id ELSE NULL::uuid END,
 	provider = EXCLUDED.provider,
     subject = EXCLUDED.subject,
     display_name = EXCLUDED.display_name,
@@ -483,13 +477,14 @@ BEGIN
 	canonical_actor_id := NEW.id;
 	IF NEW.auth_source = 'sso' AND NEW.sso_identity_id IS NOT NULL THEN
 		UPDATE actor_identities
-		   SET team_id = NEW.team_id, updated_at = now()
+		   SET team_id = NULL, updated_at = now()
 		 WHERE id = NEW.sso_identity_id;
 		SELECT a.id
 		  INTO canonical_actor_id
 		  FROM actor_identities a
 		 WHERE a.id = NEW.sso_identity_id
-		   AND a.team_id = NEW.team_id;
+		   AND a.kind = 'human'
+		   AND a.active = true;
 		IF NOT FOUND THEN
 			RAISE EXCEPTION 'SSO actor identity % is not available for team %', NEW.sso_identity_id, NEW.team_id;
 		END IF;
@@ -512,9 +507,18 @@ BEGIN
         RETURNING id INTO new_membership_id;
     END IF;
 
-    IF NEW.key_hash IS NOT NULL AND NEW.key_prefix IS NOT NULL THEN
-        INSERT INTO credentials (id, actor_identity_id, owner_identity_id, team_id, kind, key_hash, key_prefix, key_suffix, name, scopes, rate_limit, status, expires_at, revoked_at, legacy_profile_id, created_at, updated_at, last_used_at)
-		VALUES (NEW.id, NEW.id, CASE WHEN EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_owner_identity_id AND a.team_id = NEW.team_id) THEN NEW.sso_owner_identity_id ELSE NULL END, NEW.team_id, 'api_key', NEW.key_hash, NEW.key_prefix, NEW.key_suffix, NEW.name, NEW.scopes, NEW.rate_limit,
+	IF NEW.key_hash IS NOT NULL AND NEW.key_prefix IS NOT NULL THEN
+	    INSERT INTO credentials (id, actor_identity_id, owner_identity_id, team_id, kind, key_hash, key_prefix, key_suffix, name, scopes, rate_limit, status, expires_at, revoked_at, legacy_profile_id, created_at, updated_at, last_used_at)
+			VALUES (NEW.id, NEW.id, CASE WHEN EXISTS (
+				SELECT 1
+				FROM actor_identities a
+				JOIN team_profiles owner_profile
+				  ON owner_profile.team_id = NEW.team_id
+				 AND owner_profile.sso_identity_id = a.id
+				WHERE a.id = NEW.sso_owner_identity_id
+				  AND a.kind = 'human'
+				  AND a.active = true
+			) THEN NEW.sso_owner_identity_id ELSE NULL END, NEW.team_id, 'api_key', NEW.key_hash, NEW.key_prefix, NEW.key_suffix, NEW.name, NEW.scopes, NEW.rate_limit,
                 CASE WHEN NEW.revoked_at IS NOT NULL THEN 'revoked' WHEN NEW.expires_at IS NOT NULL AND NEW.expires_at <= now() THEN 'expired' ELSE 'active' END,
                 NEW.expires_at, NEW.revoked_at, NEW.id, COALESCE(NEW.created_at, now()), now(), NEW.last_used_at)
         ON CONFLICT (id) DO UPDATE SET key_hash = EXCLUDED.key_hash, key_prefix = EXCLUDED.key_prefix, key_suffix = EXCLUDED.key_suffix, name = EXCLUDED.name, scopes = EXCLUDED.scopes, rate_limit = EXCLUDED.rate_limit, status = EXCLUDED.status, expires_at = EXCLUDED.expires_at, revoked_at = EXCLUDED.revoked_at, owner_identity_id = EXCLUDED.owner_identity_id, updated_at = now(), last_used_at = EXCLUDED.last_used_at;
@@ -563,14 +567,14 @@ BEGIN
         RETURN OLD;
     END IF;
 
-    provider_key := NEW.provider_id::text;
-    external_key := COALESCE(NULLIF(NEW.external_id, ''), NULLIF(NEW.subject, ''), '');
+	provider_key := NEW.provider_id::text;
+	external_key := COALESCE(NULLIF(NEW.external_id, ''), NULLIF(NEW.subject, ''), '');
 
 	INSERT INTO actor_identities (id, kind, team_id, provider, subject, display_name, active, created_at, updated_at)
-	VALUES (NEW.id, 'human', (SELECT tp.team_id FROM team_profiles tp WHERE tp.sso_identity_id = NEW.id ORDER BY tp.created_at ASC, tp.id ASC LIMIT 1), provider_key, NEW.subject, COALESCE(NEW.display_name, ''), NEW.active, COALESCE(NEW.created_at, now()), now())
+	VALUES (NEW.id, 'human', NULL::uuid, provider_key, NEW.subject, COALESCE(NEW.display_name, ''), NEW.active, COALESCE(NEW.created_at, now()), now())
 	ON CONFLICT (id) DO UPDATE SET
 		kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
-		team_id = COALESCE(EXCLUDED.team_id, actor_identities.team_id),
+		team_id = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.team_id ELSE NULL::uuid END,
         provider = EXCLUDED.provider,
         subject = EXCLUDED.subject,
         display_name = EXCLUDED.display_name,

--- a/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
+++ b/migrations/postgres/v2_5/2026081001_v2_5_identity_bridge.sql
@@ -155,15 +155,27 @@ ALTER TABLE identity_compatibility_state ENABLE ROW LEVEL SECURITY;
 ALTER TABLE identity_compatibility_state FORCE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS actor_identities_context_access ON actor_identities;
-CREATE POLICY actor_identities_context_access ON actor_identities
+	CREATE POLICY actor_identities_context_access ON actor_identities
     FOR ALL TO PUBLIC
     USING (
-        current_setting('app.tx_mode', true) IN ('system', 'migration')
-        OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
-    )
-    WITH CHECK (
-        current_setting('app.tx_mode', true) IN ('system', 'migration')
-        OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+		current_setting('app.tx_mode', true) IN ('system', 'migration')
+		OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+		OR EXISTS (
+			SELECT 1
+			FROM team_profiles p
+			WHERE p.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			  AND p.sso_identity_id = actor_identities.id
+		)
+	)
+	WITH CHECK (
+		current_setting('app.tx_mode', true) IN ('system', 'migration')
+		OR team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+		OR EXISTS (
+			SELECT 1
+			FROM team_profiles p
+			WHERE p.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+			  AND p.sso_identity_id = actor_identities.id
+		)
     );
 
 DROP POLICY IF EXISTS team_memberships_context_access ON team_memberships;
@@ -218,9 +230,25 @@ CREATE POLICY membership_grants_context_access ON membership_grants
 
 DROP POLICY IF EXISTS identity_external_links_context_access ON identity_external_links;
 CREATE POLICY identity_external_links_context_access ON identity_external_links
-    FOR ALL TO PUBLIC
-    USING (current_setting('app.tx_mode', true) IN ('system', 'migration'))
-    WITH CHECK (current_setting('app.tx_mode', true) IN ('system', 'migration'));
+	FOR ALL TO PUBLIC
+	USING (
+		current_setting('app.tx_mode', true) IN ('system', 'migration')
+		OR EXISTS (
+			SELECT 1
+			FROM actor_identities a
+			WHERE a.id = identity_id
+			  AND a.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+		)
+	)
+	WITH CHECK (
+		current_setting('app.tx_mode', true) IN ('system', 'migration')
+		OR EXISTS (
+			SELECT 1
+			FROM actor_identities a
+			WHERE a.id = identity_id
+			  AND a.team_id = NULLIF(current_setting('app.current_team_id', true), '')::uuid
+		)
+	);
 
 DROP POLICY IF EXISTS ownership_aliases_context_access ON ownership_aliases;
 CREATE POLICY ownership_aliases_context_access ON ownership_aliases
@@ -307,13 +335,21 @@ ON CONFLICT (team_id, legacy_owner_id) DO UPDATE SET
 
 -- SSO identities have stable external links. Existing profile IDs remain the
 -- ownership aliases; the SSO actor is added only when it is not already linked.
-INSERT INTO actor_identities (id, kind, provider, subject, display_name, active, created_at, updated_at)
-SELECT i.id, 'human', p.id::text, i.subject, COALESCE(i.display_name, ''), i.active, i.created_at, i.updated_at
+INSERT INTO actor_identities (id, kind, team_id, provider, subject, display_name, active, created_at, updated_at)
+SELECT i.id, 'human', owner.team_id, p.id::text, i.subject, COALESCE(i.display_name, ''), i.active, i.created_at, i.updated_at
 FROM sso_identities i
 JOIN sso_providers p ON p.id = i.provider_id
+LEFT JOIN LATERAL (
+	SELECT tp.team_id
+	FROM team_profiles tp
+	WHERE tp.sso_identity_id = i.id
+	ORDER BY tp.created_at ASC, tp.id ASC
+	LIMIT 1
+) owner ON true
 ON CONFLICT (id) DO UPDATE SET
-    kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
-    provider = EXCLUDED.provider,
+	kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
+	team_id = COALESCE(EXCLUDED.team_id, actor_identities.team_id),
+	provider = EXCLUDED.provider,
     subject = EXCLUDED.subject,
     display_name = EXCLUDED.display_name,
     active = EXCLUDED.active,
@@ -382,14 +418,21 @@ DECLARE
     new_membership_id UUID;
     canonical_actor_id UUID;
 BEGIN
-    IF TG_OP = 'DELETE' THEN
+	IF TG_OP = 'DELETE' THEN
         UPDATE credentials
            SET status = 'revoked', revoked_at = COALESCE(revoked_at, now()), updated_at = now()
          WHERE id = OLD.id;
-        UPDATE team_memberships
-           SET status = 'revoked', updated_at = now()
-         WHERE legacy_profile_id = OLD.id
-            OR (actor_identity_id = OLD.id AND team_id = OLD.team_id);
+		UPDATE team_memberships
+		   SET status = 'revoked', updated_at = now()
+		 WHERE legacy_profile_id = OLD.id
+		    OR (actor_identity_id = OLD.id AND team_id = OLD.team_id)
+		    OR EXISTS (
+				SELECT 1
+				FROM ownership_aliases a
+				WHERE a.team_id = OLD.team_id
+				  AND a.legacy_owner_id = OLD.id
+				  AND a.canonical_identity_id = team_memberships.actor_identity_id
+			);
 		UPDATE actor_identities
 		   SET active = false, updated_at = now()
 		 WHERE id = OLD.id;
@@ -437,13 +480,20 @@ BEGIN
             NEW.team_id, COALESCE(NEW.name, ''), NEW.revoked_at IS NULL, COALESCE(NEW.created_at, now()), now())
     ON CONFLICT (id) DO UPDATE SET team_id = EXCLUDED.team_id, display_name = EXCLUDED.display_name, active = EXCLUDED.active, updated_at = now();
 
-    canonical_actor_id := NEW.id;
-    IF NEW.auth_source = 'sso'
-       AND NEW.sso_identity_id IS NOT NULL
-       AND EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_identity_id)
-    THEN
-        canonical_actor_id := NEW.sso_identity_id;
-    END IF;
+	canonical_actor_id := NEW.id;
+	IF NEW.auth_source = 'sso' AND NEW.sso_identity_id IS NOT NULL THEN
+		UPDATE actor_identities
+		   SET team_id = NEW.team_id, updated_at = now()
+		 WHERE id = NEW.sso_identity_id;
+		SELECT a.id
+		  INTO canonical_actor_id
+		  FROM actor_identities a
+		 WHERE a.id = NEW.sso_identity_id
+		   AND a.team_id = NEW.team_id;
+		IF NOT FOUND THEN
+			RAISE EXCEPTION 'SSO actor identity % is not available for team %', NEW.sso_identity_id, NEW.team_id;
+		END IF;
+	END IF;
 
     UPDATE team_memberships
        SET actor_identity_id = canonical_actor_id,
@@ -464,7 +514,7 @@ BEGIN
 
     IF NEW.key_hash IS NOT NULL AND NEW.key_prefix IS NOT NULL THEN
         INSERT INTO credentials (id, actor_identity_id, owner_identity_id, team_id, kind, key_hash, key_prefix, key_suffix, name, scopes, rate_limit, status, expires_at, revoked_at, legacy_profile_id, created_at, updated_at, last_used_at)
-        VALUES (NEW.id, NEW.id, CASE WHEN EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_owner_identity_id) THEN NEW.sso_owner_identity_id ELSE NULL END, NEW.team_id, 'api_key', NEW.key_hash, NEW.key_prefix, NEW.key_suffix, NEW.name, NEW.scopes, NEW.rate_limit,
+		VALUES (NEW.id, NEW.id, CASE WHEN EXISTS (SELECT 1 FROM actor_identities a WHERE a.id = NEW.sso_owner_identity_id AND a.team_id = NEW.team_id) THEN NEW.sso_owner_identity_id ELSE NULL END, NEW.team_id, 'api_key', NEW.key_hash, NEW.key_prefix, NEW.key_suffix, NEW.name, NEW.scopes, NEW.rate_limit,
                 CASE WHEN NEW.revoked_at IS NOT NULL THEN 'revoked' WHEN NEW.expires_at IS NOT NULL AND NEW.expires_at <= now() THEN 'expired' ELSE 'active' END,
                 NEW.expires_at, NEW.revoked_at, NEW.id, COALESCE(NEW.created_at, now()), now(), NEW.last_used_at)
         ON CONFLICT (id) DO UPDATE SET key_hash = EXCLUDED.key_hash, key_prefix = EXCLUDED.key_prefix, key_suffix = EXCLUDED.key_suffix, name = EXCLUDED.name, scopes = EXCLUDED.scopes, rate_limit = EXCLUDED.rate_limit, status = EXCLUDED.status, expires_at = EXCLUDED.expires_at, revoked_at = EXCLUDED.revoked_at, owner_identity_id = EXCLUDED.owner_identity_id, updated_at = now(), last_used_at = EXCLUDED.last_used_at;
@@ -516,10 +566,11 @@ BEGIN
     provider_key := NEW.provider_id::text;
     external_key := COALESCE(NULLIF(NEW.external_id, ''), NULLIF(NEW.subject, ''), '');
 
-    INSERT INTO actor_identities (id, kind, provider, subject, display_name, active, created_at, updated_at)
-    VALUES (NEW.id, 'human', provider_key, NEW.subject, COALESCE(NEW.display_name, ''), NEW.active, COALESCE(NEW.created_at, now()), now())
-    ON CONFLICT (id) DO UPDATE SET
-        kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
+	INSERT INTO actor_identities (id, kind, team_id, provider, subject, display_name, active, created_at, updated_at)
+	VALUES (NEW.id, 'human', (SELECT tp.team_id FROM team_profiles tp WHERE tp.sso_identity_id = NEW.id ORDER BY tp.created_at ASC, tp.id ASC LIMIT 1), provider_key, NEW.subject, COALESCE(NEW.display_name, ''), NEW.active, COALESCE(NEW.created_at, now()), now())
+	ON CONFLICT (id) DO UPDATE SET
+		kind = CASE WHEN actor_identities.kind = 'api_client' THEN actor_identities.kind ELSE EXCLUDED.kind END,
+		team_id = COALESCE(EXCLUDED.team_id, actor_identities.team_id),
         provider = EXCLUDED.provider,
         subject = EXCLUDED.subject,
         display_name = EXCLUDED.display_name,

--- a/migrations/postgres/v2_5/README.md
+++ b/migrations/postgres/v2_5/README.md
@@ -1,0 +1,11 @@
+# v2.5 migrations
+
+The executable PostgreSQL history is split by release family:
+
+- `v2_4/` contains the immutable v2.4 and earlier migration files.
+- `v2_5/` contains additive v2.5 migrations with versions greater than the
+  v2.4 history.
+
+The runtime validates and loads both directories as one strictly ordered Goose
+history. The compatibility bridge is additive; cleanup of `team_profiles` is
+not part of this release.

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export DENSE_MEM_E2E_COMMIT_SHA="${DENSE_MEM_E2E_COMMIT_SHA:-$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf '%s' unknown)}"
 COMPOSE_SOURCE_FILE="${DENSE_MEM_E2E_COMPOSE_SOURCE:-${ROOT_DIR}/docker-compose.yml}"
 ROOT_ENV_SOURCE_FILE="${DENSE_MEM_E2E_ENV_SOURCE:-${ROOT_DIR}/.env}"
 COMPOSE_FILE="$COMPOSE_SOURCE_FILE"
@@ -273,7 +274,8 @@ prepare_e2e_environment() {
   fi
   printf '%s\n' \
     "CONFLICT_REVIEW_START_TIME_LOCAL=00:00" \
-    "CONFLICT_REVIEW_JITTER_SECONDS=0" >> "$E2E_ENV_FILE"
+    "CONFLICT_REVIEW_JITTER_SECONDS=0" \
+    "MCP_TRANSPORT=${DENSE_MEM_E2E_MCP_TRANSPORT:-sdk}" >> "$E2E_ENV_FILE"
   append_conflict_e2e_environment && append_embedding_reconciliation_environment && prepare_embedding_proxy_files && ROOT_ENV_FILE="$E2E_ENV_FILE"
 }
 
@@ -589,6 +591,7 @@ create_control_profile() {
     --data "$payload" \
     "${CONTROL_URL}/control/api/teams/${team_id}/profiles")"
   CREATED_API_KEY="$(printf '%s' "$response" | json_field data.api_key)"
+  CREATED_PROFILE_ID="$(printf '%s' "$response" | json_field data.key.id)"
 }
 
 remove_e2e_playwright_container() {
@@ -695,8 +698,8 @@ if [[ "$E2E_MODE" != "standard" && "$E2E_MODE" != "entra_scim" ]]; then
   echo "DENSE_MEM_E2E_MODE must be standard or entra_scim." >&2
   exit 1
 fi
-if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "security_runtime" && "$E2E_SCENARIO" != "infrastructure_credentials" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "conflict" && "$E2E_SCENARIO" != "conflict_queue" && "$E2E_SCENARIO" != "embedding_reconciliation" && "$E2E_SCENARIO" != "embedding_resilience" && "$E2E_SCENARIO" != "all" ]]; then
-  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, security_runtime, infrastructure_credentials, submission_status, security_intake, submission_assessment, semantic_holds, community, conflict, conflict_queue, embedding_reconciliation, embedding_resilience, or all." >&2
+if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "mcp_sdk_parity" && "$E2E_SCENARIO" != "mcp_sdk_transport" && "$E2E_SCENARIO" != "security_runtime" && "$E2E_SCENARIO" != "infrastructure_credentials" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "submission_terminal_errors" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "identity_cutover" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "conflict" && "$E2E_SCENARIO" != "conflict_queue" && "$E2E_SCENARIO" != "embedding_reconciliation" && "$E2E_SCENARIO" != "embedding_resilience" && "$E2E_SCENARIO" != "all" ]]; then
+  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, mcp_sdk_parity, mcp_sdk_transport, security_runtime, infrastructure_credentials, submission_status, submission_terminal_errors, security_intake, submission_assessment, semantic_holds, identity_cutover, community, conflict, conflict_queue, embedding_reconciliation, embedding_resilience, or all." >&2
   exit 1
 fi
 
@@ -710,7 +713,7 @@ if [[ "$E2E_SCENARIO" == "all" ]]; then
     echo "DENSE_MEM_E2E_SCENARIO=all requires DENSE_MEM_E2E_MODE=standard." >&2
     exit 1
   fi
-  for scenario in mcp_boundaries security_runtime infrastructure_credentials submission_status security_intake submission_assessment semantic_holds community conflict conflict_queue embedding_reconciliation embedding_resilience full; do
+  for scenario in mcp_boundaries mcp_sdk_parity mcp_sdk_transport security_runtime infrastructure_credentials submission_status submission_terminal_errors security_intake submission_assessment semantic_holds identity_cutover community conflict conflict_queue embedding_reconciliation embedding_resilience full; do
     echo "Running compose e2e scenario ${scenario} as part of all."
     DENSE_MEM_E2E_SCENARIO="$scenario" \
     DENSE_MEM_E2E_RUN_ID="${DENSE_MEM_E2E_RUN_ID:-all}-$(printf '%s' "$scenario" | tr '[:upper:]' '[:lower:]')" \
@@ -773,7 +776,7 @@ require_env_value AI_API_URL >/dev/null
 require_env_value AI_API_KEY >/dev/null
 require_env_value AI_API_EMBEDDING_MODEL >/dev/null
 require_env_value AI_API_EMBEDDING_DIMENSIONS >/dev/null
-if [[ "$E2E_SCENARIO" == "submission_status" || "$E2E_SCENARIO" == "security_intake" || "$E2E_SCENARIO" == "submission_assessment" || "$E2E_SCENARIO" == "semantic_holds" || "$E2E_SCENARIO" == "community" || "$E2E_SCENARIO" == "conflict_queue" || "${DENSE_MEM_E2E_REQUIRE_LIVE_DREAM_PROVIDER:-0}" == "1" ]]; then
+if [[ "$E2E_SCENARIO" == "submission_status" || "$E2E_SCENARIO" == "submission_terminal_errors" || "$E2E_SCENARIO" == "security_intake" || "$E2E_SCENARIO" == "submission_assessment" || "$E2E_SCENARIO" == "semantic_holds" || "$E2E_SCENARIO" == "community" || "$E2E_SCENARIO" == "conflict_queue" || "${DENSE_MEM_E2E_REQUIRE_LIVE_DREAM_PROVIDER:-0}" == "1" ]]; then
   require_env_value AI_VERIFIER_API_URL >/dev/null
   require_env_value AI_VERIFIER_API_KEY >/dev/null
   require_env_value AI_VERIFIER_MODEL >/dev/null
@@ -903,6 +906,8 @@ if [[ "$E2E_SCENARIO" == "mcp_boundaries" ]]; then
   node "$ROOT_DIR/tests/uat/mcp_boundaries_e2e.mjs"
   exit 0
 fi
+if [[ "$E2E_SCENARIO" == "mcp_sdk_parity" ]]; then echo "Running the official Go MCP SDK differential harness and live public boundary."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_E2E_API_KEY="$api_key" node "$ROOT_DIR/tests/uat/mcp_sdk_parity_e2e.mjs"; exit 0; fi
+if [[ "$E2E_SCENARIO" == "mcp_sdk_transport" ]]; then echo "Running the production MCP SDK transport matrix with live credentials."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_E2E_API_KEY="$api_key" node "$ROOT_DIR/tests/uat/mcp_sdk_transport_e2e.mjs"; exit 0; fi
 
 if [[ "$E2E_SCENARIO" == "security_runtime" ]]; then
   run_security_runtime_e2e
@@ -927,6 +932,7 @@ if [[ "$E2E_SCENARIO" == "submission_status" ]]; then
   run_submission_status_e2e "$team_id"
   exit 0
 fi
+if [[ "$E2E_SCENARIO" == "submission_terminal_errors" ]]; then echo "Running compose-backed terminal submission error completeness e2e with the configured live verifier."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_E2E_API_KEY="$api_key" DENSE_MEM_E2E_TEAM_ID="$team_id" DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" node "$ROOT_DIR/tests/uat/submission_terminal_errors_e2e.mjs"; exit 0; fi
 if [[ "$E2E_SCENARIO" == "submission_assessment" ]]; then
   echo "Running compose-backed submission-wide assessor e2e with the configured live verifier."
   DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
@@ -952,6 +958,7 @@ if [[ "$E2E_SCENARIO" == "semantic_holds" ]]; then
   node "$ROOT_DIR/tests/uat/semantic_holds_mcp_e2e.mjs"
   exit 0
 fi
+if [[ "$E2E_SCENARIO" == "identity_cutover" ]]; then echo "Running compose-backed identity bridge and A/B/C isolation e2e."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_CONTROL_URL="$CONTROL_URL" DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" DENSE_MEM_E2E_TEAM_ID="$team_id" DENSE_MEM_E2E_PROFILE_ID="$CREATED_PROFILE_ID" DENSE_MEM_E2E_API_KEY="$api_key" DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" node "$ROOT_DIR/tests/uat/identity_cutover_e2e.mjs"; exit 0; fi
 if [[ "$E2E_SCENARIO" == "community" ]]; then
   echo "Running compose-backed community recall e2e with the configured live verifier."; export DENSE_MEM_CONTROL_URL="$CONTROL_URL" DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" DENSE_MEM_E2E_TEAM_ID="$team_id" DENSE_MEM_E2E_API_KEY="$api_key" DENSE_MEM_PROMETHEUS_URL="$PROMETHEUS_URL" DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE"; node "$ROOT_DIR/tests/uat/community_recall_mcp_e2e.mjs"
   if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then echo "Skipping compose-backed community Playwright tests by DENSE_MEM_E2E_SKIP_PLAYWRIGHT."; else echo "Running compose-backed community Playwright tests."; export DENSE_MEM_E2E_TEAM_NAME="E2E Team"; run_compose_playwright_tests community; fi; exit 0

--- a/tests/uat/identity_cutover_e2e.mjs
+++ b/tests/uat/identity_cutover_e2e.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+const profileID = requiredEnv("DENSE_MEM_E2E_PROFILE_ID");
+const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
+const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
+const runID = `identity-cutover-${Date.now()}`;
+let rpcID = 0;
+
+const baseline = postgresRow(`
+  SELECT concat(
+    p.id::text, '|', COALESCE(c.id::text, ''), '|',
+    COALESCE(a.legacy_owner_id::text, ''), '|',
+    COALESCE(m.id::text, ''), '|', COALESCE(m.team_admin::text, 'false')
+  )
+  FROM team_profiles p
+  LEFT JOIN credentials c ON c.legacy_profile_id = p.id
+  LEFT JOIN ownership_aliases a ON a.team_id = p.team_id AND a.legacy_owner_id = p.id
+  LEFT JOIN team_memberships m ON m.legacy_profile_id = p.id
+  WHERE p.id = ${sqlLiteral(profileID)}::uuid
+  LIMIT 1;
+`);
+const [stableProfileID, credentialID, aliasOwnerID, membershipID, teamAdmin] = baseline;
+if (stableProfileID !== profileID || credentialID !== profileID || aliasOwnerID !== profileID || !membershipID || teamAdmin !== "true") {
+  throw new Error("legacy profile did not retain stable credential, alias, and membership IDs");
+}
+
+const listed = await mcpList(apiKey);
+if (!listed.tools?.some((tool) => tool.name === "remember")) throw new Error("canonical credential could not authenticate against MCP");
+
+const sameTeam = await createProfile(teamID, `${runID}-same-team`);
+const otherTeam = await createTeam(`${runID}-other-team`);
+const crossTeam = await createProfile(otherTeam.id, `${runID}-cross-team`);
+
+const receipt = await mcpSuccess(apiKey, "remember", rememberInput());
+const submissionID = requiredString(receipt.submission_id, "submission_id");
+const ownerStatus = await mcpSuccess(apiKey, "get_submission_status", { submission_id: submissionID });
+if (ownerStatus.submission_id !== submissionID) throw new Error("owner could not read its staged submission");
+for (const [label, key] of [["same-team other owner", sameTeam.apiKey], ["cross-team owner", crossTeam.apiKey]]) {
+  const isolated = await mcpRaw(key, "get_submission_status", { submission_id: submissionID });
+  if (!isolated.error || isolated.result !== undefined || JSON.stringify(isolated).includes(submissionID)) {
+    throw new Error(`${label} crossed submission ownership boundary`);
+  }
+}
+
+postgresQuery(`
+  SELECT set_config('app.tx_mode', 'system', true);
+  UPDATE team_profiles
+  SET scopes = ARRAY['read']
+  WHERE id = ${sqlLiteral(profileID)}::uuid;
+`);
+const reconciled = postgresRow(`
+  SELECT concat(
+    c.scopes::text, '|', m.maximum_grants::text, '|',
+    (SELECT count(*) FROM membership_grants g WHERE g.membership_id = m.id AND g.grant_name = 'read'), '|',
+    (SELECT count(*) FROM membership_grants g WHERE g.membership_id = m.id AND g.grant_name = 'write')
+  )
+  FROM credentials c
+  JOIN team_memberships m ON m.actor_identity_id = c.actor_identity_id AND m.team_id = c.team_id
+  WHERE c.id = ${sqlLiteral(profileID)}::uuid;
+`);
+const [credentialScopes, membershipMaximum, readGrant, writeGrant] = reconciled;
+if (credentialScopes !== "{read}" || membershipMaximum !== "{read}" || readGrant !== "1" || writeGrant !== "0") {
+  throw new Error(`legacy write did not reconcile canonical grants: ${reconciled}`);
+}
+
+console.log(JSON.stringify({
+  status: "ok",
+  scenario: "identity_cutover",
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  stable_ids: true,
+  manager_backfill: true,
+  owner_authentication: true,
+  same_team_owner_isolation: true,
+  cross_team_isolation: true,
+  legacy_write_reconciled: true,
+}, null, 2));
+
+function rememberInput() {
+  const content = "Identity bridge uses credentials.";
+  const subject = "Identity bridge";
+  const predicate = "uses";
+  const object = "credentials";
+  const subjectStart = 0;
+  const predicateStart = subject.length + 1;
+  const objectStart = predicateStart + predicate.length + 1;
+  return {
+    evidence: [{ content, source_type: "document", source: `${runID}:source`, source_group: runID, idempotency_key: `${runID}:evidence` }],
+    relationships: [{
+      ref: `${runID}:relationship`,
+      subject: { name: subject, entity_kind: "concept", span: { evidence_index: 0, start: subjectStart, end: subjectStart + subject.length } },
+      predicate: { proposed_key: predicate, surface: predicate, span: { evidence_index: 0, start: predicateStart, end: predicateStart + predicate.length } },
+      object: { entity: { name: object, entity_kind: "concept", span: { evidence_index: 0, start: objectStart, end: objectStart + object.length } } },
+      polarity: "+", modality: "statement", supports: [{ evidence_index: 0, start: 0, end: Array.from(content).length }],
+    }],
+  };
+}
+
+async function createTeam(name) {
+  const response = await controlJSON("/control/api/teams", { method: "POST", body: { name, description: "identity cutover e2e" } });
+  const id = requiredString(response.data?.id, "team id");
+  return { id };
+}
+
+async function createProfile(targetTeamID, name) {
+  const response = await controlJSON(`/control/api/teams/${targetTeamID}/profiles`, { method: "POST", body: { name, scopes: ["read", "write"], rate_limit: 300 } });
+  return { apiKey: requiredString(response.data?.api_key, "api key"), id: requiredString(response.data?.key?.id, "profile id") };
+}
+
+async function mcpSuccess(key, name, args) {
+  const response = await mcpRaw(key, name, args);
+  if (response.error || response.result === undefined) {
+    throw new Error(`MCP ${name} returned a bounded error: ${response.error?.code ?? "missing"} ${response.error?.message ?? ""}`.trim());
+  }
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} did not return JSON content`);
+  return JSON.parse(text);
+}
+
+async function mcpList(key) {
+  const response = await fetch(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/list", params: {} }),
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!response.ok || payload.error || !payload.result) throw new Error("MCP tools/list returned a bounded error");
+  return payload.result;
+}
+
+async function mcpRaw(key, name, args) {
+  const response = await fetch(`${userURL}/mcp`, { method: "POST", headers: { Authorization: `Bearer ${key}`, Accept: "application/json", "Content-Type": "application/json" }, body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/call", params: { name, arguments: args } }) });
+  const text = await response.text();
+  return text ? JSON.parse(text) : {};
+}
+
+async function controlJSON(path, options = {}) {
+  const response = await fetch(`${controlURL}${path}`, { method: options.method ?? "GET", headers: { Authorization: `Bearer ${controlToken}`, Accept: "application/json", "Content-Type": "application/json" }, body: options.body ? JSON.stringify(options.body) : undefined });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`control HTTP ${response.status} response body redacted`);
+  return text ? JSON.parse(text) : {};
+}
+
+function postgresQuery(sql) { return postgresRow(sql).join("|"); }
+function postgresRow(sql) {
+  const result = spawnSync("docker", ["compose", "-p", composeProject, "-f", composeFile, "exec", "-T", "postgres", "sh", "-ec", 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -F "|" -c "$1"', "identity-cutover-e2e", sql], { cwd: fileURLToPath(new URL("../..", import.meta.url)), encoding: "utf8" });
+  if (result.status !== 0) throw new Error("postgres identity fixture failed");
+  return result.stdout.trim().split("|");
+}
+function sqlLiteral(value) { return `'${String(value).replaceAll("'", "''")}'`; }
+function requiredString(value, field) { if (typeof value !== "string" || !value.trim()) throw new Error(`${field} missing`); return value; }
+function requiredEnv(name) { const value = process.env[name]; if (!value) throw new Error(`${name} is required`); return value; }

--- a/tests/uat/mcp_sdk_parity_e2e.mjs
+++ b/tests/uat/mcp_sdk_parity_e2e.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const result = spawnSync("go", ["test", "./internal/mcp", "-run", "TestConformanceHarness", "-count=1"], { cwd: root, encoding: "utf8", timeout: 300_000 });
+if (result.status !== 0) throw new Error(`MCP SDK parity harness failed: ${result.stderr || "redacted"}`);
+console.log(JSON.stringify({ status: "ok", scenario: "mcp_sdk_parity", official_sdk: "v1.7.0", shared_registry: true, cancellation_and_errors: true }, null, 2));

--- a/tests/uat/mcp_sdk_parity_e2e.mjs
+++ b/tests/uat/mcp_sdk_parity_e2e.mjs
@@ -6,4 +6,61 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("../..", import.meta.url));
 const result = spawnSync("go", ["test", "./internal/mcp", "-run", "TestConformanceHarness", "-count=1"], { cwd: root, encoding: "utf8", timeout: 300_000 });
 if (result.status !== 0) throw new Error(`MCP SDK parity harness failed: ${result.stderr || "redacted"}`);
-console.log(JSON.stringify({ status: "ok", scenario: "mcp_sdk_parity", official_sdk: "v1.7.0", shared_registry: true, cancellation_and_errors: true }, null, 2));
+
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+let rpcID = 0;
+for (const version of ["2025-11-25", "2026-07-28"]) {
+  const method = version === "2026-07-28" ? "server/discover" : "initialize";
+  const headers = { "MCP-Protocol-Version": version };
+  if (version === "2026-07-28") headers["Mcp-Method"] = method;
+  const negotiated = await rpc(method, initializeParams(version), headers);
+  if (negotiated.error || (version === "2026-07-28" ? !negotiated.result?.supportedVersions?.includes(version) : negotiated.result?.protocolVersion !== version)) {
+    throw new Error(`live SDK protocol negotiation failed for ${version}`);
+  }
+}
+const listed = await rpc("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25" });
+if (listed.error || !listed.result?.tools?.some((tool) => tool.name === "remember")) {
+  throw new Error("live SDK tools/list did not expose the shared registry");
+}
+const bounded = await rpc("tools/call", {
+  name: "get_submission_status",
+  arguments: { submission_id: "00000000-0000-0000-0000-000000000000" },
+}, { "MCP-Protocol-Version": "2025-11-25" });
+if (!bounded.error || typeof bounded.error.message !== "string" || bounded.error.message.length > 512) {
+  throw new Error("live SDK error mapping was not bounded");
+}
+console.log(JSON.stringify({
+  status: "ok",
+  scenario: "mcp_sdk_parity",
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  official_sdk: "v1.7.0",
+  shared_registry: true,
+  local_differential_harness: true,
+  live_public_boundary: true,
+  protocol_2025: true,
+  protocol_2026: true,
+  bounded_errors: true,
+}, null, 2));
+
+async function rpc(method, params, headers = {}) {
+  const response = await fetch(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`MCP HTTP ${response.status} response body redacted`);
+  return text ? JSON.parse(text) : {};
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function initializeParams(version) {
+  if (version === "2026-07-28") return { protocolVersion: version, _meta: { "io.modelcontextprotocol/protocolVersion": version, "io.modelcontextprotocol/clientCapabilities": {} } };
+  return { protocolVersion: version };
+}

--- a/tests/uat/mcp_sdk_transport_e2e.mjs
+++ b/tests/uat/mcp_sdk_transport_e2e.mjs
@@ -4,22 +4,84 @@ const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
 const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
 let rpcID = 0;
 
-const legacy = await rpc("initialize", { protocolVersion: "2025-11-25" }, { "MCP-Protocol-Version": "2025-11-25" });
-if (legacy.error || legacy.result?.protocolVersion !== "2025-11-25") throw new Error("2025-11-25 initialize negotiation failed");
-const discover = await rpc("server/discover", { _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } }, { "MCP-Protocol-Version": "2026-07-28", "Mcp-Method": "server/discover" });
-if (discover.error || !discover.result?.supportedVersions?.includes("2026-07-28")) throw new Error("2026-07-28 server/discover negotiation failed");
+for (const version of ["2025-11-25", "2026-07-28"]) {
+  const method = version === "2026-07-28" ? "server/discover" : "initialize";
+  const headers = { "MCP-Protocol-Version": version };
+  if (version === "2026-07-28") headers["Mcp-Method"] = method;
+  const negotiated = await rpc(method, initializeParams(version), headers);
+  if (negotiated.error || (version === "2026-07-28" ? !negotiated.result?.supportedVersions?.includes(version) : negotiated.result?.protocolVersion !== version)) {
+    throw new Error(`${version} protocol negotiation failed`);
+  }
+}
 const list = await rpc("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25" });
-if (list.error || !list.result?.tools?.some((tool) => tool.name === "remember")) throw new Error("SDK tools/list did not expose the shared registry");
+if (list.error || !list.result?.tools?.some((tool) => tool.name === "remember")) {
+  throw new Error("SDK tools/list did not expose the shared registry");
+}
 const unknownVersion = await rawRPC("initialize", { protocolVersion: "2099-01-01" }, { "MCP-Protocol-Version": "2099-01-01" });
 if (unknownVersion.status !== 400) throw new Error("unknown protocol version was not rejected");
 const invalidContent = await rawRPC("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25", "Content-Type": "text/plain" });
 if (![400, 415].includes(invalidContent.status)) throw new Error("invalid content type was not rejected");
-const controller = new AbortController();
-const pending = fetch(`${userURL}/mcp`, { method: "POST", signal: controller.signal, headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json", "MCP-Protocol-Version": "2025-11-25" }, body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/list", params: {} }) });
-controller.abort();
-try { await pending; } catch (error) { if (error.name !== "AbortError") throw error; }
-console.log(JSON.stringify({ status: "ok", scenario: "mcp_sdk_transport", protocol_2025: true, protocol_2026: true, unknown_version_rejected: true, malformed_content_rejected: true, cancellation_observed: true }, null, 2));
+const invalidNotificationContent = await rawNotification("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25", "Content-Type": "text/plain" });
+if (![400, 415].includes(invalidNotificationContent.status)) throw new Error("invalid notification content type was not rejected");
+const initializedNotification = await rawNotification("notifications/initialized", {}, { "MCP-Protocol-Version": "2025-11-25" });
+if (initializedNotification.status !== 202 || initializedNotification.body !== "") throw new Error("initialized notification returned a response");
 
-async function rpc(method, params, headers) { const response = await rawRPC(method, params, headers); if (!response.body) return {}; return JSON.parse(response.body); }
-async function rawRPC(method, params, headers = {}) { const response = await fetch(`${userURL}/mcp`, { method: "POST", headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json", ...headers }, body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }) }); return { status: response.status, body: await response.text() }; }
-function requiredEnv(name) { const value = process.env[name]; if (!value) throw new Error(`${name} is required`); return value; }
+const controller = new AbortController();
+const pending = fetch(`${userURL}/mcp`, {
+  method: "POST",
+  signal: controller.signal,
+  headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json", "MCP-Protocol-Version": "2025-11-25" },
+  body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/list", params: {} }),
+});
+controller.abort();
+try {
+  await pending;
+} catch (error) {
+  if (error.name !== "AbortError") throw error;
+}
+console.log(JSON.stringify({
+  status: "ok",
+  scenario: "mcp_sdk_transport",
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  protocol_2025: true,
+  protocol_2026: true,
+  unknown_version_rejected: true,
+  malformed_content_rejected: true,
+  notification_response_suppressed: true,
+  cancellation_observed: true,
+}, null, 2));
+
+async function rpc(method, params, headers) {
+  const response = await rawRPC(method, params, headers);
+  if (!response.body) return {};
+  return JSON.parse(response.body);
+}
+
+async function rawRPC(method, params, headers = {}) {
+  const response = await fetch(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }),
+  });
+  return { status: response.status, body: await response.text() };
+}
+
+async function rawNotification(method, params, headers = {}) {
+  const response = await fetch(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+  });
+  return { status: response.status, body: await response.text() };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function initializeParams(version) {
+  if (version === "2026-07-28") return { protocolVersion: version, _meta: { "io.modelcontextprotocol/protocolVersion": version, "io.modelcontextprotocol/clientCapabilities": {} } };
+  return { protocolVersion: version };
+}

--- a/tests/uat/mcp_sdk_transport_e2e.mjs
+++ b/tests/uat/mcp_sdk_transport_e2e.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+let rpcID = 0;
+
+const legacy = await rpc("initialize", { protocolVersion: "2025-11-25" }, { "MCP-Protocol-Version": "2025-11-25" });
+if (legacy.error || legacy.result?.protocolVersion !== "2025-11-25") throw new Error("2025-11-25 initialize negotiation failed");
+const discover = await rpc("server/discover", { _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } }, { "MCP-Protocol-Version": "2026-07-28", "Mcp-Method": "server/discover" });
+if (discover.error || !discover.result?.supportedVersions?.includes("2026-07-28")) throw new Error("2026-07-28 server/discover negotiation failed");
+const list = await rpc("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25" });
+if (list.error || !list.result?.tools?.some((tool) => tool.name === "remember")) throw new Error("SDK tools/list did not expose the shared registry");
+const unknownVersion = await rawRPC("initialize", { protocolVersion: "2099-01-01" }, { "MCP-Protocol-Version": "2099-01-01" });
+if (unknownVersion.status !== 400) throw new Error("unknown protocol version was not rejected");
+const invalidContent = await rawRPC("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25", "Content-Type": "text/plain" });
+if (![400, 415].includes(invalidContent.status)) throw new Error("invalid content type was not rejected");
+const controller = new AbortController();
+const pending = fetch(`${userURL}/mcp`, { method: "POST", signal: controller.signal, headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json", "MCP-Protocol-Version": "2025-11-25" }, body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/list", params: {} }) });
+controller.abort();
+try { await pending; } catch (error) { if (error.name !== "AbortError") throw error; }
+console.log(JSON.stringify({ status: "ok", scenario: "mcp_sdk_transport", protocol_2025: true, protocol_2026: true, unknown_version_rejected: true, malformed_content_rejected: true, cancellation_observed: true }, null, 2));
+
+async function rpc(method, params, headers) { const response = await rawRPC(method, params, headers); if (!response.body) return {}; return JSON.parse(response.body); }
+async function rawRPC(method, params, headers = {}) { const response = await fetch(`${userURL}/mcp`, { method: "POST", headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json", ...headers }, body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }) }); return { status: response.status, body: await response.text() }; }
+function requiredEnv(name) { const value = process.env[name]; if (!value) throw new Error(`${name} is required`); return value; }

--- a/tests/uat/mcp_sdk_transport_e2e.mjs
+++ b/tests/uat/mcp_sdk_transport_e2e.mjs
@@ -34,11 +34,14 @@ const pending = fetch(`${userURL}/mcp`, {
   body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/list", params: {} }),
 });
 controller.abort();
+let cancellationObserved = false;
 try {
   await pending;
 } catch (error) {
   if (error.name !== "AbortError") throw error;
+  cancellationObserved = true;
 }
+if (!cancellationObserved) throw new Error("client cancellation was not observed");
 console.log(JSON.stringify({
   status: "ok",
   scenario: "mcp_sdk_transport",
@@ -48,7 +51,7 @@ console.log(JSON.stringify({
   unknown_version_rejected: true,
   malformed_content_rejected: true,
   notification_response_suppressed: true,
-  cancellation_observed: true,
+  cancellation_observed: cancellationObserved,
 }, null, 2));
 
 async function rpc(method, params, headers) {

--- a/tests/uat/submission_terminal_errors_e2e.mjs
+++ b/tests/uat/submission_terminal_errors_e2e.mjs
@@ -58,14 +58,42 @@ function assertTerminalErrors(status) {
     "no_change", "confirmation_expired", "relationship_changed", "support_set_changed",
     "persistent_ambiguity", "inactive_relationship_collision",
   ]);
+  const allowedMessages = new Set([
+    "submission was rejected by semantic hold policy",
+    "submission was rejected by semantic placement policy",
+    "submission assessment returned an invalid response",
+    "submission assessment was unavailable after bounded retries",
+    "submission replacement conflicted with current state",
+    "submission processing failed",
+    "search indexing is delayed",
+    "relationship version is stale",
+    "relationship must be active, supported, and canonical",
+    "a Value object cannot be replaced with an Entity",
+    "supports must exactly match the relationship's effective evidence spans",
+    "corrected Entity is not active and available to the team",
+    "corrected Entity name has too many exact candidates",
+    "predicate is not registered and active for the team",
+    "predicate does not allow the corrected subject kind",
+    "predicate does not allow the corrected object kind",
+    "correction does not change the Relationship",
+    "relationship correction confirmation expired",
+    "relationship changed while confirmation was pending",
+    "relationship supports changed while confirmation was pending",
+    "selected Entity candidate is no longer available",
+    "corrected Relationship collides with inactive or unsupported history",
+    "Semantic search indexing is delayed.",
+    "Semantic search indexing is delayed; check the control portal for recovery guidance.",
+  ]);
   const seen = new Set();
   for (const item of status.errors) {
-    const code = String(item.code ?? "");
-    const message = String(item.message ?? "");
-    if (!allowedCodes.has(code) || message.length === 0 || message.length > 512) {
+    if (item === null || typeof item !== "object" || Array.isArray(item) || typeof item.code !== "string" || typeof item.message !== "string") {
+      throw new Error("terminal error fields were not strings");
+    }
+    const { code, message } = item;
+    if (!allowedCodes.has(code) || !allowedMessages.has(message) || message.length === 0 || message.length > 512) {
       throw new Error("terminal error was not bounded and typed");
     }
-    if (/[\r\n]|api[_-]?key|password|token|stack|provider/i.test(message)) {
+    if (/[\r\n]|api[_-]?key|password|token|stack|provider|cookie|prompt|embedding|database|cross[- ]?team/i.test(message)) {
       throw new Error("terminal error leaked prohibited data");
     }
     if (seen.has(`${code}\0${message}`)) throw new Error("terminal errors were not deduplicated");

--- a/tests/uat/submission_terminal_errors_e2e.mjs
+++ b/tests/uat/submission_terminal_errors_e2e.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
+const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
+const runID = `submission-terminal-errors-${Date.now()}`;
+const predicatePrefix = runID.replace(/[^A-Za-z0-9]+/g, "_").toLowerCase();
+let rpcID = 0;
+
+seedOverflowPredicates();
+const receipt = await mcpSuccess("remember", overflowFixture());
+const submissionID = requiredString(receipt.submission_id, "submission_id");
+const terminal = await waitForTerminal(submissionID);
+const repeated = await mcpSuccess("get_submission_status", { submission_id: submissionID });
+if (stableJSON(terminal) !== stableJSON(repeated)) throw new Error("terminal status changed between polls");
+assertTerminalErrors(terminal);
+
+const missing = await mcpRaw("get_submission_status", { submission_id: "00000000-0000-0000-0000-000000000000" });
+if (!missing.error || missing.result !== undefined || typeof missing.error.message !== "string" || missing.error.message.length > 512) {
+  throw new Error("missing submission did not return a bounded error");
+}
+console.log(JSON.stringify({
+  status: "ok",
+  scenario: "submission_terminal_errors",
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  submission_id: submissionID,
+  processing_state: terminal.processing_state,
+  terminal_errors_nonempty: true,
+  closed_codes: true,
+  stable_polling: true,
+  missing_owner_bounded: true,
+}, null, 2));
+
+async function waitForTerminal(id) {
+  for (let attempt = 0; attempt < 360; attempt += 1) {
+    const status = await mcpSuccess("get_submission_status", { submission_id: id });
+    if (["completed", "rejected", "failed", "quarantined"].includes(status.processing_state)) return status;
+    await delay(2_000);
+  }
+  throw new Error("submission did not reach a terminal state");
+}
+
+function assertTerminalErrors(status) {
+  if (status.processing_state !== "failed" || !Array.isArray(status.errors) || status.errors.length === 0) {
+    throw new Error("terminal failure returned an empty errors array");
+  }
+  const seen = new Set();
+  for (const item of status.errors) {
+    const code = String(item.code ?? "");
+    const message = String(item.message ?? "");
+    if (!/^[a-z0-9_]+$/.test(code) || message.length === 0 || message.length > 512) {
+      throw new Error("terminal error was not bounded and typed");
+    }
+    if (/[\r\n]|api[_-]?key|password|token|stack|provider/i.test(message)) {
+      throw new Error("terminal error leaked prohibited data");
+    }
+    if (seen.has(`${code}\0${message}`)) throw new Error("terminal errors were not deduplicated");
+    seen.add(`${code}\0${message}`);
+  }
+}
+
+async function mcpSuccess(name, args) {
+  const response = await mcpRaw(name, args);
+  if (response.error || response.result === undefined) throw new Error(`MCP ${name} failed with a bounded error`);
+  const text = response.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} returned no JSON content`);
+  return JSON.parse(text);
+}
+
+async function mcpRaw(name, args) {
+  const response = await fetch(`${userURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method: "tools/call", params: { name, arguments: args } }),
+  });
+  const text = await response.text();
+  return text ? JSON.parse(text) : {};
+}
+
+function overflowFixture() {
+  const evidence = [];
+  const relationships = [];
+  for (let evidenceIndex = 0; evidenceIndex < Math.ceil(101 / 6); evidenceIndex += 1) {
+    const clauses = [];
+    const indexes = [];
+    for (let slot = 0; slot < 6; slot += 1) {
+      const index = evidenceIndex * 6 + slot;
+      if (index >= 101) break;
+      clauses.push(`A ${predicateKey(index)} B`);
+      indexes.push(index);
+    }
+    const content = `${clauses.join(". ")}.`;
+    evidence.push({ content, source_type: "document", source: `${runID}:evidence:${evidenceIndex}`, source_group: runID, idempotency_key: `${runID}:evidence:${evidenceIndex}` });
+    for (const index of indexes) relationships.push(relationship(content, evidenceIndex, `${runID}:${index}`, "A", predicateKey(index), "B"));
+  }
+  return { evidence, relationships, idempotency_key: `${runID}:batch` };
+}
+
+function relationship(content, evidenceIndex, ref, subject, predicate, object) {
+  const subjectStart = content.indexOf(subject);
+  const predicateStart = content.indexOf(predicate, subjectStart + subject.length);
+  const objectStart = content.indexOf(object, predicateStart + predicate.length);
+  return {
+    ref,
+    subject: { name: subject, entity_kind: "project", span: { evidence_index: evidenceIndex, start: subjectStart, end: subjectStart + subject.length } },
+    predicate: { proposed_key: predicate, surface: predicate, span: { evidence_index: evidenceIndex, start: predicateStart, end: predicateStart + predicate.length } },
+    object: { entity: { name: object, entity_kind: "product", span: { evidence_index: evidenceIndex, start: objectStart, end: objectStart + object.length } } },
+    polarity: "+", modality: "statement", supports: [{ evidence_index: evidenceIndex, start: 0, end: Array.from(content).length }],
+  };
+}
+
+function seedOverflowPredicates() {
+  const team = sqlLiteral(teamID);
+  const prefix = sqlLiteral(`${predicatePrefix}_predicate_`);
+  postgresQuery(`
+    INSERT INTO semantic_team_refs (team_id) VALUES (${team}::uuid) ON CONFLICT (team_id) DO NOTHING;
+    INSERT INTO team_predicate_definitions (
+      team_id, predicate_key, version, aliases, allowed_subject_kinds,
+      allowed_object_kinds, relationship_kind, current_cardinality,
+      lifecycle_state, origin, metadata
+    )
+    SELECT ${team}::uuid, ${prefix} || series::text, 1, ARRAY[]::text[],
+      ARRAY['project']::text[], ARRAY['product']::text[], 'state', 'many',
+      'active', 'built_in', '{}'::jsonb
+    FROM generate_series(0, 100) AS series
+    ON CONFLICT (team_id, predicate_key, version) DO NOTHING;
+  `);
+}
+
+function postgresQuery(sql) {
+  const result = spawnSync("docker", ["compose", "-p", composeProject, "-f", composeFile, "exec", "-T", "postgres", "sh", "-ec", 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "$1"', "submission-terminal-errors-e2e", sql], { cwd: fileURLToPath(new URL("../..", import.meta.url)), encoding: "utf8" });
+  if (result.status !== 0) throw new Error("postgres terminal-error fixture failed");
+  return result.stdout.trim();
+}
+
+function sqlLiteral(value) { return `'${String(value).replaceAll("'", "''")}'`; }
+function predicateKey(index) { return `${predicatePrefix}_predicate_${index}`; }
+function requiredString(value, field) { if (typeof value !== "string" || !value.trim()) throw new Error(`${field} missing`); return value; }
+function requiredEnv(name) { const value = process.env[name]; if (!value) throw new Error(`${name} is required`); return value; }
+function stableJSON(value) { if (Array.isArray(value)) return `[${value.map(stableJSON).sort().join(",")}]`; if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJSON(value[key])}`).join(",")}}`; return JSON.stringify(value); }
+function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/tests/uat/submission_terminal_errors_e2e.mjs
+++ b/tests/uat/submission_terminal_errors_e2e.mjs
@@ -46,14 +46,23 @@ async function waitForTerminal(id) {
 }
 
 function assertTerminalErrors(status) {
-  if (status.processing_state !== "failed" || !Array.isArray(status.errors) || status.errors.length === 0) {
+  if (!["rejected", "failed"].includes(status.processing_state) || !Array.isArray(status.errors) || status.errors.length === 0) {
     throw new Error("terminal failure returned an empty errors array");
   }
+  const allowedCodes = new Set([
+    "submission_semantic_hold", "submission_policy_rejected", "assessor_response_invalid", "assessor_unavailable",
+    "submission_replacement_conflict", "submission_processing_failed", "search_indexing_delayed",
+    "relationship_version_stale", "relationship_not_active", "object_kind_change_forbidden",
+    "support_set_mismatch", "entity_not_found", "too_many_entity_candidates",
+    "predicate_not_found", "predicate_subject_kind_mismatch", "predicate_object_kind_mismatch",
+    "no_change", "confirmation_expired", "relationship_changed", "support_set_changed",
+    "persistent_ambiguity", "inactive_relationship_collision",
+  ]);
   const seen = new Set();
   for (const item of status.errors) {
     const code = String(item.code ?? "");
     const message = String(item.message ?? "");
-    if (!/^[a-z0-9_]+$/.test(code) || message.length === 0 || message.length > 512) {
+    if (!allowedCodes.has(code) || message.length === 0 || message.length > 512) {
       throw new Error("terminal error was not bounded and typed");
     }
     if (/[\r\n]|api[_-]?key|password|token|stack|provider/i.test(message)) {
@@ -142,5 +151,5 @@ function sqlLiteral(value) { return `'${String(value).replaceAll("'", "''")}'`; 
 function predicateKey(index) { return `${predicatePrefix}_predicate_${index}`; }
 function requiredString(value, field) { if (typeof value !== "string" || !value.trim()) throw new Error(`${field} missing`); return value; }
 function requiredEnv(name) { const value = process.env[name]; if (!value) throw new Error(`${name} is required`); return value; }
-function stableJSON(value) { if (Array.isArray(value)) return `[${value.map(stableJSON).sort().join(",")}]`; if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJSON(value[key])}`).join(",")}}`; return JSON.stringify(value); }
+function stableJSON(value) { if (Array.isArray(value)) return `[${value.map(stableJSON).join(",")}]`; if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJSON(value[key])}`).join(",")}}`; return JSON.stringify(value); }
 function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }


### PR DESCRIPTION
## Summary

Implements the focused Part B scope for #206–#209 on current `main`. #159 migration-layout work is already in the base branch; this PR adds the v2.5 identity bridge on top of that layout.

- #206: closed terminal submission error vocabulary, bounded nonempty terminal errors, deterministic deduplication.
- #207/#208: official Go MCP SDK v1.7.0 seam, shared registry/conformance harness, SDK production transport, and boot-only legacy rollback.
- #209: additive v2.5 identity/membership/grant/credential bridge, backfill, RLS, legacy-write reconciliation, startup validation, and canonical credential authentication.
- Live Compose UAT scenarios for terminal errors, SDK parity/transport, and identity cutover.
- Wiki updates are in the separately maintained `dense-mem.wiki` working tree and intentionally uncommitted.

## Scope boundary

#210 cleanup/preflight remains deferred. No generated `schema/` mirror or second schema authority is included.

## Validation

- `./scripts/ci-check.sh`
- `scripts/static-analysis.sh`
- `scripts/check-postgres-migrations.sh origin/main`
- Focused Go and race tests
- Full PostgreSQL storage integration suite with disposable containers
- Committed-head live Compose UAT using configured live verifier credentials:
  - `mcp_sdk_transport`
  - `mcp_sdk_parity`
  - `submission_terminal_errors`
  - `identity_cutover`

All committed-head UAT output records `tested_commit=233873e730a0c4e3d293352c8e18b22ff49abde9`.

Closes #206
Closes #207
Closes #208
Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP SDK transport support with protocol negotiation, JSON responses, request limits, cancellation, and improved error handling.
  * Added configurable MCP transport selection with legacy compatibility.
  * Added identity and credential migration support while preserving profiles, memberships, permissions, aliases, and SSO links.
  * Added canonical credential authorization checks and standardized submission error codes.

* **Bug Fixes**
  * Startup now detects incompatible or incomplete database migrations and stops with an actionable error.
  * Improved handling of invalid MCP requests and terminal submission failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->