### PR TITLE
Add OAuth bearer authentication for MCP

### DIFF
--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -353,11 +353,10 @@ func RunActiveServer(
 		Degraded: backend.degraded,
 		Reason:   backend.reason,
 	}).WithSharedDependencyChecks()
-
 	e := http.NewServer(cfg, logger, healthConfig)
-	e.Use(middleware.CorrelationIDMiddleware())
-	e.Use(middleware.ClientIPMiddleware())
+	e.Use(middleware.CorrelationIDMiddleware(), middleware.ClientIPMiddleware())
 	e.Use(middleware.SecurityBanMiddleware(securityService))
+	http.RegisterOAuthProtectedResourceRoutes(e, ssoService)
 	if err := http.RegisterDirectorySCIM(e, directoryIdentityService, http.DirectorySCIMConfig{
 		RuntimeConfig: appConfigService,
 		Security:      securityService,
@@ -380,6 +379,8 @@ func RunActiveServer(
 		AuditService:       auditService,
 		SecurityService:    securityService,
 		SSOAuthenticator:   ssoService,
+		OAuthAuthenticator: ssoService,
+		OAuthMetadata:      ssoService,
 		Config:             &cfg,
 		Logger:             logger,
 		CredentialVerifier: credentialVerifier,

--- a/internal/domain/app_config.go
+++ b/internal/domain/app_config.go
@@ -16,6 +16,7 @@ const (
 	AppConfigSSOStateTTLSeconds            = "SSO_STATE_TTL_SECONDS"
 	AppConfigSSOHTTPTimeoutSeconds         = "SSO_HTTP_TIMEOUT_SECONDS"
 	AppConfigSSOCookieSecure               = "SSO_COOKIE_SECURE"
+	AppConfigMCPPublicBaseURL              = "MCP_PUBLIC_BASE_URL"
 
 	AppConfigDreamingEnabled        = "DREAMING_ENABLED"
 	AppConfigDreamingForceEnabled   = "DREAMING_FORCE_ENABLED"

--- a/internal/domain/oauth_protected_resource.go
+++ b/internal/domain/oauth_protected_resource.go
@@ -2,6 +2,8 @@ package domain
 
 import "time"
 
+const OAuthProtectedResourceMaximumProfiles = 16
+
 type OAuthProtectedResourceProfile struct {
 	Name              string                       `json:"name"`
 	Issuer            string                       `json:"issuer"`

--- a/internal/domain/sso.go
+++ b/internal/domain/sso.go
@@ -15,22 +15,30 @@ const (
 )
 
 type SSOProvider struct {
-	ID              uuid.UUID
-	Name            string
-	Kind            SSOProviderKind
-	IssuerURL       string
-	TenantID        string
-	IdentityClaim   string
-	ClientID        string
-	ClientSecretEnv string
-	Scopes          []string
-	GroupClaims     []string
-	GroupsEndpoint  string
-	GroupsScopes    []string
-	Enabled         bool
-	RetiredAt       *time.Time
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID                uuid.UUID
+	Name              string
+	Kind              SSOProviderKind
+	IssuerURL         string
+	TenantID          string
+	IdentityClaim     string
+	ClientID          string
+	ClientSecretEnv   string
+	Scopes            []string
+	GroupClaims       []string
+	GroupsEndpoint    string
+	GroupsScopes      []string
+	ProtectedResource SSOProtectedResourceConfig
+	Enabled           bool
+	RetiredAt         *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// SSOProtectedResourceConfig enables the existing OAuth validator profile for
+// an SSO provider without duplicating its validation contract.
+type SSOProtectedResourceConfig struct {
+	Enabled bool `json:"enabled"`
+	OAuthProtectedResourceConfig
 }
 
 type SSOGroupMapping struct {

--- a/internal/http/control_portal_config_test.go
+++ b/internal/http/control_portal_config_test.go
@@ -35,6 +35,8 @@ type controlAppConfigSvc struct {
 	telemetryValues      map[string]string
 	getErr               error
 	updateErr            error
+	ssoRuntime           service.SSORuntimeConfig
+	ssoRuntimeErr        error
 	dreamingRuntime      domain.DreamingRuntimeConfig
 	dreamingRuntimeErr   error
 	recallRuntime        domain.RecallFeedbackRuntimeConfig
@@ -88,7 +90,10 @@ func (s *controlAppConfigSvc) UpdateSSOSettings(_ context.Context, values map[st
 }
 
 func (s *controlAppConfigSvc) SSORuntimeConfig(context.Context) (service.SSORuntimeConfig, error) {
-	return service.SSORuntimeConfig{}, nil
+	if s.ssoRuntimeErr != nil {
+		return service.SSORuntimeConfig{}, s.ssoRuntimeErr
+	}
+	return s.ssoRuntime, nil
 }
 
 func (s *controlAppConfigSvc) GetDreamingSettings(context.Context) (*domain.DreamingConfigSettings, error) {

--- a/internal/http/control_portal_sso.go
+++ b/internal/http/control_portal_sso.go
@@ -56,7 +56,20 @@ func (h *controlPortalHandler) updateSSOProvider(c echo.Context) error {
 	if err := jsonstrict.Decode(c.Request().Body, &body, maximumControlSSOProviderRequestBytes); err != nil {
 		return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
 	}
-	provider, err := h.sso.UpdateProvider(c.Request().Context(), body.toDomain(providerID))
+	providerUpdate := body.toDomain(providerID)
+	if body.ProtectedResource == nil {
+		providers, err := h.sso.ListProviders(c.Request().Context())
+		if err != nil {
+			return err
+		}
+		for _, provider := range providers {
+			if provider != nil && provider.ID == providerID {
+				providerUpdate.ProtectedResource = provider.ProtectedResource
+				break
+			}
+		}
+	}
+	provider, err := h.sso.UpdateProvider(c.Request().Context(), providerUpdate)
 	if err != nil {
 		return controlSSOServiceError(err)
 	}
@@ -157,25 +170,29 @@ func (h *controlPortalHandler) deleteSSOMapping(c echo.Context) error {
 }
 
 type controlSSOProviderRequest struct {
-	Name              string                            `json:"name"`
-	Kind              string                            `json:"kind"`
-	IssuerURL         string                            `json:"issuer_url"`
-	TenantID          string                            `json:"tenant_id"`
-	IdentityClaim     string                            `json:"identity_claim"`
-	ClientID          string                            `json:"client_id"`
-	ClientSecretEnv   string                            `json:"client_secret_env"`
-	Scopes            []string                          `json:"scopes"`
-	GroupClaims       []string                          `json:"group_claims"`
-	GroupsEndpoint    string                            `json:"groups_endpoint"`
-	GroupsScopes      []string                          `json:"groups_scopes"`
-	ProtectedResource domain.SSOProtectedResourceConfig `json:"protected_resource"`
-	Enabled           *bool                             `json:"enabled"`
+	Name              string                             `json:"name"`
+	Kind              string                             `json:"kind"`
+	IssuerURL         string                             `json:"issuer_url"`
+	TenantID          string                             `json:"tenant_id"`
+	IdentityClaim     string                             `json:"identity_claim"`
+	ClientID          string                             `json:"client_id"`
+	ClientSecretEnv   string                             `json:"client_secret_env"`
+	Scopes            []string                           `json:"scopes"`
+	GroupClaims       []string                           `json:"group_claims"`
+	GroupsEndpoint    string                             `json:"groups_endpoint"`
+	GroupsScopes      []string                           `json:"groups_scopes"`
+	ProtectedResource *domain.SSOProtectedResourceConfig `json:"protected_resource"`
+	Enabled           *bool                              `json:"enabled"`
 }
 
 func (r controlSSOProviderRequest) toDomain(id uuid.UUID) domain.SSOProvider {
 	enabled := true
 	if r.Enabled != nil {
 		enabled = *r.Enabled
+	}
+	protectedResource := domain.SSOProtectedResourceConfig{}
+	if r.ProtectedResource != nil {
+		protectedResource = *r.ProtectedResource
 	}
 	return domain.SSOProvider{
 		ID:                id,
@@ -190,7 +207,7 @@ func (r controlSSOProviderRequest) toDomain(id uuid.UUID) domain.SSOProvider {
 		GroupClaims:       append([]string(nil), r.GroupClaims...),
 		GroupsEndpoint:    r.GroupsEndpoint,
 		GroupsScopes:      append([]string(nil), r.GroupsScopes...),
-		ProtectedResource: r.ProtectedResource,
+		ProtectedResource: protectedResource,
 		Enabled:           enabled,
 	}
 }

--- a/internal/http/control_portal_sso.go
+++ b/internal/http/control_portal_sso.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/jsonstrict"
 )
+
+const maximumControlSSOProviderRequestBytes = 128 * 1024
 
 func (h *controlPortalHandler) listSSOProviders(c echo.Context) error {
 	if h.sso == nil {
@@ -31,7 +34,7 @@ func (h *controlPortalHandler) createSSOProvider(c echo.Context) error {
 		return httperr.New(httperr.SERVICE_UNAVAILABLE, "sso service unavailable")
 	}
 	var body controlSSOProviderRequest
-	if err := c.Bind(&body); err != nil {
+	if err := jsonstrict.Decode(c.Request().Body, &body, maximumControlSSOProviderRequestBytes); err != nil {
 		return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
 	}
 	provider, err := h.sso.CreateProvider(c.Request().Context(), body.toDomain(uuid.Nil))
@@ -50,7 +53,7 @@ func (h *controlPortalHandler) updateSSOProvider(c echo.Context) error {
 		return err
 	}
 	var body controlSSOProviderRequest
-	if err := c.Bind(&body); err != nil {
+	if err := jsonstrict.Decode(c.Request().Body, &body, maximumControlSSOProviderRequestBytes); err != nil {
 		return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
 	}
 	provider, err := h.sso.UpdateProvider(c.Request().Context(), body.toDomain(providerID))
@@ -154,18 +157,19 @@ func (h *controlPortalHandler) deleteSSOMapping(c echo.Context) error {
 }
 
 type controlSSOProviderRequest struct {
-	Name            string   `json:"name"`
-	Kind            string   `json:"kind"`
-	IssuerURL       string   `json:"issuer_url"`
-	TenantID        string   `json:"tenant_id"`
-	IdentityClaim   string   `json:"identity_claim"`
-	ClientID        string   `json:"client_id"`
-	ClientSecretEnv string   `json:"client_secret_env"`
-	Scopes          []string `json:"scopes"`
-	GroupClaims     []string `json:"group_claims"`
-	GroupsEndpoint  string   `json:"groups_endpoint"`
-	GroupsScopes    []string `json:"groups_scopes"`
-	Enabled         *bool    `json:"enabled"`
+	Name              string                            `json:"name"`
+	Kind              string                            `json:"kind"`
+	IssuerURL         string                            `json:"issuer_url"`
+	TenantID          string                            `json:"tenant_id"`
+	IdentityClaim     string                            `json:"identity_claim"`
+	ClientID          string                            `json:"client_id"`
+	ClientSecretEnv   string                            `json:"client_secret_env"`
+	Scopes            []string                          `json:"scopes"`
+	GroupClaims       []string                          `json:"group_claims"`
+	GroupsEndpoint    string                            `json:"groups_endpoint"`
+	GroupsScopes      []string                          `json:"groups_scopes"`
+	ProtectedResource domain.SSOProtectedResourceConfig `json:"protected_resource"`
+	Enabled           *bool                             `json:"enabled"`
 }
 
 func (r controlSSOProviderRequest) toDomain(id uuid.UUID) domain.SSOProvider {
@@ -174,19 +178,20 @@ func (r controlSSOProviderRequest) toDomain(id uuid.UUID) domain.SSOProvider {
 		enabled = *r.Enabled
 	}
 	return domain.SSOProvider{
-		ID:              id,
-		Name:            r.Name,
-		Kind:            domain.SSOProviderKind(r.Kind),
-		IssuerURL:       r.IssuerURL,
-		TenantID:        r.TenantID,
-		IdentityClaim:   r.IdentityClaim,
-		ClientID:        r.ClientID,
-		ClientSecretEnv: r.ClientSecretEnv,
-		Scopes:          append([]string(nil), r.Scopes...),
-		GroupClaims:     append([]string(nil), r.GroupClaims...),
-		GroupsEndpoint:  r.GroupsEndpoint,
-		GroupsScopes:    append([]string(nil), r.GroupsScopes...),
-		Enabled:         enabled,
+		ID:                id,
+		Name:              r.Name,
+		Kind:              domain.SSOProviderKind(r.Kind),
+		IssuerURL:         r.IssuerURL,
+		TenantID:          r.TenantID,
+		IdentityClaim:     r.IdentityClaim,
+		ClientID:          r.ClientID,
+		ClientSecretEnv:   r.ClientSecretEnv,
+		Scopes:            append([]string(nil), r.Scopes...),
+		GroupClaims:       append([]string(nil), r.GroupClaims...),
+		GroupsEndpoint:    r.GroupsEndpoint,
+		GroupsScopes:      append([]string(nil), r.GroupsScopes...),
+		ProtectedResource: r.ProtectedResource,
+		Enabled:           enabled,
 	}
 }
 
@@ -217,21 +222,22 @@ func (r controlSSOGroupMappingRequest) toDomain(providerID, mappingID uuid.UUID)
 }
 
 type controlSSOProviderResponse struct {
-	ID              uuid.UUID `json:"id"`
-	Name            string    `json:"name"`
-	Kind            string    `json:"kind"`
-	IssuerURL       string    `json:"issuer_url"`
-	TenantID        string    `json:"tenant_id"`
-	IdentityClaim   string    `json:"identity_claim"`
-	ClientID        string    `json:"client_id"`
-	ClientSecretEnv string    `json:"client_secret_env"`
-	Scopes          []string  `json:"scopes"`
-	GroupClaims     []string  `json:"group_claims"`
-	GroupsEndpoint  string    `json:"groups_endpoint"`
-	GroupsScopes    []string  `json:"groups_scopes"`
-	Enabled         bool      `json:"enabled"`
-	CreatedAt       string    `json:"created_at"`
-	UpdatedAt       string    `json:"updated_at"`
+	ID                uuid.UUID                         `json:"id"`
+	Name              string                            `json:"name"`
+	Kind              string                            `json:"kind"`
+	IssuerURL         string                            `json:"issuer_url"`
+	TenantID          string                            `json:"tenant_id"`
+	IdentityClaim     string                            `json:"identity_claim"`
+	ClientID          string                            `json:"client_id"`
+	ClientSecretEnv   string                            `json:"client_secret_env"`
+	Scopes            []string                          `json:"scopes"`
+	GroupClaims       []string                          `json:"group_claims"`
+	GroupsEndpoint    string                            `json:"groups_endpoint"`
+	GroupsScopes      []string                          `json:"groups_scopes"`
+	ProtectedResource domain.SSOProtectedResourceConfig `json:"protected_resource"`
+	Enabled           bool                              `json:"enabled"`
+	CreatedAt         string                            `json:"created_at"`
+	UpdatedAt         string                            `json:"updated_at"`
 }
 
 func toControlSSOProvider(provider *domain.SSOProvider) controlSSOProviderResponse {
@@ -239,22 +245,34 @@ func toControlSSOProvider(provider *domain.SSOProvider) controlSSOProviderRespon
 		return controlSSOProviderResponse{}
 	}
 	return controlSSOProviderResponse{
-		ID:              provider.ID,
-		Name:            provider.Name,
-		Kind:            string(provider.Kind),
-		IssuerURL:       provider.IssuerURL,
-		TenantID:        provider.TenantID,
-		IdentityClaim:   provider.IdentityClaim,
-		ClientID:        provider.ClientID,
-		ClientSecretEnv: provider.ClientSecretEnv,
-		Scopes:          append([]string{}, provider.Scopes...),
-		GroupClaims:     append([]string{}, provider.GroupClaims...),
-		GroupsEndpoint:  provider.GroupsEndpoint,
-		GroupsScopes:    append([]string{}, provider.GroupsScopes...),
-		Enabled:         provider.Enabled,
-		CreatedAt:       provider.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:       provider.UpdatedAt.Format(time.RFC3339),
+		ID:                provider.ID,
+		Name:              provider.Name,
+		Kind:              string(provider.Kind),
+		IssuerURL:         provider.IssuerURL,
+		TenantID:          provider.TenantID,
+		IdentityClaim:     provider.IdentityClaim,
+		ClientID:          provider.ClientID,
+		ClientSecretEnv:   provider.ClientSecretEnv,
+		Scopes:            append([]string{}, provider.Scopes...),
+		GroupClaims:       append([]string{}, provider.GroupClaims...),
+		GroupsEndpoint:    provider.GroupsEndpoint,
+		GroupsScopes:      append([]string{}, provider.GroupsScopes...),
+		ProtectedResource: controlSSOProtectedResourceConfig(provider.ProtectedResource),
+		Enabled:           provider.Enabled,
+		CreatedAt:         provider.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:         provider.UpdatedAt.Format(time.RFC3339),
 	}
+}
+
+func controlSSOProtectedResourceConfig(config domain.SSOProtectedResourceConfig) domain.SSOProtectedResourceConfig {
+	copyConfig := config
+	copyConfig.Audiences = append([]string{}, config.Audiences...)
+	copyConfig.Algorithms = append([]string{}, config.Algorithms...)
+	copyConfig.ScopeMappings = append([]domain.OAuthScopeMapping{}, config.ScopeMappings...)
+	for index := range copyConfig.ScopeMappings {
+		copyConfig.ScopeMappings[index].InternalScopes = append([]string{}, config.ScopeMappings[index].InternalScopes...)
+	}
+	return copyConfig
 }
 
 type controlSSOGroupMappingResponse struct {
@@ -304,7 +322,7 @@ func controlSSOServiceError(err error) error {
 		return nil
 	}
 	message := err.Error()
-	if strings.HasPrefix(message, "sso ") || strings.Contains(message, "api key scopes") || strings.Contains(message, "api key role") {
+	if strings.HasPrefix(message, "sso ") || strings.HasPrefix(message, "OAuth ") || strings.Contains(message, "api key scopes") || strings.Contains(message, "api key role") {
 		return httperr.New(httperr.VALIDATION_ERROR, message)
 	}
 	return err

--- a/internal/http/control_portal_sso.go
+++ b/internal/http/control_portal_sso.go
@@ -57,19 +57,12 @@ func (h *controlPortalHandler) updateSSOProvider(c echo.Context) error {
 		return httperr.New(httperr.VALIDATION_ERROR, "malformed JSON body")
 	}
 	providerUpdate := body.toDomain(providerID)
+	var provider *domain.SSOProvider
 	if body.ProtectedResource == nil {
-		providers, err := h.sso.ListProviders(c.Request().Context())
-		if err != nil {
-			return err
-		}
-		for _, provider := range providers {
-			if provider != nil && provider.ID == providerID {
-				providerUpdate.ProtectedResource = provider.ProtectedResource
-				break
-			}
-		}
+		provider, err = h.sso.UpdateProviderPreservingProtectedResource(c.Request().Context(), providerUpdate)
+	} else {
+		provider, err = h.sso.UpdateProvider(c.Request().Context(), providerUpdate)
 	}
-	provider, err := h.sso.UpdateProvider(c.Request().Context(), providerUpdate)
 	if err != nil {
 		return controlSSOServiceError(err)
 	}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -173,9 +173,11 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 				}
 				actor, err := opts.OAuthBearerAuthenticator.AuthenticateOAuthBearer(c.Request().Context(), rawKey, pathTeamID)
 				if err != nil {
-					failureSecurity := securitySvc
-					if errors.Is(err, service.ErrOAuthProviderUnavailable) || errors.Is(err, service.ErrOAuthTeamRequired) {
-						failureSecurity = nil
+					var failureSecurity SecurityBanService
+					if errors.Is(err, service.ErrOAuthTokenExpired) ||
+						errors.Is(err, service.ErrOAuthTokenInvalid) ||
+						errors.Is(err, service.ErrOAuthAccessDenied) {
+						failureSecurity = securitySvc
 					}
 					logAuthFailure(c, auditSvc, failureSecurity, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
 					return oauthAuthError(err)

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -173,7 +173,11 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 				}
 				actor, err := opts.OAuthBearerAuthenticator.AuthenticateOAuthBearer(c.Request().Context(), rawKey, pathTeamID)
 				if err != nil {
-					logAuthFailure(c, auditSvc, securitySvc, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
+					failureSecurity := securitySvc
+					if errors.Is(err, service.ErrOAuthProviderUnavailable) {
+						failureSecurity = nil
+					}
+					logAuthFailure(c, auditSvc, failureSecurity, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
 					return oauthAuthError(err)
 				}
 				principal, actorContext, err := principalAndActorContext(actor, "oauth", "")

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -168,7 +168,7 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 			}
 			if service.IsJWTBearer(rawKey) {
 				if opts.OAuthBearerAuthenticator == nil {
-					logAuthFailure(c, auditSvc, securitySvc, nil, "OAUTH_INVALID", "oauth bearer authentication is unavailable")
+					logOAuthAuthFailure(c, auditSvc, securitySvc, nil, "OAUTH_INVALID", "oauth bearer authentication is unavailable")
 					return httperr.New(httperr.AUTH_INVALID, "invalid bearer token")
 				}
 				actor, err := opts.OAuthBearerAuthenticator.AuthenticateOAuthBearer(c.Request().Context(), rawKey, pathTeamID)
@@ -179,7 +179,7 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 						errors.Is(err, service.ErrOAuthAccessDenied) {
 						failureSecurity = securitySvc
 					}
-					logAuthFailure(c, auditSvc, failureSecurity, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
+					logOAuthAuthFailure(c, auditSvc, failureSecurity, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
 					return oauthAuthError(err)
 				}
 				principal, actorContext, err := principalAndActorContext(actor, "oauth", "")
@@ -575,6 +575,14 @@ func LastUsedMiddleware(recorder LastUsedRecorder) echo.MiddlewareFunc {
 
 // logAuthFailure logs an authentication failure event to the audit service.
 func logAuthFailure(c echo.Context, auditSvc service.AuditService, securitySvc SecurityBanService, profileID *string, reason, message string) {
+	logAuthFailureForEntity(c, auditSvc, securitySvc, profileID, "api_key", reason, message)
+}
+
+func logOAuthAuthFailure(c echo.Context, auditSvc service.AuditService, securitySvc SecurityBanService, profileID *string, reason, message string) {
+	logAuthFailureForEntity(c, auditSvc, securitySvc, profileID, "oauth", reason, message)
+}
+
+func logAuthFailureForEntity(c echo.Context, auditSvc service.AuditService, securitySvc SecurityBanService, profileID *string, entityType, reason, message string) {
 	if securitySvc != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if _, err := securitySvc.RecordAuthFailure(ctx, c.RealIP(), authFailureSurface(c), reason); err != nil {
@@ -599,7 +607,7 @@ func logAuthFailure(c echo.Context, auditSvc service.AuditService, securitySvc S
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_ = auditSvc.AuthFailure(ctx, profileID, "api_key", "", metadata, clientIP, correlationID)
+	_ = auditSvc.AuthFailure(ctx, profileID, entityType, "", metadata, clientIP, correlationID)
 }
 
 func authFailureSurface(c echo.Context) string {

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -92,11 +92,16 @@ type UserPortalSessionAuthenticator interface {
 	AuthenticateSession(ctx context.Context, sessionToken, csrfToken string, requireCSRF bool) (*domain.AuthenticatedActor, error)
 }
 
+type OAuthBearerAuthenticator interface {
+	AuthenticateOAuthBearer(ctx context.Context, rawToken string, pathTeamID *uuid.UUID) (*domain.AuthenticatedActor, error)
+}
+
 type AuthOptions struct {
 	CredentialVerifier             crypto.CredentialVerifier
 	SSOEntitlementValidator        SSOEntitlementValidator
 	SSOSessionAuthenticator        SSOSessionAuthenticator
 	UserPortalSessionAuthenticator UserPortalSessionAuthenticator
+	OAuthBearerAuthenticator       OAuthBearerAuthenticator
 	AllowMissingCredentials        bool
 }
 
@@ -154,6 +159,33 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 			if rawKey == "" {
 				logAuthFailure(c, auditSvc, securitySvc, nil, "AUTH_INVALID", "empty bearer token")
 				return httperr.New(httperr.AUTH_INVALID, "empty bearer token")
+			}
+
+			pathTeamID, err := authenticatedPathTeamID(c)
+			if err != nil {
+				logAuthFailure(c, auditSvc, securitySvc, nil, "TEAM_PATH_INVALID", "malformed scoped mcp team ID")
+				return err
+			}
+			if service.IsJWTBearer(rawKey) {
+				if opts.OAuthBearerAuthenticator == nil {
+					logAuthFailure(c, auditSvc, securitySvc, nil, "OAUTH_INVALID", "oauth bearer authentication is unavailable")
+					return httperr.New(httperr.AUTH_INVALID, "invalid bearer token")
+				}
+				actor, err := opts.OAuthBearerAuthenticator.AuthenticateOAuthBearer(c.Request().Context(), rawKey, pathTeamID)
+				if err != nil {
+					logAuthFailure(c, auditSvc, securitySvc, nil, "OAUTH_DENIED", "oauth bearer authentication failed")
+					return oauthAuthError(err)
+				}
+				principal, actorContext, err := principalAndActorContext(actor, "oauth", "")
+				if err != nil {
+					return err
+				}
+				ctx := context.WithValue(c.Request().Context(), principalContextKey{}, principal)
+				ctx = requestctx.WithActor(ctx, actorContext)
+				req := c.Request().Clone(ctx)
+				req.Header.Del("Authorization")
+				c.SetRequest(req)
+				return next(c)
 			}
 
 			prefixes := crypto.GetLookupPrefixes(rawKey)
@@ -237,6 +269,11 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 				logAuthFailure(c, auditSvc, securitySvc, nil, "AUTH_INVALID", "api credential is not team bound")
 				return httperr.New(httperr.AUTH_INVALID, "invalid api key")
 			}
+			if pathTeamID != nil && teamID != *pathTeamID {
+				teamIDStr := teamID.String()
+				logAuthFailure(c, auditSvc, securitySvc, &teamIDStr, "TEAM_PATH_MISMATCH", "scoped mcp team does not match credential")
+				return httperr.New(httperr.FORBIDDEN, "access denied to this team")
+			}
 
 			actor := authenticatedActorFromCredential(key)
 			principal, actorContext, err := principalAndActorContext(actor, "api_key", prefix)
@@ -253,6 +290,35 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 
 			return next(c)
 		}
+	}
+}
+
+func authenticatedPathTeamID(c echo.Context) (*uuid.UUID, error) {
+	raw := strings.TrimSpace(c.Param("teamId"))
+	if raw == "" {
+		return nil, nil
+	}
+	teamID, err := uuid.Parse(raw)
+	if err != nil || teamID == uuid.Nil {
+		return nil, httperr.New(httperr.INVALID_UUID, "invalid team ID format")
+	}
+	return &teamID, nil
+}
+
+func oauthAuthError(err error) error {
+	switch {
+	case errors.Is(err, service.ErrOAuthTokenExpired):
+		return httperr.New(httperr.AUTH_EXPIRED, "oauth access token expired")
+	case errors.Is(err, service.ErrOAuthTokenInvalid):
+		return httperr.New(httperr.AUTH_INVALID, "invalid oauth access token")
+	case errors.Is(err, service.ErrOAuthTeamRequired):
+		return httperr.New(httperr.TEAM_REQUIRED, "use /teams/{team_id}/mcp or supply the configured team claim")
+	case errors.Is(err, service.ErrOAuthAccessDenied):
+		return httperr.New(httperr.FORBIDDEN, "oauth membership access denied")
+	case errors.Is(err, service.ErrOAuthProviderUnavailable):
+		return httperr.New(httperr.SERVICE_UNAVAILABLE, "oauth provider unavailable")
+	default:
+		return httperr.New(httperr.INTERNAL_ERROR, "oauth authentication failed")
 	}
 }
 
@@ -535,7 +601,7 @@ func authFailureSurface(c echo.Context) string {
 	if path == "" {
 		path = c.Request().URL.Path
 	}
-	if strings.HasPrefix(path, "/mcp") {
+	if strings.HasPrefix(path, "/mcp") || (strings.HasPrefix(path, "/teams/") && strings.HasSuffix(path, "/mcp")) {
 		return "mcp"
 	}
 	return "api"

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -174,7 +174,7 @@ func AuthMiddlewareWithOptions(repo repository.CredentialRepository, auditSvc se
 				actor, err := opts.OAuthBearerAuthenticator.AuthenticateOAuthBearer(c.Request().Context(), rawKey, pathTeamID)
 				if err != nil {
 					failureSecurity := securitySvc
-					if errors.Is(err, service.ErrOAuthProviderUnavailable) {
+					if errors.Is(err, service.ErrOAuthProviderUnavailable) || errors.Is(err, service.ErrOAuthTeamRequired) {
 						failureSecurity = nil
 					}
 					logAuthFailure(c, auditSvc, failureSecurity, nil, "OAUTH_DENIED", "oauth bearer authentication failed")

--- a/internal/http/middleware/auth_sso_test.go
+++ b/internal/http/middleware/auth_sso_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -253,7 +254,7 @@ func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 	}{
 		{name: "expired", err: service.ErrOAuthTokenExpired, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_EXPIRED", wantSecurityFailure: true},
 		{name: "invalid", err: service.ErrOAuthTokenInvalid, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_INVALID", wantSecurityFailure: true},
-		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required", wantSecurityFailure: true},
+		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required"},
 		{name: "membership denied", err: service.ErrOAuthAccessDenied, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN", wantSecurityFailure: true},
 		{name: "provider unavailable", err: service.ErrOAuthProviderUnavailable, wantStatus: http.StatusServiceUnavailable, wantCode: "SERVICE_UNAVAILABLE"},
 		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR", wantSecurityFailure: true},
@@ -279,6 +280,48 @@ func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 			assert.Equal(t, test.wantSecurityFailure, security.recordAuthFailureCalled)
 		})
 	}
+}
+
+func TestAuthMiddlewareOAuthTeamRequiredDoesNotCountTowardAutomaticBan(t *testing.T) {
+	securityRepo := newOAuthAuthSecurityRepository(2)
+	security := service.NewSecurityService(securityRepo, nil)
+	audit := &mockAuditService{}
+	authenticator := &stubOAuthBearerAuthenticator{err: service.ErrOAuthTeamRequired}
+	e := newTestEcho()
+	e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, audit, security, AuthOptions{
+		OAuthBearerAuthenticator: authenticator,
+	}))
+	e.GET("/mcp", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	request := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req.RemoteAddr = "192.0.2.10:12345"
+		req.Header.Set("Authorization", "Bearer header.payload.signature")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec
+	}
+
+	for range 2 {
+		rec := request()
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"code":"team_required"`)
+		assert.True(t, audit.authFailureCalled)
+		audit.authFailureCalled = false
+	}
+	assert.Empty(t, securityRepo.failures)
+	assert.Empty(t, securityRepo.bans)
+
+	authenticator.err = service.ErrOAuthTokenInvalid
+	for range 2 {
+		rec := request()
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"code":"AUTH_INVALID"`)
+		assert.True(t, audit.authFailureCalled)
+		audit.authFailureCalled = false
+	}
+	assert.Equal(t, 2, securityRepo.failures["192.0.2.10"])
+	assert.Contains(t, securityRepo.bans, "192.0.2.10")
 }
 
 func TestAuthMiddlewareStaticCredentialMustMatchScopedTeam(t *testing.T) {
@@ -331,4 +374,70 @@ func TestAuthMiddlewareOAuthOnlyRejectsBrowserCookies(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Zero(t, authenticator.calls)
+}
+
+type oauthAuthSecurityRepository struct {
+	settings domain.SecuritySettings
+	failures map[string]int
+	bans     map[string]*domain.SecurityIPBan
+}
+
+func newOAuthAuthSecurityRepository(failureThreshold int) *oauthAuthSecurityRepository {
+	return &oauthAuthSecurityRepository{
+		settings: domain.SecuritySettings{
+			Enabled:              true,
+			FailureThreshold:     failureThreshold,
+			FailureWindowSeconds: 600,
+		},
+		failures: map[string]int{},
+		bans:     map[string]*domain.SecurityIPBan{},
+	}
+}
+
+func (r *oauthAuthSecurityRepository) GetSettings(context.Context) (*domain.SecuritySettings, error) {
+	settings := r.settings
+	return &settings, nil
+}
+
+func (r *oauthAuthSecurityRepository) UpdateSettings(_ context.Context, settings domain.SecuritySettings) (*domain.SecuritySettings, error) {
+	r.settings = settings
+	return &settings, nil
+}
+
+func (r *oauthAuthSecurityRepository) GetActiveBan(_ context.Context, ip string, now time.Time) (*domain.SecurityIPBan, error) {
+	ban := r.bans[ip]
+	if ban == nil || !ban.ActiveAt(now) {
+		return nil, nil
+	}
+	copy := *ban
+	return &copy, nil
+}
+
+func (r *oauthAuthSecurityRepository) RecordFailure(_ context.Context, ip, surface, reason string, _ int, now time.Time) (*domain.SecurityIPFailure, error) {
+	r.failures[ip]++
+	return &domain.SecurityIPFailure{
+		IP:            ip,
+		FailureCount:  r.failures[ip],
+		FirstFailedAt: now,
+		LastFailedAt:  now,
+		LastReason:    reason,
+		LastSurface:   surface,
+		UpdatedAt:     now,
+	}, nil
+}
+
+func (r *oauthAuthSecurityRepository) UpsertBan(_ context.Context, ban *domain.SecurityIPBan) error {
+	copy := *ban
+	r.bans[ban.IP] = &copy
+	return nil
+}
+
+func (r *oauthAuthSecurityRepository) ListBans(context.Context, bool, int, int) ([]domain.SecurityIPBan, int64, error) {
+	return nil, int64(len(r.bans)), nil
+}
+
+func (r *oauthAuthSecurityRepository) DeleteBan(_ context.Context, ip string, _ time.Time) error {
+	delete(r.bans, ip)
+	delete(r.failures, ip)
+	return nil
 }

--- a/internal/http/middleware/auth_sso_test.go
+++ b/internal/http/middleware/auth_sso_test.go
@@ -257,7 +257,7 @@ func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required"},
 		{name: "membership denied", err: service.ErrOAuthAccessDenied, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN", wantSecurityFailure: true},
 		{name: "provider unavailable", err: service.ErrOAuthProviderUnavailable, wantStatus: http.StatusServiceUnavailable, wantCode: "SERVICE_UNAVAILABLE"},
-		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR", wantSecurityFailure: true},
+		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR"},
 	}
 
 	for _, test := range tests {
@@ -306,6 +306,17 @@ func TestAuthMiddlewareOAuthTeamRequiredDoesNotCountTowardAutomaticBan(t *testin
 		rec := request()
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		assert.Contains(t, rec.Body.String(), `"code":"team_required"`)
+		assert.True(t, audit.authFailureCalled)
+		audit.authFailureCalled = false
+	}
+	assert.Empty(t, securityRepo.failures)
+	assert.Empty(t, securityRepo.bans)
+
+	authenticator.err = errors.New("repository unavailable")
+	for range 2 {
+		rec := request()
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"code":"INTERNAL_ERROR"`)
 		assert.True(t, audit.authFailureCalled)
 		audit.authFailureCalled = false
 	}

--- a/internal/http/middleware/auth_sso_test.go
+++ b/internal/http/middleware/auth_sso_test.go
@@ -245,23 +245,26 @@ func TestAuthMiddlewareOAuthBearerSetsImmutablePrincipal(t *testing.T) {
 
 func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 	tests := []struct {
-		name       string
-		err        error
-		wantStatus int
-		wantCode   string
+		name                string
+		err                 error
+		wantStatus          int
+		wantCode            string
+		wantSecurityFailure bool
 	}{
-		{name: "expired", err: service.ErrOAuthTokenExpired, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_EXPIRED"},
-		{name: "invalid", err: service.ErrOAuthTokenInvalid, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_INVALID"},
-		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required"},
-		{name: "membership denied", err: service.ErrOAuthAccessDenied, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN"},
+		{name: "expired", err: service.ErrOAuthTokenExpired, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_EXPIRED", wantSecurityFailure: true},
+		{name: "invalid", err: service.ErrOAuthTokenInvalid, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_INVALID", wantSecurityFailure: true},
+		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required", wantSecurityFailure: true},
+		{name: "membership denied", err: service.ErrOAuthAccessDenied, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN", wantSecurityFailure: true},
 		{name: "provider unavailable", err: service.ErrOAuthProviderUnavailable, wantStatus: http.StatusServiceUnavailable, wantCode: "SERVICE_UNAVAILABLE"},
-		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR"},
+		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR", wantSecurityFailure: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			audit := &mockAuditService{}
+			security := &mockSecurityService{}
 			e := newTestEcho()
-			e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, nil, nil, AuthOptions{
+			e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, audit, security, AuthOptions{
 				OAuthBearerAuthenticator: &stubOAuthBearerAuthenticator{err: test.err},
 			}))
 			e.GET("/mcp", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
@@ -272,6 +275,8 @@ func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 			assert.Equal(t, test.wantStatus, rec.Code)
 			assert.Contains(t, rec.Body.String(), `"code":"`+test.wantCode+`"`)
 			assert.NotContains(t, rec.Body.String(), "backend details")
+			assert.True(t, audit.authFailureCalled)
+			assert.Equal(t, test.wantSecurityFailure, security.recordAuthFailureCalled)
 		})
 	}
 }

--- a/internal/http/middleware/auth_sso_test.go
+++ b/internal/http/middleware/auth_sso_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,24 @@ type stubCredentialVerifier struct {
 
 func (s stubCredentialVerifier) Verify(context.Context, string, string) (bool, error) {
 	return s.valid, s.err
+}
+
+type stubOAuthBearerAuthenticator struct {
+	actor      *domain.AuthenticatedActor
+	err        error
+	rawToken   string
+	pathTeamID *uuid.UUID
+	calls      int
+}
+
+func (s *stubOAuthBearerAuthenticator) AuthenticateOAuthBearer(_ context.Context, rawToken string, pathTeamID *uuid.UUID) (*domain.AuthenticatedActor, error) {
+	s.calls++
+	s.rawToken = rawToken
+	if pathTeamID != nil {
+		teamID := *pathTeamID
+		s.pathTeamID = &teamID
+	}
+	return s.actor, s.err
 }
 
 func TestAuthMiddlewareRejectsCredentialVerificationAndEntitlementFailures(t *testing.T) {
@@ -156,4 +175,155 @@ func TestAuthMiddleware_OptionalMissingCredentialsHasNoFailureSideEffects(t *tes
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.False(t, mockAudit.authFailureCalled)
 	assert.False(t, mockSecurity.recordAuthFailureCalled)
+}
+
+func TestAuthMiddleware_MalformedScopedTeamRecordsAuthFailure(t *testing.T) {
+	e := newTestEcho()
+	mockAudit := &mockAuditService{}
+	mockSecurity := &mockSecurityService{}
+	e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, mockAudit, mockSecurity, AuthOptions{}))
+	e.GET("/teams/:teamId/mcp", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/teams/not-a-uuid/mcp", nil)
+	req.Header.Set("Authorization", "Bearer header.payload.signature")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_UUID")
+	assert.True(t, mockAudit.authFailureCalled)
+	assert.True(t, mockSecurity.recordAuthFailureCalled)
+	assert.Equal(t, "TEAM_PATH_INVALID", mockSecurity.recordAuthFailureReason)
+}
+
+func TestAuthMiddlewareOAuthBearerSetsImmutablePrincipal(t *testing.T) {
+	teamID := uuid.New()
+	identityID := uuid.New()
+	membershipID := uuid.New()
+	ownerID := uuid.New()
+	providerID := uuid.New()
+	actor := testSSOActor(teamID, identityID, membershipID, ownerID, &providerID, []string{"read"})
+	actor.Membership.MemorySpaceID = uuid.New()
+	authenticator := &stubOAuthBearerAuthenticator{actor: actor}
+	e := newTestEcho()
+	e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, nil, nil, AuthOptions{
+		OAuthBearerAuthenticator: authenticator,
+	}))
+	e.GET("/teams/:teamId/mcp", func(c echo.Context) error {
+		principal := GetPrincipal(c.Request().Context())
+		assert.NotNil(t, principal)
+		assert.Equal(t, teamID, principal.TeamID)
+		assert.Equal(t, identityID, principal.IdentityID)
+		assert.Equal(t, membershipID, principal.MembershipID)
+		assert.Equal(t, ownerID, principal.OwnerID)
+		assert.Equal(t, "oauth", principal.AuthMethod)
+		assert.Nil(t, principal.CredentialID)
+		assert.Equal(t, []string{"read"}, principal.Grants)
+		assert.Equal(t, []domain.MemorySpaceAccess{
+			{ID: uuid.Nil, Kind: domain.MemorySpaceTeamShared},
+			{ID: actor.Membership.MemorySpaceID, Kind: domain.MemorySpaceProfilePrivate},
+		}, principal.AllowedSpaces)
+		assert.Empty(t, c.Request().Header.Get("Authorization"))
+		return c.NoContent(http.StatusOK)
+	})
+
+	rawToken := "header.payload.signature"
+	req := httptest.NewRequest(http.MethodGet, "/teams/"+teamID.String()+"/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, authenticator.calls)
+	assert.Equal(t, rawToken, authenticator.rawToken)
+	if assert.NotNil(t, authenticator.pathTeamID) {
+		assert.Equal(t, teamID, *authenticator.pathTeamID)
+	}
+}
+
+func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "expired", err: service.ErrOAuthTokenExpired, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_EXPIRED"},
+		{name: "invalid", err: service.ErrOAuthTokenInvalid, wantStatus: http.StatusUnauthorized, wantCode: "AUTH_INVALID"},
+		{name: "ambiguous team", err: service.ErrOAuthTeamRequired, wantStatus: http.StatusBadRequest, wantCode: "team_required"},
+		{name: "membership denied", err: service.ErrOAuthAccessDenied, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN"},
+		{name: "provider unavailable", err: service.ErrOAuthProviderUnavailable, wantStatus: http.StatusServiceUnavailable, wantCode: "SERVICE_UNAVAILABLE"},
+		{name: "unknown", err: errors.New("backend details"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := newTestEcho()
+			e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, nil, nil, AuthOptions{
+				OAuthBearerAuthenticator: &stubOAuthBearerAuthenticator{err: test.err},
+			}))
+			e.GET("/mcp", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+			req.Header.Set("Authorization", "Bearer header.payload.signature")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			assert.Equal(t, test.wantStatus, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"code":"`+test.wantCode+`"`)
+			assert.NotContains(t, rec.Body.String(), "backend details")
+		})
+	}
+}
+
+func TestAuthMiddlewareStaticCredentialMustMatchScopedTeam(t *testing.T) {
+	credentialTeamID := uuid.New()
+	credentialID := uuid.New()
+	rawKey := "testprefix12345678901234567890"
+	credential := testCredential(credentialID, credentialTeamID)
+	credential.Name = "Static MCP credential"
+	credential.KeyHash = "encoded-hash"
+	credential.KeyPrefix = crypto.GetKeyPrefix(rawKey)
+	credential.Scopes = []string{"read"}
+	credential.Role = service.CredentialRoleMember
+
+	for _, test := range []struct {
+		name       string
+		pathTeamID uuid.UUID
+		wantStatus int
+	}{
+		{name: "match", pathTeamID: credentialTeamID, wantStatus: http.StatusOK},
+		{name: "mismatch", pathTeamID: uuid.New(), wantStatus: http.StatusForbidden},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := newTestEcho()
+			e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{getActiveByPrefixFunc: func(context.Context, string) (*domain.Credential, error) {
+				copy := *credential
+				return &copy, nil
+			}}, nil, nil, AuthOptions{CredentialVerifier: stubCredentialVerifier{valid: true}}))
+			e.GET("/teams/:teamId/mcp", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+			req := httptest.NewRequest(http.MethodGet, "/teams/"+test.pathTeamID.String()+"/mcp", nil)
+			req.Header.Set("Authorization", "Bearer "+rawKey)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			assert.Equal(t, test.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestAuthMiddlewareOAuthOnlyRejectsBrowserCookies(t *testing.T) {
+	authenticator := &stubOAuthBearerAuthenticator{}
+	e := newTestEcho()
+	e.Use(AuthMiddlewareWithOptions(&mockCredentialRepository{}, nil, nil, AuthOptions{
+		OAuthBearerAuthenticator: authenticator,
+	}))
+	e.GET("/mcp", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.AddCookie(&http.Cookie{Name: service.SSOSessionCookieName, Value: "sso-session"})
+	req.AddCookie(&http.Cookie{Name: service.UserPortalSessionCookieName, Value: "portal-session"})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Zero(t, authenticator.calls)
 }

--- a/internal/http/middleware/auth_sso_test.go
+++ b/internal/http/middleware/auth_sso_test.go
@@ -277,6 +277,7 @@ func TestAuthMiddlewareOAuthBearerMapsBoundedErrors(t *testing.T) {
 			assert.Contains(t, rec.Body.String(), `"code":"`+test.wantCode+`"`)
 			assert.NotContains(t, rec.Body.String(), "backend details")
 			assert.True(t, audit.authFailureCalled)
+			assert.Equal(t, "oauth", audit.authFailureParams.entityType)
 			assert.Equal(t, test.wantSecurityFailure, security.recordAuthFailureCalled)
 		})
 	}

--- a/internal/http/middleware/rate_limit.go
+++ b/internal/http/middleware/rate_limit.go
@@ -31,7 +31,7 @@ func RateLimitMiddleware(svc service.RateLimitServiceInterface, cfg config.Confi
 			ownerID := principal.OwnerID.String()
 
 			// Get route path for stable bucket
-			routePath := c.Path()
+			routePath := rateLimitRoutePath(c.Path())
 
 			limit := selectRateLimit(cfg)
 			if principal.RateLimit > 0 && principal.RateLimit < limit {
@@ -72,6 +72,15 @@ func RateLimitMiddleware(svc service.RateLimitServiceInterface, cfg config.Confi
 
 			return next(c)
 		}
+	}
+}
+
+func rateLimitRoutePath(routePath string) string {
+	switch routePath {
+	case "/mcp", "/teams/:teamId/mcp":
+		return "/mcp"
+	default:
+		return routePath
 	}
 }
 

--- a/internal/http/middleware/rate_limit_test.go
+++ b/internal/http/middleware/rate_limit_test.go
@@ -117,6 +117,29 @@ func TestRateLimitMiddleware_Contract_InMemory(t *testing.T) {
 	runRateLimitMiddlewareContract(t, "InMemory", svc)
 }
 
+func TestRateLimitMiddlewareSharesMCPRouteAliasBucket(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	e.Use(RateLimitMiddleware(service.NewRateLimitService(inmem.NewInMemoryRateLimitStore()), &testRateLimitConfig{rateLimitPerMinute: 1}, nil))
+	handler := func(c echo.Context) error { return c.NoContent(http.StatusOK) }
+	e.GET("/mcp", handler)
+	e.GET("/teams/:teamId/mcp", handler)
+	e.GET("/ui/api/other", handler)
+
+	principal := &Principal{CredentialID: testUUIDPtr(uuid.New()), OwnerID: uuid.New()}
+	request := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(SetPrincipalForTest(req.Context(), principal))
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	assert.Equal(t, http.StatusOK, request("/mcp").Code)
+	assert.Equal(t, http.StatusTooManyRequests, request("/teams/"+uuid.NewString()+"/mcp").Code)
+	assert.Equal(t, http.StatusOK, request("/ui/api/other").Code)
+}
+
 // redisRateLimitConfig implements config.ConfigProvider for Redis-backed rate limit tests.
 type redisRateLimitConfig struct {
 	addr               string

--- a/internal/http/middleware/team_resolution.go
+++ b/internal/http/middleware/team_resolution.go
@@ -34,6 +34,9 @@ type ResolvedTeamContext struct {
 }
 
 func isTeamResolvedRoute(path string) bool {
+	if isScopedMCPRoute(path) {
+		return true
+	}
 	headerScopedPrefixes := []string{
 		"/mcp",
 		"/ui/api/recall",
@@ -48,6 +51,11 @@ func isTeamResolvedRoute(path string) bool {
 	}
 
 	return false
+}
+
+func isScopedMCPRoute(path string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	return len(parts) == 3 && parts[0] == "teams" && parts[1] != "" && parts[2] == "mcp"
 }
 
 // TeamResolutionMiddleware resolves the authenticated team for MCP and

--- a/internal/http/oauth_protected_resource.go
+++ b/internal/http/oauth_protected_resource.go
@@ -1,0 +1,160 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+type OAuthProtectedResourceProvider interface {
+	OAuthProtectedResourceMetadata(context.Context) (service.OAuthProtectedResourceMetadata, error)
+	MCPPublicBaseURL(context.Context) (string, error)
+}
+
+type oauthProtectedResourceDocument struct {
+	Resource             string   `json:"resource"`
+	ResourceName         string   `json:"resource_name"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported"`
+	BearerMethods        []string `json:"bearer_methods_supported"`
+}
+
+func RegisterOAuthProtectedResourceRoutes(e *echo.Echo, provider OAuthProtectedResourceProvider) {
+	if e == nil || provider == nil {
+		return
+	}
+	handler := oauthProtectedResourceMetadataHandler(provider)
+	e.GET("/.well-known/oauth-protected-resource/mcp", handler)
+	e.GET("/.well-known/oauth-protected-resource/teams/:teamId/mcp", handler)
+}
+
+func oauthProtectedResourceMetadataHandler(provider OAuthProtectedResourceProvider) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		teamID, err := oauthMetadataTeamID(c)
+		if err != nil {
+			return err
+		}
+		metadata, err := provider.OAuthProtectedResourceMetadata(c.Request().Context())
+		if err != nil {
+			return httperr.New(httperr.SERVICE_UNAVAILABLE, "oauth resource metadata unavailable")
+		}
+		if len(metadata.AuthorizationServers) == 0 {
+			return httperr.New(httperr.NOT_FOUND, "oauth protected resource is not configured")
+		}
+		resourceURL := oauthResourceURL(c, provider, teamID)
+		if resourceURL == "" {
+			return httperr.New(httperr.SERVICE_UNAVAILABLE, "oauth resource metadata unavailable")
+		}
+		c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+		return c.JSON(nethttp.StatusOK, oauthProtectedResourceDocument{
+			Resource:             resourceURL,
+			ResourceName:         "Dense-Mem MCP",
+			AuthorizationServers: metadata.AuthorizationServers,
+			ScopesSupported:      metadata.ScopesSupported,
+			BearerMethods:        []string{"header"},
+		})
+	}
+}
+
+func oauthProtectedResourceChallenge(provider OAuthProtectedResourceProvider) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			err := next(c)
+			if err == nil || provider == nil || oauthErrorStatus(err) != nethttp.StatusUnauthorized {
+				return err
+			}
+			metadata, metadataErr := provider.OAuthProtectedResourceMetadata(c.Request().Context())
+			if metadataErr != nil || len(metadata.AuthorizationServers) == 0 {
+				return err
+			}
+			teamID, teamErr := oauthRequestTeamID(c)
+			if teamErr != nil {
+				return err
+			}
+			metadataURL := oauthResourceMetadataURL(c, provider, teamID)
+			if metadataURL != "" {
+				c.Response().Header().Set(echo.HeaderWWWAuthenticate, fmt.Sprintf("Bearer resource_metadata=%q", metadataURL))
+			}
+			return err
+		}
+	}
+}
+
+func oauthErrorStatus(err error) int {
+	var apiErr *httperr.APIError
+	if errors.As(err, &apiErr) {
+		return httperr.HTTPStatusCode(apiErr.Code)
+	}
+	var echoErr *echo.HTTPError
+	if errors.As(err, &echoErr) {
+		return echoErr.Code
+	}
+	return nethttp.StatusInternalServerError
+}
+
+func oauthMetadataTeamID(c echo.Context) (*uuid.UUID, error) {
+	raw := strings.TrimSpace(c.Param("teamId"))
+	if raw == "" {
+		return nil, nil
+	}
+	teamID, err := uuid.Parse(raw)
+	if err != nil || teamID == uuid.Nil {
+		return nil, httperr.New(httperr.INVALID_UUID, "invalid team ID format")
+	}
+	return &teamID, nil
+}
+
+func oauthRequestTeamID(c echo.Context) (*uuid.UUID, error) {
+	if c.Path() != "/teams/:teamId/mcp" {
+		return nil, nil
+	}
+	return oauthMetadataTeamID(c)
+}
+
+func oauthResourceURL(c echo.Context, provider OAuthProtectedResourceProvider, teamID *uuid.UUID) string {
+	base := oauthPublicBaseURL(c, provider)
+	if base == "" {
+		return ""
+	}
+	if teamID != nil {
+		return base + "/teams/" + teamID.String() + "/mcp"
+	}
+	return base + "/mcp"
+}
+
+func oauthResourceMetadataURL(c echo.Context, provider OAuthProtectedResourceProvider, teamID *uuid.UUID) string {
+	base := oauthPublicBaseURL(c, provider)
+	if base == "" {
+		return ""
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
+		return ""
+	}
+	resourcePath := strings.TrimSuffix(parsed.Path, "/")
+	if teamID != nil {
+		resourcePath += "/teams/" + teamID.String() + "/mcp"
+	} else {
+		resourcePath += "/mcp"
+	}
+	parsed.Path = "/.well-known/oauth-protected-resource" + resourcePath
+	parsed.RawPath = ""
+	return parsed.String()
+}
+
+func oauthPublicBaseURL(c echo.Context, provider OAuthProtectedResourceProvider) string {
+	configured, err := provider.MCPPublicBaseURL(c.Request().Context())
+	if err != nil || strings.TrimSpace(configured) == "" {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(configured), "/")
+}

--- a/internal/http/oauth_protected_resource.go
+++ b/internal/http/oauth_protected_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	nethttp "net/http"
 	"net/url"
 	"strings"
@@ -28,21 +29,23 @@ type oauthProtectedResourceDocument struct {
 	BearerMethods        []string `json:"bearer_methods_supported"`
 }
 
+const (
+	oauthProtectedResourceMetadataPrefix        = "/.well-known/oauth-protected-resource"
+	oauthProtectedResourceMetadataWildcardRoute = oauthProtectedResourceMetadataPrefix + "/*"
+)
+
 func RegisterOAuthProtectedResourceRoutes(e *echo.Echo, provider OAuthProtectedResourceProvider) {
 	if e == nil || provider == nil {
 		return
 	}
 	handler := oauthProtectedResourceMetadataHandler(provider)
-	e.GET("/.well-known/oauth-protected-resource/mcp", handler)
-	e.GET("/.well-known/oauth-protected-resource/teams/:teamId/mcp", handler)
+	e.GET(oauthProtectedResourceMetadataPrefix+"/mcp", handler)
+	e.GET(oauthProtectedResourceMetadataPrefix+"/teams/:teamId/mcp", handler)
+	e.GET(oauthProtectedResourceMetadataWildcardRoute, handler)
 }
 
 func oauthProtectedResourceMetadataHandler(provider OAuthProtectedResourceProvider) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		teamID, err := oauthMetadataTeamID(c)
-		if err != nil {
-			return err
-		}
 		metadata, err := provider.OAuthProtectedResourceMetadata(c.Request().Context())
 		if err != nil {
 			return httperr.New(httperr.SERVICE_UNAVAILABLE, "oauth resource metadata unavailable")
@@ -50,13 +53,21 @@ func oauthProtectedResourceMetadataHandler(provider OAuthProtectedResourceProvid
 		if len(metadata.AuthorizationServers) == 0 {
 			return httperr.New(httperr.NOT_FOUND, "oauth protected resource is not configured")
 		}
-		resourceURL := oauthResourceURL(c, provider, teamID)
-		if resourceURL == "" {
+		base := oauthPublicBaseURL(c, provider)
+		if base == nil {
 			return httperr.New(httperr.SERVICE_UNAVAILABLE, "oauth resource metadata unavailable")
+		}
+		teamID, err := oauthMetadataTeamID(c, base.Path)
+		if err != nil {
+			return err
+		}
+		resourceURL, metadataURL := oauthResourceURLs(base, teamID)
+		if c.Path() == oauthProtectedResourceMetadataWildcardRoute && c.Request().URL.Path != metadataURL.Path {
+			return httperr.New(httperr.NOT_FOUND, "oauth protected resource metadata not found")
 		}
 		c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
 		return c.JSON(nethttp.StatusOK, oauthProtectedResourceDocument{
-			Resource:             resourceURL,
+			Resource:             resourceURL.String(),
 			ResourceName:         "Dense-Mem MCP",
 			AuthorizationServers: metadata.AuthorizationServers,
 			ScopesSupported:      metadata.ScopesSupported,
@@ -80,9 +91,10 @@ func oauthProtectedResourceChallenge(provider OAuthProtectedResourceProvider) ec
 			if teamErr != nil {
 				return err
 			}
-			metadataURL := oauthResourceMetadataURL(c, provider, teamID)
-			if metadataURL != "" {
-				c.Response().Header().Set(echo.HeaderWWWAuthenticate, fmt.Sprintf("Bearer resource_metadata=%q", metadataURL))
+			base := oauthPublicBaseURL(c, provider)
+			if base != nil {
+				_, metadataURL := oauthResourceURLs(base, teamID)
+				c.Response().Header().Set(echo.HeaderWWWAuthenticate, fmt.Sprintf("Bearer resource_metadata=%q", metadataURL.String()))
 			}
 			return err
 		}
@@ -101,7 +113,31 @@ func oauthErrorStatus(err error) int {
 	return nethttp.StatusInternalServerError
 }
 
-func oauthMetadataTeamID(c echo.Context) (*uuid.UUID, error) {
+func oauthMetadataTeamID(c echo.Context, basePath string) (*uuid.UUID, error) {
+	if c.Path() != oauthProtectedResourceMetadataWildcardRoute {
+		return oauthTeamIDParam(c)
+	}
+	requestPath := c.Request().URL.Path
+	configuredPrefix := oauthProtectedResourceMetadataPrefix + strings.TrimSuffix(basePath, "/")
+	relative, ok := strings.CutPrefix(requestPath, configuredPrefix)
+	if !ok {
+		return nil, httperr.New(httperr.NOT_FOUND, "oauth protected resource metadata not found")
+	}
+	if relative == "/mcp" {
+		return nil, nil
+	}
+	parts := strings.Split(strings.TrimPrefix(relative, "/"), "/")
+	if len(parts) != 3 || parts[0] != "teams" || parts[2] != "mcp" {
+		return nil, httperr.New(httperr.NOT_FOUND, "oauth protected resource metadata not found")
+	}
+	teamID, err := uuid.Parse(parts[1])
+	if err != nil || teamID == uuid.Nil {
+		return nil, httperr.New(httperr.INVALID_UUID, "invalid team ID format")
+	}
+	return &teamID, nil
+}
+
+func oauthTeamIDParam(c echo.Context) (*uuid.UUID, error) {
 	raw := strings.TrimSpace(c.Param("teamId"))
 	if raw == "" {
 		return nil, nil
@@ -117,44 +153,53 @@ func oauthRequestTeamID(c echo.Context) (*uuid.UUID, error) {
 	if c.Path() != "/teams/:teamId/mcp" {
 		return nil, nil
 	}
-	return oauthMetadataTeamID(c)
+	return oauthTeamIDParam(c)
 }
 
-func oauthResourceURL(c echo.Context, provider OAuthProtectedResourceProvider, teamID *uuid.UUID) string {
-	base := oauthPublicBaseURL(c, provider)
-	if base == "" {
-		return ""
-	}
-	if teamID != nil {
-		return base + "/teams/" + teamID.String() + "/mcp"
-	}
-	return base + "/mcp"
-}
-
-func oauthResourceMetadataURL(c echo.Context, provider OAuthProtectedResourceProvider, teamID *uuid.UUID) string {
-	base := oauthPublicBaseURL(c, provider)
-	if base == "" {
-		return ""
-	}
-	parsed, err := url.Parse(base)
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
-		return ""
-	}
-	resourcePath := strings.TrimSuffix(parsed.Path, "/")
+func oauthResourceURLs(base *url.URL, teamID *uuid.UUID) (*url.URL, *url.URL) {
+	resourcePath := strings.TrimSuffix(base.Path, "/")
 	if teamID != nil {
 		resourcePath += "/teams/" + teamID.String() + "/mcp"
 	} else {
 		resourcePath += "/mcp"
 	}
-	parsed.Path = "/.well-known/oauth-protected-resource" + resourcePath
-	parsed.RawPath = ""
-	return parsed.String()
+
+	resourceURL := *base
+	resourceURL.Path = resourcePath
+	resourceURL.RawPath = ""
+	metadataURL := *base
+	metadataURL.Path = oauthProtectedResourceMetadataPrefix + resourcePath
+	metadataURL.RawPath = ""
+	return &resourceURL, &metadataURL
 }
 
-func oauthPublicBaseURL(c echo.Context, provider OAuthProtectedResourceProvider) string {
+func oauthPublicBaseURL(c echo.Context, provider OAuthProtectedResourceProvider) *url.URL {
 	configured, err := provider.MCPPublicBaseURL(c.Request().Context())
 	if err != nil || strings.TrimSpace(configured) == "" {
-		return ""
+		return nil
 	}
-	return strings.TrimRight(strings.TrimSpace(configured), "/")
+	parsed, err := url.Parse(strings.TrimSpace(configured))
+	if err != nil || !oauthPublicBaseSchemeAllowed(parsed) || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" || parsed.RawPath != "" {
+		return nil
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+	return parsed
+}
+
+func oauthPublicBaseSchemeAllowed(parsed *url.URL) bool {
+	if parsed == nil {
+		return false
+	}
+	if parsed.Scheme == "https" {
+		return true
+	}
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := parsed.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/internal/http/oauth_protected_resource_test.go
+++ b/internal/http/oauth_protected_resource_test.go
@@ -1,0 +1,253 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	nethttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service"
+)
+
+func TestOAuthProtectedResourceMetadataRoutes(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	provider := &oauthMetadataStub{
+		baseURL: "https://memory.example.test/",
+		metadata: service.OAuthProtectedResourceMetadata{
+			AuthorizationServers: []string{"https://idp.example.test"},
+			ScopesSupported:      []string{"densemem.read", "densemem.write"},
+		},
+	}
+	RegisterOAuthProtectedResourceRoutes(e, provider)
+
+	t.Run("unscoped", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+		require.Equal(t, nethttp.StatusOK, recorder.Code)
+		var body oauthProtectedResourceDocument
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+		require.Equal(t, "https://memory.example.test/mcp", body.Resource)
+		require.Equal(t, provider.metadata.AuthorizationServers, body.AuthorizationServers)
+		require.Equal(t, provider.metadata.ScopesSupported, body.ScopesSupported)
+		require.Equal(t, []string{"header"}, body.BearerMethods)
+		require.Equal(t, "no-store", recorder.Header().Get(echo.HeaderCacheControl))
+	})
+
+	t.Run("team scoped", func(t *testing.T) {
+		teamID := uuid.New()
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/teams/"+teamID.String()+"/mcp", nil))
+		require.Equal(t, nethttp.StatusOK, recorder.Code)
+		var body oauthProtectedResourceDocument
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+		require.Equal(t, "https://memory.example.test/teams/"+teamID.String()+"/mcp", body.Resource)
+	})
+
+	t.Run("invalid team", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/teams/not-a-uuid/mcp", nil))
+		require.Equal(t, nethttp.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("configured base path", func(t *testing.T) {
+		provider.baseURL = "https://memory.example.test/base/"
+		recorder := httptest.NewRecorder()
+		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+		require.Equal(t, nethttp.StatusOK, recorder.Code)
+		var body oauthProtectedResourceDocument
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+		require.Equal(t, "https://memory.example.test/base/mcp", body.Resource)
+	})
+}
+
+func TestOAuthProtectedResourceMetadataIsDormantWithoutEnabledProvider(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	RegisterOAuthProtectedResourceRoutes(e, &oauthMetadataStub{})
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+	require.Equal(t, nethttp.StatusNotFound, recorder.Code)
+}
+
+func TestOAuthProtectedResourceChallengeUsesMatchingMetadataDocument(t *testing.T) {
+	provider := &oauthMetadataStub{
+		baseURL:  "https://memory.example.test",
+		metadata: service.OAuthProtectedResourceMetadata{AuthorizationServers: []string{"https://idp.example.test"}},
+	}
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	RegisterProtectedRoutesWithHandlers(e, ProtectedDeps{OAuthMetadata: provider}, ProtectedHandlers{
+		MCPGet: func(c echo.Context) error { return c.NoContent(nethttp.StatusOK) },
+	})
+
+	tests := []struct {
+		name      string
+		baseURL   string
+		path      string
+		challenge string
+	}{
+		{name: "root unscoped", baseURL: "https://memory.example.test", path: "/mcp", challenge: `Bearer resource_metadata="https://memory.example.test/.well-known/oauth-protected-resource/mcp"`},
+		{name: "root team scoped", baseURL: "https://memory.example.test", path: "/teams/11111111-1111-4111-8111-111111111111/mcp", challenge: `Bearer resource_metadata="https://memory.example.test/.well-known/oauth-protected-resource/teams/11111111-1111-4111-8111-111111111111/mcp"`},
+		{name: "prefixed unscoped", baseURL: "https://memory.example.test/base", path: "/mcp", challenge: `Bearer resource_metadata="https://memory.example.test/.well-known/oauth-protected-resource/base/mcp"`},
+		{name: "prefixed team scoped", baseURL: "https://memory.example.test/base", path: "/teams/11111111-1111-4111-8111-111111111111/mcp", challenge: `Bearer resource_metadata="https://memory.example.test/.well-known/oauth-protected-resource/base/teams/11111111-1111-4111-8111-111111111111/mcp"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider.baseURL = test.baseURL
+			recorder := httptest.NewRecorder()
+			e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, test.path, nil))
+			require.Equal(t, nethttp.StatusUnauthorized, recorder.Code)
+			require.Equal(t, test.challenge, recorder.Header().Get(echo.HeaderWWWAuthenticate))
+		})
+	}
+}
+
+func TestOAuthProtectedResourceMetadataRequiresConfiguredOrigin(t *testing.T) {
+	provider := &oauthMetadataStub{
+		metadata: service.OAuthProtectedResourceMetadata{
+			AuthorizationServers: []string{"https://idp.example.test"},
+		},
+	}
+	RegisterOAuthProtectedResourceRoutes(nil, provider)
+	e := echo.New()
+	e.HTTPErrorHandler = httperr.ErrorHandler
+	RegisterOAuthProtectedResourceRoutes(e, nil)
+	recorder := httptest.NewRecorder()
+	e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+	require.Equal(t, nethttp.StatusNotFound, recorder.Code)
+
+	RegisterOAuthProtectedResourceRoutes(e, provider)
+	provider.metadataErr = errors.New("metadata unavailable")
+	recorder = httptest.NewRecorder()
+	e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+	require.Equal(t, nethttp.StatusServiceUnavailable, recorder.Code)
+	provider.metadataErr = nil
+
+	provider.baseErr = errors.New("config unavailable")
+	recorder = httptest.NewRecorder()
+	e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "https://fallback.example.test/.well-known/oauth-protected-resource/mcp", nil))
+	require.Equal(t, nethttp.StatusServiceUnavailable, recorder.Code, recorder.Body.String())
+	require.Empty(t, recorder.Header().Get(echo.HeaderCacheControl))
+
+	request := httptest.NewRequest(nethttp.MethodGet, "https://fallback.example.test/.well-known/oauth-protected-resource/mcp", nil)
+	request.Host = "attacker.example.test"
+	recorder = httptest.NewRecorder()
+	e.ServeHTTP(recorder, request)
+	require.Equal(t, nethttp.StatusServiceUnavailable, recorder.Code)
+}
+
+func TestOAuthProtectedResourceChallengeSkipsNonOAuthFailureSurfaces(t *testing.T) {
+	provider := &oauthMetadataStub{
+		baseURL: "https://memory.example.test",
+		metadata: service.OAuthProtectedResourceMetadata{
+			AuthorizationServers: []string{"https://idp.example.test"},
+		},
+	}
+	tests := []struct {
+		name     string
+		provider OAuthProtectedResourceProvider
+		path     string
+		next     echo.HandlerFunc
+	}{
+		{
+			name:     "successful handler",
+			provider: provider,
+			next:     func(echo.Context) error { return nil },
+		},
+		{
+			name: "provider absent",
+			next: func(echo.Context) error { return httperr.New(httperr.AUTH_MISSING, "unauthorized") },
+		},
+		{
+			name:     "non unauthorized api error",
+			provider: provider,
+			next:     func(echo.Context) error { return httperr.New(httperr.FORBIDDEN, "forbidden") },
+		},
+		{
+			name:     "invalid scoped team",
+			provider: provider,
+			path:     "/teams/:teamId/mcp",
+			next:     func(echo.Context) error { return echo.NewHTTPError(nethttp.StatusUnauthorized) },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(nethttp.MethodGet, "/teams/invalid/mcp", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath(test.path)
+			if test.path != "" {
+				c.SetParamNames("teamId")
+				c.SetParamValues("invalid")
+			}
+			err := oauthProtectedResourceChallenge(test.provider)(test.next)(c)
+			if test.name == "successful handler" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			require.Empty(t, rec.Header().Get(echo.HeaderWWWAuthenticate))
+		})
+	}
+
+	provider.metadataErr = errors.New("metadata unavailable")
+	e := echo.New()
+	req := httptest.NewRequest(nethttp.MethodGet, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/mcp")
+	err := oauthProtectedResourceChallenge(provider)(func(echo.Context) error {
+		return echo.NewHTTPError(nethttp.StatusUnauthorized)
+	})(c)
+	require.Error(t, err)
+	require.Empty(t, rec.Header().Get(echo.HeaderWWWAuthenticate))
+
+	provider.metadataErr = nil
+	provider.metadata.AuthorizationServers = nil
+	err = oauthProtectedResourceChallenge(provider)(func(echo.Context) error {
+		return echo.NewHTTPError(nethttp.StatusUnauthorized)
+	})(c)
+	require.Error(t, err)
+	require.Empty(t, rec.Header().Get(echo.HeaderWWWAuthenticate))
+
+	provider.metadata.AuthorizationServers = []string{"https://idp.example.test"}
+	provider.baseURL = ""
+	provider.baseErr = errors.New("base URL unavailable")
+	req = httptest.NewRequest(nethttp.MethodGet, "/mcp", nil)
+	req.Host = ""
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	c.SetPath("/mcp")
+	err = oauthProtectedResourceChallenge(provider)(func(echo.Context) error {
+		return echo.NewHTTPError(nethttp.StatusUnauthorized)
+	})(c)
+	require.Error(t, err)
+	require.Empty(t, rec.Header().Get(echo.HeaderWWWAuthenticate))
+
+	require.Equal(t, nethttp.StatusInternalServerError, oauthErrorStatus(errors.New("unknown")))
+	require.Equal(t, nethttp.StatusUnauthorized, oauthErrorStatus(echo.NewHTTPError(nethttp.StatusUnauthorized)))
+}
+
+type oauthMetadataStub struct {
+	baseURL     string
+	metadata    service.OAuthProtectedResourceMetadata
+	metadataErr error
+	baseErr     error
+}
+
+func (s *oauthMetadataStub) OAuthProtectedResourceMetadata(context.Context) (service.OAuthProtectedResourceMetadata, error) {
+	return s.metadata, s.metadataErr
+}
+
+func (s *oauthMetadataStub) MCPPublicBaseURL(context.Context) (string, error) {
+	return s.baseURL, s.baseErr
+}

--- a/internal/http/oauth_protected_resource_test.go
+++ b/internal/http/oauth_protected_resource_test.go
@@ -59,12 +59,25 @@ func TestOAuthProtectedResourceMetadataRoutes(t *testing.T) {
 
 	t.Run("configured base path", func(t *testing.T) {
 		provider.baseURL = "https://memory.example.test/base/"
+		teamID := uuid.New()
+		for _, test := range []struct {
+			path     string
+			resource string
+		}{
+			{path: "/.well-known/oauth-protected-resource/base/mcp", resource: "https://memory.example.test/base/mcp"},
+			{path: "/.well-known/oauth-protected-resource/base/teams/" + teamID.String() + "/mcp", resource: "https://memory.example.test/base/teams/" + teamID.String() + "/mcp"},
+		} {
+			recorder := httptest.NewRecorder()
+			e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, test.path, nil))
+			require.Equal(t, nethttp.StatusOK, recorder.Code)
+			var body oauthProtectedResourceDocument
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+			require.Equal(t, test.resource, body.Resource)
+		}
+
 		recorder := httptest.NewRecorder()
-		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
-		require.Equal(t, nethttp.StatusOK, recorder.Code)
-		var body oauthProtectedResourceDocument
-		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
-		require.Equal(t, "https://memory.example.test/base/mcp", body.Resource)
+		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/wrong/mcp", nil))
+		require.Equal(t, nethttp.StatusNotFound, recorder.Code)
 	})
 }
 
@@ -139,8 +152,18 @@ func TestOAuthProtectedResourceMetadataRequiresConfiguredOrigin(t *testing.T) {
 
 	request := httptest.NewRequest(nethttp.MethodGet, "https://fallback.example.test/.well-known/oauth-protected-resource/mcp", nil)
 	request.Host = "attacker.example.test"
+	provider.baseErr = nil
+	provider.baseURL = "https://memory.example.test/base"
 	recorder = httptest.NewRecorder()
 	e.ServeHTTP(recorder, request)
+	require.Equal(t, nethttp.StatusOK, recorder.Code)
+	var body oauthProtectedResourceDocument
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "https://memory.example.test/base/mcp", body.Resource)
+
+	provider.baseURL = "ftp://memory.example.test"
+	recorder = httptest.NewRecorder()
+	e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
 	require.Equal(t, nethttp.StatusServiceUnavailable, recorder.Code)
 }
 

--- a/internal/http/oauth_protected_resource_test.go
+++ b/internal/http/oauth_protected_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 
+	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/service"
 )
@@ -88,6 +89,35 @@ func TestControlPortalRejectsInvalidOAuthProviderAlgorithm(t *testing.T) {
 	recorder := serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", body)
 	require.Equal(t, nethttp.StatusUnprocessableEntity, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "is not allowed")
+}
+
+func TestControlPortalLegacyProviderUpdatePreservesOAuthConfigWhenOmitted(t *testing.T) {
+	now := time.Now().UTC()
+	providerID := uuid.New()
+	provider := httpSSOProvider(providerID, "OAuth", now)
+	provider.ProtectedResource = domain.SSOProtectedResourceConfig{
+		Enabled: true,
+		OAuthProtectedResourceConfig: domain.OAuthProtectedResourceConfig{
+			Audiences:  []string{"dense-mem"},
+			JWKSSource: "static",
+			JWKSURI:    "https://idp.example.com/jwks",
+			Algorithms: []string{"RS256"},
+			ScopeClaim: "scope",
+		},
+	}
+	repo := &httpSSORepoStub{providers: map[uuid.UUID]*domain.SSOProvider{providerID: provider}, now: now}
+	server := controlPortalSSOServer(t, repo, now)
+	legacyBody := `{"name":"Renamed OAuth","kind":"generic_oidc","issuer_url":"https://idp.example.com","client_id":"client-id","enabled":true}`
+
+	recorder := serveControlSSO(server, nethttp.MethodPatch, "/control/api/sso/providers/"+providerID.String(), legacyBody)
+	require.Equal(t, nethttp.StatusOK, recorder.Code)
+	require.True(t, repo.providers[providerID].ProtectedResource.Enabled)
+	require.Equal(t, []string{"dense-mem"}, repo.providers[providerID].ProtectedResource.Audiences)
+
+	disableBody := `{"name":"Renamed OAuth","kind":"generic_oidc","issuer_url":"https://idp.example.com","client_id":"client-id","protected_resource":{"enabled":false},"enabled":true}`
+	recorder = serveControlSSO(server, nethttp.MethodPatch, "/control/api/sso/providers/"+providerID.String(), disableBody)
+	require.Equal(t, nethttp.StatusOK, recorder.Code)
+	require.False(t, repo.providers[providerID].ProtectedResource.Enabled)
 }
 
 func TestOAuthProtectedResourceMetadataIsDormantWithoutEnabledProvider(t *testing.T) {

--- a/internal/http/oauth_protected_resource_test.go
+++ b/internal/http/oauth_protected_resource_test.go
@@ -7,6 +7,7 @@ import (
 	nethttp "net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -79,6 +80,14 @@ func TestOAuthProtectedResourceMetadataRoutes(t *testing.T) {
 		e.ServeHTTP(recorder, httptest.NewRequest(nethttp.MethodGet, "/.well-known/oauth-protected-resource/wrong/mcp", nil))
 		require.Equal(t, nethttp.StatusNotFound, recorder.Code)
 	})
+}
+
+func TestControlPortalRejectsInvalidOAuthProviderAlgorithm(t *testing.T) {
+	server := controlPortalSSOServer(t, &httpSSORepoStub{}, time.Now().UTC())
+	body := `{"name":"OAuth","kind":"generic_oidc","issuer_url":"https://issuer.example.test","client_id":"client","protected_resource":{"enabled":true,"audiences":["dense-mem"],"jwks_source":"static","jwks_uri":"https://issuer.example.test/jwks","algorithms":["none"],"scope_claim":"scope","scope_mappings":[],"team_claim":""},"enabled":true}`
+	recorder := serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", body)
+	require.Equal(t, nethttp.StatusUnprocessableEntity, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "is not allowed")
 }
 
 func TestOAuthProtectedResourceMetadataIsDormantWithoutEnabledProvider(t *testing.T) {

--- a/internal/http/router_protected.go
+++ b/internal/http/router_protected.go
@@ -33,6 +33,10 @@ type ProtectedDeps struct {
 		middleware.SSOEntitlementValidator
 		middleware.SSOSessionAuthenticator
 	}
+	// OAuthAuthenticator validates customer-IdP JWT bearer tokens for MCP.
+	OAuthAuthenticator middleware.OAuthBearerAuthenticator
+	// OAuthMetadata publishes and links the protected-resource contract.
+	OAuthMetadata OAuthProtectedResourceProvider
 	// Config is the application configuration.
 	Config config.ConfigProvider
 	// Logger is the structured logger.
@@ -105,14 +109,17 @@ func RegisterProtectedRoutesWithHandlers(e *echo.Echo, deps ProtectedDeps, handl
 	// Create team authorization service from audit service.
 	teamAuthzSvc := middleware.NewTeamAuthorizationService(deps.AuditService)
 	credentialAuthMW := middleware.AuthMiddlewareWithOptions(deps.CredentialRepo, deps.AuditService, deps.SecurityService, middleware.AuthOptions{
-		CredentialVerifier:      deps.CredentialVerifier,
-		SSOEntitlementValidator: deps.SSOAuthenticator,
+		CredentialVerifier:       deps.CredentialVerifier,
+		SSOEntitlementValidator:  deps.SSOAuthenticator,
+		OAuthBearerAuthenticator: deps.OAuthAuthenticator,
 	})
+	challengeMW := oauthProtectedResourceChallenge(deps.OAuthMetadata)
 	usageMW := middleware.UsageMetricsMiddleware(deps.UsageMetrics)
 	rateLimitMW := middleware.RateLimitMiddleware(deps.RateLimitService, deps.Config, deps.AuditService)
 	lastUsedMW := middleware.LastUsedMiddleware(deps.LastUsedRecorder)
 	protectedGroup := func(prefix string) *echo.Group {
 		group := e.Group(prefix)
+		group.Use(challengeMW)
 		group.Use(credentialAuthMW)
 		group.Use(middleware.TeamResolutionMiddleware(deps.TeamSvc))
 		group.Use(middleware.AuthorizeTeam(teamAuthzSvc))
@@ -123,13 +130,21 @@ func RegisterProtectedRoutesWithHandlers(e *echo.Echo, deps ProtectedDeps, handl
 		return group
 	}
 
-	// MCP Streamable HTTP endpoint. External memory integrations use bearer API keys only.
+	// MCP Streamable HTTP endpoints share one registry and immutable auth context.
 	mcpGroup := protectedGroup("/mcp")
 	if handlers.MCPPost != nil {
 		mcpGroup.POST("", handlers.MCPPost)
 	}
 	if handlers.MCPGet != nil {
 		mcpGroup.GET("", handlers.MCPGet)
+	}
+
+	scopedMCPGroup := protectedGroup("/teams/:teamId/mcp")
+	if handlers.MCPPost != nil {
+		scopedMCPGroup.POST("", handlers.MCPPost)
+	}
+	if handlers.MCPGet != nil {
+		scopedMCPGroup.GET("", handlers.MCPGet)
 	}
 }
 

--- a/internal/http/router_protected_test.go
+++ b/internal/http/router_protected_test.go
@@ -173,6 +173,8 @@ func TestRegisterProtectedRoutesWithHandlersRegistersConfiguredSurface(t *testin
 	required := []string{
 		"POST /mcp",
 		"GET /mcp",
+		"POST /teams/:teamId/mcp",
+		"GET /teams/:teamId/mcp",
 	}
 
 	for _, route := range required {

--- a/internal/http/sso_oauth_repository_stub_test.go
+++ b/internal/http/sso_oauth_repository_stub_test.go
@@ -1,0 +1,14 @@
+package http
+
+import (
+	"context"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func (r *httpSSORepoStub) UpdateProviderPreservingProtectedResource(ctx context.Context, provider *domain.SSOProvider) error {
+	if stored := r.providers[provider.ID]; stored != nil {
+		provider.ProtectedResource = stored.ProtectedResource
+	}
+	return r.UpdateProvider(ctx, provider)
+}

--- a/internal/http/sso_portal_test.go
+++ b/internal/http/sso_portal_test.go
@@ -49,11 +49,14 @@ func TestControlPortalSSOProviderAndMappingFlows(t *testing.T) {
 	rec := serveControlSSO(server, nethttp.MethodGet, "/control/api/sso/providers", "")
 	require.Equal(t, nethttp.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), `"name":"Enterprise IdP"`)
+	require.Contains(t, rec.Body.String(), `"protected_resource":{"enabled":false,"audiences":[]`)
 
-	createBody := `{"name":"Azure","kind":"azure_ad","issuer_url":"https://login.microsoftonline.com/tenant/v2.0","tenant_id":"tenant","client_id":"azure-client","client_secret_env":"AZURE_SECRET","scopes":["profile","openid"],"group_claims":["groups"],"enabled":true}`
+	createBody := `{"name":"Azure","kind":"azure_ad","issuer_url":"https://login.microsoftonline.com/tenant/v2.0","tenant_id":"tenant","client_id":"azure-client","client_secret_env":"AZURE_SECRET","scopes":["profile","openid"],"group_claims":["groups"],"protected_resource":{"enabled":true,"audiences":["api://dense-mem"],"jwks_source":"discovery","jwks_uri":"","algorithms":["RS256"],"scope_claim":"scp","scope_mappings":[{"external_scope":"memory.read","internal_scopes":["read"]}],"team_claim":"dense_mem_team_id"},"enabled":true}`
 	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", createBody)
 	require.Equal(t, nethttp.StatusCreated, rec.Code)
 	require.Contains(t, rec.Body.String(), `"kind":"azure_ad"`)
+	require.Contains(t, rec.Body.String(), `"protected_resource":{"enabled":true`)
+	require.Contains(t, rec.Body.String(), `"external_scope":"memory.read"`)
 
 	updateBody := `{"name":"PingOne","kind":"pingone","issuer_url":"https://auth.pingone.com/example/as","client_id":"ping-client","scopes":["openid","email"],"group_claims":["memberOf"],"enabled":false}`
 	rec = serveControlSSO(server, nethttp.MethodPatch, "/control/api/sso/providers/"+providerID.String(), updateBody)
@@ -86,6 +89,19 @@ func TestControlPortalSSOProviderAndMappingFlows(t *testing.T) {
 	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", `{"kind":"bad"}`)
 	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
 	require.Contains(t, rec.Body.String(), "sso provider name is required")
+
+	unknownBody := strings.Replace(createBody, `"enabled":true,"audiences"`, `"enabled":true,"unknown_contract_field":true,"audiences"`, 1)
+	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", unknownBody)
+	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
+	require.Contains(t, rec.Body.String(), "malformed JSON body")
+
+	duplicateBody := strings.Replace(createBody, `"scope_claim":"scp"`, `"scope_claim":"scp","scope_claim":"scope"`, 1)
+	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", duplicateBody)
+	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
+	require.Contains(t, rec.Body.String(), "malformed JSON body")
+
+	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", `{"name":"`+strings.Repeat("a", maximumControlSSOProviderRequestBytes)+`"}`)
+	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
 }
 
 func TestUserPortalSSOHandlers(t *testing.T) {
@@ -148,6 +164,9 @@ func TestUserPortalSSOHandlers(t *testing.T) {
 			PublicBaseURL: "https://portal.example.com",
 			Now:           func() time.Time { return now },
 		}),
+		appConfig: &controlAppConfigSvc{ssoRuntime: service.SSORuntimeConfig{
+			MCPPublicBaseURL: "https://memory.example.test",
+		}},
 	}
 
 	c, rec := userSSOContext(nethttp.MethodGet, "/ui/api/sso/providers", "", "")
@@ -164,6 +183,7 @@ func TestUserPortalSSOHandlers(t *testing.T) {
 	require.Equal(t, ownerOneID, repo.teamProfiles[0].Membership.OwnerID)
 	require.Equal(t, "Team One", session.Team.Name)
 	require.Equal(t, "SSO Team One", session.Membership.Name)
+	require.Equal(t, "https://memory.example.test", session.MCPPublicBaseURL)
 
 	c, rec = userSSOContext(nethttp.MethodPost, "/ui/api/sso/team", `{"team_id":"`+teamTwoID.String()+`"}`, sessionToken)
 	setUserSSOPrincipal(c, ownerOneID, teamOneID)

--- a/internal/http/sso_portal_test.go
+++ b/internal/http/sso_portal_test.go
@@ -103,10 +103,6 @@ func TestControlPortalSSOProviderAndMappingFlows(t *testing.T) {
 	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", `{"name":"`+strings.Repeat("a", maximumControlSSOProviderRequestBytes)+`"}`)
 	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
 
-	invalidAlgorithm := strings.Replace(createBody, `"algorithms":["RS256"]`, `"algorithms":["none"]`, 1)
-	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", invalidAlgorithm)
-	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
-	require.Contains(t, rec.Body.String(), "is not allowed")
 }
 
 func TestUserPortalSSOHandlers(t *testing.T) {

--- a/internal/http/sso_portal_test.go
+++ b/internal/http/sso_portal_test.go
@@ -102,6 +102,11 @@ func TestControlPortalSSOProviderAndMappingFlows(t *testing.T) {
 
 	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", `{"name":"`+strings.Repeat("a", maximumControlSSOProviderRequestBytes)+`"}`)
 	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
+
+	invalidAlgorithm := strings.Replace(createBody, `"algorithms":["RS256"]`, `"algorithms":["none"]`, 1)
+	rec = serveControlSSO(server, nethttp.MethodPost, "/control/api/sso/providers", invalidAlgorithm)
+	require.Equal(t, nethttp.StatusUnprocessableEntity, rec.Code)
+	require.Contains(t, rec.Body.String(), "is not allowed")
 }
 
 func TestUserPortalSSOHandlers(t *testing.T) {

--- a/internal/http/user_portal.go
+++ b/internal/http/user_portal.go
@@ -77,6 +77,7 @@ type userPortalSessionResponse struct {
 	Credential          *userPortalCredentialResponse  `json:"credential"`
 	Teams               []userPortalTeamOptionResponse `json:"teams"`
 	PersonalCredentials []userPortalCredentialResponse `json:"personal_credentials"`
+	MCPPublicBaseURL    string                         `json:"mcp_public_base_url"`
 }
 
 type userPortalTeamOptionResponse struct {
@@ -374,12 +375,17 @@ func (h *userPortalHandler) currentSession(c echo.Context) (userPortalSessionRes
 		return userPortalSessionResponse{}, err
 	}
 	credentialResponse := toUserPortalCredential(credential)
+	mcpPublicBaseURL, err := h.mcpPublicBaseURL(ctx)
+	if err != nil {
+		return userPortalSessionResponse{}, err
+	}
 	return userPortalSessionResponse{
 		Team:                teamResponse,
 		Membership:          userPortalMembershipFromPrincipal(principal),
 		Credential:          &credentialResponse,
 		Teams:               []userPortalTeamOptionResponse{},
 		PersonalCredentials: []userPortalCredentialResponse{},
+		MCPPublicBaseURL:    mcpPublicBaseURL,
 	}, nil
 }
 
@@ -408,12 +414,17 @@ func (h *userPortalHandler) currentSSOSession(c echo.Context) (userPortalSession
 	if err != nil {
 		return userPortalSessionResponse{}, err
 	}
+	mcpPublicBaseURL, err := h.mcpPublicBaseURL(ctx)
+	if err != nil {
+		return userPortalSessionResponse{}, err
+	}
 	response := userPortalSessionResponse{
 		Team:                selected.Team,
 		Membership:          selected.Membership,
 		Credential:          nil,
 		Teams:               teams,
 		PersonalCredentials: []userPortalCredentialResponse{},
+		MCPPublicBaseURL:    mcpPublicBaseURL,
 	}
 	if selected.Membership.Role != service.CredentialRoleManager && h.credentials != nil {
 		personalCredentials, err := h.ssoOwnedCredentials(ctx, info.Selected.Team.ID, info.Identity.ID)
@@ -425,6 +436,17 @@ func (h *userPortalHandler) currentSSOSession(c echo.Context) (userPortalSession
 		}
 	}
 	return response, nil
+}
+
+func (h *userPortalHandler) mcpPublicBaseURL(ctx context.Context) (string, error) {
+	if h.appConfig == nil {
+		return "", nil
+	}
+	runtime, err := h.appConfig.SSORuntimeConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(strings.TrimSpace(runtime.MCPPublicBaseURL), "/"), nil
 }
 
 func (h *userPortalHandler) ssoProviders(c echo.Context) error {

--- a/internal/http/user_portal_test.go
+++ b/internal/http/user_portal_test.go
@@ -556,6 +556,32 @@ func TestUserPortalRotateRejectsEditableFields(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "does not accept editable fields")
 }
 
+func TestUserPortalCurrentSessionIncludesTrustedMCPBaseURL(t *testing.T) {
+	teamID := uuid.New()
+	keyID := uuid.New()
+	authKey, _ := userPortalTestKey(t, teamID, keyID, "Current profile", []string{"read"})
+	h := &userPortalHandler{
+		teams: &controlProfileSvc{profiles: []*domain.Team{{
+			ID:        teamID,
+			Name:      "Team",
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}}},
+		credentials: &userPortalKeySvc{keys: []*domain.Credential{authKey}},
+		appConfig: &controlAppConfigSvc{ssoRuntime: service.SSORuntimeConfig{
+			MCPPublicBaseURL: "https://memory.example.test/base",
+		}},
+	}
+
+	session, err := h.currentSession(userPortalEchoContext(t, http.MethodGet, "/ui/api/session", "", userPortalPrincipal(teamID, keyID, service.CredentialRoleMember, []string{"read"}, "api_key")))
+	require.NoError(t, err)
+	require.Equal(t, "https://memory.example.test/base", session.MCPPublicBaseURL)
+
+	h.appConfig = &controlAppConfigSvc{ssoRuntimeErr: errors.New("load sso runtime config")}
+	_, err = h.currentSession(userPortalEchoContext(t, http.MethodGet, "/ui/api/session", "", userPortalPrincipal(teamID, keyID, service.CredentialRoleMember, []string{"read"}, "api_key")))
+	require.ErrorContains(t, err, "load sso runtime config")
+}
+
 func TestUserPortalCurrentSessionErrors(t *testing.T) {
 	teamID := uuid.New()
 	keyID := uuid.New()

--- a/internal/httperr/errors.go
+++ b/internal/httperr/errors.go
@@ -28,6 +28,7 @@ const (
 	PROFILE_ID_REQUIRED                 ErrorCode = "PROFILE_ID_REQUIRED"
 	INVALID_UUID                        ErrorCode = "INVALID_UUID"
 	CONFLICT                            ErrorCode = "CONFLICT"
+	TEAM_REQUIRED                       ErrorCode = "team_required"
 	RATE_LIMITED                        ErrorCode = "RATE_LIMITED"
 	SERVICE_UNAVAILABLE                 ErrorCode = "SERVICE_UNAVAILABLE"
 	INTERNAL_ERROR                      ErrorCode = "INTERNAL_ERROR"

--- a/internal/httperr/handler.go
+++ b/internal/httperr/handler.go
@@ -19,6 +19,8 @@ func HTTPStatusCode(code ErrorCode) int {
 		return http.StatusUnprocessableEntity
 	case PROFILE_ID_REQUIRED, INVALID_UUID:
 		return http.StatusBadRequest
+	case TEAM_REQUIRED:
+		return http.StatusBadRequest
 	case CONFLICT:
 		return http.StatusConflict
 	case RATE_LIMITED:

--- a/internal/repository/sso_oauth_provider_write.go
+++ b/internal/repository/sso_oauth_provider_write.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func lockSSOProtectedResourceProviderSetTx(tx *gorm.DB) error {
+	return tx.Exec(
+		`SELECT pg_advisory_xact_lock(hashtext(?))`,
+		"sso-protected-resource-provider-set",
+	).Error
+}
+
+func enforceSSOProtectedResourceProfileLimitTx(tx *gorm.DB) error {
+	var count int
+	if err := tx.Raw(`
+		SELECT count(*)
+		FROM sso_providers
+		WHERE enabled = true
+		  AND retired_at IS NULL
+		  AND protected_resource_config @> '{"enabled": true}'::jsonb
+	`).Row().Scan(&count); err != nil {
+		return err
+	}
+	if count > domain.OAuthProtectedResourceMaximumProfiles {
+		return fmt.Errorf("%w: maximum %d", ErrSSOProtectedResourceProfileLimit, domain.OAuthProtectedResourceMaximumProfiles)
+	}
+	return nil
+}

--- a/internal/repository/sso_oauth_repository_integration_test.go
+++ b/internal/repository/sso_oauth_repository_integration_test.go
@@ -1,0 +1,97 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestSSOProviderProtectedResourceConfigRoundTripAndStrictRead(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := NewSSORepository(appDB, rls)
+	provider := &domain.SSOProvider{
+		Name:          "oauth protected resource provider",
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     "https://issuer.example.test/",
+		IdentityClaim: "sub",
+		ClientID:      "oauth-client",
+		GroupsScopes:  []string{},
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled: true,
+			OAuthProtectedResourceConfig: domain.OAuthProtectedResourceConfig{
+				Audiences:  []string{"https://memory.example.test/mcp"},
+				JWKSSource: "static",
+				JWKSURI:    "https://issuer.example.test/jwks",
+				Algorithms: []string{"RS256"},
+				ScopeClaim: "scope",
+				ScopeMappings: []domain.OAuthScopeMapping{
+					{ExternalScope: "memory.read", InternalScopes: []string{"read"}},
+					{ExternalScope: "memory.write", InternalScopes: []string{"write"}},
+				},
+				TeamClaim: "dense_mem_team_id",
+			},
+		},
+		Enabled: true,
+	}
+
+	require.NoError(t, repo.CreateProvider(ctx, provider))
+	loaded, err := repo.GetProvider(ctx, provider.ID)
+	require.NoError(t, err)
+	require.Equal(t, provider.IssuerURL, loaded.IssuerURL)
+	require.Equal(t, provider.ProtectedResource, loaded.ProtectedResource)
+
+	provider.ProtectedResource.TeamClaim = "tenant_id"
+	provider.ProtectedResource.ScopeMappings[0].InternalScopes = []string{"read", "feedback:read"}
+	require.NoError(t, repo.UpdateProvider(ctx, provider))
+	loaded, err = repo.GetProvider(ctx, provider.ID)
+	require.NoError(t, err)
+	require.Equal(t, provider.ProtectedResource, loaded.ProtectedResource)
+
+	providers, err := repo.ListEnabledProviders(ctx)
+	require.NoError(t, err)
+	require.Len(t, providers, 1)
+	require.Equal(t, provider.ID, providers[0].ID)
+
+	var directCount int64
+	require.NoError(t, appDB.WithContext(ctx).Raw(`SELECT count(*) FROM sso_providers WHERE id = $1`, provider.ID).Scan(&directCount).Error)
+	require.Zero(t, directCount, "provider configuration must remain hidden outside a system transaction")
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE sso_providers
+			SET protected_resource_config = protected_resource_config || '{"unknown_contract_field":true}'::jsonb
+			WHERE id = $1
+		`, provider.ID).Error
+	}))
+	_, err = repo.GetProvider(ctx, provider.ID)
+	require.ErrorContains(t, err, "unknown field")
+}
+
+func TestSSOProviderProtectedResourceDefaultIsDormant(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	providerID := uuid.New()
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO sso_providers (id, name, kind, issuer_url, client_id, enabled)
+			VALUES ($1, 'dormant oauth provider', 'generic_oidc', 'https://dormant.example.test', 'client', true)
+		`, providerID).Error
+	}))
+
+	loaded, err := NewSSORepository(appDB, rls).GetProvider(ctx, providerID)
+	require.NoError(t, err)
+	require.False(t, loaded.ProtectedResource.Enabled)
+	require.Empty(t, loaded.ProtectedResource.Audiences)
+	require.Equal(t, "discovery", loaded.ProtectedResource.JWKSSource)
+	require.Equal(t, []string{"RS256"}, loaded.ProtectedResource.Algorithms)
+	require.Equal(t, "scope", loaded.ProtectedResource.ScopeClaim)
+}

--- a/internal/repository/sso_oauth_repository_integration_test.go
+++ b/internal/repository/sso_oauth_repository_integration_test.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -145,6 +147,127 @@ func TestSSOProviderProtectedResourceIssuerUniquenessIsAtomic(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, matching)
+}
+
+func TestSSOProviderProtectedResourceOmittedUpdatePreservesConcurrentConfig(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := NewSSORepository(appDB, rls)
+	provider := activeOAuthRepositoryProvider(
+		uuid.New(),
+		"https://"+uuid.NewString()+".issuer.example.test",
+		"preserve",
+	)
+	require.NoError(t, repo.CreateProvider(ctx, provider))
+	staleUpdate := *provider
+	staleUpdate.Name = "legacy provider rename"
+
+	concurrentConfig := domain.SSOProtectedResourceConfig{
+		Enabled: false,
+		OAuthProtectedResourceConfig: domain.OAuthProtectedResourceConfig{
+			Audiences:  []string{"concurrent-audience"},
+			JWKSSource: "static",
+			JWKSURI:    "https://rotated.example.test/jwks",
+			Algorithms: []string{"RS256"},
+			ScopeClaim: "scope",
+		},
+	}
+	encodedConfig, err := json.Marshal(concurrentConfig)
+	require.NoError(t, err)
+	configLocked := make(chan struct{})
+	releaseConfig := make(chan struct{})
+	configResult := make(chan error, 1)
+	go func() {
+		configResult <- rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+			if err := tx.Exec(`
+				UPDATE sso_providers
+				SET protected_resource_config = $1::jsonb
+				WHERE id = $2
+			`, string(encodedConfig), provider.ID).Error; err != nil {
+				return err
+			}
+			close(configLocked)
+			<-releaseConfig
+			return nil
+		})
+	}()
+	<-configLocked
+
+	updateStarted := make(chan struct{})
+	updateResult := make(chan error, 1)
+	go func() {
+		close(updateStarted)
+		updateResult <- repo.UpdateProviderPreservingProtectedResource(ctx, &staleUpdate)
+	}()
+	<-updateStarted
+	close(releaseConfig)
+	require.NoError(t, <-configResult)
+	require.NoError(t, <-updateResult)
+
+	loaded, err := repo.GetProvider(ctx, provider.ID)
+	require.NoError(t, err)
+	require.Equal(t, "legacy provider rename", loaded.Name)
+	require.Equal(t, concurrentConfig, loaded.ProtectedResource)
+}
+
+func TestSSOProviderProtectedResourceProfileLimitIsAtomic(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := NewSSORepository(appDB, rls)
+
+	for index := 0; index < domain.OAuthProtectedResourceMaximumProfiles-1; index++ {
+		provider := activeOAuthRepositoryProvider(
+			uuid.New(),
+			"https://"+uuid.NewString()+".issuer.example.test",
+			uuid.NewString(),
+		)
+		require.NoError(t, repo.CreateProvider(ctx, provider))
+	}
+
+	providers := []*domain.SSOProvider{
+		activeOAuthRepositoryProvider(uuid.New(), "https://"+uuid.NewString()+".issuer.example.test", "first contender"),
+		activeOAuthRepositoryProvider(uuid.New(), "https://"+uuid.NewString()+".issuer.example.test", "second contender"),
+	}
+	start := make(chan struct{})
+	results := make(chan error, len(providers))
+	var workers sync.WaitGroup
+	for _, provider := range providers {
+		provider := provider
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			results <- repo.CreateProvider(ctx, provider)
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	succeeded := 0
+	failed := 0
+	for err := range results {
+		if err == nil {
+			succeeded++
+		} else {
+			require.True(t, errors.Is(err, ErrSSOProtectedResourceProfileLimit), "unexpected create error: %v", err)
+			failed++
+		}
+	}
+	require.Equal(t, 1, succeeded)
+	require.Equal(t, 1, failed)
+
+	listed, err := repo.ListEnabledProviders(ctx)
+	require.NoError(t, err)
+	activeProfiles := 0
+	for _, provider := range listed {
+		if provider.ProtectedResource.Enabled {
+			activeProfiles++
+		}
+	}
+	require.Equal(t, domain.OAuthProtectedResourceMaximumProfiles, activeProfiles)
 }
 
 func activeOAuthRepositoryProvider(id uuid.UUID, issuer, suffix string) *domain.SSOProvider {

--- a/internal/repository/sso_oauth_repository_integration_test.go
+++ b/internal/repository/sso_oauth_repository_integration_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -94,4 +95,70 @@ func TestSSOProviderProtectedResourceDefaultIsDormant(t *testing.T) {
 	require.Equal(t, "discovery", loaded.ProtectedResource.JWKSSource)
 	require.Equal(t, []string{"RS256"}, loaded.ProtectedResource.Algorithms)
 	require.Equal(t, "scope", loaded.ProtectedResource.ScopeClaim)
+}
+
+func TestSSOProviderProtectedResourceIssuerUniquenessIsAtomic(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	repo := NewSSORepository(appDB, rls)
+	issuer := "https://" + uuid.NewString() + ".issuer.example.test"
+	providers := []*domain.SSOProvider{
+		activeOAuthRepositoryProvider(uuid.New(), issuer, "first"),
+		activeOAuthRepositoryProvider(uuid.New(), issuer, "second"),
+	}
+
+	start := make(chan struct{})
+	results := make(chan error, len(providers))
+	var workers sync.WaitGroup
+	for _, provider := range providers {
+		provider := provider
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			results <- repo.CreateProvider(ctx, provider)
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	succeeded := 0
+	failed := 0
+	for err := range results {
+		if err == nil {
+			succeeded++
+		} else {
+			failed++
+		}
+	}
+	require.Equal(t, 1, succeeded)
+	require.Equal(t, 1, failed)
+
+	listed, err := repo.ListEnabledProviders(ctx)
+	require.NoError(t, err)
+	matching := 0
+	for _, provider := range listed {
+		if provider.IssuerURL == issuer && provider.ProtectedResource.Enabled {
+			matching++
+		}
+	}
+	require.Equal(t, 1, matching)
+}
+
+func activeOAuthRepositoryProvider(id uuid.UUID, issuer, suffix string) *domain.SSOProvider {
+	return &domain.SSOProvider{
+		ID:            id,
+		Name:          "atomic oauth provider " + suffix,
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     issuer,
+		IdentityClaim: "sub",
+		ClientID:      "client-" + suffix,
+		GroupsScopes:  []string{},
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled: true,
+		},
+		Enabled: true,
+	}
 }

--- a/internal/repository/sso_repository.go
+++ b/internal/repository/sso_repository.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	ErrDirectoryIdentityNotProvisioned = errors.New("directory identity is not provisioned and active")
-	ErrDirectoryManagedMapping         = errors.New("directory-managed sso mappings are read-only")
-	ErrSSOIdentityConflict             = errors.New("sso identity conflicts with a different external identity")
+	ErrDirectoryIdentityNotProvisioned  = errors.New("directory identity is not provisioned and active")
+	ErrDirectoryManagedMapping          = errors.New("directory-managed sso mappings are read-only")
+	ErrSSOIdentityConflict              = errors.New("sso identity conflicts with a different external identity")
+	ErrSSOProtectedResourceProfileLimit = errors.New("sso protected-resource profile limit exceeded")
 )
 
 type SSORepository interface {
@@ -28,6 +29,7 @@ type SSORepository interface {
 	GetProvider(ctx context.Context, id uuid.UUID) (*domain.SSOProvider, error)
 	CreateProvider(ctx context.Context, provider *domain.SSOProvider) error
 	UpdateProvider(ctx context.Context, provider *domain.SSOProvider) error
+	UpdateProviderPreservingProtectedResource(ctx context.Context, provider *domain.SSOProvider) error
 	DeleteProvider(ctx context.Context, id uuid.UUID) error
 
 	ListMappings(ctx context.Context, providerID uuid.UUID) ([]*domain.SSOGroupMapping, error)
@@ -156,10 +158,16 @@ func (r *SSORepositoryImpl) CreateProvider(ctx context.Context, provider *domain
 		return fmt.Errorf("failed to encode protected-resource config: %w", err)
 	}
 	err = r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
-		return tx.Exec(`
+		if err := lockSSOProtectedResourceProviderSetTx(tx); err != nil {
+			return err
+		}
+		if err := tx.Exec(`
 			INSERT INTO sso_providers (id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, protected_resource_config, enabled, retired_at, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, NULL, $15, $15)
-		`, provider.ID, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), provider.Enabled, now).Error
+		`, provider.ID, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), provider.Enabled, now).Error; err != nil {
+			return err
+		}
+		return enforceSSOProtectedResourceProfileLimitTx(tx)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create sso provider: %w", err)
@@ -168,6 +176,14 @@ func (r *SSORepositoryImpl) CreateProvider(ctx context.Context, provider *domain
 }
 
 func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain.SSOProvider) error {
+	return r.updateProvider(ctx, provider, false)
+}
+
+func (r *SSORepositoryImpl) UpdateProviderPreservingProtectedResource(ctx context.Context, provider *domain.SSOProvider) error {
+	return r.updateProvider(ctx, provider, true)
+}
+
+func (r *SSORepositoryImpl) updateProvider(ctx context.Context, provider *domain.SSOProvider, preserveProtectedResource bool) error {
 	now := time.Now().UTC()
 	provider.UpdatedAt = now
 	protectedResource, err := json.Marshal(provider.ProtectedResource)
@@ -175,6 +191,9 @@ func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain
 		return fmt.Errorf("failed to encode protected-resource config: %w", err)
 	}
 	err = r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		if err := lockSSOProtectedResourceProviderSetTx(tx); err != nil {
+			return err
+		}
 		res := tx.Exec(`
 			UPDATE sso_providers
 			SET name = $1,
@@ -188,12 +207,12 @@ func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain
 			    group_claims = $9,
 			    groups_endpoint = $10,
 			    groups_scopes = $11,
-			    protected_resource_config = $12::jsonb,
-			    enabled = $13,
-			    retired_at = CASE WHEN $13 THEN NULL ELSE retired_at END,
-			    updated_at = $14
-			WHERE id = $15
-		`, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), provider.Enabled, now, provider.ID)
+			    protected_resource_config = CASE WHEN $13 THEN protected_resource_config ELSE $12::jsonb END,
+			    enabled = $14,
+			    retired_at = CASE WHEN $14 THEN NULL ELSE retired_at END,
+			    updated_at = $15
+			WHERE id = $16
+		`, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), preserveProtectedResource, provider.Enabled, now, provider.ID)
 		if res.Error != nil {
 			return res.Error
 		}
@@ -201,9 +220,11 @@ func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain
 			return gorm.ErrRecordNotFound
 		}
 		if !provider.Enabled {
-			return disableDirectoryProvisioningForProviderTx(tx, provider.ID, now)
+			if err := disableDirectoryProvisioningForProviderTx(tx, provider.ID, now); err != nil {
+				return err
+			}
 		}
-		return nil
+		return enforceSSOProtectedResourceProfileLimitTx(tx)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update sso provider: %w", err)
@@ -214,6 +235,9 @@ func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain
 func (r *SSORepositoryImpl) DeleteProvider(ctx context.Context, id uuid.UUID) error {
 	now := time.Now().UTC()
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+		if err := lockSSOProtectedResourceProviderSetTx(tx); err != nil {
+			return err
+		}
 		res := tx.Exec(`
 			UPDATE sso_providers
 			SET enabled = false, retired_at = COALESCE(retired_at, $1), updated_at = $1

--- a/internal/repository/sso_repository.go
+++ b/internal/repository/sso_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -82,7 +83,7 @@ func (r *SSORepositoryImpl) listProviders(ctx context.Context, enabledOnly bool)
 	providers := make([]*domain.SSOProvider, 0)
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		query := `
-			SELECT id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, enabled, retired_at, created_at, updated_at
+			SELECT id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, protected_resource_config, enabled, retired_at, created_at, updated_at
 			FROM sso_providers`
 		if enabledOnly {
 			query += ` WHERE enabled = true AND retired_at IS NULL`
@@ -113,7 +114,7 @@ func (r *SSORepositoryImpl) GetProvider(ctx context.Context, id uuid.UUID) (*dom
 	var provider *domain.SSOProvider
 	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		rows, err := tx.Raw(`
-			SELECT id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, enabled, retired_at, created_at, updated_at
+			SELECT id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, protected_resource_config, enabled, retired_at, created_at, updated_at
 			FROM sso_providers
 			WHERE id = $1
 		`, id).Rows()
@@ -150,11 +151,15 @@ func (r *SSORepositoryImpl) CreateProvider(ctx context.Context, provider *domain
 	if len(provider.GroupClaims) == 0 {
 		provider.GroupClaims = []string{"groups"}
 	}
-	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+	protectedResource, err := json.Marshal(provider.ProtectedResource)
+	if err != nil {
+		return fmt.Errorf("failed to encode protected-resource config: %w", err)
+	}
+	err = r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		return tx.Exec(`
-			INSERT INTO sso_providers (id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, enabled, retired_at, created_at, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NULL, $14, $14)
-		`, provider.ID, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), provider.Enabled, now).Error
+			INSERT INTO sso_providers (id, name, kind, issuer_url, tenant_id, identity_claim, client_id, client_secret_env, scopes, group_claims, groups_endpoint, groups_scopes, protected_resource_config, enabled, retired_at, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, NULL, $15, $15)
+		`, provider.ID, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), provider.Enabled, now).Error
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create sso provider: %w", err)
@@ -165,7 +170,11 @@ func (r *SSORepositoryImpl) CreateProvider(ctx context.Context, provider *domain
 func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain.SSOProvider) error {
 	now := time.Now().UTC()
 	provider.UpdatedAt = now
-	err := r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
+	protectedResource, err := json.Marshal(provider.ProtectedResource)
+	if err != nil {
+		return fmt.Errorf("failed to encode protected-resource config: %w", err)
+	}
+	err = r.rls.WithSystemTx(ctx, r.db, func(tx *gorm.DB) error {
 		res := tx.Exec(`
 			UPDATE sso_providers
 			SET name = $1,
@@ -179,11 +188,12 @@ func (r *SSORepositoryImpl) UpdateProvider(ctx context.Context, provider *domain
 			    group_claims = $9,
 			    groups_endpoint = $10,
 			    groups_scopes = $11,
-			    enabled = $12,
-			    retired_at = CASE WHEN $12 THEN NULL ELSE retired_at END,
-			    updated_at = $13
-			WHERE id = $14
-		`, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), provider.Enabled, now, provider.ID)
+			    protected_resource_config = $12::jsonb,
+			    enabled = $13,
+			    retired_at = CASE WHEN $13 THEN NULL ELSE retired_at END,
+			    updated_at = $14
+			WHERE id = $15
+		`, provider.Name, string(provider.Kind), provider.IssuerURL, provider.TenantID, provider.IdentityClaim, provider.ClientID, provider.ClientSecretEnv, pq.Array(provider.Scopes), pq.Array(provider.GroupClaims), provider.GroupsEndpoint, pq.Array(provider.GroupsScopes), string(protectedResource), provider.Enabled, now, provider.ID)
 		if res.Error != nil {
 			return res.Error
 		}

--- a/internal/repository/sso_repository_scan.go
+++ b/internal/repository/sso_repository_scan.go
@@ -1,16 +1,21 @@
 package repository
 
 import (
+	"bytes"
 	"database/sql"
 
 	"github.com/lib/pq"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/jsonstrict"
 )
+
+const maximumSSOProtectedResourceConfigBytes = 64 * 1024
 
 func scanSSOProvider(rows *sql.Rows) (*domain.SSOProvider, error) {
 	var provider domain.SSOProvider
 	var kind string
+	var protectedResource []byte
 	if err := rows.Scan(
 		&provider.ID,
 		&provider.Name,
@@ -24,6 +29,7 @@ func scanSSOProvider(rows *sql.Rows) (*domain.SSOProvider, error) {
 		pq.Array(&provider.GroupClaims),
 		&provider.GroupsEndpoint,
 		pq.Array(&provider.GroupsScopes),
+		&protectedResource,
 		&provider.Enabled,
 		&provider.RetiredAt,
 		&provider.CreatedAt,
@@ -32,6 +38,9 @@ func scanSSOProvider(rows *sql.Rows) (*domain.SSOProvider, error) {
 		return nil, err
 	}
 	provider.Kind = domain.SSOProviderKind(kind)
+	if err := jsonstrict.Decode(bytes.NewReader(protectedResource), &provider.ProtectedResource, maximumSSOProtectedResourceConfigBytes); err != nil {
+		return nil, err
+	}
 	return &provider, nil
 }
 

--- a/internal/service/app_config_mcp.go
+++ b/internal/service/app_config_mcp.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func editableSSOConfigKeys() []string {
+	return []string{
+		domain.AppConfigSSOPublicBaseURL,
+		domain.AppConfigMCPPublicBaseURL,
+		domain.AppConfigSCIMPublicBaseURL,
+		domain.AppConfigControlPublicBaseURL,
+		domain.AppConfigSSOEntitlementCacheTTLSeconds,
+		domain.AppConfigSSOSessionTTLSeconds,
+		domain.AppConfigSSOStateTTLSeconds,
+		domain.AppConfigSSOHTTPTimeoutSeconds,
+		domain.AppConfigSSOCookieSecure,
+	}
+}
+
+func normalizeMCPPublicBaseURL(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if len(raw) > 2048 || raw != strings.TrimSpace(raw) {
+		return "", fmt.Errorf("MCP_PUBLIC_BASE_URL must be a bounded exact URL")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
+		return "", fmt.Errorf("MCP_PUBLIC_BASE_URL must be an absolute URL without credentials, query, or fragment")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && mcpLoopbackHost(parsed.Hostname())) {
+		return "", fmt.Errorf("MCP_PUBLIC_BASE_URL must use https except for loopback http")
+	}
+	if port := parsed.Port(); port != "" {
+		value, err := strconv.ParseUint(port, 10, 16)
+		if err != nil || value == 0 {
+			return "", fmt.Errorf("MCP_PUBLIC_BASE_URL has an invalid port")
+		}
+	}
+	basePath := strings.TrimSuffix(parsed.Path, "/")
+	if parsed.RawPath != "" || strings.ContainsAny(parsed.Path, "{} \t?#") || strings.Contains(parsed.Path, "//") || (parsed.Path != "" && parsed.Path != "/" && path.Clean(parsed.Path) != basePath) {
+		return "", fmt.Errorf("MCP_PUBLIC_BASE_URL path must be canonical and literal")
+	}
+	return strings.TrimSuffix(raw, "/"), nil
+}
+
+func mcpLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/service/app_config_service.go
+++ b/internal/service/app_config_service.go
@@ -441,6 +441,7 @@ func ssoRuntimeConfigFromEntries(entries map[string]domain.AppConfigEntry) (SSOR
 
 	runtime := SSORuntimeConfig{
 		PublicBaseURL:        normalized[domain.AppConfigSSOPublicBaseURL],
+		MCPPublicBaseURL:     normalized[domain.AppConfigMCPPublicBaseURL],
 		SCIMPublicBaseURL:    normalized[domain.AppConfigSCIMPublicBaseURL],
 		ControlPublicBaseURL: normalized[domain.AppConfigControlPublicBaseURL],
 		EntitlementCacheTTL:  entitlementTTL,
@@ -453,6 +454,7 @@ func ssoRuntimeConfigFromEntries(entries map[string]domain.AppConfigEntry) (SSOR
 	updateTime := entries[domain.AppConfigUpdateTimeKey].Value
 	items := []domain.SSOConfigItem{
 		ssoConfigItem(entries, domain.AppConfigSSOPublicBaseURL, normalized[domain.AppConfigSSOPublicBaseURL]),
+		ssoConfigItem(entries, domain.AppConfigMCPPublicBaseURL, normalized[domain.AppConfigMCPPublicBaseURL]),
 		ssoConfigItem(entries, domain.AppConfigSCIMPublicBaseURL, normalized[domain.AppConfigSCIMPublicBaseURL]),
 		ssoConfigItem(entries, domain.AppConfigControlPublicBaseURL, normalized[domain.AppConfigControlPublicBaseURL]),
 		ssoConfigItem(entries, domain.AppConfigSSOEntitlementCacheTTLSeconds, entitlementEffective),
@@ -742,6 +744,12 @@ func normalizeSSOConfigValues(values map[string]string) (map[string]string, erro
 		}
 		trimmed := strings.TrimSpace(value)
 		switch key {
+		case domain.AppConfigMCPPublicBaseURL:
+			normalizedValue, err := normalizeMCPPublicBaseURL(trimmed)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s", ErrInvalidAppConfig, err)
+			}
+			normalized[key] = normalizedValue
 		case domain.AppConfigSSOPublicBaseURL, domain.AppConfigSCIMPublicBaseURL, domain.AppConfigControlPublicBaseURL:
 			normalized[key] = strings.TrimRight(trimmed, "/")
 			if normalized[key] != "" {
@@ -786,19 +794,6 @@ func editableGeneralConfigKeys() []string {
 	return []string{
 		domain.AppConfigTimezone,
 		domain.AppConfigEmbeddingReconciliationStartTimeLocal,
-	}
-}
-
-func editableSSOConfigKeys() []string {
-	return []string{
-		domain.AppConfigSSOPublicBaseURL,
-		domain.AppConfigSCIMPublicBaseURL,
-		domain.AppConfigControlPublicBaseURL,
-		domain.AppConfigSSOEntitlementCacheTTLSeconds,
-		domain.AppConfigSSOSessionTTLSeconds,
-		domain.AppConfigSSOStateTTLSeconds,
-		domain.AppConfigSSOHTTPTimeoutSeconds,
-		domain.AppConfigSSOCookieSecure,
 	}
 }
 

--- a/internal/service/app_config_service_test.go
+++ b/internal/service/app_config_service_test.go
@@ -25,6 +25,7 @@ func TestAppConfigServiceSSOSettingsDefaultsAndUpdate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, now.Format(time.RFC3339Nano), settings.UpdateTime)
 	assert.Equal(t, "", appConfigItem(t, settings, domain.AppConfigSSOPublicBaseURL).Value)
+	assert.Equal(t, "", appConfigItem(t, settings, domain.AppConfigMCPPublicBaseURL).Value)
 	assert.Equal(t, "300", appConfigItem(t, settings, domain.AppConfigSSOEntitlementCacheTTLSeconds).EffectiveValue)
 	assert.Equal(t, "28800", appConfigItem(t, settings, domain.AppConfigSSOSessionTTLSeconds).EffectiveValue)
 	assert.Equal(t, "600", appConfigItem(t, settings, domain.AppConfigSSOStateTTLSeconds).EffectiveValue)
@@ -42,11 +43,13 @@ func TestAppConfigServiceSSOSettingsDefaultsAndUpdate(t *testing.T) {
 	now = now.Add(time.Minute)
 	updated, err := svc.UpdateSSOSettings(ctx, map[string]string{
 		domain.AppConfigSSOPublicBaseURL:     "https://portal.example.com/",
+		domain.AppConfigMCPPublicBaseURL:     "https://memory.example.com/base/",
 		domain.AppConfigSSOSessionTTLSeconds: "3600",
 		domain.AppConfigSSOCookieSecure:      "true",
 	}, "control", "127.0.0.1", "corr")
 	require.NoError(t, err)
 	assert.Equal(t, "https://portal.example.com", appConfigItem(t, updated, domain.AppConfigSSOPublicBaseURL).Value)
+	assert.Equal(t, "https://memory.example.com/base", appConfigItem(t, updated, domain.AppConfigMCPPublicBaseURL).Value)
 	assert.Equal(t, "3600", appConfigItem(t, updated, domain.AppConfigSSOSessionTTLSeconds).EffectiveValue)
 	assert.Equal(t, "true", appConfigItem(t, updated, domain.AppConfigSSOCookieSecure).EffectiveValue)
 	assert.Equal(t, now.Format(time.RFC3339Nano), updated.UpdateTime)
@@ -54,6 +57,7 @@ func TestAppConfigServiceSSOSettingsDefaultsAndUpdate(t *testing.T) {
 	runtime, err = svc.SSORuntimeConfig(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "https://portal.example.com", runtime.PublicBaseURL)
+	assert.Equal(t, "https://memory.example.com/base", runtime.MCPPublicBaseURL)
 	assert.Equal(t, time.Hour, runtime.SessionTTL)
 	assert.True(t, runtime.CookieSecure)
 }
@@ -532,6 +536,24 @@ func TestAppConfigServiceValidation(t *testing.T) {
 
 	_, err = svc.UpdateSSOSettings(ctx, map[string]string{domain.AppConfigSSOPublicBaseURL: "://bad"}, "control", "", "")
 	require.ErrorIs(t, err, ErrInvalidAppConfig)
+
+	for _, value := range []string{
+		"http://memory.example.com",
+		"https://user:pass@memory.example.com",
+		"https://memory.example.com/path?query=1",
+		"https://memory.example.com/path#fragment",
+		"https://memory.example.com:0",
+		"https://memory.example.com:65536",
+		"https://memory.example.com/a/../b",
+		"https://memory.example.com/{team}",
+	} {
+		_, err = svc.UpdateSSOSettings(ctx, map[string]string{domain.AppConfigMCPPublicBaseURL: value}, "control", "", "")
+		require.ErrorIs(t, err, ErrInvalidAppConfig, value)
+	}
+
+	localMCP, err := svc.UpdateSSOSettings(ctx, map[string]string{domain.AppConfigMCPPublicBaseURL: "http://127.0.0.1:8080/"}, "control", "", "")
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8080", appConfigItem(t, localMCP, domain.AppConfigMCPPublicBaseURL).EffectiveValue)
 
 	_, err = svc.UpdateDreamingSettings(ctx, map[string]string{"unknown": "value"}, "control", "", "")
 	require.ErrorIs(t, err, ErrInvalidAppConfig)

--- a/internal/service/oauth_protected_resource.go
+++ b/internal/service/oauth_protected_resource.go
@@ -333,7 +333,15 @@ func validateOAuthProfiles(profiles []domain.OAuthProtectedResourceProfile) (map
 }
 
 func validateOAuthProtectedResourceConfig(name string, config domain.OAuthProtectedResourceConfig) error {
-	if len(config.Audiences) == 0 || len(config.Audiences) > oauthMaximumAudiences {
+	return validateOAuthProtectedResourceConfigWithAudienceRequirement(name, config, true)
+}
+
+func validateOptionalOAuthProtectedResourceConfig(name string, config domain.OAuthProtectedResourceConfig) error {
+	return validateOAuthProtectedResourceConfigWithAudienceRequirement(name, config, false)
+}
+
+func validateOAuthProtectedResourceConfigWithAudienceRequirement(name string, config domain.OAuthProtectedResourceConfig, requireAudience bool) error {
+	if len(config.Audiences) > oauthMaximumAudiences || (requireAudience && len(config.Audiences) == 0) {
 		return fmt.Errorf("OAuth profile %q must configure between 1 and %d audiences", name, oauthMaximumAudiences)
 	}
 	if err := validateUniqueOAuthValues(config.Audiences, 512, validNonControlValue); err != nil {

--- a/internal/service/oauth_protected_resource.go
+++ b/internal/service/oauth_protected_resource.go
@@ -25,7 +25,7 @@ const (
 	oauthJWTHeaderLimit       = 16 * 1024
 	oauthJWTClaimsLimit       = 256 * 1024
 	oauthEncodedTokenLimit    = 512 * 1024
-	oauthMaximumProfiles      = 16
+	oauthMaximumProfiles      = domain.OAuthProtectedResourceMaximumProfiles
 	oauthMaximumAudiences     = 16
 	oauthMaximumScopeMappings = 32
 	oauthMaximumMappedScopes  = 16

--- a/internal/service/sso_helpers.go
+++ b/internal/service/sso_helpers.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
 )
 
 type oidcLoginClaims struct {
@@ -748,6 +749,9 @@ func (s *SSOService) validateProtectedResourceProviderSet(ctx context.Context, c
 }
 
 func ssoProviderWriteError(err error, issuer string) error {
+	if errors.Is(err, repository.ErrSSOProtectedResourceProfileLimit) {
+		return fmt.Errorf("OAuth protected-resource config requires between 1 and %d profiles", domain.OAuthProtectedResourceMaximumProfiles)
+	}
 	if uniqueViolationName(err) == "idx_sso_providers_active_oauth_issuer_unique" {
 		return fmt.Errorf("OAuth profile issuer %q is duplicated", issuer)
 	}

--- a/internal/service/sso_helpers.go
+++ b/internal/service/sso_helpers.go
@@ -747,6 +747,13 @@ func (s *SSOService) validateProtectedResourceProviderSet(ctx context.Context, c
 	return err
 }
 
+func ssoProviderWriteError(err error, issuer string) error {
+	if uniqueViolationName(err) == "idx_sso_providers_active_oauth_issuer_unique" {
+		return fmt.Errorf("OAuth profile issuer %q is duplicated", issuer)
+	}
+	return err
+}
+
 func oauthProfileFromSSOProvider(provider *domain.SSOProvider) domain.OAuthProtectedResourceProfile {
 	return domain.OAuthProtectedResourceProfile{
 		Name:              provider.ID.String(),

--- a/internal/service/sso_helpers.go
+++ b/internal/service/sso_helpers.go
@@ -620,7 +620,7 @@ func normalizeSSOProvider(provider *domain.SSOProvider) error {
 	default:
 		return fmt.Errorf("sso provider kind must be azure_ad, pingone, or generic_oidc")
 	}
-	provider.IssuerURL = strings.TrimRight(strings.TrimSpace(provider.IssuerURL), "/")
+	provider.IssuerURL = strings.TrimSpace(provider.IssuerURL)
 	if provider.IssuerURL == "" {
 		return fmt.Errorf("sso issuer_url is required")
 	}
@@ -679,7 +679,80 @@ func normalizeSSOProviderForWrite(provider *domain.SSOProvider) error {
 	if provider.Kind == domain.SSOProviderKindAzureAD && provider.TenantID == "" {
 		return fmt.Errorf("sso tenant_id is required for azure_ad providers")
 	}
-	return nil
+	return normalizeSSOProtectedResourceConfig(provider)
+}
+
+func normalizeSSOProtectedResourceConfig(provider *domain.SSOProvider) error {
+	config := &provider.ProtectedResource.OAuthProtectedResourceConfig
+	if config.JWKSSource == "" {
+		config.JWKSSource = "discovery"
+	}
+	if len(config.Algorithms) == 0 {
+		config.Algorithms = []string{"RS256"}
+	}
+	if config.ScopeClaim == "" {
+		config.ScopeClaim = "scope"
+	}
+	for _, mapping := range config.ScopeMappings {
+		for _, internalScope := range mapping.InternalScopes {
+			switch internalScope {
+			case CredentialScopeRead, CredentialScopeWrite, CredentialScopeFeedbackRead:
+			default:
+				return fmt.Errorf("sso protected_resource internal scopes may contain only read, write, or feedback:read")
+			}
+		}
+	}
+	name := provider.ID.String()
+	if provider.ProtectedResource.Enabled {
+		_, err := validateOAuthProfiles([]domain.OAuthProtectedResourceProfile{{
+			Name:              name,
+			Issuer:            provider.IssuerURL,
+			ProtectedResource: *config,
+		}})
+		return err
+	}
+	return validateOptionalOAuthProtectedResourceConfig(name, *config)
+}
+
+func (s *SSOService) validateProtectedResourceProviderSet(ctx context.Context, candidate *domain.SSOProvider) error {
+	if s == nil || s.repo == nil || candidate == nil {
+		return fmt.Errorf("sso provider repository is unavailable")
+	}
+	providers, err := s.repo.ListProviders(ctx)
+	if err != nil {
+		return err
+	}
+	profiles := make([]domain.OAuthProtectedResourceProfile, 0, len(providers)+1)
+	seenCandidate := false
+	for _, provider := range providers {
+		if provider == nil {
+			continue
+		}
+		if provider.ID == candidate.ID {
+			provider = candidate
+			seenCandidate = true
+		}
+		if !provider.Enabled || provider.RetiredAt != nil || !provider.ProtectedResource.Enabled {
+			continue
+		}
+		profiles = append(profiles, oauthProfileFromSSOProvider(provider))
+	}
+	if !seenCandidate && candidate.Enabled && candidate.RetiredAt == nil && candidate.ProtectedResource.Enabled {
+		profiles = append(profiles, oauthProfileFromSSOProvider(candidate))
+	}
+	if len(profiles) == 0 {
+		return nil
+	}
+	_, err = validateOAuthProfiles(profiles)
+	return err
+}
+
+func oauthProfileFromSSOProvider(provider *domain.SSOProvider) domain.OAuthProtectedResourceProfile {
+	return domain.OAuthProtectedResourceProfile{
+		Name:              provider.ID.String(),
+		Issuer:            provider.IssuerURL,
+		ProtectedResource: provider.ProtectedResource.OAuthProtectedResourceConfig,
+	}
 }
 
 func normalizeSSOGroupMapping(mapping *domain.SSOGroupMapping) error {

--- a/internal/service/sso_helpers_test.go
+++ b/internal/service/sso_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
 )
 
 func TestSSOTokenAndRedirectHelpers(t *testing.T) {
@@ -398,6 +400,14 @@ func TestSSOSetupErrorMessage(t *testing.T) {
 	message, ok := SSOSetupErrorMessage(errors.New("plain error"))
 	assert.False(t, ok)
 	assert.Empty(t, message)
+}
+
+func TestSSOProviderWriteErrorMapsProtectedResourceProfileLimit(t *testing.T) {
+	err := ssoProviderWriteError(fmt.Errorf("wrapped: %w", repository.ErrSSOProtectedResourceProfileLimit), "")
+	require.EqualError(t, err, fmt.Sprintf(
+		"OAuth protected-resource config requires between 1 and %d profiles",
+		domain.OAuthProtectedResourceMaximumProfiles,
+	))
 }
 
 func TestSSOEntitlementCacheHelpers(t *testing.T) {

--- a/internal/service/sso_helpers_test.go
+++ b/internal/service/sso_helpers_test.go
@@ -107,7 +107,7 @@ func TestNormalizeSSOProviderAndMapping(t *testing.T) {
 	require.NoError(t, normalizeSSOProvider(&provider))
 	require.NoError(t, normalizeSSOProviderForWrite(&provider))
 	assert.Equal(t, "Enterprise", provider.Name)
-	assert.Equal(t, "https://login.example.com", provider.IssuerURL)
+	assert.Equal(t, "https://login.example.com/", provider.IssuerURL)
 	assert.Equal(t, "client-id", provider.ClientID)
 	assert.Equal(t, []string{"email", "openid"}, provider.Scopes)
 	assert.Equal(t, []string{"groups"}, provider.GroupClaims)
@@ -141,6 +141,50 @@ func TestNormalizeSSOProviderAndMapping(t *testing.T) {
 	provider = domain.SSOProvider{Name: "Ping", Kind: domain.SSOProviderKindPingOne, IssuerURL: "https://ping.example.com", ClientID: "client", Scopes: []string{"email"}}
 	require.NoError(t, normalizeSSOProvider(&provider))
 	assert.Equal(t, []string{"openid", "email"}, provider.Scopes)
+
+	protectedProvider := domain.SSOProvider{
+		ID:            uuid.New(),
+		Name:          "Protected",
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     "https://issuer.example.com/",
+		IdentityClaim: "sub",
+		ClientID:      "browser-client",
+		Enabled:       true,
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled: true,
+			OAuthProtectedResourceConfig: domain.OAuthProtectedResourceConfig{
+				Audiences:  []string{"api://dense-mem"},
+				JWKSSource: "discovery",
+				Algorithms: []string{"RS256"},
+				ScopeClaim: "scope",
+				ScopeMappings: []domain.OAuthScopeMapping{{
+					ExternalScope:  "memory.read",
+					InternalScopes: []string{CredentialScopeRead},
+				}},
+			},
+		},
+	}
+	require.NoError(t, normalizeSSOProviderForWrite(&protectedProvider))
+	assert.Equal(t, "https://issuer.example.com/", protectedProvider.IssuerURL)
+
+	invalidProtected := protectedProvider
+	invalidProtected.ProtectedResource.ScopeMappings = []domain.OAuthScopeMapping{{
+		ExternalScope:  "memory.admin",
+		InternalScopes: []string{"admin"},
+	}}
+	require.ErrorContains(t, normalizeSSOProviderForWrite(&invalidProtected), "read, write, or feedback:read")
+
+	disabledProtected := domain.SSOProvider{
+		ID:        uuid.New(),
+		Name:      "Dormant",
+		Kind:      domain.SSOProviderKindGenericOIDC,
+		IssuerURL: "https://dormant.example.com",
+		ClientID:  "browser-client",
+	}
+	require.NoError(t, normalizeSSOProviderForWrite(&disabledProtected))
+	assert.Equal(t, "discovery", disabledProtected.ProtectedResource.JWKSSource)
+	assert.Equal(t, []string{"RS256"}, disabledProtected.ProtectedResource.Algorithms)
+	assert.Equal(t, "scope", disabledProtected.ProtectedResource.ScopeClaim)
 
 	mapping := domain.SSOGroupMapping{
 		ProviderID: uuid.New(),

--- a/internal/service/sso_protected_resource.go
+++ b/internal/service/sso_protected_resource.go
@@ -20,6 +20,8 @@ var (
 	ErrOAuthTeamRequired error = oauthTeamRequiredError{}
 )
 
+const oauthValidatorReconfigurationLimit = 4
+
 type oauthAccessDeniedError struct{}
 
 func (oauthAccessDeniedError) Error() string { return "oauth membership access denied" }
@@ -226,7 +228,10 @@ func (s *SSOService) oauthProviderSnapshot(ctx context.Context) (oauthProviderSn
 }
 
 func (s *SSOService) validateOAuthBearer(ctx context.Context, raw string, snapshot oauthProviderSnapshot) (*domain.OAuthValidatedToken, *domain.SSOProvider, error) {
-	for {
+	for attempt := 0; attempt < oauthValidatorReconfigurationLimit; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		s.oauth.mu.RLock()
 		if s.oauth.configured && s.oauth.validator != nil && s.oauth.fingerprint == snapshot.fingerprint {
 			validated, err := s.oauth.validator.Validate(ctx, raw)
@@ -244,6 +249,10 @@ func (s *SSOService) validateOAuthBearer(ctx context.Context, raw string, snapsh
 		s.oauth.mu.RUnlock()
 
 		s.oauth.mu.Lock()
+		if err := ctx.Err(); err != nil {
+			s.oauth.mu.Unlock()
+			return nil, nil, err
+		}
 		if !s.oauth.configured || s.oauth.validator == nil || s.oauth.fingerprint != snapshot.fingerprint {
 			if s.oauth.validator == nil {
 				validator, err := NewOAuthProtectedResourceValidator(snapshot.profiles, OAuthProtectedResourceValidatorOptions{
@@ -264,6 +273,7 @@ func (s *SSOService) validateOAuthBearer(ctx context.Context, raw string, snapsh
 		}
 		s.oauth.mu.Unlock()
 	}
+	return nil, nil, ErrOAuthProviderUnavailable
 }
 
 func validatedOAuthIdentityClaim(raw, claimName string) (string, error) {

--- a/internal/service/sso_protected_resource.go
+++ b/internal/service/sso_protected_resource.go
@@ -1,0 +1,359 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/jsonstrict"
+)
+
+var (
+	ErrOAuthAccessDenied error = oauthAccessDeniedError{}
+	ErrOAuthTeamRequired error = oauthTeamRequiredError{}
+)
+
+type oauthAccessDeniedError struct{}
+
+func (oauthAccessDeniedError) Error() string { return "oauth membership access denied" }
+
+type oauthTeamRequiredError struct{}
+
+func (oauthTeamRequiredError) Error() string { return "oauth team selection required" }
+
+type OAuthProtectedResourceMetadata struct {
+	AuthorizationServers []string
+	ScopesSupported      []string
+}
+
+type oauthProtectedResourceState struct {
+	mu          sync.RWMutex
+	validator   *OAuthProtectedResourceValidator
+	fingerprint [sha256.Size]byte
+	configured  bool
+}
+
+type oauthProviderSnapshot struct {
+	profiles           []domain.OAuthProtectedResourceProfile
+	providers          map[string]*domain.SSOProvider
+	unavailableIssuers map[string]struct{}
+	fingerprint        [sha256.Size]byte
+}
+
+func IsJWTBearer(raw string) bool {
+	parts := strings.Split(raw, ".")
+	return len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != ""
+}
+
+func (s *SSOService) MCPPublicBaseURL(ctx context.Context) (string, error) {
+	cfg, err := s.runtimeConfig(ctx)
+	if err != nil {
+		s.debugSSOFailure("mcp public base url runtime config failed", err)
+		return "", err
+	}
+	return cfg.MCPPublicBaseURL, nil
+}
+
+func (s *SSOService) AuthenticateOAuthBearer(ctx context.Context, raw string, pathTeamID *uuid.UUID) (*domain.AuthenticatedActor, error) {
+	if s == nil || s.repo == nil || !IsJWTBearer(raw) {
+		return nil, ErrOAuthTokenInvalid
+	}
+	issuer, err := unverifiedOAuthIssuer(raw)
+	if err != nil {
+		return nil, ErrOAuthTokenInvalid
+	}
+	snapshot, err := s.oauthProviderSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, unavailable := snapshot.unavailableIssuers[issuer]; unavailable {
+		return nil, ErrOAuthProviderUnavailable
+	}
+	if len(snapshot.profiles) == 0 {
+		return nil, ErrOAuthTokenInvalid
+	}
+
+	validated, provider, err := s.validateOAuthBearer(ctx, raw, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	identitySubject, err := validatedOAuthIdentityClaim(raw, provider.IdentityClaim)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := s.repo.GetIdentityByProviderSubject(ctx, provider.ID, identitySubject)
+	if err != nil {
+		return nil, err
+	}
+	if identity == nil || !identity.Active || identity.ProviderID != provider.ID || identity.Subject != identitySubject {
+		return nil, ErrOAuthAccessDenied
+	}
+
+	memberships, err := s.repo.ListTeamMembershipsForIdentity(ctx, identity.ID)
+	if err != nil {
+		return nil, err
+	}
+	claimedTeamID, err := oauthValidatedTeamID(validated.Team)
+	if err != nil {
+		return nil, err
+	}
+	selected, err := selectOAuthMembership(memberships, pathTeamID, claimedTeamID)
+	if err != nil {
+		return nil, err
+	}
+	if selected.Membership.ActorIdentityID != identity.ID ||
+		selected.Membership.TeamID != selected.Team.ID ||
+		selected.Membership.SSOProviderID == nil ||
+		*selected.Membership.SSOProviderID != provider.ID ||
+		selected.Membership.SSOSubject != identity.Subject {
+		return nil, ErrOAuthAccessDenied
+	}
+
+	membership, err := s.ValidateMembership(ctx, &selected.Membership)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrSSOAccessDenied), errors.Is(err, ErrSSOProviderDisabled):
+			return nil, ErrOAuthAccessDenied
+		case errors.Is(err, ErrSSOEntitlementRefreshStale):
+			return nil, ErrOAuthProviderUnavailable
+		default:
+			return nil, err
+		}
+	}
+	membership.Grants = intersectOAuthGrants(validated.Scopes, membership.Grants)
+
+	return &domain.AuthenticatedActor{
+		Team: selected.Team,
+		Identity: domain.ActorIdentity{
+			ID:          identity.ID,
+			Kind:        "human",
+			DisplayName: identity.DisplayName,
+		},
+		Membership: *membership,
+		OwnerID:    membership.OwnerID,
+	}, nil
+}
+
+func (s *SSOService) OAuthProtectedResourceMetadata(ctx context.Context) (OAuthProtectedResourceMetadata, error) {
+	if s == nil || s.repo == nil {
+		return OAuthProtectedResourceMetadata{}, nil
+	}
+	snapshot, err := s.oauthProviderSnapshot(ctx)
+	if err != nil {
+		return OAuthProtectedResourceMetadata{}, err
+	}
+	if len(snapshot.profiles) == 0 && len(snapshot.unavailableIssuers) > 0 {
+		return OAuthProtectedResourceMetadata{}, ErrOAuthProviderUnavailable
+	}
+	issuers := make(map[string]struct{}, len(snapshot.profiles))
+	scopes := make(map[string]struct{})
+	for _, profile := range snapshot.profiles {
+		issuers[profile.Issuer] = struct{}{}
+		for _, mapping := range profile.ProtectedResource.ScopeMappings {
+			scopes[mapping.ExternalScope] = struct{}{}
+		}
+	}
+	return OAuthProtectedResourceMetadata{
+		AuthorizationServers: sortedOAuthKeys(issuers),
+		ScopesSupported:      sortedOAuthKeys(scopes),
+	}, nil
+}
+
+func (s *SSOService) oauthProviderSnapshot(ctx context.Context) (oauthProviderSnapshot, error) {
+	providers, err := s.repo.ListEnabledProviders(ctx)
+	if err != nil {
+		return oauthProviderSnapshot{}, ErrOAuthProviderUnavailable
+	}
+	profilesByIssuer := make(map[string]domain.OAuthProtectedResourceProfile, len(providers))
+	byName := make(map[string]*domain.SSOProvider, len(providers))
+	unavailableIssuers := make(map[string]struct{})
+	for _, provider := range providers {
+		if provider == nil || provider.RetiredAt != nil || !provider.ProtectedResource.Enabled {
+			continue
+		}
+		copyProvider := *provider
+		if err := normalizeSSOProviderForWrite(&copyProvider); err != nil {
+			if issuer := strings.TrimSpace(provider.IssuerURL); issuer != "" {
+				unavailableIssuers[issuer] = struct{}{}
+				if existing, ok := profilesByIssuer[issuer]; ok {
+					delete(byName, existing.Name)
+					delete(profilesByIssuer, issuer)
+				}
+			}
+			continue
+		}
+		profile := oauthProfileFromSSOProvider(&copyProvider)
+		if _, unavailable := unavailableIssuers[profile.Issuer]; unavailable {
+			continue
+		}
+		if existing, duplicated := profilesByIssuer[profile.Issuer]; duplicated {
+			delete(byName, existing.Name)
+			delete(profilesByIssuer, profile.Issuer)
+			unavailableIssuers[profile.Issuer] = struct{}{}
+			continue
+		}
+		profilesByIssuer[profile.Issuer] = profile
+		byName[profile.Name] = &copyProvider
+	}
+	profiles := make([]domain.OAuthProtectedResourceProfile, 0, len(profilesByIssuer))
+	for _, profile := range profilesByIssuer {
+		profiles = append(profiles, profile)
+	}
+	if len(profiles) == 0 {
+		return oauthProviderSnapshot{providers: byName, unavailableIssuers: unavailableIssuers}, nil
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	if _, err := validateOAuthProfiles(profiles); err != nil {
+		return oauthProviderSnapshot{}, ErrOAuthProviderUnavailable
+	}
+	encoded, err := json.Marshal(profiles)
+	if err != nil {
+		return oauthProviderSnapshot{}, ErrOAuthProviderUnavailable
+	}
+	return oauthProviderSnapshot{
+		profiles:           profiles,
+		providers:          byName,
+		unavailableIssuers: unavailableIssuers,
+		fingerprint:        sha256.Sum256(encoded),
+	}, nil
+}
+
+func (s *SSOService) validateOAuthBearer(ctx context.Context, raw string, snapshot oauthProviderSnapshot) (*domain.OAuthValidatedToken, *domain.SSOProvider, error) {
+	for {
+		s.oauth.mu.RLock()
+		if s.oauth.configured && s.oauth.validator != nil && s.oauth.fingerprint == snapshot.fingerprint {
+			validated, err := s.oauth.validator.Validate(ctx, raw)
+			if err != nil {
+				s.oauth.mu.RUnlock()
+				return nil, nil, err
+			}
+			provider := snapshot.providers[validated.ProfileName]
+			s.oauth.mu.RUnlock()
+			if provider == nil || provider.IssuerURL != validated.Issuer {
+				return nil, nil, ErrOAuthTokenInvalid
+			}
+			return validated, provider, nil
+		}
+		s.oauth.mu.RUnlock()
+
+		s.oauth.mu.Lock()
+		if !s.oauth.configured || s.oauth.validator == nil || s.oauth.fingerprint != snapshot.fingerprint {
+			if s.oauth.validator == nil {
+				validator, err := NewOAuthProtectedResourceValidator(snapshot.profiles, OAuthProtectedResourceValidatorOptions{
+					HTTPClient: s.httpClient,
+					Now:        s.now,
+				})
+				if err != nil {
+					s.oauth.mu.Unlock()
+					return nil, nil, ErrOAuthProviderUnavailable
+				}
+				s.oauth.validator = validator
+			} else if err := s.oauth.validator.Configure(snapshot.profiles); err != nil {
+				s.oauth.mu.Unlock()
+				return nil, nil, ErrOAuthProviderUnavailable
+			}
+			s.oauth.fingerprint = snapshot.fingerprint
+			s.oauth.configured = true
+		}
+		s.oauth.mu.Unlock()
+	}
+}
+
+func validatedOAuthIdentityClaim(raw, claimName string) (string, error) {
+	_, claimsJSON, err := strictOAuthJWTParts(raw)
+	if err != nil {
+		return "", ErrOAuthTokenInvalid
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil || claims == nil {
+		return "", ErrOAuthTokenInvalid
+	}
+	return requiredExactOAuthString(claims, claimName)
+}
+
+func unverifiedOAuthIssuer(raw string) (string, error) {
+	headerJSON, claimsJSON, err := strictOAuthJWTParts(raw)
+	if err != nil || jsonstrict.RejectDuplicateFields(headerJSON) != nil || jsonstrict.RejectDuplicateFields(claimsJSON) != nil {
+		return "", ErrOAuthTokenInvalid
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil || claims == nil {
+		return "", ErrOAuthTokenInvalid
+	}
+	return requiredExactOAuthString(claims, "iss")
+}
+
+func oauthValidatedTeamID(raw string) (*uuid.UUID, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	teamID, err := uuid.Parse(raw)
+	if err != nil || teamID == uuid.Nil {
+		return nil, ErrOAuthTokenInvalid
+	}
+	return &teamID, nil
+}
+
+func selectOAuthMembership(memberships []*domain.SSOTeamMembership, pathTeamID, claimedTeamID *uuid.UUID) (*domain.SSOTeamMembership, error) {
+	if pathTeamID != nil && claimedTeamID != nil && *pathTeamID != *claimedTeamID {
+		return nil, ErrOAuthAccessDenied
+	}
+	target := pathTeamID
+	if target == nil {
+		target = claimedTeamID
+	}
+	if target == nil {
+		if len(memberships) == 0 {
+			return nil, ErrOAuthAccessDenied
+		}
+		if len(memberships) != 1 {
+			return nil, ErrOAuthTeamRequired
+		}
+		if memberships[0] == nil {
+			return nil, ErrOAuthAccessDenied
+		}
+		return memberships[0], nil
+	}
+	for _, membership := range memberships {
+		if membership != nil && membership.Team.ID == *target {
+			return membership, nil
+		}
+	}
+	return nil, ErrOAuthAccessDenied
+}
+
+func intersectOAuthGrants(mapped, membership []string) []string {
+	membershipSet := make(map[string]struct{}, len(membership))
+	for _, grant := range membership {
+		membershipSet[grant] = struct{}{}
+	}
+	mappedSet := make(map[string]struct{}, len(mapped))
+	for _, grant := range mapped {
+		if _, ok := membershipSet[grant]; ok {
+			mappedSet[grant] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(mappedSet))
+	for _, grant := range []string{CredentialScopeRead, CredentialScopeWrite, CredentialScopeFeedbackRead} {
+		if _, ok := mappedSet[grant]; ok {
+			result = append(result, grant)
+		}
+	}
+	return result
+}
+
+func sortedOAuthKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/service/sso_protected_resource_isolation_test.go
+++ b/internal/service/sso_protected_resource_isolation_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestOAuthProtectedResourceIsolatesInvalidProviderByIssuer(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+	invalid := *fixture.provider
+	invalid.ID = uuid.New()
+	invalid.IssuerURL = "https://invalid.example.test"
+	invalid.ProtectedResource.Algorithms = []string{"none"}
+	fixture.repo.providerList = []*domain.SSOProvider{&invalid, fixture.provider}
+
+	_, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.NoError(t, err)
+	metadata, err := fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{fixture.provider.IssuerURL}, metadata.AuthorizationServers)
+
+	invalid.IssuerURL = fixture.provider.IssuerURL
+	fixture.repo.providerList = []*domain.SSOProvider{&invalid}
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+	_, err = fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+}
+
+func TestOAuthProtectedResourceIsolatesDuplicateIssuerConfiguration(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+	duplicate := *fixture.provider
+	duplicate.ID = uuid.New()
+
+	genericProfile := fixture.compatibility.profiles()[2]
+	generic := &domain.SSOProvider{
+		ID:            uuid.New(),
+		Name:          "Generic",
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     genericProfile.Issuer,
+		IdentityClaim: "sub",
+		ClientID:      "generic-client",
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled:                      true,
+			OAuthProtectedResourceConfig: genericProfile.ProtectedResource,
+		},
+		Enabled: true,
+	}
+	fixture.repo.providerList = []*domain.SSOProvider{fixture.provider, &duplicate, generic}
+
+	metadata, err := fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{generic.IssuerURL}, metadata.AuthorizationServers)
+
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+}

--- a/internal/service/sso_protected_resource_test.go
+++ b/internal/service/sso_protected_resource_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -209,6 +210,18 @@ func TestOAuthProtectedResourcePublicURLAndErrors(t *testing.T) {
 	require.ErrorIs(t, err, runtimeErr)
 	require.Equal(t, "oauth membership access denied", ErrOAuthAccessDenied.Error())
 	require.Equal(t, "oauth team selection required", ErrOAuthTeamRequired.Error())
+}
+
+func TestValidateOAuthBearerHonorsCanceledContextBeforeReconfiguration(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+	snapshot, err := fixture.service.oauthProviderSnapshot(t.Context())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err = fixture.service.validateOAuthBearer(ctx, fixture.token(t, true), snapshot)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, fixture.service.oauth.configured)
 }
 
 func TestOAuthProtectedResourceFailsClosedBeforeIdentityResolution(t *testing.T) {

--- a/internal/service/sso_protected_resource_test.go
+++ b/internal/service/sso_protected_resource_test.go
@@ -1,0 +1,389 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestAuthenticateOAuthBearerValidatesBeforeFixingMembershipContext(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+
+	actor, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), &fixture.teamID)
+	require.NoError(t, err)
+	require.Equal(t, fixture.teamID, actor.Team.ID)
+	require.Equal(t, fixture.identity.ID, actor.Identity.ID)
+	require.Equal(t, fixture.membership.Membership.OwnerID, actor.OwnerID)
+	require.Equal(t, []string{CredentialScopeRead}, actor.Membership.Grants)
+	require.Equal(t, fixture.membership.Membership.MemorySpaceID, actor.Membership.MemorySpaceID)
+	require.Equal(t, 1, fixture.repo.identityLookupCalls)
+
+	claims := fixture.claims(true)
+	claims["aud"] = "wrong-audience"
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.compatibility.token(t, "entra", "primary", claims), nil)
+	require.ErrorIs(t, err, ErrOAuthTokenInvalid)
+	require.Equal(t, 1, fixture.repo.identityLookupCalls, "invalid bearer material must not reach identity lookup")
+
+	otherTeamID := uuid.New()
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), &otherTeamID)
+	require.ErrorIs(t, err, ErrOAuthAccessDenied)
+}
+
+func TestAuthenticateOAuthBearerSupportsSubAndEntraOIDIdentityClaims(t *testing.T) {
+	for _, identityClaim := range []string{"sub", "oid"} {
+		t.Run(identityClaim, func(t *testing.T) {
+			fixture := newSSOOAuthFixture(t)
+			fixture.provider.IdentityClaim = identityClaim
+			if identityClaim == "sub" {
+				fixture.identity.Subject = "entra-user"
+				fixture.membership.Membership.SSOSubject = fixture.identity.Subject
+				fixture.repo.cache.Subject = fixture.identity.Subject
+			}
+
+			actor, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+			require.NoError(t, err)
+			require.Equal(t, fixture.identity.ID, actor.Identity.ID)
+		})
+	}
+}
+
+func TestAuthenticateOAuthBearerRequiresUnambiguousVerifiedTeam(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+
+	actor, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, false), nil)
+	require.NoError(t, err)
+	require.Equal(t, fixture.teamID, actor.Team.ID)
+
+	otherTeamID := uuid.New()
+	other := fixture.addMembership(otherTeamID)
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, false), nil)
+	require.ErrorIs(t, err, ErrOAuthTeamRequired)
+
+	actor, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, false), &otherTeamID)
+	require.NoError(t, err)
+	require.Equal(t, other.Team.ID, actor.Team.ID)
+
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), &otherTeamID)
+	require.ErrorIs(t, err, ErrOAuthAccessDenied)
+}
+
+func TestAuthenticateOAuthBearerFailsClosedForIdentityAndMembershipMismatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ssoOAuthFixture)
+	}{
+		{
+			name: "disabled identity",
+			mutate: func(fixture *ssoOAuthFixture) {
+				fixture.identity.Active = false
+			},
+		},
+		{
+			name: "missing membership",
+			mutate: func(fixture *ssoOAuthFixture) {
+				fixture.repo.teamProfiles = nil
+			},
+		},
+		{
+			name: "provider mismatch",
+			mutate: func(fixture *ssoOAuthFixture) {
+				otherProviderID := uuid.New()
+				fixture.membership.Membership.SSOProviderID = &otherProviderID
+			},
+		},
+		{
+			name: "subject mismatch",
+			mutate: func(fixture *ssoOAuthFixture) {
+				fixture.membership.Membership.SSOSubject = "other-subject"
+			},
+		},
+		{
+			name: "revoked mapping",
+			mutate: func(fixture *ssoOAuthFixture) {
+				fixture.repo.mappings = nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newSSOOAuthFixture(t)
+			test.mutate(fixture)
+
+			_, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+			require.ErrorIs(t, err, ErrOAuthAccessDenied)
+		})
+	}
+}
+
+func TestAuthenticateOAuthBearerRevalidatesDirectoryMembership(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+	fixture.repo.directoryAuthorityActive = true
+	fixture.repo.directoryProfileEntitled = map[uuid.UUID]bool{fixture.identity.ID: false}
+
+	_, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthAccessDenied)
+	require.Equal(t, []uuid.UUID{fixture.identity.ID}, fixture.repo.directoryProfileEntitledCalls)
+
+	fixture.repo.directoryProfileEntitled[fixture.identity.ID] = true
+	claims := fixture.claims(true)
+	claims["scp"] = "memory.read"
+	actor, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.compatibility.token(t, "entra", "primary", claims), nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{CredentialScopeRead}, actor.Membership.Grants)
+}
+
+func TestOAuthProtectedResourceMetadataIsDormantAndSorted(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+	fixture.provider.ProtectedResource.Enabled = false
+
+	metadata, err := fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, metadata.AuthorizationServers)
+	require.Empty(t, metadata.ScopesSupported)
+
+	fixture.provider.ProtectedResource.Enabled = true
+	genericProfile := fixture.compatibility.profiles()[2]
+	genericProvider := &domain.SSOProvider{
+		ID:            uuid.New(),
+		Name:          "Generic",
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     genericProfile.Issuer,
+		IdentityClaim: "sub",
+		ClientID:      "generic-client",
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled:                      true,
+			OAuthProtectedResourceConfig: genericProfile.ProtectedResource,
+		},
+		Enabled: true,
+	}
+	fixture.repo.providerList = []*domain.SSOProvider{genericProvider, fixture.provider}
+
+	metadata, err = fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{fixture.provider.IssuerURL, genericProvider.IssuerURL}, metadata.AuthorizationServers)
+	require.Equal(t, []string{"generic.read", "generic.write", "memory.read", "memory.write"}, metadata.ScopesSupported)
+}
+
+func TestAuthenticateOAuthBearerReconfiguresWithoutDiscardingCompatibleJWKS(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+
+	_, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.NoError(t, err)
+	initialRequests := fixture.compatibility.jwksRequests("entra")
+
+	fixture.provider.ProtectedResource.ScopeMappings[0].InternalScopes = []string{CredentialScopeRead, CredentialScopeFeedbackRead}
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.NoError(t, err)
+	require.Equal(t, initialRequests, fixture.compatibility.jwksRequests("entra"))
+
+	fixture.provider.ProtectedResource.JWKSSource = "static"
+	fixture.provider.ProtectedResource.JWKSURI = fixture.compatibility.server.URL + "/entra/alternate-jwks"
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.NoError(t, err)
+	require.Equal(t, initialRequests+1, fixture.compatibility.jwksRequests("entra"))
+}
+
+func TestOAuthProtectedResourcePublicURLAndErrors(t *testing.T) {
+	repo := &ssoRepositoryStub{t: t}
+	service := NewSSOService(repo, SSOConfig{
+		RuntimeConfig: ssoRuntimeConfigStub{cfg: SSORuntimeConfig{MCPPublicBaseURL: "https://memory.example.test/base/"}},
+	})
+
+	publicURL, err := service.MCPPublicBaseURL(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "https://memory.example.test/base", publicURL)
+
+	publicURL, err = (*SSOService)(nil).MCPPublicBaseURL(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, publicURL)
+
+	runtimeErr := errors.New("runtime unavailable")
+	service = NewSSOService(repo, SSOConfig{RuntimeConfig: ssoRuntimeConfigStub{err: runtimeErr}})
+	_, err = service.MCPPublicBaseURL(t.Context())
+	require.ErrorIs(t, err, runtimeErr)
+	require.Equal(t, "oauth membership access denied", ErrOAuthAccessDenied.Error())
+	require.Equal(t, "oauth team selection required", ErrOAuthTeamRequired.Error())
+}
+
+func TestOAuthProtectedResourceFailsClosedBeforeIdentityResolution(t *testing.T) {
+	fixture := newSSOOAuthFixture(t)
+
+	_, err := (*SSOService)(nil).AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthTokenInvalid)
+	_, err = NewSSOService(nil, SSOConfig{}).AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthTokenInvalid)
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), "not-a-jwt", nil)
+	require.ErrorIs(t, err, ErrOAuthTokenInvalid)
+	require.Zero(t, fixture.repo.identityLookupCalls)
+
+	backendErr := errors.New("provider list unavailable")
+	fixture.repo.listProvidersErr = backendErr
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+	metadata, err := fixture.service.OAuthProtectedResourceMetadata(t.Context())
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+	require.Empty(t, metadata.AuthorizationServers)
+
+	metadata, err = (*SSOService)(nil).OAuthProtectedResourceMetadata(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, metadata.AuthorizationServers)
+}
+
+func TestAuthenticateOAuthBearerPropagatesAuthoritativeLookupFailures(t *testing.T) {
+	backendErr := errors.New("authoritative lookup failed")
+
+	fixture := newSSOOAuthFixture(t)
+	fixture.repo.getIdentityErr = backendErr
+	_, err := fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, backendErr)
+
+	fixture = newSSOOAuthFixture(t)
+	fixture.repo.listTeamProfilesErr = backendErr
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, backendErr)
+
+	fixture = newSSOOAuthFixture(t)
+	claims := fixture.claims(false)
+	claims["tenant"] = "not-a-team-id"
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.compatibility.token(t, "entra", "primary", claims), nil)
+	require.ErrorIs(t, err, ErrOAuthTokenInvalid)
+
+	fixture = newSSOOAuthFixture(t)
+	fixture.repo.cache = nil
+	fixture.service.groupResolver = &ssoGroupResolverStub{t: t, err: backendErr}
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, ErrOAuthProviderUnavailable)
+
+	fixture = newSSOOAuthFixture(t)
+	fixture.repo.getProviderErr = backendErr
+	_, err = fixture.service.AuthenticateOAuthBearer(t.Context(), fixture.token(t, true), nil)
+	require.ErrorIs(t, err, backendErr)
+}
+
+type ssoOAuthFixture struct {
+	compatibility *oauthCompatibilityFixture
+	service       *SSOService
+	repo          *ssoRepositoryStub
+	provider      *domain.SSOProvider
+	identity      *domain.SSOIdentity
+	membership    *domain.SSOTeamMembership
+	teamID        uuid.UUID
+}
+
+func newSSOOAuthFixture(t *testing.T) *ssoOAuthFixture {
+	t.Helper()
+	compatibility := newOAuthCompatibilityFixture(t)
+	profile := compatibility.profiles()[0]
+	providerID := uuid.New()
+	teamID := uuid.New()
+	identity := &domain.SSOIdentity{
+		ID:          uuid.New(),
+		ProviderID:  providerID,
+		Subject:     "entra-object-id",
+		DisplayName: "Entra User",
+		Active:      true,
+	}
+	provider := &domain.SSOProvider{
+		ID:            providerID,
+		Name:          "Entra",
+		Kind:          domain.SSOProviderKindAzureAD,
+		IssuerURL:     profile.Issuer,
+		TenantID:      "tenant",
+		IdentityClaim: "oid",
+		ClientID:      "entra-client",
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled:                      true,
+			OAuthProtectedResourceConfig: profile.ProtectedResource,
+		},
+		Enabled: true,
+	}
+	membership := newSSOOAuthMembership(providerID, identity.ID, identity.Subject, teamID)
+	repo := &ssoRepositoryStub{
+		t:            t,
+		providers:    map[uuid.UUID]*domain.SSOProvider{providerID: provider},
+		providerList: []*domain.SSOProvider{provider},
+		identities:   map[uuid.UUID]*domain.SSOIdentity{identity.ID: identity},
+		teamProfiles: []*domain.SSOTeamMembership{membership},
+		cache: &domain.SSOEntitlementCache{
+			ProviderID: providerID,
+			Subject:    identity.Subject,
+			Groups:     []string{"memory-users"},
+			Status:     "active",
+			CheckedAt:  compatibility.currentTime(),
+			ExpiresAt:  compatibility.currentTime().Add(time.Hour),
+		},
+		mappings: []*domain.SSOGroupMapping{newSSOOAuthMapping(providerID, teamID)},
+	}
+	return &ssoOAuthFixture{
+		compatibility: compatibility,
+		service: NewSSOService(repo, SSOConfig{
+			HTTPClient: compatibility.server.Client(),
+			Now:        func() time.Time { return compatibility.currentTime() },
+		}),
+		repo:       repo,
+		provider:   provider,
+		identity:   identity,
+		membership: membership,
+		teamID:     teamID,
+	}
+}
+
+func (fixture *ssoOAuthFixture) claims(includeTeam bool) map[string]any {
+	claims := fixture.compatibility.claims("entra")
+	claims["oid"] = fixture.identity.Subject
+	claims["scp"] = "memory.read memory.write"
+	if includeTeam {
+		claims["tenant"] = fixture.teamID.String()
+	}
+	return claims
+}
+
+func (fixture *ssoOAuthFixture) token(t *testing.T, includeTeam bool) string {
+	t.Helper()
+	return fixture.compatibility.token(t, "entra", "primary", fixture.claims(includeTeam))
+}
+
+func (fixture *ssoOAuthFixture) addMembership(teamID uuid.UUID) *domain.SSOTeamMembership {
+	membership := newSSOOAuthMembership(fixture.provider.ID, fixture.identity.ID, fixture.identity.Subject, teamID)
+	fixture.repo.teamProfiles = append(fixture.repo.teamProfiles, membership)
+	fixture.repo.mappings = append(fixture.repo.mappings, newSSOOAuthMapping(fixture.provider.ID, teamID))
+	return membership
+}
+
+func newSSOOAuthMembership(providerID, identityID uuid.UUID, subject string, teamID uuid.UUID) *domain.SSOTeamMembership {
+	return &domain.SSOTeamMembership{
+		Team: domain.Team{ID: teamID, Name: "OAuth Team"},
+		Membership: domain.Membership{
+			ID:              uuid.New(),
+			MemorySpaceID:   uuid.New(),
+			ActorIdentityID: identityID,
+			TeamID:          teamID,
+			OwnerID:         uuid.New(),
+			Name:            "OAuth User",
+			Grants:          []string{CredentialScopeRead, CredentialScopeWrite},
+			Role:            CredentialRoleMember,
+			Status:          "active",
+			SSOProviderID:   &providerID,
+			SSOSubject:      subject,
+			SSOGroupID:      "memory-users",
+		},
+	}
+}
+
+func newSSOOAuthMapping(providerID, teamID uuid.UUID) *domain.SSOGroupMapping {
+	return &domain.SSOGroupMapping{
+		ID:         uuid.New(),
+		ProviderID: providerID,
+		TeamID:     teamID,
+		GroupID:    "memory-users",
+		Scopes:     []string{CredentialScopeRead},
+		Role:       CredentialRoleMember,
+		Enabled:    true,
+	}
+}

--- a/internal/service/sso_provider_update.go
+++ b/internal/service/sso_provider_update.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProvider) (*domain.SSOProvider, error) {
+	return s.updateProvider(ctx, provider, false)
+}
+
+func (s *SSOService) UpdateProviderPreservingProtectedResource(ctx context.Context, provider domain.SSOProvider) (*domain.SSOProvider, error) {
+	return s.updateProvider(ctx, provider, true)
+}
+
+func (s *SSOService) updateProvider(ctx context.Context, provider domain.SSOProvider, preserveProtectedResource bool) (*domain.SSOProvider, error) {
+	if provider.ID == uuid.Nil {
+		err := fmt.Errorf("sso provider ID is required")
+		s.debugSSOProviderFailure("sso update provider validation failed", err, &provider)
+		return nil, err
+	}
+	if preserveProtectedResource {
+		stored, err := s.repo.GetProvider(ctx, provider.ID)
+		if err != nil {
+			s.debugSSOProviderFailure("sso update provider config load failed", err, &provider)
+			return nil, err
+		}
+		if stored != nil {
+			provider.ProtectedResource = stored.ProtectedResource
+		}
+	}
+	if err := normalizeSSOProviderForWrite(&provider); err != nil {
+		s.debugSSOProviderFailure("sso update provider validation failed", err, &provider)
+		return nil, err
+	}
+	if err := s.validateProtectedResourceProviderSet(ctx, &provider); err != nil {
+		s.debugSSOProviderFailure("sso update protected-resource set validation failed", err, &provider)
+		return nil, err
+	}
+	var err error
+	if preserveProtectedResource {
+		err = s.repo.UpdateProviderPreservingProtectedResource(ctx, &provider)
+	} else {
+		err = s.repo.UpdateProvider(ctx, &provider)
+	}
+	if err != nil {
+		err = ssoProviderWriteError(err, provider.IssuerURL)
+		s.debugSSOProviderFailure("sso update provider query failed", err, &provider)
+		return nil, err
+	}
+	updated, err := s.repo.GetProvider(ctx, provider.ID)
+	if err != nil {
+		s.debugSSOProviderFailure("sso update provider reload failed", err, &provider)
+		return nil, err
+	}
+	return updated, nil
+}

--- a/internal/service/sso_service.go
+++ b/internal/service/sso_service.go
@@ -235,13 +235,6 @@ func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProv
 	return updated, nil
 }
 
-func ssoProviderWriteError(err error, issuer string) error {
-	if uniqueViolationName(err) == "idx_sso_providers_active_oauth_issuer_unique" {
-		return fmt.Errorf("OAuth profile issuer %q is duplicated", issuer)
-	}
-	return err
-}
-
 func (s *SSOService) DeleteProvider(ctx context.Context, providerID uuid.UUID) error {
 	if providerID == uuid.Nil {
 		err := fmt.Errorf("sso provider ID is required")

--- a/internal/service/sso_service.go
+++ b/internal/service/sso_service.go
@@ -201,6 +201,7 @@ func (s *SSOService) CreateProvider(ctx context.Context, provider domain.SSOProv
 		return nil, err
 	}
 	if err := s.repo.CreateProvider(ctx, &provider); err != nil {
+		err = ssoProviderWriteError(err, provider.IssuerURL)
 		s.debugSSOProviderFailure("sso create provider query failed", err, &provider)
 		return nil, err
 	}
@@ -222,6 +223,7 @@ func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProv
 		return nil, err
 	}
 	if err := s.repo.UpdateProvider(ctx, &provider); err != nil {
+		err = ssoProviderWriteError(err, provider.IssuerURL)
 		s.debugSSOProviderFailure("sso update provider query failed", err, &provider)
 		return nil, err
 	}
@@ -231,6 +233,13 @@ func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProv
 		return nil, err
 	}
 	return updated, nil
+}
+
+func ssoProviderWriteError(err error, issuer string) error {
+	if uniqueViolationName(err) == "idx_sso_providers_active_oauth_issuer_unique" {
+		return fmt.Errorf("OAuth profile issuer %q is duplicated", issuer)
+	}
+	return err
 }
 
 func (s *SSOService) DeleteProvider(ctx context.Context, providerID uuid.UUID) error {

--- a/internal/service/sso_service.go
+++ b/internal/service/sso_service.go
@@ -50,6 +50,7 @@ type SSORuntimeConfigProvider interface {
 
 type SSORuntimeConfig struct {
 	PublicBaseURL        string
+	MCPPublicBaseURL     string
 	SCIMPublicBaseURL    string
 	ControlPublicBaseURL string
 	EntitlementCacheTTL  time.Duration
@@ -81,6 +82,7 @@ type SSOService struct {
 	groupResolver       SSOGroupResolver
 	logger              observability.LogProvider
 	now                 func() time.Time
+	oauth               oauthProtectedResourceState
 }
 
 type SSOLoginStart struct {
@@ -187,8 +189,15 @@ func (s *SSOService) ListProviders(ctx context.Context) ([]*domain.SSOProvider, 
 }
 
 func (s *SSOService) CreateProvider(ctx context.Context, provider domain.SSOProvider) (*domain.SSOProvider, error) {
+	if provider.ID == uuid.Nil {
+		provider.ID = uuid.New()
+	}
 	if err := normalizeSSOProviderForWrite(&provider); err != nil {
 		s.debugSSOProviderFailure("sso create provider validation failed", err, &provider)
+		return nil, err
+	}
+	if err := s.validateProtectedResourceProviderSet(ctx, &provider); err != nil {
+		s.debugSSOProviderFailure("sso create protected-resource set validation failed", err, &provider)
 		return nil, err
 	}
 	if err := s.repo.CreateProvider(ctx, &provider); err != nil {
@@ -206,6 +215,10 @@ func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProv
 	}
 	if err := normalizeSSOProviderForWrite(&provider); err != nil {
 		s.debugSSOProviderFailure("sso update provider validation failed", err, &provider)
+		return nil, err
+	}
+	if err := s.validateProtectedResourceProviderSet(ctx, &provider); err != nil {
+		s.debugSSOProviderFailure("sso update protected-resource set validation failed", err, &provider)
 		return nil, err
 	}
 	if err := s.repo.UpdateProvider(ctx, &provider); err != nil {
@@ -957,6 +970,7 @@ func (s *SSOService) runtimeConfig(ctx context.Context) (SSORuntimeConfig, error
 
 func normalizeSSORuntimeConfig(cfg SSORuntimeConfig) SSORuntimeConfig {
 	cfg.PublicBaseURL = strings.TrimRight(strings.TrimSpace(cfg.PublicBaseURL), "/")
+	cfg.MCPPublicBaseURL = strings.TrimRight(strings.TrimSpace(cfg.MCPPublicBaseURL), "/")
 	cfg.SCIMPublicBaseURL = strings.TrimRight(strings.TrimSpace(cfg.SCIMPublicBaseURL), "/")
 	cfg.ControlPublicBaseURL = strings.TrimRight(strings.TrimSpace(cfg.ControlPublicBaseURL), "/")
 	if cfg.EntitlementCacheTTL <= 0 {

--- a/internal/service/sso_service.go
+++ b/internal/service/sso_service.go
@@ -208,33 +208,6 @@ func (s *SSOService) CreateProvider(ctx context.Context, provider domain.SSOProv
 	return &provider, nil
 }
 
-func (s *SSOService) UpdateProvider(ctx context.Context, provider domain.SSOProvider) (*domain.SSOProvider, error) {
-	if provider.ID == uuid.Nil {
-		err := fmt.Errorf("sso provider ID is required")
-		s.debugSSOProviderFailure("sso update provider validation failed", err, &provider)
-		return nil, err
-	}
-	if err := normalizeSSOProviderForWrite(&provider); err != nil {
-		s.debugSSOProviderFailure("sso update provider validation failed", err, &provider)
-		return nil, err
-	}
-	if err := s.validateProtectedResourceProviderSet(ctx, &provider); err != nil {
-		s.debugSSOProviderFailure("sso update protected-resource set validation failed", err, &provider)
-		return nil, err
-	}
-	if err := s.repo.UpdateProvider(ctx, &provider); err != nil {
-		err = ssoProviderWriteError(err, provider.IssuerURL)
-		s.debugSSOProviderFailure("sso update provider query failed", err, &provider)
-		return nil, err
-	}
-	updated, err := s.repo.GetProvider(ctx, provider.ID)
-	if err != nil {
-		s.debugSSOProviderFailure("sso update provider reload failed", err, &provider)
-		return nil, err
-	}
-	return updated, nil
-}
-
 func (s *SSOService) DeleteProvider(ctx context.Context, providerID uuid.UUID) error {
 	if providerID == uuid.Nil {
 		err := fmt.Errorf("sso provider ID is required")

--- a/internal/service/sso_service_test.go
+++ b/internal/service/sso_service_test.go
@@ -273,6 +273,7 @@ type ssoRepositoryStub struct {
 	deletedMappingID              uuid.UUID
 	identities                    map[uuid.UUID]*domain.SSOIdentity
 	getIdentityErr                error
+	identityLookupCalls           int
 	upsertIdentityErr             error
 	upsertIdentityID              uuid.UUID
 	upsertProfileErrors           map[uuid.UUID]error
@@ -504,7 +505,17 @@ func (r *ssoRepositoryStub) GetIdentity(ctx context.Context, id uuid.UUID) (*dom
 }
 
 func (r *ssoRepositoryStub) GetIdentityByProviderSubject(ctx context.Context, providerID uuid.UUID, subject string) (*domain.SSOIdentity, error) {
-	r.unexpected("GetIdentityByProviderSubject")
+	r.identityLookupCalls++
+	if r.getIdentityErr != nil {
+		return nil, r.getIdentityErr
+	}
+	for _, identity := range r.identities {
+		if identity.ProviderID != providerID || identity.Subject != subject {
+			continue
+		}
+		copy := *identity
+		return &copy, nil
+	}
 	return nil, nil
 }
 

--- a/internal/service/sso_service_test.go
+++ b/internal/service/sso_service_test.go
@@ -422,6 +422,13 @@ func (r *ssoRepositoryStub) UpdateProvider(ctx context.Context, provider *domain
 	return nil
 }
 
+func (r *ssoRepositoryStub) UpdateProviderPreservingProtectedResource(ctx context.Context, provider *domain.SSOProvider) error {
+	if stored := r.providers[provider.ID]; stored != nil {
+		provider.ProtectedResource = stored.ProtectedResource
+	}
+	return r.UpdateProvider(ctx, provider)
+}
+
 func (r *ssoRepositoryStub) DeleteProvider(ctx context.Context, id uuid.UUID) error {
 	if r.deleteProviderErr != nil {
 		return r.deleteProviderErr

--- a/internal/service/sso_service_test.go
+++ b/internal/service/sso_service_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,6 +16,39 @@ import (
 func TestSSOServiceDeleteMappingRequiresProviderID(t *testing.T) {
 	svc := NewSSOService(&ssoRepositoryStub{}, SSOConfig{})
 	require.ErrorContains(t, svc.DeleteMapping(context.Background(), uuid.Nil, uuid.New()), "sso provider ID is required")
+}
+
+func TestSSOServiceMapsAtomicOAuthIssuerConflict(t *testing.T) {
+	issuer := "https://issuer.example.test"
+	repo := &ssoRepositoryStub{
+		createProviderErr: &pgconn.PgError{
+			Code:           "23505",
+			ConstraintName: "idx_sso_providers_active_oauth_issuer_unique",
+		},
+	}
+	svc := NewSSOService(repo, SSOConfig{})
+	_, err := svc.CreateProvider(t.Context(), domain.SSOProvider{
+		Name:          "OAuth provider",
+		Kind:          domain.SSOProviderKindGenericOIDC,
+		IssuerURL:     issuer,
+		IdentityClaim: "sub",
+		ClientID:      "oauth-client",
+		ProtectedResource: domain.SSOProtectedResourceConfig{
+			Enabled: true,
+			OAuthProtectedResourceConfig: domain.OAuthProtectedResourceConfig{
+				Audiences:  []string{"dense-mem"},
+				JWKSSource: "static",
+				JWKSURI:    issuer + "/jwks",
+				Algorithms: []string{"RS256"},
+				ScopeClaim: "scope",
+				ScopeMappings: []domain.OAuthScopeMapping{
+					{ExternalScope: "memory.read", InternalScopes: []string{CredentialScopeRead}},
+				},
+			},
+		},
+		Enabled: true,
+	})
+	require.ErrorContains(t, err, `OAuth profile issuer "https://issuer.example.test" is duplicated`)
 }
 
 func TestSSOValidateCredentialUsesFreshCacheMappings(t *testing.T) {

--- a/internal/storage/postgres/oauth_protected_resource_migration_integration_test.go
+++ b/internal/storage/postgres/oauth_protected_resource_migration_integration_test.go
@@ -51,13 +51,15 @@ func TestOAuthProtectedResourceMigrationDefaultsDormantAndRetainsSystemRLS(t *te
 		}
 		require.Empty(t, baseURL)
 
-		var indexExists bool
+		var indexIsUnique bool
 		if err := tx.QueryRowContext(ctx, `
-			SELECT to_regclass('public.idx_sso_providers_protected_resource_enabled') IS NOT NULL
-		`).Scan(&indexExists); err != nil {
+			SELECT indisunique
+			FROM pg_index
+			WHERE indexrelid = 'idx_sso_providers_active_oauth_issuer_unique'::regclass
+		`).Scan(&indexIsUnique); err != nil {
 			return err
 		}
-		require.True(t, indexExists)
+		require.True(t, indexIsUnique)
 
 		var constraintValidated bool
 		if err := tx.QueryRowContext(ctx, `

--- a/internal/storage/postgres/oauth_protected_resource_migration_integration_test.go
+++ b/internal/storage/postgres/oauth_protected_resource_migration_integration_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+const oauthProtectedResourceMigrationVersion int64 = 2026081901
+
+func TestOAuthProtectedResourceMigrationDefaultsDormantAndRetainsSystemRLS(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, db, 2026081801)
+
+	providerID := uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_providers (id, name, kind, issuer_url, client_id, enabled)
+			VALUES ($1, 'oauth migration provider', 'generic_oidc', 'https://issuer.example.test', 'client', true)
+		`, providerID)
+		return err
+	}))
+	require.NoError(t, migrationUpTo(ctx, db, oauthProtectedResourceMigrationVersion))
+
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		var config []byte
+		if err := tx.QueryRowContext(ctx, `SELECT protected_resource_config FROM sso_providers WHERE id = $1`, providerID).Scan(&config); err != nil {
+			return err
+		}
+		require.JSONEq(t, `{
+			"enabled": false,
+			"audiences": [],
+			"jwks_source": "discovery",
+			"jwks_uri": "",
+			"algorithms": ["RS256"],
+			"scope_claim": "scope",
+			"scope_mappings": [],
+			"team_claim": ""
+		}`, string(config))
+
+		var baseURL string
+		if err := tx.QueryRowContext(ctx, `SELECT value FROM app_config WHERE key = 'MCP_PUBLIC_BASE_URL'`).Scan(&baseURL); err != nil {
+			return err
+		}
+		require.Empty(t, baseURL)
+
+		var indexExists bool
+		if err := tx.QueryRowContext(ctx, `
+			SELECT to_regclass('public.idx_sso_providers_protected_resource_enabled') IS NOT NULL
+		`).Scan(&indexExists); err != nil {
+			return err
+		}
+		require.True(t, indexExists)
+
+		var constraintValidated bool
+		if err := tx.QueryRowContext(ctx, `
+			SELECT convalidated
+			FROM pg_constraint
+			WHERE conrelid = 'sso_providers'::regclass
+			  AND conname = 'sso_providers_protected_resource_object'
+		`).Scan(&constraintValidated); err != nil {
+			return err
+		}
+		require.False(t, constraintValidated)
+		return nil
+	}))
+
+	roleName := "dense_mem_oauth_rls_" + uuid.NewString()[:8]
+	quotedRole := quoteMigrationIdentifier(roleName)
+	if _, err := db.ExecContext(ctx, "CREATE ROLE "+quotedRole+" NOLOGIN NOBYPASSRLS"); err != nil {
+		if isPostgresInsufficientPrivilege(err) {
+			t.Skipf("migration RLS test requires role administration: %v", err)
+		}
+		require.NoError(t, err)
+	}
+	defer func() {
+		_, _ = db.ExecContext(ctx, "DROP OWNED BY "+quotedRole)
+		_, _ = db.ExecContext(ctx, "DROP ROLE IF EXISTS "+quotedRole)
+	}()
+	_, err := db.ExecContext(ctx, "GRANT SELECT, UPDATE ON sso_providers, app_config TO "+quotedRole)
+	require.NoError(t, err)
+
+	providers, configs, updated, err := oauthMigrationRoleVisibility(ctx, db, quotedRole, "profile", providerID)
+	require.NoError(t, err)
+	require.Zero(t, providers)
+	require.Zero(t, configs)
+	require.Zero(t, updated)
+
+	providers, configs, updated, err = oauthMigrationRoleVisibility(ctx, db, quotedRole, "system", providerID)
+	require.NoError(t, err)
+	require.Equal(t, 1, providers)
+	require.Equal(t, 1, configs)
+	require.Equal(t, int64(1), updated)
+}
+
+func TestOAuthProtectedResourceMigrationGuardsCustomizedRollback(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup := openMigrationSQLDB(t, ctx)
+	defer cleanup()
+	runGooseUpTo(t, ctx, db, oauthProtectedResourceMigrationVersion)
+
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `UPDATE app_config SET value = 'https://memory.example.test' WHERE key = 'MCP_PUBLIC_BASE_URL'`)
+		return err
+	}))
+	err := migrationDownTo(ctx, db, 2026081801)
+	require.ErrorContains(t, err, "refusing OAuth protected-resource rollback with customized MCP_PUBLIC_BASE_URL")
+
+	providerID := uuid.New()
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `UPDATE app_config SET value = '' WHERE key = 'MCP_PUBLIC_BASE_URL'`); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO sso_providers (
+				id, name, kind, issuer_url, client_id, enabled, protected_resource_config
+			) VALUES (
+				$1, 'custom oauth provider', 'generic_oidc', 'https://issuer.example.test', 'client', true,
+				'{"enabled":true}'::jsonb
+			)
+		`, providerID)
+		return err
+	}))
+	err = migrationDownTo(ctx, db, 2026081801)
+	require.ErrorContains(t, err, "refusing OAuth protected-resource rollback with customized provider configuration")
+
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE sso_providers
+			SET protected_resource_config = '{
+				"enabled": false,
+				"audiences": [],
+				"jwks_source": "discovery",
+				"jwks_uri": "",
+				"algorithms": ["RS256"],
+				"scope_claim": "scope",
+				"scope_mappings": [],
+				"team_claim": ""
+			}'::jsonb
+			WHERE id = $1
+		`, providerID)
+		return err
+	}))
+	require.NoError(t, migrationDownTo(ctx, db, 2026081801))
+
+	var columnExists bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = 'sso_providers'
+			  AND column_name = 'protected_resource_config'
+		)
+	`).Scan(&columnExists))
+	require.False(t, columnExists)
+
+	var configExists bool
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM app_config WHERE key = 'MCP_PUBLIC_BASE_URL')`).Scan(&configExists)
+	}))
+	require.False(t, configExists)
+}
+
+func oauthMigrationRoleVisibility(ctx context.Context, db *sql.DB, quotedRole, mode string, providerID uuid.UUID) (int, int, int64, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, "SET LOCAL ROLE "+quotedRole); err != nil {
+		return 0, 0, 0, err
+	}
+	if _, err := tx.ExecContext(ctx, `SELECT set_config('app.tx_mode', $1, true)`, mode); err != nil {
+		return 0, 0, 0, err
+	}
+	var providers int
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM sso_providers WHERE id = $1`, providerID).Scan(&providers); err != nil {
+		return 0, 0, 0, err
+	}
+	var configs int
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM app_config WHERE key = 'MCP_PUBLIC_BASE_URL'`).Scan(&configs); err != nil {
+		return 0, 0, 0, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE app_config SET value = value WHERE key = 'MCP_PUBLIC_BASE_URL'`)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return providers, configs, updated, tx.Commit()
+}

--- a/migrations/postgres/v2_5/2026081901_oauth_protected_resource.sql
+++ b/migrations/postgres/v2_5/2026081901_oauth_protected_resource.sql
@@ -1,0 +1,103 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- +goose StatementBegin
+
+-- Lock/rewrite impact: the constant JSONB default is metadata-only on supported
+-- PostgreSQL versions. The CHECK is installed NOT VALID, and the partial index
+-- is built concurrently so neither operation holds a table-wide scan lock.
+-- RLS impact: no policy changes; sso_providers and app_config retain their
+-- system-only control-plane policies.
+-- Backfill: existing providers receive a disabled config, so OAuth remains
+-- dormant until a provider is explicitly enabled. Metadata additionally
+-- requires MCP_PUBLIC_BASE_URL.
+-- Rollback: down refuses customized state so operator configuration is never
+-- silently discarded.
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+SELECT set_config('app.allowed_space_ids', '', true);
+
+ALTER TABLE sso_providers
+    ADD COLUMN IF NOT EXISTS protected_resource_config JSONB NOT NULL DEFAULT '{
+        "enabled": false,
+        "audiences": [],
+        "jwks_source": "discovery",
+        "jwks_uri": "",
+        "algorithms": ["RS256"],
+        "scope_claim": "scope",
+        "scope_mappings": [],
+        "team_claim": ""
+    }'::jsonb;
+
+ALTER TABLE sso_providers
+    DROP CONSTRAINT IF EXISTS sso_providers_protected_resource_object;
+ALTER TABLE sso_providers
+    ADD CONSTRAINT sso_providers_protected_resource_object
+    CHECK (jsonb_typeof(protected_resource_config) = 'object') NOT VALID;
+
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sso_providers_protected_resource_enabled
+    ON sso_providers (id)
+    WHERE enabled = true
+      AND retired_at IS NULL
+      AND protected_resource_config @> '{"enabled": true}'::jsonb;
+
+-- +goose StatementBegin
+SELECT set_config('app.tx_mode', 'system', true);
+INSERT INTO app_config (key, value)
+VALUES ('MCP_PUBLIC_BASE_URL', '')
+ON CONFLICT (key) DO NOTHING;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'system', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+SELECT set_config('app.allowed_space_ids', '', true);
+
+DO $$
+DECLARE
+    default_config JSONB := '{
+        "enabled": false,
+        "audiences": [],
+        "jwks_source": "discovery",
+        "jwks_uri": "",
+        "algorithms": ["RS256"],
+        "scope_claim": "scope",
+        "scope_mappings": [],
+        "team_claim": ""
+    }'::jsonb;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM sso_providers
+        WHERE protected_resource_config IS DISTINCT FROM default_config
+    ) THEN
+        RAISE EXCEPTION 'refusing OAuth protected-resource rollback with customized provider configuration';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM app_config
+        WHERE key = 'MCP_PUBLIC_BASE_URL' AND value <> ''
+    ) THEN
+        RAISE EXCEPTION 'refusing OAuth protected-resource rollback with customized MCP_PUBLIC_BASE_URL';
+    END IF;
+END $$;
+
+-- +goose StatementEnd
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sso_providers_protected_resource_enabled;
+
+-- +goose StatementBegin
+SELECT set_config('app.tx_mode', 'system', true);
+DELETE FROM app_config WHERE key = 'MCP_PUBLIC_BASE_URL' AND value = '';
+ALTER TABLE sso_providers DROP CONSTRAINT IF EXISTS sso_providers_protected_resource_object;
+ALTER TABLE sso_providers DROP COLUMN IF EXISTS protected_resource_config;
+
+-- +goose StatementEnd

--- a/migrations/postgres/v2_5/2026081901_oauth_protected_resource.sql
+++ b/migrations/postgres/v2_5/2026081901_oauth_protected_resource.sql
@@ -5,12 +5,15 @@
 
 -- Lock/rewrite impact: the constant JSONB default is metadata-only on supported
 -- PostgreSQL versions. The CHECK is installed NOT VALID, and the partial index
--- is built concurrently so neither operation holds a table-wide scan lock.
+-- unique index is built concurrently so neither operation holds a table-wide
+-- scan lock.
 -- RLS impact: no policy changes; sso_providers and app_config retain their
 -- system-only control-plane policies.
 -- Backfill: existing providers receive a disabled config, so OAuth remains
 -- dormant until a provider is explicitly enabled. Metadata additionally
 -- requires MCP_PUBLIC_BASE_URL.
+-- Backward compatibility: old binaries ignore the additive config and base URL;
+-- new binaries remain dormant until both are configured.
 -- Rollback: down refuses customized state so operator configuration is never
 -- silently discarded.
 
@@ -39,8 +42,8 @@ ALTER TABLE sso_providers
 
 -- +goose StatementEnd
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sso_providers_protected_resource_enabled
-    ON sso_providers (id)
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_sso_providers_active_oauth_issuer_unique
+    ON sso_providers (issuer_url)
     WHERE enabled = true
       AND retired_at IS NULL
       AND protected_resource_config @> '{"enabled": true}'::jsonb;
@@ -92,7 +95,7 @@ END $$;
 
 -- +goose StatementEnd
 
-DROP INDEX CONCURRENTLY IF EXISTS idx_sso_providers_protected_resource_enabled;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sso_providers_active_oauth_issuer_unique;
 
 -- +goose StatementBegin
 SELECT set_config('app.tx_mode', 'system', true);

--- a/scripts/e2e-compose-oauth.sh
+++ b/scripts/e2e-compose-oauth.sh
@@ -3,6 +3,9 @@ E2E_OAUTH_PROVIDER_PORT=""
 E2E_OAUTH_HARNESS_PORT=""
 E2E_OAUTH_FIXTURE_TOKEN=""
 E2E_OAUTH_HARNESS_IMAGE=""
+E2E_OAUTH_SESSION_TOKEN=""
+E2E_OAUTH_CSRF_TOKEN=""
+E2E_OAUTH_SECOND_TEAM_ID=""
 
 validate_oauth_port_override() {
   local field="$1"
@@ -19,6 +22,10 @@ validate_oauth_port_override() {
 
 oauth_compatibility_e2e_enabled() {
   [[ "$E2E_SCENARIO" == "oauth_provider_compatibility" ]]
+}
+
+mcp_oauth_e2e_enabled() {
+  [[ "$E2E_SCENARIO" == "mcp_oauth" ]]
 }
 
 prepare_oauth_compatibility_files() {
@@ -189,6 +196,113 @@ run_oauth_compatibility_e2e() {
   DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
   DENSE_MEM_E2E_OAUTH_COMPOSE_FILE="$E2E_COMPOSE_OVERLAY_FILE" \
   node "$ROOT_DIR/tests/uat/oauth_provider_compatibility_e2e.mjs"
+}
+
+prepare_mcp_oauth_files() {
+  if ! mcp_oauth_e2e_enabled; then
+    return
+  fi
+  if [[ -e "$E2E_OAUTH_DIR" ]]; then
+    echo "Refusing to replace existing MCP OAuth directory ${E2E_OAUTH_DIR}." >&2
+    return 1
+  fi
+  mkdir "$E2E_OAUTH_DIR"
+  printf '%s\n' "$E2E_MARKER" > "${E2E_OAUTH_DIR}/.dense-mem-e2e-marker"
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "${E2E_OAUTH_DIR}/server.key" \
+    -out "${E2E_OAUTH_DIR}/ca.pem" \
+    -days 1 \
+    -subj "/CN=mcp-oauth-e2e" \
+    -addext "subjectAltName=DNS:oauth-provider-mock,DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+  chmod 600 "${E2E_OAUTH_DIR}/server.key"
+  chmod 644 "${E2E_OAUTH_DIR}/ca.pem"
+  E2E_OAUTH_FIXTURE_TOKEN="oauth-fixture-$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("base64url"))')"
+  E2E_OAUTH_SESSION_TOKEN="oauth-session-$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("base64url"))')"
+  E2E_OAUTH_CSRF_TOKEN="oauth-csrf-$(node -e 'process.stdout.write(require("node:crypto").randomBytes(24).toString("base64url"))')"
+
+  E2E_COMPOSE_OVERLAY_FILE="${ROOT_DIR}/docker-compose.mcp-oauth-e2e-${E2E_FILE_ID}.yml"
+  node - "$E2E_COMPOSE_OVERLAY_FILE" "$ROOT_DIR" "$E2E_OAUTH_DIR" "$E2E_OAUTH_PROVIDER_PORT" "$E2E_OAUTH_FIXTURE_TOKEN" "$E2E_MARKER" <<'NODE'
+const fs = require("node:fs");
+
+const [destination, rootDir, oauthDir, providerPort, fixtureToken, marker] = process.argv.slice(2);
+const quote = (value) => JSON.stringify(value);
+const mount = (source, target) => quote(`${source}:${target}:ro`);
+const mockScript = `${oauthDir}/oauth-provider-mock.mjs`;
+fs.copyFileSync(`${rootDir}/tests/uat/oauth_provider_mock.mjs`, mockScript);
+const contents = `${marker}
+services:
+  server:
+    environment:
+      SSL_CERT_FILE: /e2e/oauth-ca.pem
+    volumes:
+      - ${mount(`${oauthDir}/ca.pem`, "/e2e/oauth-ca.pem")}
+    depends_on:
+      oauth-provider-mock:
+        condition: service_healthy
+  oauth-provider-mock:
+    image: node:26-alpine
+    working_dir: /e2e
+    command: ["node", "/e2e/oauth-provider-mock.mjs"]
+    environment:
+      DENSE_MEM_OAUTH_CERT: /e2e/tls/ca.pem
+      DENSE_MEM_OAUTH_KEY: /e2e/tls/server.key
+      DENSE_MEM_OAUTH_ISSUER_BASE: https://oauth-provider-mock:9444
+      DENSE_MEM_OAUTH_FIXTURE_TOKEN: ${quote(fixtureToken)}
+    volumes:
+      - ${mount(mockScript, "/e2e/oauth-provider-mock.mjs")}
+      - ${mount(oauthDir, "/e2e/tls")}
+    ports:
+      - "127.0.0.1:${providerPort}:9444"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('node:https').get({hostname:'127.0.0.1',port:9444,path:'/health',rejectUnauthorized:false},r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 1s
+      timeout: 2s
+      retries: 60
+`;
+fs.writeFileSync(destination, contents);
+NODE
+}
+
+wait_for_mcp_oauth_provider() {
+  for _ in $(seq 1 90); do
+    if curl --cacert "${E2E_OAUTH_DIR}/ca.pem" -fsS "https://localhost:${E2E_OAUTH_PROVIDER_PORT}/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for the MCP OAuth provider mock." >&2
+  return 1
+}
+
+run_mcp_oauth_e2e() {
+  local team_id="$1"
+  local api_key="$2"
+  local result_file="${TEMP_DIR}/mcp-oauth-result.json"
+
+  wait_for_mcp_oauth_provider
+  echo "Running compose-backed MCP OAuth protected-resource e2e."
+  NODE_EXTRA_CA_CERTS="${E2E_OAUTH_DIR}/ca.pem" \
+  DENSE_MEM_CONTROL_URL="$CONTROL_URL" \
+  DENSE_MEM_USER_URL="$USER_URL" \
+  DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
+  DENSE_MEM_E2E_TEAM_ID="$team_id" \
+  DENSE_MEM_E2E_API_KEY="$api_key" \
+  DENSE_MEM_E2E_OAUTH_INTERNAL_URL="https://oauth-provider-mock:9444" \
+  DENSE_MEM_E2E_OAUTH_MOCK_URL="https://localhost:${E2E_OAUTH_PROVIDER_PORT}" \
+  DENSE_MEM_E2E_OAUTH_FIXTURE_TOKEN="$E2E_OAUTH_FIXTURE_TOKEN" \
+  DENSE_MEM_E2E_SSO_SESSION_TOKEN="$E2E_OAUTH_SESSION_TOKEN" \
+  DENSE_MEM_E2E_SSO_CSRF_TOKEN="$E2E_OAUTH_CSRF_TOKEN" \
+  DENSE_MEM_E2E_RESULT_FILE="$result_file" \
+  DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
+  DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
+  node "$ROOT_DIR/tests/uat/oauth_mcp_e2e.mjs"
+
+  if [[ "${DENSE_MEM_E2E_SKIP_PLAYWRIGHT:-0}" == "1" ]]; then
+    return
+  fi
+  E2E_OAUTH_SECOND_TEAM_ID="$(json_field second_team_id < "$result_file")"
+  echo "Running compose-backed OAuth team-resource Playwright e2e."
+  run_compose_playwright_tests oauth
 }
 
 cleanup_oauth_compatibility_files() {

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -593,6 +593,7 @@ run_compose_playwright_tests() {
     set_submission_status_playwright_args
   elif [[ "${1:-}" == "community" ]]; then test_args=("tests-compose/community-recall.spec.ts");
   elif [[ "${1:-}" == "conflict_queue" ]]; then test_args=("tests-compose/compose-conflict-queue.spec.ts");
+  elif [[ "${1:-}" == "oauth" ]]; then test_args=("tests-compose/oauth-team-resource.spec.ts");
   fi
   image="${DENSE_MEM_E2E_PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.62.1-noble}"
   E2E_PLAYWRIGHT_CONTAINER="densemem-e2e-${E2E_FILE_ID}-playwright"
@@ -626,6 +627,9 @@ run_compose_playwright_tests() {
     -e "DENSE_MEM_E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID=$E2E_GRAPH_CORRECTED_OBJECT_ENTITY_ID" \
     -e "DENSE_MEM_E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID=$E2E_GRAPH_ORIGINAL_RELATIONSHIP_ID" \
     -e "DENSE_MEM_E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID=$E2E_GRAPH_SUCCESSOR_RELATIONSHIP_ID" \
+    -e "DENSE_MEM_E2E_OAUTH_SECOND_TEAM_ID=${E2E_OAUTH_SECOND_TEAM_ID:-}" \
+    -e "DENSE_MEM_E2E_SSO_SESSION_TOKEN=${E2E_OAUTH_SESSION_TOKEN:-}" \
+    -e "DENSE_MEM_E2E_SSO_CSRF_TOKEN=${E2E_OAUTH_CSRF_TOKEN:-}" \
     "$E2E_PLAYWRIGHT_CONTAINER" \
     sh -ec 'cd /tmp/web && npm ci && ./node_modules/.bin/playwright test --config playwright.compose.config.ts "$@"' \
     sh "${test_args[@]}"
@@ -676,8 +680,8 @@ if [[ "$E2E_MODE" != "standard" && "$E2E_MODE" != "entra_scim" ]]; then
   echo "DENSE_MEM_E2E_MODE must be standard or entra_scim." >&2
   exit 1
 fi
-if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "mcp_sdk_parity" && "$E2E_SCENARIO" != "mcp_sdk_transport" && "$E2E_SCENARIO" != "oauth_provider_compatibility" && "$E2E_SCENARIO" != "security_runtime" && "$E2E_SCENARIO" != "infrastructure_credentials" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "submission_terminal_errors" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "identity_cleanup" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "conflict" && "$E2E_SCENARIO" != "conflict_queue" && "$E2E_SCENARIO" != "embedding_reconciliation" && "$E2E_SCENARIO" != "embedding_resilience" && "$E2E_SCENARIO" != "memory_space_backfill" && "$E2E_SCENARIO" != "memory_space_isolation" && "$E2E_SCENARIO" != "space_aware_recall" && "$E2E_SCENARIO" != "credential_memory_binding" && "$E2E_SCENARIO" != "all" ]]; then
-  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, mcp_sdk_parity, mcp_sdk_transport, oauth_provider_compatibility, security_runtime, infrastructure_credentials, submission_status, submission_terminal_errors, security_intake, submission_assessment, semantic_holds, identity_cleanup, community, conflict, conflict_queue, embedding_reconciliation, embedding_resilience, memory_space_backfill, memory_space_isolation, space_aware_recall, credential_memory_binding, or all." >&2
+if [[ "$E2E_SCENARIO" != "full" && "$E2E_SCENARIO" != "portal" && "$E2E_SCENARIO" != "mcp_boundaries" && "$E2E_SCENARIO" != "mcp_sdk_parity" && "$E2E_SCENARIO" != "mcp_sdk_transport" && "$E2E_SCENARIO" != "oauth_provider_compatibility" && "$E2E_SCENARIO" != "mcp_oauth" && "$E2E_SCENARIO" != "security_runtime" && "$E2E_SCENARIO" != "infrastructure_credentials" && "$E2E_SCENARIO" != "submission_status" && "$E2E_SCENARIO" != "submission_terminal_errors" && "$E2E_SCENARIO" != "security_intake" && "$E2E_SCENARIO" != "submission_assessment" && "$E2E_SCENARIO" != "semantic_holds" && "$E2E_SCENARIO" != "identity_cleanup" && "$E2E_SCENARIO" != "community" && "$E2E_SCENARIO" != "conflict" && "$E2E_SCENARIO" != "conflict_queue" && "$E2E_SCENARIO" != "embedding_reconciliation" && "$E2E_SCENARIO" != "embedding_resilience" && "$E2E_SCENARIO" != "memory_space_backfill" && "$E2E_SCENARIO" != "memory_space_isolation" && "$E2E_SCENARIO" != "space_aware_recall" && "$E2E_SCENARIO" != "credential_memory_binding" && "$E2E_SCENARIO" != "all" ]]; then
+  echo "DENSE_MEM_E2E_SCENARIO must be full, portal, mcp_boundaries, mcp_sdk_parity, mcp_sdk_transport, oauth_provider_compatibility, mcp_oauth, security_runtime, infrastructure_credentials, submission_status, submission_terminal_errors, security_intake, submission_assessment, semantic_holds, identity_cleanup, community, conflict, conflict_queue, embedding_reconciliation, embedding_resilience, memory_space_backfill, memory_space_isolation, space_aware_recall, credential_memory_binding, or all." >&2
   exit 1
 fi
 
@@ -691,7 +695,7 @@ if [[ "$E2E_SCENARIO" == "all" ]]; then
     echo "DENSE_MEM_E2E_SCENARIO=all requires DENSE_MEM_E2E_MODE=standard." >&2
     exit 1
   fi
-  for scenario in mcp_boundaries mcp_sdk_parity mcp_sdk_transport oauth_provider_compatibility security_runtime infrastructure_credentials submission_status submission_terminal_errors security_intake submission_assessment semantic_holds identity_cleanup community conflict conflict_queue embedding_reconciliation embedding_resilience memory_space_backfill memory_space_isolation space_aware_recall credential_memory_binding full; do
+  for scenario in mcp_boundaries mcp_sdk_parity mcp_sdk_transport oauth_provider_compatibility mcp_oauth security_runtime infrastructure_credentials submission_status submission_terminal_errors security_intake submission_assessment semantic_holds identity_cleanup community conflict conflict_queue embedding_reconciliation embedding_resilience memory_space_backfill memory_space_isolation space_aware_recall credential_memory_binding full; do
     echo "Running compose e2e scenario ${scenario} as part of all."
     DENSE_MEM_E2E_SCENARIO="$scenario" \
     DENSE_MEM_E2E_RUN_ID="${DENSE_MEM_E2E_RUN_ID:-all}-$(printf '%s' "$scenario" | tr '[:upper:]' '[:lower:]')" \
@@ -812,6 +816,7 @@ prepare_postgres_e2e_overlay
 prepare_e2e_prometheus_files
 prepare_entra_mock_files
 prepare_oauth_compatibility_files
+prepare_mcp_oauth_files
 prepare_conflict_provider_files
 
 if ! compose config -q; then
@@ -899,6 +904,7 @@ if [[ "$E2E_SCENARIO" == "oauth_provider_compatibility" ]]; then
   run_oauth_compatibility_e2e "$api_key"
   exit 0
 fi
+if [[ "$E2E_SCENARIO" == "mcp_oauth" ]]; then run_mcp_oauth_e2e "$team_id" "$api_key"; exit 0; fi
 if [[ "$E2E_SCENARIO" == "mcp_sdk_parity" ]]; then echo "Running the official Go MCP SDK differential harness and live public boundary."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_E2E_API_KEY="$api_key" node "$ROOT_DIR/tests/uat/mcp_sdk_parity_e2e.mjs"; exit 0; fi
 if [[ "$E2E_SCENARIO" == "mcp_sdk_transport" ]]; then echo "Running the production MCP SDK transport matrix with live credentials."; DENSE_MEM_USER_URL="$USER_URL" DENSE_MEM_E2E_API_KEY="$api_key" node "$ROOT_DIR/tests/uat/mcp_sdk_transport_e2e.mjs"; exit 0; fi
 

--- a/tests/uat/oauth_mcp_e2e.mjs
+++ b/tests/uat/oauth_mcp_e2e.mjs
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const scenario = requiredEnv("DENSE_MEM_E2E_SCENARIO");
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+const seedTeamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+const oauthInternalURL = requiredEnv("DENSE_MEM_E2E_OAUTH_INTERNAL_URL").replace(/\/$/, "");
+const oauthMockURL = requiredEnv("DENSE_MEM_E2E_OAUTH_MOCK_URL").replace(/\/$/, "");
+const oauthFixtureToken = requiredEnv("DENSE_MEM_E2E_OAUTH_FIXTURE_TOKEN");
+const ssoSessionToken = requiredEnv("DENSE_MEM_E2E_SSO_SESSION_TOKEN");
+const ssoCSRFToken = requiredEnv("DENSE_MEM_E2E_SSO_CSRF_TOKEN");
+const resultFile = requiredEnv("DENSE_MEM_E2E_RESULT_FILE");
+const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
+const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
+const runID = `oauth-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const logSentinel = `oauth-private-token-sentinel-${randomUUID()}`;
+const issuedTokens = [];
+let rpcID = 0;
+
+if (scenario !== "mcp_oauth") {
+  throw new Error(`unsupported OAuth E2E scenario ${scenario}`);
+}
+
+const secondTeam = await createTeam(`${runID} Team B`);
+const thirdTeam = await createTeam(`${runID} Team C`);
+await controlJSON("/config/sso", {
+  method: "PATCH",
+  body: { items: [{ key: "MCP_PUBLIC_BASE_URL", value: userURL }] },
+});
+
+const providerInputs = {
+  entra: providerInput({
+    name: `${runID} Entra`,
+    kind: "azure_ad",
+    tenantID: "dense-mem-e2e-tenant",
+    identityClaim: "oid",
+    audience: "dense-mem-entra",
+    algorithm: "RS256",
+    scopeClaim: "scp",
+    teamClaim: "dense_mem_team_id",
+    mappings: [
+      ["memory.read", ["read"]],
+      ["memory.write", ["write"]],
+    ],
+  }),
+  pingone: providerInput({
+    name: `${runID} PingOne`,
+    kind: "pingone",
+    identityClaim: "sub",
+    audience: "urn:dense-mem:pingone",
+    algorithm: "PS256",
+    scopeClaim: "scope",
+    jwksSource: "static",
+    mappings: [
+      ["ping.read", ["read"]],
+      ["ping.write", ["write"]],
+    ],
+  }),
+  generic: providerInput({
+    name: `${runID} Generic OIDC`,
+    kind: "generic_oidc",
+    identityClaim: "sub",
+    audience: "https://dense-mem.example.test/mcp",
+    algorithm: "ES256",
+    scopeClaim: "permissions",
+    teamClaim: "dense_mem_team_id",
+    mappings: [
+      ["generic.read", ["read"]],
+      ["generic.write", ["write"]],
+    ],
+  }),
+};
+
+const strictProviderResponse = await controlRaw("/sso/providers", {
+  method: "POST",
+  body: { ...providerInputs.generic, unsupported_field: true },
+});
+assert(strictProviderResponse.status === 422, "provider configuration accepted an unknown field");
+
+const providers = {};
+for (const name of ["entra", "pingone", "generic"]) {
+  providers[name] = (await controlJSON("/sso/providers", { method: "POST", body: providerInputs[name] })).data;
+  assertUUID(providers[name]?.id, `${name} provider ID`);
+}
+
+const entraTeamAMapping = await createMapping(providers.entra.id, seedTeamID, "oauth-team-a", ["read", "write"]);
+await createMapping(providers.entra.id, secondTeam.id, "oauth-team-b", ["read", "write"]);
+await createMapping(providers.pingone.id, seedTeamID, "ping-team", ["read", "write"]);
+await createMapping(providers.generic.id, seedTeamID, "generic-team", ["read", "write"]);
+
+const identities = {
+  entra: identityFixture(providers.entra.id, "entra-user", true),
+  pingone: identityFixture(providers.pingone.id, "pingone-user", true),
+  generic: identityFixture(providers.generic.id, "generic-user", true),
+  noMembership: identityFixture(providers.entra.id, "oauth-no-membership", true),
+  disabled: identityFixture(providers.entra.id, "oauth-disabled", false),
+  suspended: identityFixture(providers.entra.id, "oauth-suspended", true),
+};
+
+const memberships = [
+  membershipFixture(identities.entra, seedTeamID, ["read"], "oauth-team-a", "active"),
+  membershipFixture(identities.entra, secondTeam.id, ["read", "write"], "oauth-team-b", "active"),
+  membershipFixture(identities.pingone, seedTeamID, ["read", "write"], "ping-team", "active"),
+  membershipFixture(identities.generic, seedTeamID, ["read", "write"], "generic-team", "active"),
+  membershipFixture(identities.disabled, seedTeamID, ["read"], "oauth-disabled", "active"),
+  membershipFixture(identities.suspended, seedTeamID, ["read"], "oauth-suspended", "suspended"),
+];
+seedOAuthPrincipals(Object.values(identities), memberships, memberships[0]);
+assertProfilePrivateSpaces(identities.entra.id, [seedTeamID, secondTeam.id], thirdTeam.id);
+
+const metadata = await publicJSON("/.well-known/oauth-protected-resource/mcp");
+assert(metadata.status === 200, "unscoped RFC 9728 metadata was unavailable");
+assert(metadata.payload.resource === `${userURL}/mcp`, "unscoped metadata resource did not use the configured public base URL");
+assert(metadata.payload.resource_name === "Dense-Mem MCP", "metadata resource name changed");
+assert(JSON.stringify(metadata.payload.bearer_methods_supported) === JSON.stringify(["header"]), "metadata bearer method changed");
+for (const name of ["entra", "pingone", "generic"]) {
+  assert(metadata.payload.authorization_servers?.includes(providerInputs[name].issuer_url), `${name} issuer was missing from metadata`);
+}
+for (const scope of ["memory.read", "memory.write", "ping.read", "ping.write", "generic.read", "generic.write"]) {
+  assert(metadata.payload.scopes_supported?.includes(scope), `metadata omitted external scope ${scope}`);
+}
+
+const scopedMetadata = await publicJSON(`/.well-known/oauth-protected-resource/teams/${secondTeam.id}/mcp`);
+assert(scopedMetadata.status === 200, "team-scoped RFC 9728 metadata was unavailable");
+assert(scopedMetadata.payload.resource === `${userURL}/teams/${secondTeam.id}/mcp`, "team metadata resource was not canonical");
+
+await assertChallenge("/mcp", `${userURL}/.well-known/oauth-protected-resource/mcp`);
+await assertChallenge(`/teams/${seedTeamID}/mcp`, `${userURL}/.well-known/oauth-protected-resource/teams/${seedTeamID}/mcp`);
+
+const apiUnscoped = await mcpTools(apiKey, "/mcp");
+assertMCPTools(apiUnscoped, { present: ["recall_memory", "remember"] });
+const apiScoped = await mcpTools(apiKey, `/teams/${seedTeamID}/mcp`);
+assertMCPTools(apiScoped, { present: ["recall_memory", "remember"] });
+await assertMCPToolSuccess(apiKey, `/teams/${seedTeamID}/mcp`, "recall_memory", { query: `${runID} static credential`, limit: 1 });
+await expectMCPStatus(apiKey, `/teams/${secondTeam.id}/mcp`, 403);
+
+const cookieOnly = await mcpRequest(undefined, "/mcp", {
+  Cookie: `dense_mem_sso_session=${ssoSessionToken}; dense_mem_sso_csrf=${ssoCSRFToken}`,
+});
+assert(cookieOnly.status === 401, "MCP accepted a browser SSO cookie without a bearer token");
+
+const entraTeamA = await issueToken("entra", {
+  claims: { dense_mem_team_id: seedTeamID, log_sentinel: logSentinel },
+});
+const entraTeamATools = await mcpTools(entraTeamA, "/mcp");
+assertMCPTools(entraTeamATools, { present: ["recall_memory"], absent: ["remember"] });
+await assertMCPToolSuccess(entraTeamA, "/mcp", "recall_memory", { query: `${runID} OAuth profile private`, limit: 1 });
+await assertMCPToolScopeRejected(entraTeamA, "/mcp", "remember", {});
+
+const entraTeamB = await issueToken("entra", { claims: { dense_mem_team_id: secondTeam.id } });
+const entraTeamBTools = await mcpTools(entraTeamB, `/teams/${secondTeam.id}/mcp`);
+assertMCPTools(entraTeamBTools, { present: ["recall_memory", "remember"] });
+
+const entraMultipleAudiences = await issueToken("entra", {
+  claims: { aud: ["unrelated-audience", "dense-mem-entra"], dense_mem_team_id: seedTeamID },
+});
+assert((await mcpTools(entraMultipleAudiences, "/mcp")).status === 200, "valid audience array was rejected");
+
+const ambiguous = await issueToken("entra", { omit: ["dense_mem_team_id"] });
+await expectMCPError(ambiguous, "/mcp", 400, "team_required");
+assert((await mcpTools(ambiguous, `/teams/${seedTeamID}/mcp`)).status === 200, "scoped route did not resolve a multi-team token");
+
+await expectMCPError(entraTeamA, `/teams/${secondTeam.id}/mcp`, 403, "FORBIDDEN");
+const nonMemberClaim = await issueToken("entra", { claims: { dense_mem_team_id: thirdTeam.id } });
+await expectMCPError(nonMemberClaim, `/teams/${thirdTeam.id}/mcp`, 403, "FORBIDDEN");
+
+const pingToken = await issueToken("pingone");
+assert((await mcpTools(pingToken, "/mcp")).status === 200, "PingOne PS256/static-JWKS token was rejected");
+const genericToken = await issueToken("generic", { claims: { dense_mem_team_id: seedTeamID } });
+assert((await mcpTools(genericToken, "/mcp")).status === 200, "generic OIDC ES256 token was rejected");
+
+for (const test of [
+  ["wrong issuer", { claims: { iss: `${oauthInternalURL}/unknown`, dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["wrong audience", { claims: { aud: "wrong-audience", dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["wrong key", { key: "wrong", claims: { dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["unknown kid", { kid: "unknown", claims: { dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["algorithm confusion", { header_alg: "PS256", sign_alg: "RS256", claims: { dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["expired", { claims: { exp: Math.floor(Date.now() / 1000) - 120, dense_mem_team_id: seedTeamID } }, 401, "AUTH_EXPIRED"],
+  ["not yet valid", { claims: { nbf: Math.floor(Date.now() / 1000) + 120, dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["future issued at", { claims: { iat: Math.floor(Date.now() / 1000) + 120, dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["duplicate header", { mode: "duplicate_header", claims: { dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+  ["duplicate claim", { mode: "duplicate_claim", claims: { dense_mem_team_id: seedTeamID } }, 401, "AUTH_INVALID"],
+]) {
+  const [label, options, status, code] = test;
+  await expectMCPError(await issueToken("entra", options), "/mcp", status, code, label);
+}
+
+for (const claim of ["iss", "aud", "sub", "exp"]) {
+  const options = { omit: [claim], claims: { dense_mem_team_id: seedTeamID } };
+  await expectMCPError(await issueToken("entra", options), "/mcp", 401, "AUTH_INVALID", `missing ${claim}`);
+}
+await expectMCPError("not.a.jwt", "/mcp", 401, "AUTH_INVALID", "malformed JWT");
+
+const noMembership = await issueToken("entra", { claims: { oid: identities.noMembership.subject, dense_mem_team_id: seedTeamID } });
+await expectMCPError(noMembership, "/mcp", 403, "FORBIDDEN", "identity without membership");
+const disabledIdentity = await issueToken("entra", { claims: { oid: identities.disabled.subject, dense_mem_team_id: seedTeamID } });
+await expectMCPError(disabledIdentity, "/mcp", 403, "FORBIDDEN", "disabled identity");
+const suspendedMembership = await issueToken("entra", { claims: { oid: identities.suspended.subject, dense_mem_team_id: seedTeamID } });
+await expectMCPError(suspendedMembership, "/mcp", 403, "FORBIDDEN", "suspended membership");
+
+await controlJSON(`/sso/providers/${providers.entra.id}/mappings/${entraTeamAMapping.id}`, { method: "DELETE" });
+await expectMCPError(entraTeamA, "/mcp", 403, "FORBIDDEN", "revoked membership mapping");
+await controlJSON(`/sso/providers/${providers.entra.id}/mappings/${entraTeamAMapping.id}`, {
+  method: "PATCH",
+  body: {
+    team_id: seedTeamID,
+    group_id: "oauth-team-a",
+    group_name: "oauth-team-a",
+    scopes: ["read", "write"],
+    role: "member",
+    enabled: true,
+  },
+});
+assert((await mcpTools(entraTeamA, "/mcp")).status === 200, "restored membership mapping did not restore access");
+
+await setMockState("generic", { active_key: "secondary" });
+await delay(1_100);
+const rotatedGeneric = await issueToken("generic", { claims: { dense_mem_team_id: seedTeamID } });
+assert((await mcpTools(rotatedGeneric, "/mcp")).status === 200, "unknown rotated key did not trigger bounded JWKS refresh");
+await setMockState("generic", { jwks_outage: true });
+assert((await mcpTools(rotatedGeneric, "/mcp")).status === 200, "cached known key failed during a JWKS outage");
+await delay(1_100);
+const unavailableUnknownKey = await issueToken("generic", { key: "future", claims: { dense_mem_team_id: seedTeamID } });
+await expectMCPError(unavailableUnknownKey, "/mcp", 503, "SERVICE_UNAVAILABLE", "unknown key during outage");
+const statsAfterFailure = await mockJSON("/fixture/stats", { profile: "generic" });
+await expectMCPError(unavailableUnknownKey, "/mcp", 503, "SERVICE_UNAVAILABLE", "repeated unknown key during outage");
+const statsAfterRepeat = await mockJSON("/fixture/stats", { profile: "generic" });
+assert(statsAfterRepeat.jwks_requests === statsAfterFailure.jwks_requests, "provider outage caused an unbounded repeat refresh");
+await setMockState("generic", { jwks_outage: false });
+
+assertNoOAuthSecretsPersisted();
+assertNoOAuthSecretsInLogs();
+
+writeFileSync(resultFile, JSON.stringify({
+  status: "ok",
+  scenario,
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  second_team_id: secondTeam.id,
+  provider_profiles: ["entra-rs256-discovery", "pingone-ps256-static", "generic-es256-discovery-trailing-slash"],
+  metadata_and_challenges: true,
+  team_selection_and_scope_intersection: true,
+  a_b_c_profile_private_authorization: true,
+  mcp_tool_invocation_for_both_token_families: true,
+  key_rotation_and_outage: true,
+  api_key_compatibility: true,
+  browser_cookie_rejected: true,
+  token_persistence_and_log_scan: true,
+}, null, 2));
+
+console.log(JSON.stringify({
+  status: "ok",
+  scenario,
+  tested_commit: requiredEnv("DENSE_MEM_E2E_COMMIT_SHA"),
+  provider_profiles: 3,
+  second_team_id: secondTeam.id,
+}, null, 2));
+
+function providerInput({ name, kind, tenantID = "", identityClaim, audience, algorithm, scopeClaim, teamClaim = "", jwksSource = "discovery", mappings }) {
+  const profile = kind === "azure_ad" ? "entra" : kind === "pingone" ? "pingone" : "generic";
+  return {
+    name,
+    kind,
+    issuer_url: oauthProfileIssuer(profile),
+    tenant_id: tenantID,
+    identity_claim: identityClaim,
+    client_id: `${runID}-${profile}-browser-client`,
+    client_secret_env: "",
+    scopes: ["openid", "profile", "email"],
+    group_claims: ["groups"],
+    groups_endpoint: "",
+    groups_scopes: [],
+    protected_resource: {
+      enabled: true,
+      audiences: [audience],
+      jwks_source: jwksSource,
+      jwks_uri: jwksSource === "static" ? `${oauthInternalURL}/${profile}/jwks` : "",
+      algorithms: [algorithm],
+      scope_claim: scopeClaim,
+      scope_mappings: mappings.map(([external_scope, internal_scopes]) => ({ external_scope, internal_scopes })),
+      team_claim: teamClaim,
+    },
+    enabled: true,
+  };
+}
+
+function oauthProfileIssuer(profile) {
+  const issuer = `${oauthInternalURL}/${profile}`;
+  return profile === "generic" ? `${issuer}/` : issuer;
+}
+
+function identityFixture(providerID, subject, active) {
+  return { id: randomUUID(), providerID, subject, active };
+}
+
+function membershipFixture(identity, teamID, grants, groupID, status) {
+  return {
+    id: randomUUID(),
+    ownerID: randomUUID(),
+    identity,
+    teamID,
+    grants,
+    groupID,
+    status,
+  };
+}
+
+function seedOAuthPrincipals(identityFixtures, membershipFixtures, initialMembership) {
+  const statements = ["BEGIN", "SELECT set_config('app.tx_mode', 'system', true)"];
+  for (const identity of identityFixtures) {
+    statements.push(`
+      INSERT INTO actor_identities (id, kind, team_id, provider, subject, display_name, active)
+      VALUES (${sqlLiteral(identity.id)}::uuid, 'human', NULL, ${sqlLiteral(identity.providerID)}, ${sqlLiteral(identity.subject)}, ${sqlLiteral(`E2E ${identity.subject}`)}, ${identity.active});
+      INSERT INTO sso_identities (id, provider_id, subject, external_id, email, display_name, active, last_login_at, last_entitlement_check_at)
+      VALUES (${sqlLiteral(identity.id)}::uuid, ${sqlLiteral(identity.providerID)}::uuid, ${sqlLiteral(identity.subject)}, ${sqlLiteral(identity.subject)}, ${sqlLiteral(`${identity.subject}@example.test`)}, ${sqlLiteral(`E2E ${identity.subject}`)}, ${identity.active}, now(), now());
+    `);
+  }
+  for (const membership of membershipFixtures) {
+    statements.push(`
+      INSERT INTO team_memberships (
+        id, actor_identity_id, team_id, status, team_admin, maximum_grants,
+        sso_provider_id, sso_group_id, sso_profile_name, sso_entitlement_status,
+        sso_last_entitlement_checked_at, sso_last_login_at
+      ) VALUES (
+        ${sqlLiteral(membership.id)}::uuid, ${sqlLiteral(membership.identity.id)}::uuid,
+        ${sqlLiteral(membership.teamID)}::uuid, ${sqlLiteral(membership.status)}, false,
+        ARRAY[${membership.grants.map(sqlLiteral).join(",")}]::text[],
+        ${sqlLiteral(membership.identity.providerID)}::uuid, ${sqlLiteral(membership.groupID)},
+        ${sqlLiteral(`E2E ${membership.identity.subject}`)}, 'active', now(), now()
+      );
+      INSERT INTO ownership_aliases (team_id, legacy_owner_id, canonical_identity_id, credential_id, reason)
+      VALUES (${sqlLiteral(membership.teamID)}::uuid, ${sqlLiteral(membership.ownerID)}::uuid, ${sqlLiteral(membership.identity.id)}::uuid, NULL, 'oauth_e2e');
+      INSERT INTO membership_grants (membership_id, grant_name, source)
+      SELECT ${sqlLiteral(membership.id)}::uuid, grant_name, 'explicit'
+      FROM unnest(ARRAY[${membership.grants.map(sqlLiteral).join(",")}]::text[]) AS grant_name;
+    `);
+  }
+  const entitlementGroups = new Map();
+  for (const membership of membershipFixtures) {
+    const key = `${membership.identity.providerID}:${membership.identity.subject}`;
+    const existing = entitlementGroups.get(key) ?? { identity: membership.identity, groups: new Set() };
+    existing.groups.add(membership.groupID);
+    entitlementGroups.set(key, existing);
+  }
+  for (const { identity, groups } of entitlementGroups.values()) {
+    statements.push(`
+      INSERT INTO sso_entitlement_cache (provider_id, subject, groups, status, checked_at, expires_at, error)
+      VALUES (
+        ${sqlLiteral(identity.providerID)}::uuid, ${sqlLiteral(identity.subject)},
+        ARRAY[${[...groups].map(sqlLiteral).join(",")}]::text[], 'active', now(), now() + interval '8 hours', ''
+      );
+    `);
+  }
+  statements.push(`
+    INSERT INTO sso_sessions (
+      session_hash, identity_id, provider_id, membership_id, team_id, csrf_hash,
+      expires_at, created_at, last_seen_at
+    ) VALUES (
+      ${sqlLiteral(sha256(ssoSessionToken))}, ${sqlLiteral(initialMembership.identity.id)}::uuid,
+      ${sqlLiteral(initialMembership.identity.providerID)}::uuid, ${sqlLiteral(initialMembership.id)}::uuid,
+      ${sqlLiteral(initialMembership.teamID)}::uuid, ${sqlLiteral(sha256(ssoCSRFToken))},
+      now() + interval '8 hours', now(), now()
+    );
+    COMMIT;
+  `);
+  const result = postgresCommand(statements.join(";\n"));
+  if (result.status !== 0) throw new Error("PostgreSQL OAuth fixture seeding failed");
+}
+
+function assertProfilePrivateSpaces(identityID, allowedTeamIDs, deniedTeamID) {
+  const result = postgresCommand(`
+    SELECT team_id::text
+    FROM memory_spaces
+    WHERE kind = 'profile_private'
+      AND owner_profile_id = ${sqlLiteral(identityID)}::uuid
+    ORDER BY team_id;
+  `);
+  if (result.status !== 0) throw new Error("could not verify OAuth profile-private memory spaces");
+  const actual = new Set(result.stdout.trim().split(/\s+/).filter(Boolean));
+  for (const teamID of allowedTeamIDs) {
+    assert(actual.has(teamID), `OAuth identity is missing its profile-private space for team ${teamID}`);
+  }
+  assert(!actual.has(deniedTeamID), "OAuth identity received a profile-private space in unrelated team C");
+  assert(actual.size === allowedTeamIDs.length, "OAuth identity received an unexpected profile-private space");
+}
+
+async function createTeam(name) {
+  const response = await controlJSON("/teams", {
+    method: "POST",
+    body: { name, description: "OAuth protected-resource E2E" },
+  });
+  assertUUID(response.data?.id, "created team ID");
+  return response.data;
+}
+
+async function createMapping(providerID, teamID, groupID, scopes) {
+  const response = await controlJSON(`/sso/providers/${providerID}/mappings`, {
+    method: "POST",
+    body: { team_id: teamID, group_id: groupID, group_name: groupID, scopes, role: "member", enabled: true },
+  });
+  assertUUID(response.data?.id, "mapping ID");
+  return response.data;
+}
+
+async function issueToken(profile, options = {}) {
+  const response = await mockJSON("/fixture/token", { profile, ...options });
+  const token = response.token;
+  if (typeof token !== "string" || token.split(".").length !== 3) throw new Error("OAuth fixture did not return a JWT");
+  issuedTokens.push(token);
+  return token;
+}
+
+async function setMockState(profile, state) {
+  await mockJSON("/fixture/state", { profile, ...state });
+}
+
+async function mockJSON(path, body) {
+  const response = await fetch(`${oauthMockURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${oauthFixtureToken}`, Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(`OAuth fixture HTTP ${response.status}; response body redacted`);
+  return payload;
+}
+
+async function assertChallenge(path, expectedMetadataURL) {
+  const response = await mcpRequest(undefined, path);
+  assert(response.status === 401, `${path} missing-auth response was not 401`);
+  assert(response.headers.get("www-authenticate") === `Bearer resource_metadata="${expectedMetadataURL}"`, `${path} challenge did not identify its matching RFC 9728 document`);
+}
+
+async function mcpTools(token, path) {
+  const response = await mcpRequest(token, path);
+  const names = new Set((response.payload.result?.tools ?? []).map((tool) => tool.name));
+  return { ...response, names };
+}
+
+async function expectMCPStatus(token, path, status) {
+  const response = await mcpRequest(token, path);
+  assert(response.status === status, `${path} returned HTTP ${response.status}; expected ${status}`);
+}
+
+async function expectMCPError(token, path, status, code, label = path) {
+  const response = await mcpRequest(token, path);
+  assert(response.status === status, `${label} returned HTTP ${response.status}; expected ${status}`);
+  assert(response.payload.code === code, `${label} returned bounded code ${String(response.payload.code)}; expected ${code}`);
+  assert(!JSON.stringify(response.payload).includes(token), `${label} reflected bearer material`);
+}
+
+function assertMCPTools(response, { present = [], absent = [] }) {
+  assert(response.status === 200 && response.payload.result && !response.payload.error, `MCP tools/list returned HTTP ${response.status}`);
+  for (const name of present) assert(response.names.has(name), `MCP tools/list omitted ${name}`);
+  for (const name of absent) assert(!response.names.has(name), `MCP tools/list exposed ${name} beyond intersected grants`);
+}
+
+async function mcpRequest(token, path, extraHeaders = {}) {
+  return mcpRPC(token, path, "tools/list", {}, extraHeaders);
+}
+
+async function assertMCPToolSuccess(token, path, name, args) {
+  const response = await mcpRPC(token, path, "tools/call", { name, arguments: args });
+  assert(response.status === 200 && response.payload.result !== undefined && !response.payload.error, `${name} was not invokable through ${path}`);
+}
+
+async function assertMCPToolScopeRejected(token, path, name, args) {
+  const response = await mcpRPC(token, path, "tools/call", { name, arguments: args });
+  assert(response.status === 200 && response.payload.error?.code === -32000 && response.payload.error?.message === "insufficient scope for tool" && response.payload.result === undefined, `hidden tool ${name} bypassed scope enforcement through ${path}`);
+}
+
+async function mcpRPC(token, path, method, params, extraHeaders = {}) {
+  const headers = { Accept: "application/json", "Content-Type": "application/json", ...extraHeaders };
+  if (token !== undefined) headers.Authorization = `Bearer ${token}`;
+  const response = await fetch(`${userURL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++rpcID, method, params }),
+  });
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`MCP ${path} returned non-JSON HTTP ${response.status}`);
+  }
+  return { status: response.status, headers: response.headers, payload };
+}
+
+async function publicJSON(path) {
+  const response = await fetch(`${userURL}${path}`, { headers: { Accept: "application/json" } });
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`public ${path} returned non-JSON HTTP ${response.status}`);
+  }
+  return { status: response.status, payload };
+}
+
+async function controlJSON(path, options = {}) {
+  const response = await controlRaw(path, options);
+  if (response.status < 200 || response.status > 299) {
+    throw new Error(`control ${path} returned HTTP ${response.status}; response body redacted`);
+  }
+  return response.payload;
+}
+
+async function controlRaw(path, options = {}) {
+  const response = await fetch(`${controlURL}/control/api${path}`, {
+    method: options.method ?? "GET",
+    headers: { Authorization: `Bearer ${controlToken}`, Accept: "application/json", "Content-Type": "application/json" },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`control ${path} returned non-JSON HTTP ${response.status}`);
+  }
+  return { status: response.status, payload };
+}
+
+function assertNoOAuthSecretsPersisted() {
+  for (const token of issuedTokens) {
+    const result = postgresCommand(`
+      SELECT count(*)
+      FROM (
+        SELECT protected_resource_config::text AS value FROM sso_providers
+        UNION ALL SELECT metadata::text FROM audit_log
+        UNION ALL SELECT COALESCE(before_payload::text, '') FROM audit_log
+        UNION ALL SELECT COALESCE(after_payload::text, '') FROM audit_log
+      ) persisted
+      WHERE value LIKE '%' || ${sqlLiteral(token)} || '%';
+    `);
+    if (result.status !== 0 || Number(result.stdout.trim()) !== 0) throw new Error("OAuth bearer material crossed a persistence boundary");
+  }
+  const sentinel = postgresCommand(`
+    SELECT count(*)
+    FROM audit_log
+    WHERE metadata::text LIKE '%' || ${sqlLiteral(logSentinel)} || '%'
+       OR COALESCE(before_payload::text, '') LIKE '%' || ${sqlLiteral(logSentinel)} || '%'
+       OR COALESCE(after_payload::text, '') LIKE '%' || ${sqlLiteral(logSentinel)} || '%';
+  `);
+  if (sentinel.status !== 0 || Number(sentinel.stdout.trim()) !== 0) throw new Error("OAuth claim content crossed an audit persistence boundary");
+}
+
+function assertNoOAuthSecretsInLogs() {
+  const result = spawnSync("docker", ["compose", "-p", composeProject, "-f", composeFile, "logs", "--no-color", "server"], {
+    cwd: repositoryRoot(), encoding: "utf8", maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) throw new Error("could not inspect server logs for OAuth bearer leakage");
+  const logs = `${result.stdout}\n${result.stderr}`;
+  if (logs.includes(logSentinel) || issuedTokens.some((token) => logs.includes(token))) {
+    throw new Error("OAuth bearer or claim material crossed the server log boundary");
+  }
+}
+
+function postgresCommand(sql) {
+  return spawnSync("docker", [
+    "compose", "-p", composeProject, "-f", composeFile, "exec", "-T", "postgres", "sh", "-ec",
+    'psql -X -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "$1"',
+    "oauth-mcp-e2e", sql,
+  ], { cwd: repositoryRoot(), encoding: "utf8", maxBuffer: 20 * 1024 * 1024 });
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sqlLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function repositoryRoot() {
+  return fileURLToPath(new URL("../..", import.meta.url));
+}
+
+function assertUUID(value, label) {
+  assert(typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value), `${label} missing`);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/tests/uat/oauth_mcp_e2e.mjs
+++ b/tests/uat/oauth_mcp_e2e.mjs
@@ -539,16 +539,16 @@ function assertNoOAuthSecretsPersisted() {
         UNION ALL SELECT COALESCE(before_payload::text, '') FROM audit_log
         UNION ALL SELECT COALESCE(after_payload::text, '') FROM audit_log
       ) persisted
-      WHERE value LIKE '%' || ${sqlLiteral(token)} || '%';
+      WHERE strpos(value, ${sqlLiteral(token)}) > 0;
     `);
     if (result.status !== 0 || Number(result.stdout.trim()) !== 0) throw new Error("OAuth bearer material crossed a persistence boundary");
   }
   const sentinel = postgresCommand(`
     SELECT count(*)
     FROM audit_log
-    WHERE metadata::text LIKE '%' || ${sqlLiteral(logSentinel)} || '%'
-       OR COALESCE(before_payload::text, '') LIKE '%' || ${sqlLiteral(logSentinel)} || '%'
-       OR COALESCE(after_payload::text, '') LIKE '%' || ${sqlLiteral(logSentinel)} || '%';
+    WHERE strpos(metadata::text, ${sqlLiteral(logSentinel)}) > 0
+       OR strpos(COALESCE(before_payload::text, ''), ${sqlLiteral(logSentinel)}) > 0
+       OR strpos(COALESCE(after_payload::text, ''), ${sqlLiteral(logSentinel)}) > 0;
   `);
   if (sentinel.status !== 0 || Number(sentinel.stdout.trim()) !== 0) throw new Error("OAuth claim content crossed an audit persistence boundary");
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,5 +1,6 @@
 import type { ControlTelemetryQuery, TelemetrySnapshot } from "./telemetry/types";
 import type { CommunityStatus } from "./community-api-types";
+import type { OAuthProtectedResourceConfig } from "./oauth-protected-resource-types";
 import type { SearchConvergence } from "./search-convergence-types";
 import { requestJson } from "./http";
 import {
@@ -35,6 +36,7 @@ export type {
   ConflictQueueSupporter,
 } from "./conflict-queue-api-types";
 import type { ConflictQueuePage, ConflictQueueQuery } from "./conflict-queue-api-types";
+export type { OAuthProtectedResourceConfig, OAuthScopeMapping } from "./oauth-protected-resource-types";
 export type { SearchConvergence } from "./search-convergence-types";
 export type Team = {
   id: string;
@@ -193,6 +195,7 @@ export type SSOProvider = {
   group_claims: string[];
   groups_endpoint: string;
   groups_scopes: string[];
+  protected_resource: OAuthProtectedResourceConfig;
   enabled: boolean;
   created_at: string;
   updated_at: string;
@@ -226,6 +229,7 @@ export type SSOProviderInput = {
   group_claims: string[];
   groups_endpoint: string;
   groups_scopes: string[];
+  protected_resource: OAuthProtectedResourceConfig;
   enabled: boolean;
 };
 

--- a/web/src/control/ConfigPanel.tsx
+++ b/web/src/control/ConfigPanel.tsx
@@ -9,7 +9,8 @@ type ConfigTab = "general" | "sso" | "dreaming" | "community" | "operation-logs"
 const CONFIG_LABELS: Record<string, string> = {
   APP_TIMEZONE: "Timezone",
   EMBEDDING_RECONCILIATION_START_TIME_LOCAL: "Embedding recovery start time",
-  SSO_PUBLIC_BASE_URL: "Public base URL",
+	SSO_PUBLIC_BASE_URL: "Public base URL",
+	MCP_PUBLIC_BASE_URL: "MCP public base URL",
   SCIM_PUBLIC_BASE_URL: "SCIM ingress URL",
   CONTROL_PUBLIC_BASE_URL: "Control portal ingress URL",
   SSO_ENTITLEMENT_CACHE_TTL_SECONDS: "Entitlement cache TTL",
@@ -35,7 +36,8 @@ const CONFIG_LABELS: Record<string, string> = {
 
 const CONFIG_PLACEHOLDERS: Record<string, string> = {
   APP_TIMEZONE: "Local",
-  EMBEDDING_RECONCILIATION_START_TIME_LOCAL: "04:30",
+	EMBEDDING_RECONCILIATION_START_TIME_LOCAL: "04:30",
+	MCP_PUBLIC_BASE_URL: "https://memory.example.com",
   SCIM_PUBLIC_BASE_URL: "https://memory.example.com",
   CONTROL_PUBLIC_BASE_URL: "https://control.example.com",
   SSO_ENTITLEMENT_CACHE_TTL_SECONDS: "300",

--- a/web/src/control/SSOPanel.test.tsx
+++ b/web/src/control/SSOPanel.test.tsx
@@ -22,7 +22,52 @@ beforeEach(() => {
 });
 
 describe("SSOPanel", () => {
-  it("ignores stale mapping responses after switching providers", async () => {
+	it("renders and saves the protected-resource contract", async () => {
+		const oauthProvider: SSOProvider = {
+			...providerA,
+			protected_resource: {
+				enabled: true,
+				audiences: ["api://dense-mem"],
+				jwks_source: "static",
+				jwks_uri: "https://provider-a.example.com/jwks.json",
+				algorithms: ["RS256", "ES256"],
+				scope_claim: "scp",
+				scope_mappings: [{ external_scope: "densemem.read", internal_scopes: ["read"] }],
+				team_claim: "dense_mem_team_id",
+			},
+		};
+		const api = {
+			listSSOProviders: vi.fn(async () => [oauthProvider]),
+			listSSOGroupMappings: vi.fn(async () => []),
+			updateSSOProvider: vi.fn(async (_providerId, input) => ({ ...oauthProvider, ...input })),
+			getDirectoryConnector: vi.fn(async () => { throw new ApiError(404, "not found"); }),
+			listControlAdminGroups: vi.fn(async () => []),
+		} as unknown as ControlApi;
+
+		render(<SSOPanel api={api} teams={[team]} />);
+
+		await waitFor(() => expect(screen.getByLabelText("Accept OAuth JWTs on MCP")).toBeChecked());
+		expect(screen.getByLabelText("Allowed audiences")).toHaveValue("api://dense-mem");
+		expect(screen.getByLabelText("JWKS source")).toHaveValue("static");
+		expect(screen.getByLabelText("JWKS URL")).toHaveValue("https://provider-a.example.com/jwks.json");
+		expect(screen.getByLabelText("Signature algorithms")).toHaveValue("RS256, ES256");
+		expect(screen.getByLabelText("Scope claim")).toHaveValue("scp");
+		expect(screen.getByLabelText("Team claim")).toHaveValue("dense_mem_team_id");
+		expect(screen.getByLabelText("External scope")).toHaveValue("densemem.read");
+
+		await userEvent.clear(screen.getByLabelText("Allowed audiences"));
+		await userEvent.type(screen.getByLabelText("Allowed audiences"), "api://dense-mem-v2");
+		await userEvent.click(screen.getByRole("button", { name: "Save provider" }));
+		await waitFor(() => expect(api.updateSSOProvider).toHaveBeenCalledWith(providerA.id, expect.objectContaining({
+			protected_resource: expect.objectContaining({
+				enabled: true,
+				audiences: ["api://dense-mem-v2"],
+				scope_mappings: [{ external_scope: "densemem.read", internal_scopes: ["read"] }],
+			}),
+		})));
+	});
+
+	it("ignores stale mapping responses after switching providers", async () => {
     const providerAMappings = deferred<SSOGroupMapping[]>();
     const api = {
       listSSOProviders: vi.fn(async () => [providerA, providerB]),
@@ -67,9 +112,19 @@ function ssoProvider(id: string, name: string): SSOProvider {
     client_secret_env: "",
     scopes: ["openid", "profile", "email"],
     group_claims: ["groups"],
-    groups_endpoint: "",
-    groups_scopes: [],
-    enabled: true,
+		groups_endpoint: "",
+		groups_scopes: [],
+		protected_resource: {
+			enabled: false,
+			audiences: [],
+			jwks_source: "discovery",
+			jwks_uri: "",
+			algorithms: ["RS256"],
+			scope_claim: "scope",
+			scope_mappings: [],
+			team_claim: "",
+		},
+		enabled: true,
     created_at: "2026-05-01T12:00:00Z",
     updated_at: "2026-05-01T12:00:00Z",
   };

--- a/web/src/control/SSOPanel.test.tsx
+++ b/web/src/control/SSOPanel.test.tsx
@@ -67,6 +67,30 @@ describe("SSOPanel", () => {
 		})));
 	});
 
+	it("keeps OAuth scope mapping inputs mounted while editing and removing rows", async () => {
+		const api = {
+			listSSOProviders: vi.fn(async () => [providerA]),
+			listSSOGroupMappings: vi.fn(async () => []),
+			getDirectoryConnector: vi.fn(async () => { throw new ApiError(404, "not found"); }),
+			listControlAdminGroups: vi.fn(async () => []),
+		} as unknown as ControlApi;
+
+		render(<SSOPanel api={api} teams={[team]} />);
+		await screen.findByText("Provider A");
+
+		await userEvent.click(screen.getByRole("button", { name: "Add mapping" }));
+		await userEvent.click(screen.getByRole("button", { name: "Add mapping" }));
+		const inputs = screen.getAllByLabelText("External scope");
+		await userEvent.type(inputs[0], "memory.read");
+		await userEvent.type(inputs[1], "memory.write");
+		expect(inputs[0]).toHaveValue("memory.read");
+		expect(inputs[1]).toHaveValue("memory.write");
+
+		await userEvent.click(screen.getByRole("button", { name: "Remove OAuth scope mapping 1" }));
+		expect(screen.getByLabelText("External scope")).toBe(inputs[1]);
+		expect(inputs[1]).toHaveValue("memory.write");
+	});
+
 	it("ignores stale mapping responses after switching providers", async () => {
     const providerAMappings = deferred<SSOGroupMapping[]>();
     const api = {

--- a/web/src/control/SSOPanel.tsx
+++ b/web/src/control/SSOPanel.tsx
@@ -249,7 +249,17 @@ function SSOProviderForm({
   onChange: (draft: SSOProviderInput) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }) {
-  return (
+	const protectedResource = draft.protected_resource;
+	const updateProtectedResource = (patch: Partial<SSOProviderInput["protected_resource"]>) => {
+		onChange({ ...draft, protected_resource: { ...protectedResource, ...patch } });
+	};
+	const updateScopeMapping = (index: number, patch: Partial<SSOProviderInput["protected_resource"]["scope_mappings"][number]>) => {
+		updateProtectedResource({
+			scope_mappings: protectedResource.scope_mappings.map((mapping, current) => current === index ? { ...mapping, ...patch } : mapping),
+		});
+	};
+
+	return (
     <form className="edit-grid" onSubmit={onSubmit}>
       <label htmlFor="sso-provider-name">Name</label>
       <input id="sso-provider-name" value={draft.name} onChange={(event) => onChange({ ...draft, name: event.target.value })} />
@@ -284,9 +294,60 @@ function SSOProviderForm({
       <input id="sso-group-claims" value={draft.group_claims.join(", ")} onChange={(event) => onChange({ ...draft, group_claims: splitList(event.target.value) })} />
       <label htmlFor="sso-groups-endpoint">Groups endpoint</label>
       <input id="sso-groups-endpoint" value={draft.groups_endpoint} onChange={(event) => onChange({ ...draft, groups_endpoint: event.target.value })} />
-      <label htmlFor="sso-groups-scopes">Groups scopes</label>
-      <input id="sso-groups-scopes" value={draft.groups_scopes.join(", ")} onChange={(event) => onChange({ ...draft, groups_scopes: splitList(event.target.value) })} />
-      <label htmlFor="sso-enabled">Enabled</label>
+		<label htmlFor="sso-groups-scopes">Groups scopes</label>
+		<input id="sso-groups-scopes" value={draft.groups_scopes.join(", ")} onChange={(event) => onChange({ ...draft, groups_scopes: splitList(event.target.value) })} />
+		<label>OAuth protected resource</label>
+		<fieldset className="oauth-provider-config">
+			<legend>MCP access tokens</legend>
+			<label className="toggle-row span" htmlFor="sso-oauth-enabled">
+				<span>Accept OAuth JWTs on MCP</span>
+				<input id="sso-oauth-enabled" type="checkbox" checked={protectedResource.enabled} onChange={(event) => updateProtectedResource({ enabled: event.target.checked })} />
+			</label>
+			<label htmlFor="sso-oauth-audiences">Allowed audiences</label>
+			<input id="sso-oauth-audiences" value={protectedResource.audiences.join(", ")} onChange={(event) => updateProtectedResource({ audiences: splitList(event.target.value) })} placeholder="api://dense-mem" />
+			<label htmlFor="sso-oauth-jwks-source">JWKS source</label>
+			<select id="sso-oauth-jwks-source" value={protectedResource.jwks_source} onChange={(event) => updateProtectedResource({ jwks_source: event.target.value as "discovery" | "static", jwks_uri: event.target.value === "discovery" ? "" : protectedResource.jwks_uri })}>
+				<option value="discovery">OIDC discovery</option>
+				<option value="static">Static JWKS URL</option>
+			</select>
+			<label htmlFor="sso-oauth-jwks-uri">JWKS URL</label>
+			<input id="sso-oauth-jwks-uri" value={protectedResource.jwks_uri} disabled={protectedResource.jwks_source === "discovery"} onChange={(event) => updateProtectedResource({ jwks_uri: event.target.value })} placeholder="https://idp.example.com/.well-known/jwks.json" />
+			<label htmlFor="sso-oauth-algorithms">Signature algorithms</label>
+			<input id="sso-oauth-algorithms" value={protectedResource.algorithms.join(", ")} onChange={(event) => updateProtectedResource({ algorithms: splitList(event.target.value) })} />
+			<label htmlFor="sso-oauth-scope-claim">Scope claim</label>
+			<input id="sso-oauth-scope-claim" value={protectedResource.scope_claim} onChange={(event) => updateProtectedResource({ scope_claim: event.target.value })} placeholder="scope or scp" />
+			<label htmlFor="sso-oauth-team-claim">Team claim</label>
+			<input id="sso-oauth-team-claim" value={protectedResource.team_claim} onChange={(event) => updateProtectedResource({ team_claim: event.target.value })} placeholder="Optional UUID claim" />
+			<div className="oauth-mapping-heading span">
+				<strong>Scope mappings</strong>
+				<button className="ghost-button compact" type="button" onClick={() => updateProtectedResource({ scope_mappings: [...protectedResource.scope_mappings, { external_scope: "", internal_scopes: ["read"] }] })}>
+					<Plus size={15} aria-hidden="true" />
+					Add mapping
+				</button>
+			</div>
+			{protectedResource.scope_mappings.map((mapping, index) => (
+				<div className="oauth-scope-mapping span" key={`${mapping.external_scope}-${index}`}>
+					<label htmlFor={`sso-oauth-external-scope-${index}`}>External scope</label>
+					<input id={`sso-oauth-external-scope-${index}`} value={mapping.external_scope} onChange={(event) => updateScopeMapping(index, { external_scope: event.target.value })} />
+					<div className="permission-checkbox-group" aria-label={`Internal scopes for ${mapping.external_scope || `mapping ${index + 1}`}`}>
+						{(["read", "write", "feedback:read"] as const).map((scope) => (
+							<label className="permission-checkbox" key={scope}>
+								<input
+									type="checkbox"
+									checked={mapping.internal_scopes.includes(scope)}
+									onChange={(event) => updateScopeMapping(index, { internal_scopes: event.target.checked ? [...mapping.internal_scopes, scope] : mapping.internal_scopes.filter((value) => value !== scope) })}
+								/>
+								{scope}
+							</label>
+						))}
+					</div>
+					<button className="icon-button danger-icon" type="button" aria-label={`Remove OAuth scope mapping ${index + 1}`} onClick={() => updateProtectedResource({ scope_mappings: protectedResource.scope_mappings.filter((_, current) => current !== index) })}>
+						<Trash2 size={15} aria-hidden="true" />
+					</button>
+				</div>
+			))}
+		</fieldset>
+		<label htmlFor="sso-enabled">Enabled</label>
       <label className="checkbox-row" htmlFor="sso-enabled">
         <input id="sso-enabled" type="checkbox" checked={draft.enabled} onChange={(event) => onChange({ ...draft, enabled: event.target.checked })} />
         <span>{draft.enabled ? "enabled" : "disabled"}</span>
@@ -410,9 +471,19 @@ function emptyProviderInput(): SSOProviderInput {
     client_secret_env: "",
     scopes: ["openid", "profile", "email"],
     group_claims: ["groups"],
-    groups_endpoint: "",
-    groups_scopes: [],
-    enabled: true,
+		groups_endpoint: "",
+		groups_scopes: [],
+		protected_resource: {
+			enabled: false,
+			audiences: [],
+			jwks_source: "discovery",
+			jwks_uri: "",
+			algorithms: ["RS256"],
+			scope_claim: "scope",
+			scope_mappings: [],
+			team_claim: "",
+		},
+		enabled: true,
   };
 }
 
@@ -427,9 +498,10 @@ function providerToInput(provider: SSOProvider): SSOProviderInput {
     client_secret_env: provider.client_secret_env,
     scopes: provider.scopes,
     group_claims: provider.group_claims,
-    groups_endpoint: provider.groups_endpoint,
-    groups_scopes: provider.groups_scopes,
-    enabled: provider.enabled,
+		groups_endpoint: provider.groups_endpoint,
+		groups_scopes: provider.groups_scopes,
+		protected_resource: provider.protected_resource,
+		enabled: provider.enabled,
   };
 }
 

--- a/web/src/control/SSOPanel.tsx
+++ b/web/src/control/SSOPanel.tsx
@@ -218,7 +218,7 @@ export function SSOPanel({ api, teams }: { api: ControlApi; teams: Team[] }) {
             </tbody>
           </table>
         </div>
-        <SSOProviderForm draft={providerDraft} busy={loading} onChange={setProviderDraft} onSubmit={saveProvider} />
+        <SSOProviderForm key={selectedProviderId || "new"} draft={providerDraft} busy={loading} onChange={setProviderDraft} onSubmit={saveProvider} />
       </section>
 
       <section className="surface">
@@ -250,6 +250,15 @@ function SSOProviderForm({
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }) {
 	const protectedResource = draft.protected_resource;
+	const scopeMappingIDs = useRef<string[]>([]);
+	const nextScopeMappingID = useRef(0);
+	while (scopeMappingIDs.current.length < protectedResource.scope_mappings.length) {
+		scopeMappingIDs.current.push(`oauth-scope-mapping-${nextScopeMappingID.current}`);
+		nextScopeMappingID.current += 1;
+	}
+	if (scopeMappingIDs.current.length > protectedResource.scope_mappings.length) {
+		scopeMappingIDs.current.length = protectedResource.scope_mappings.length;
+	}
 	const updateProtectedResource = (patch: Partial<SSOProviderInput["protected_resource"]>) => {
 		onChange({ ...draft, protected_resource: { ...protectedResource, ...patch } });
 	};
@@ -257,6 +266,15 @@ function SSOProviderForm({
 		updateProtectedResource({
 			scope_mappings: protectedResource.scope_mappings.map((mapping, current) => current === index ? { ...mapping, ...patch } : mapping),
 		});
+	};
+	const addScopeMapping = () => {
+		scopeMappingIDs.current.push(`oauth-scope-mapping-${nextScopeMappingID.current}`);
+		nextScopeMappingID.current += 1;
+		updateProtectedResource({ scope_mappings: [...protectedResource.scope_mappings, { external_scope: "", internal_scopes: ["read"] }] });
+	};
+	const removeScopeMapping = (index: number) => {
+		scopeMappingIDs.current = scopeMappingIDs.current.filter((_, current) => current !== index);
+		updateProtectedResource({ scope_mappings: protectedResource.scope_mappings.filter((_, current) => current !== index) });
 	};
 
 	return (
@@ -320,32 +338,35 @@ function SSOProviderForm({
 			<input id="sso-oauth-team-claim" value={protectedResource.team_claim} onChange={(event) => updateProtectedResource({ team_claim: event.target.value })} placeholder="Optional UUID claim" />
 			<div className="oauth-mapping-heading span">
 				<strong>Scope mappings</strong>
-				<button className="ghost-button compact" type="button" onClick={() => updateProtectedResource({ scope_mappings: [...protectedResource.scope_mappings, { external_scope: "", internal_scopes: ["read"] }] })}>
+				<button className="ghost-button compact" type="button" onClick={addScopeMapping}>
 					<Plus size={15} aria-hidden="true" />
 					Add mapping
 				</button>
 			</div>
-			{protectedResource.scope_mappings.map((mapping, index) => (
-				<div className="oauth-scope-mapping span" key={`${mapping.external_scope}-${index}`}>
-					<label htmlFor={`sso-oauth-external-scope-${index}`}>External scope</label>
-					<input id={`sso-oauth-external-scope-${index}`} value={mapping.external_scope} onChange={(event) => updateScopeMapping(index, { external_scope: event.target.value })} />
-					<div className="permission-checkbox-group" aria-label={`Internal scopes for ${mapping.external_scope || `mapping ${index + 1}`}`}>
-						{(["read", "write", "feedback:read"] as const).map((scope) => (
-							<label className="permission-checkbox" key={scope}>
-								<input
-									type="checkbox"
-									checked={mapping.internal_scopes.includes(scope)}
-									onChange={(event) => updateScopeMapping(index, { internal_scopes: event.target.checked ? [...mapping.internal_scopes, scope] : mapping.internal_scopes.filter((value) => value !== scope) })}
-								/>
-								{scope}
-							</label>
-						))}
+			{protectedResource.scope_mappings.map((mapping, index) => {
+				const mappingID = scopeMappingIDs.current[index];
+				return (
+					<div className="oauth-scope-mapping span" key={mappingID}>
+						<label htmlFor={`${mappingID}-external-scope`}>External scope</label>
+						<input id={`${mappingID}-external-scope`} value={mapping.external_scope} onChange={(event) => updateScopeMapping(index, { external_scope: event.target.value })} />
+						<div className="permission-checkbox-group" aria-label={`Internal scopes for ${mapping.external_scope || `mapping ${index + 1}`}`}>
+							{(["read", "write", "feedback:read"] as const).map((scope) => (
+								<label className="permission-checkbox" key={scope}>
+									<input
+										type="checkbox"
+										checked={mapping.internal_scopes.includes(scope)}
+										onChange={(event) => updateScopeMapping(index, { internal_scopes: event.target.checked ? [...mapping.internal_scopes, scope] : mapping.internal_scopes.filter((value) => value !== scope) })}
+									/>
+									{scope}
+								</label>
+							))}
+						</div>
+						<button className="icon-button danger-icon" type="button" aria-label={`Remove OAuth scope mapping ${index + 1}`} onClick={() => removeScopeMapping(index)}>
+							<Trash2 size={15} aria-hidden="true" />
+						</button>
 					</div>
-					<button className="icon-button danger-icon" type="button" aria-label={`Remove OAuth scope mapping ${index + 1}`} onClick={() => updateProtectedResource({ scope_mappings: protectedResource.scope_mappings.filter((_, current) => current !== index) })}>
-						<Trash2 size={15} aria-hidden="true" />
-					</button>
-				</div>
-			))}
+				);
+			})}
 		</fieldset>
 		<label htmlFor="sso-enabled">Enabled</label>
       <label className="checkbox-row" htmlFor="sso-enabled">

--- a/web/src/control/oauth-provider.css
+++ b/web/src/control/oauth-provider.css
@@ -1,0 +1,38 @@
+.oauth-provider-config {
+	display: grid;
+	grid-template-columns: 150px minmax(0, 1fr);
+	gap: 10px;
+	min-width: 0;
+	padding: 14px;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--panel-muted);
+}
+
+.oauth-provider-config legend {
+	padding: 0 6px;
+	color: var(--text);
+	font-size: 13px;
+	font-weight: 760;
+}
+
+.oauth-mapping-heading,
+.oauth-scope-mapping {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.oauth-mapping-heading {
+	justify-content: space-between;
+	padding-top: 4px;
+}
+
+.oauth-scope-mapping {
+	display: grid;
+	grid-template-columns: 110px minmax(160px, 1fr) minmax(220px, auto) 36px;
+	padding: 10px;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--panel);
+}

--- a/web/src/control/oauth-provider.css
+++ b/web/src/control/oauth-provider.css
@@ -36,3 +36,10 @@
 	border-radius: 6px;
 	background: var(--panel);
 }
+
+@media (max-width: 640px) {
+	.oauth-provider-config,
+	.oauth-scope-mapping {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
+import "./control/oauth-provider.css";
 import "./resource-explorer.css";
 import "./knowledge-explorer.css";
 import "./observability.css";

--- a/web/src/oauth-protected-resource-types.ts
+++ b/web/src/oauth-protected-resource-types.ts
@@ -1,0 +1,15 @@
+export type OAuthScopeMapping = {
+  external_scope: string;
+  internal_scopes: Array<"read" | "write" | "feedback:read">;
+};
+
+export type OAuthProtectedResourceConfig = {
+  enabled: boolean;
+  audiences: string[];
+  jwks_source: "discovery" | "static";
+  jwks_uri: string;
+  algorithms: string[];
+  scope_claim: string;
+  scope_mappings: OAuthScopeMapping[];
+  team_claim: string;
+};

--- a/web/src/ui/components.tsx
+++ b/web/src/ui/components.tsx
@@ -321,7 +321,7 @@ export function InfoTooltip({ label, children }: InfoTooltipProps) {
   );
 }
 
-async function writeClipboardText(text: string, fallbackInput: HTMLInputElement | null): Promise<boolean> {
+export async function writeClipboardText(text: string, fallbackInput: HTMLInputElement | null): Promise<boolean> {
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);

--- a/web/src/user/App.cookie-session.test.tsx
+++ b/web/src/user/App.cookie-session.test.tsx
@@ -5,6 +5,7 @@ import { UserPortalApp } from "./App";
 import type { UserSession } from "./api";
 
 const baseSession: UserSession = {
+  mcp_public_base_url: "https://memory.example.test",
   team: {
     id: "11111111-1111-4111-8111-111111111111",
     name: "Research Team",

--- a/web/src/user/App.mcp-context.test.tsx
+++ b/web/src/user/App.mcp-context.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserPortalApp } from "./App";
+import { expectCurrentWorkspace, jsonResponse } from "./App.test-helpers";
+import type { UserSession } from "./api";
+
+const baseSession: UserSession = {
+  mcp_public_base_url: "https://memory.example.test",
+  team: {
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "Research Team",
+    description: "",
+    created_at: "2026-05-01T12:00:00Z",
+    updated_at: "2026-05-01T12:00:00Z",
+  },
+  membership: {
+    team_id: "11111111-1111-4111-8111-111111111111",
+    name: "Mine",
+    grants: ["read"],
+    role: "member",
+  },
+  credential: {
+    id: "22222222-2222-4222-8222-222222222222",
+    team_id: "11111111-1111-4111-8111-111111111111",
+    name: "Mine",
+    key_suffix: "abc123",
+    scopes: ["read"],
+    role: "member",
+    rate_limit: 120,
+    last_used_at: null,
+    expires_at: null,
+    created_at: "2026-05-01T12:00:00Z",
+    memory_binding: "shared_only",
+    memory_space_kind: "team_shared",
+  },
+  teams: [],
+  personal_credentials: [],
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.mocked(navigator.clipboard.writeText).mockClear();
+});
+
+describe("UserPortalApp MCP context", () => {
+  it("shows and copies the configured team-scoped MCP URL", async () => {
+    mockUserSession(baseSession);
+
+    render(<UserPortalApp />);
+
+    await expectCurrentWorkspace("Research Team");
+    expect(screen.getByText(baseSession.team.id)).toBeInTheDocument();
+    const expectedURL = `https://memory.example.test/teams/${baseSession.team.id}/mcp`;
+    expect(screen.getByText(expectedURL)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Copy MCP URL" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedURL);
+    expect(screen.queryByText(/browser origin/i)).not.toBeInTheDocument();
+  });
+
+  it("labels the browser-origin fallback for MCP URLs", async () => {
+    mockUserSession({ ...baseSession, mcp_public_base_url: "" });
+
+    render(<UserPortalApp />);
+
+    await expectCurrentWorkspace("Research Team");
+    expect(screen.getByText(`${window.location.origin}/teams/${baseSession.team.id}/mcp`)).toBeInTheDocument();
+    expect(screen.getByText("Using this browser origin because MCP_PUBLIC_BASE_URL is not configured.")).toBeInTheDocument();
+  });
+});
+
+function mockUserSession(session: UserSession) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (url === "/ui/api/sso/providers" && method === "GET") {
+      return jsonResponse({ data: [] });
+    }
+    if (url === "/ui/api/session" && method === "GET") {
+      return jsonResponse({ data: session });
+    }
+    return jsonResponse({ message: "not found" }, 404);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+}

--- a/web/src/user/App.test-helpers.ts
+++ b/web/src/user/App.test-helpers.ts
@@ -1,3 +1,5 @@
+import { screen } from "@testing-library/react";
+import { expect } from "vitest";
 import { RecallHit, RecallPayload } from "./api";
 
 export function optionValue<T>(value: T | T[], index: number): T {
@@ -27,6 +29,11 @@ export function jsonResponse(payload: unknown, status = 200) {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+export async function expectCurrentWorkspace(teamName: string) {
+  const workspace = await screen.findByLabelText("Current workspace");
+  expect(workspace).toHaveTextContent(teamName);
 }
 
 export function recallPayloadForHits(hits: RecallHit[]): RecallPayload {

--- a/web/src/user/App.test.tsx
+++ b/web/src/user/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserPortalApp } from "./App";
-import { authorizationHeader, isRecallSequence, jsonResponse, optionValue, recallPayloadForHits } from "./App.test-helpers";
+import { authorizationHeader, expectCurrentWorkspace, isRecallSequence, jsonResponse, optionValue, recallPayloadForHits } from "./App.test-helpers";
 import { GraphNode, GraphSnapshot, RecallHit, UserCredential, UserSession } from "./api";
 
 vi.mock("react-force-graph-2d", async () => {
@@ -32,6 +32,7 @@ vi.mock("react-force-graph-2d", async () => {
 });
 
 const baseSession: UserSession = {
+  mcp_public_base_url: "https://memory.example.test",
   team: {
     id: "11111111-1111-4111-8111-111111111111",
     name: "Research Team",
@@ -633,10 +634,12 @@ describe("UserPortalApp", () => {
     expect(screen.queryByRole("button", { name: /^team$/i })).not.toBeInTheDocument();
     const teamSelect = await screen.findByLabelText("Active team");
     expect(teamSelect).toHaveValue(initial.team.id);
+    expect(screen.getByText(`https://memory.example.test/teams/${initial.team.id}/mcp`)).toBeInTheDocument();
 
     await userEvent.selectOptions(teamSelect, secondTeam.id);
 
     await expectCurrentWorkspace("Analytics Team");
+    expect(screen.getByText(`https://memory.example.test/teams/${secondTeam.id}/mcp`)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /my credential/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^team$/i })).toBeInTheDocument();
     await waitFor(() => {
@@ -772,11 +775,6 @@ describe("UserPortalApp", () => {
     expect(screen.getByRole("button", { name: /regenerate key/i })).toBeDisabled();
   });
 });
-async function expectCurrentWorkspace(teamName: string) {
-  const workspace = await screen.findByLabelText("Current workspace");
-  expect(workspace).toHaveTextContent(teamName);
-}
-
 function mockUserFetch(session: UserSession, credentials: UserCredential[] = [], options: { recallHits?: RecallHit[] | RecallHit[][]; graphSnapshot?: GraphSnapshot | GraphSnapshot[]; graphNodeDetails?: Record<string, GraphNode> | Record<string, GraphNode>[] } = {}) {
   let currentTeam = session.team;
   let currentCredentials = credentials;

--- a/web/src/user/App.tsx
+++ b/web/src/user/App.tsx
@@ -2,6 +2,8 @@ import { Component, FormEvent, lazy, Suspense, useEffect, useMemo, useRef, useSt
 import type { ReactNode } from "react";
 import {
   BarChart3,
+  Check,
+  Copy,
   KeyRound,
   LogOut,
   Moon,
@@ -22,7 +24,7 @@ import {
   UserCredential,
   UserSession,
 } from "./api";
-import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading } from "../ui/components";
+import { AuthShell, LoadingState, PortalShell, SecretBox, SectionHeading, writeClipboardText } from "../ui/components";
 import { SearchPanel } from "./SearchPanel";
 
 const TelemetryDashboard = lazy(() => import("../telemetry/TelemetryDashboard").then((module) => ({ default: module.TelemetryDashboard })));
@@ -462,22 +464,61 @@ function UserContextBar({
   ssoTeamOptions: UserSession["teams"];
   onSwitchTeam: (teamId: string) => Promise<void>;
 }) {
+  const [copied, setCopied] = useState(false);
+  const copyFallbackRef = useRef<HTMLInputElement>(null);
+  const configuredBase = session.mcp_public_base_url.trim().replace(/\/+$/, "");
+  const browserBase = window.location.origin.replace(/\/+$/, "");
+  const mcpURL = `${configuredBase || browserBase}/teams/${session.team.id}/mcp`;
+
+  useEffect(() => {
+    setCopied(false);
+  }, [mcpURL]);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  async function copyMCPURL() {
+    setCopied(await writeClipboardText(mcpURL, copyFallbackRef.current));
+  }
+
   return (
-    <div className="session-context compact" aria-label="Current workspace">
-      <span className="context-label">Team</span>
-      {authMode === "sso" ? (
-        <select
-          aria-label="Active team"
-          value={session.team.id}
-          disabled={switchingTeam || (ssoTeamOptions?.length ?? 0) <= 1}
-          onChange={(event) => void onSwitchTeam(event.target.value)}
-        >
-          {(ssoTeamOptions ?? []).map((item) => (
-            <option value={item.team.id} key={item.team.id}>{item.team.name}</option>
-          ))}
-        </select>
-      ) : (
-        <strong className="team-select-chip">{session.team.name}</strong>
+    <div className="session-context compact mcp-context" aria-label="Current workspace">
+      <div className="mcp-context-team">
+        <span className="context-label">Team</span>
+        {authMode === "sso" ? (
+          <select
+            aria-label="Active team"
+            value={session.team.id}
+            disabled={switchingTeam || (ssoTeamOptions?.length ?? 0) <= 1}
+            onChange={(event) => void onSwitchTeam(event.target.value)}
+          >
+            {(ssoTeamOptions ?? []).map((item) => (
+              <option value={item.team.id} key={item.team.id}>{item.team.name}</option>
+            ))}
+          </select>
+        ) : (
+          <strong className="team-select-chip">{session.team.name}</strong>
+        )}
+      </div>
+      <div className="mcp-context-value">
+        <span className="context-label">Team ID</span>
+        <code>{session.team.id}</code>
+      </div>
+      <div className="mcp-context-value mcp-context-endpoint">
+        <span className="context-label">MCP URL</span>
+        <code>{mcpURL}</code>
+        <input ref={copyFallbackRef} className="sr-only" value={mcpURL} readOnly tabIndex={-1} aria-hidden="true" />
+        <button className="icon-button compact" type="button" aria-label={copied ? "MCP URL copied" : "Copy MCP URL"} onClick={() => void copyMCPURL()}>
+          {copied ? <Check size={15} aria-hidden="true" /> : <Copy size={15} aria-hidden="true" />}
+        </button>
+      </div>
+      {!configuredBase && (
+        <small className="mcp-origin-fallback">Using this browser origin because MCP_PUBLIC_BASE_URL is not configured.</small>
       )}
     </div>
   );

--- a/web/src/user/api.ts
+++ b/web/src/user/api.ts
@@ -33,6 +33,7 @@ export type UserSession = {
   credential: UserCredential | null;
   teams: UserTeamOption[];
   personal_credentials: UserCredential[];
+  mcp_public_base_url: string;
 };
 
 export type UserTeamOption = {

--- a/web/src/user/main.tsx
+++ b/web/src/user/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { UserPortalApp } from "./App";
 import "../styles.css";
 import "../resource-explorer.css";
+import "./mcp-context.css";
 import "../knowledge-explorer.css";
 import "../graph-view.css";
 import "../observability.css";

--- a/web/src/user/mcp-context.css
+++ b/web/src/user/mcp-context.css
@@ -1,0 +1,59 @@
+.session-context.compact.mcp-context {
+  display: grid;
+  grid-template-columns: auto minmax(240px, 1fr);
+  gap: 6px 14px;
+  width: min(820px, 62vw);
+  max-width: min(820px, 62vw);
+  padding: 7px 10px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.mcp-context-team,
+.mcp-context-value,
+.mcp-context-endpoint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mcp-context-value code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.mcp-context-endpoint {
+  grid-column: 1 / -1;
+}
+
+.mcp-context-endpoint code {
+  flex: 1 1 auto;
+}
+
+.mcp-context .icon-button.compact {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+}
+
+.mcp-origin-fallback {
+  grid-column: 1 / -1;
+  color: var(--subtle);
+  font-size: 11px;
+}
+
+@media (max-width: 760px) {
+  .session-context.compact.mcp-context {
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+    max-width: none;
+  }
+
+  .mcp-context-endpoint,
+  .mcp-origin-fallback {
+    grid-column: auto;
+  }
+}

--- a/web/tests-compose/oauth-team-resource.spec.ts
+++ b/web/tests-compose/oauth-team-resource.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+const userURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const firstTeamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+const secondTeamID = requiredEnv("DENSE_MEM_E2E_OAUTH_SECOND_TEAM_ID");
+const sessionToken = requiredEnv("DENSE_MEM_E2E_SSO_SESSION_TOKEN");
+const csrfToken = requiredEnv("DENSE_MEM_E2E_SSO_CSRF_TOKEN");
+const origin = new URL(userURL).origin;
+
+test("SSO workspace shows and copies the canonical team-scoped MCP URL after a team switch", async ({ context, page }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"], { origin });
+  await context.addCookies([
+    { name: "dense_mem_sso_session", value: sessionToken, url: userURL, httpOnly: true, sameSite: "Lax" },
+    { name: "dense_mem_sso_csrf", value: csrfToken, url: userURL, sameSite: "Lax" },
+  ]);
+  const resetResponse = await context.request.post(`${userURL}/ui/api/sso/team`, {
+    headers: { "X-Dense-Mem-CSRF": csrfToken },
+    data: { team_id: firstTeamID },
+  });
+  expect(resetResponse.status()).toBe(200);
+
+  await page.goto(`${userURL}/ui`);
+
+  const workspace = page.getByLabel("Current workspace");
+  const firstMCPURL = `${origin}/teams/${firstTeamID}/mcp`;
+  await expect(workspace).toBeVisible();
+  await expect(workspace.getByText(firstTeamID, { exact: true })).toBeVisible();
+  await expect(workspace.getByText(firstMCPURL, { exact: true })).toBeVisible();
+  await expect(workspace.getByText("Using this browser origin because MCP_PUBLIC_BASE_URL is not configured.")).toHaveCount(0);
+
+  await workspace.getByRole("button", { name: "Copy MCP URL" }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(firstMCPURL);
+
+  await Promise.all([
+    page.waitForResponse((response) => response.url().endsWith("/ui/api/sso/team") && response.request().method() === "POST" && response.status() === 200),
+    workspace.getByLabel("Active team").selectOption(secondTeamID),
+  ]);
+
+  const secondMCPURL = `${origin}/teams/${secondTeamID}/mcp`;
+  await expect(workspace.getByText(secondTeamID, { exact: true })).toBeVisible();
+  await expect(workspace.getByText(secondMCPURL, { exact: true })).toBeVisible();
+  await expect(workspace.getByText(firstTeamID, { exact: true })).toHaveCount(0);
+  await expect(workspace.getByText(firstMCPURL, { exact: true })).toHaveCount(0);
+
+  await workspace.getByRole("button", { name: "Copy MCP URL" }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(secondMCPURL);
+});
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}


### PR DESCRIPTION
## Summary

- Accept customer-IdP JWT access tokens on `/mcp` and `/teams/{team_id}/mcp` through the existing closed OAuth validator while preserving Dense-Mem static tokens.
- Publish RFC 9728 protected-resource metadata and trusted `WWW-Authenticate` challenges, including correct path-prefixed metadata URLs.
- Validate bearer material before resolving an active identity, membership, immutable team context, profile-private memory space, and intersected grants.
- Add dormant provider configuration, guarded PostgreSQL migration/rollback, control-portal editing, user-portal team resource URLs, and the `mcp_oauth` Compose scenario.
- Preserve the applicable #248 review fixes: entitlement revalidation, issuer-specific invalid/duplicate-provider isolation, strict duplicate JWT checks before unverified issuer use, safe JWKS reconfiguration, trusted metadata origins, and nonblocking migration operations.

## Risk

- A path or claim could select another team. JWT validation precedes membership selection; path, claim, provider, subject, and active membership must agree before immutable context is installed.
- A bad provider or JWKS outage could affect unrelated issuers or fail open. Invalid/ambiguous issuers are isolated, cache refresh is bounded, and required failures remain typed and fail closed.
- Rollback could discard live operator configuration. The down migration refuses customized provider or MCP public-base state before mutation.

## Validation

- `go test ./internal/service/... ./internal/http/... -count=1`
- `go test -tags=integration ./internal/storage/postgres -run '^TestOAuthProtectedResourceMigration' -count=1`
- `DENSE_MEM_REPOSITORY_TESTCONTAINERS=1 go test ./internal/repository -run '^TestSSOProviderProtectedResource' -count=1`
- `npm test --prefix web -- --run`
- `npm run typecheck --prefix web`
- `./scripts/ci-check.sh` — passed at the 90.0% coverage gate; the enabled pre-push hook passed again.
- `DENSE_MEM_E2E_SCENARIO=mcp_oauth DENSE_MEM_E2E_RUN_ID=issue-216-42a7fee2-final ./scripts/e2e-compose.sh` — passed at `42a7fee29948e87af8f1dd49c09cbeed210473ab`, including Chromium and mobile.
- Full Compose `all` regression passed during extraction; the final scoped OAuth fixes were then rechecked by focused tests, CI, and the committed-head `mcp_oauth` run.

The full 1k evaluation was not run by explicit direction; this change does not alter retrieval or placement behavior beyond authorized space selection.

Part of #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth-protected MCP access with bearer-token authentication and team-scoped MCP routes.
  * Added protected-resource metadata endpoints and OAuth authentication challenges.
  * Added SSO configuration for OAuth audiences, JWKS, claims, algorithms, and scope mappings.
  * Added configurable, validated MCP public URLs, displayed in the user portal with copy support.
* **Bug Fixes**
  * Improved team binding, authorization errors, validation, and protection against credential leakage.
  * Preserved existing OAuth settings when updating SSO providers without new protected-resource configuration.
* **Tests**
  * Added comprehensive unit, integration, browser, and end-to-end coverage for OAuth MCP scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->