### PR TITLE
fix: demote routine MCP SDK lifecycle logs

### DIFF
--- a/internal/mcp/sdk_server.go
+++ b/internal/mcp/sdk_server.go
@@ -15,6 +15,40 @@ import (
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
 )
 
+// The SDK treats every stateless POST as a session, so its routine lifecycle belongs at debug level.
+type sdkLifecycleLogHandler struct {
+	delegate slog.Handler
+}
+
+func (h sdkLifecycleLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.delegate.Enabled(ctx, level)
+}
+
+func (h sdkLifecycleLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if record.Level == slog.LevelInfo {
+		switch record.Message {
+		case "server connecting", "server session connected", "session initialized", "server session disconnected":
+			record.Level = slog.LevelDebug
+		}
+	}
+	if !h.delegate.Enabled(ctx, record.Level) {
+		return nil
+	}
+	return h.delegate.Handle(ctx, record)
+}
+
+func (h sdkLifecycleLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return sdkLifecycleLogHandler{delegate: h.delegate.WithAttrs(attrs)}
+}
+
+func (h sdkLifecycleLogHandler) WithGroup(name string) slog.Handler {
+	return sdkLifecycleLogHandler{delegate: h.delegate.WithGroup(name)}
+}
+
+func newSDKLogger(delegate *slog.Logger) *slog.Logger {
+	return slog.New(sdkLifecycleLogHandler{delegate: delegate.Handler()})
+}
+
 // NewSDKHTTPHandler creates a stateless official-SDK transport backed by the
 // request-scoped registry, authorization, and prompt catalog.
 func (s *Server) NewSDKHTTPHandler(jsonResponse bool) http.Handler {
@@ -166,7 +200,7 @@ func (s *Server) newSDKServer(ctx context.Context) *sdkmcp.Server {
 		Instructions: s.instructions(),
 		Capabilities: capabilities,
 		SchemaCache:  sdkmcp.NewSchemaCache(),
-		Logger:       slog.Default(),
+		Logger:       newSDKLogger(slog.Default()),
 	})
 
 	tools := s.registry.List()

--- a/internal/mcp/sdk_server_test.go
+++ b/internal/mcp/sdk_server_test.go
@@ -1,9 +1,11 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -96,6 +98,102 @@ func TestSDKHTTPHandlerUsesTheSharedRegistryAndSupportsFrozenAndCurrentFlows(t *
 	handler.ServeHTTP(callResponse, callRequest)
 	require.Equal(t, http.StatusOK, callResponse.Code)
 	require.Contains(t, callResponse.Body.String(), `\"value\":\"ok\"`)
+}
+
+func TestSDKHTTPHandlerLogsRoutineSessionLifecycleAtDebug(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		level     slog.Level
+		wantLevel string
+	}{
+		{name: "info", level: slog.LevelInfo},
+		{name: "debug", level: slog.LevelDebug, wantLevel: "DEBUG"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previous := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(previous) })
+
+			var logBuffer bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: tc.level})))
+			logger, _ := testLogger(t)
+			server := NewServer(registry.New(), "profile-a", logger)
+			request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Accept", "application/json, text/event-stream")
+			request.Header.Set("MCP-Protocol-Version", "2025-11-25")
+			response := httptest.NewRecorder()
+			server.NewSDKHTTPHandler(true).ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+
+			records := decodeSDKLogRecords(t, logBuffer.Bytes())
+			if tc.wantLevel == "" {
+				require.Empty(t, records)
+				return
+			}
+			lifecycle := map[string]int{
+				"server connecting":           0,
+				"server session connected":    0,
+				"server session disconnected": 0,
+			}
+			for _, record := range records {
+				message, ok := record["msg"].(string)
+				if !ok {
+					continue
+				}
+				if _, ok := lifecycle[message]; !ok {
+					continue
+				}
+				lifecycle[message]++
+				require.Equal(t, tc.wantLevel, record["level"])
+				if message != "server connecting" {
+					require.Contains(t, record, "session_id")
+					require.Empty(t, record["session_id"])
+				}
+			}
+			for message, count := range lifecycle {
+				require.Equal(t, 1, count, message)
+			}
+		})
+	}
+}
+
+func TestSDKLoggerDemotesOnlyRoutineSessionLifecycle(t *testing.T) {
+	var logBuffer bytes.Buffer
+	delegate := slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := newSDKLogger(delegate).With("component", "mcp_sdk").WithGroup("transport")
+
+	for _, message := range []string{
+		"server connecting",
+		"server session connected",
+		"session initialized",
+		"server session disconnected",
+	} {
+		logger.Info(message, "session_id", "session-a")
+	}
+	logger.Info("resource subscribed", "uri", "memory://resource")
+	logger.Warn("calling tools/list: warning", "method", "tools/list")
+	logger.Error("server connect error", "error", errors.New("connect failed"))
+
+	records := decodeSDKLogRecords(t, logBuffer.Bytes())
+	require.Len(t, records, 7)
+	byMessage := make(map[string]map[string]any, len(records))
+	for _, record := range records {
+		message, ok := record["msg"].(string)
+		require.True(t, ok)
+		byMessage[message] = record
+		require.Equal(t, "mcp_sdk", record["component"])
+	}
+	for _, message := range []string{
+		"server connecting",
+		"server session connected",
+		"session initialized",
+		"server session disconnected",
+	} {
+		require.Equal(t, "DEBUG", byMessage[message]["level"])
+	}
+	require.Equal(t, "INFO", byMessage["resource subscribed"]["level"])
+	require.Equal(t, "WARN", byMessage["calling tools/list: warning"]["level"])
+	require.Equal(t, "ERROR", byMessage["server connect error"]["level"])
 }
 
 func TestSDKHTTPHandlerRejectsUnknownProtocolHeader(t *testing.T) {
@@ -293,4 +391,19 @@ func requireSDKError(t *testing.T, err error, code int, message string) {
 	require.ErrorAs(t, err, &sdkErr)
 	require.Equal(t, int64(code), sdkErr.Code)
 	require.Contains(t, sdkErr.Message, message)
+}
+
+func decodeSDKLogRecords(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	if len(lines) == 1 && len(lines[0]) == 0 {
+		return nil
+	}
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(line, &record))
+		records = append(records, record)
+	}
+	return records
 }


### PR DESCRIPTION
## What changed

- Demote routine official MCP SDK connection/session lifecycle records from INFO to DEBUG.
- Preserve unrelated SDK INFO records, all warnings and errors, structured attributes, and the existing Dense-Mem HTTP access log.
- Add real stateless SDK transport coverage at INFO and DEBUG plus focused logger passthrough coverage.

## Why

The official Go SDK creates a temporary session for every stateless `POST /mcp` and logs connect, connected, and disconnected at INFO. Those expected records duplicate Dense-Mem's `http_request` outcome and produce four log lines for each successful MCP request. The empty session ID is intentional, so the lifecycle records provide little production value.

After this change, production INFO logs retain the single request record while `LOG_LEVEL=debug` still exposes SDK lifecycle diagnostics. MCP transport and session semantics are unchanged.

## Validation

- `go test ./internal/mcp ./internal/http/handler -count=1`
- `go test -race ./internal/mcp -run 'TestSDKHTTPHandlerLogsRoutineSessionLifecycleAtDebug|TestSDKLoggerDemotesOnlyRoutineSessionLifecycle' -count=1`
- `./scripts/ci-check.sh` (90.0% coverage gate)
- Full push hook checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced routine session lifecycle log noise by recording informational events at debug level.
  - Continued to preserve normal severity for resource, warning, and error messages.
  - Maintained delegated logging behavior for SDK server events.

- **Tests**
  - Added coverage verifying lifecycle messages appear at the appropriate configured log levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->