### PR TITLE
fix: reduce AI PR review cycle latency

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -18,7 +18,7 @@ permissions:
   statuses: read
 
 env:
-  REVIEW_STATUS_CONTEXT: AI PR review
+  REVIEW_STATUS_CONTEXT_PREFIX: AI PR review
   REVIEW_PROTOCOL: >-
     Before deciding, call the configured dense_mem_project_memory server's
     read-only recall_memory tool with a focused query about the affected
@@ -66,6 +66,7 @@ jobs:
     outputs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
+      review_status_context: ${{ steps.resolve.outputs.review_status_context }}
       should_run: ${{ steps.resolve.outputs.should_run }}
 
     steps:
@@ -173,6 +174,8 @@ jobs:
               return;
             }
 
+            const reviewStatusContext =
+              `${process.env.REVIEW_STATUS_CONTEXT_PREFIX} / PR #${pull.number}`;
             if (eventName === "workflow_run") {
               const statuses = await github.paginate(
                 github.rest.repos.listCommitStatusesForRef,
@@ -184,7 +187,7 @@ jobs:
                 },
               );
               const latestReviewStatus = statuses
-                .filter((status) => status.context === process.env.REVIEW_STATUS_CONTEXT)
+                .filter((status) => status.context === reviewStatusContext)
                 .sort((left, right) => right.id - left.id)[0];
               if (
                 latestReviewStatus &&
@@ -192,7 +195,7 @@ jobs:
               ) {
                 skip(
                   `Pull request #${pullNumber} already has ${latestReviewStatus.state} ` +
-                    `${process.env.REVIEW_STATUS_CONTEXT} status at this head.`,
+                    `${reviewStatusContext} status at this head.`,
                 );
                 return;
               }
@@ -200,6 +203,7 @@ jobs:
 
             core.setOutput("head_sha", pull.head.sha);
             core.setOutput("pr_number", String(pull.number));
+            core.setOutput("review_status_context", reviewStatusContext);
             core.setOutput("should_run", "true");
 
   review:
@@ -207,6 +211,8 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
     runs-on: docker-runner
+    env:
+      REVIEW_STATUS_CONTEXT: ${{ needs.resolve.outputs.review_status_context }}
 
     concurrency:
       group: ai-pr-review-${{ github.repository }}-${{ needs.resolve.outputs.pr_number }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,10 +1,6 @@
 name: AI Pull Request Review
 
 on:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened, ready_for_review]
   workflow_run:
     workflows:
       - CI Pull Request
@@ -62,6 +58,10 @@ jobs:
   resolve:
     name: Resolve pull request
     runs-on: docker-runner
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success')
 
     outputs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -84,25 +84,16 @@ jobs:
             let pullNumber;
             let triggerHeadSha;
 
-            if (eventName === "pull_request_target") {
-              const pull = context.payload.pull_request;
-              if (!pull) {
-                throw new Error("The pull_request_target payload has no pull request.");
-              }
-              if (pull.draft) {
-                skip(`Pull request #${pull.number} is a draft.`);
-                return;
-              }
-              if (pull.user?.login?.toLowerCase() === "dependabot[bot]") {
-                skip(`Pull request #${pull.number} will use the trusted CI completion path.`);
-                return;
-              }
-              pullNumber = pull.number;
-              triggerHeadSha = pull.head?.sha;
-            } else if (eventName === "workflow_run") {
+            if (eventName === "workflow_run") {
               const workflowRun = context.payload.workflow_run;
               if (!workflowRun || workflowRun.event !== "pull_request") {
                 skip("The completed CI run was not triggered by a pull request.");
+                return;
+              }
+              if (workflowRun.conclusion !== "success") {
+                skip(
+                  `The completed CI run concluded ${workflowRun.conclusion || "without a result"}.`,
+                );
                 return;
               }
               triggerHeadSha = workflowRun.head_sha;
@@ -257,7 +248,8 @@ jobs:
           ai-secret: ${{ secrets.LOCAL_AI_SECRET }}
           ai-auth-mode: auth-token
           model: auto
-          parallel-count: "5"
+          effort: high
+          parallel-count: "7"
           max-turns: "100"
           auto-approve: "false"
           review-prompts: |

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -97,8 +97,19 @@ jobs:
                 return;
               }
               triggerHeadSha = workflowRun.head_sha;
+              const triggerHeadRef = workflowRun.head_branch;
+              const triggerHeadRepositoryId = workflowRun.head_repository?.id;
               if (typeof triggerHeadSha !== "string") {
                 throw new Error("The workflow_run payload has no head SHA.");
+              }
+              if (typeof triggerHeadRef !== "string" || triggerHeadRef.length === 0) {
+                throw new Error("The workflow_run payload has no head branch.");
+              }
+              if (
+                !Number.isSafeInteger(triggerHeadRepositoryId) ||
+                triggerHeadRepositoryId < 1
+              ) {
+                throw new Error("The workflow_run payload has no head repository ID.");
               }
 
               const pulls = await github.paginate(github.rest.pulls.list, {
@@ -108,7 +119,12 @@ jobs:
                 base: "main",
                 per_page: 100,
               });
-              const matches = pulls.filter((pull) => pull.head.sha === triggerHeadSha);
+              const matches = pulls.filter(
+                (pull) =>
+                  pull.head.sha === triggerHeadSha &&
+                  pull.head.ref === triggerHeadRef &&
+                  pull.head.repo?.id === triggerHeadRepositoryId,
+              );
               if (matches.length === 0) {
                 skip(`No current open pull request targets main at ${triggerHeadSha}.`);
                 return;

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -119,7 +119,17 @@ test("automatic AI review waits for successful current-head PR CI", async () => 
   );
   assert.match(workflow, /workflowRun\.event !== "pull_request"/);
   assert.match(workflow, /workflowRun\.conclusion !== "success"/);
-  assert.match(workflow, /pull\.head\.sha === triggerHeadSha/);
+  assert.match(workflow, /const triggerHeadRef = workflowRun\.head_branch/);
+  assert.match(
+    workflow,
+    /const triggerHeadRepositoryId = workflowRun\.head_repository\?\.id/,
+  );
+  assert.match(workflow, /typeof triggerHeadRef !== "string"/);
+  assert.match(workflow, /!Number\.isSafeInteger\(triggerHeadRepositoryId\)/);
+  assert.match(
+    normalizedWorkflow,
+    /pull\.head\.sha === triggerHeadSha && pull\.head\.ref === triggerHeadRef && pull\.head\.repo\?\.id === triggerHeadRepositoryId/,
+  );
   assert.match(
     workflow,
     /pull\.head\.sha !== triggerHeadSha/,

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -92,7 +92,8 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   );
   assert.match(workflow, /EXPECTED_HEAD_SHA: \$\{\{ needs\.resolve\.outputs\.head_sha \}\}/);
   assert.match(workflow, /persist-credentials: false/);
-  assert.match(workflow, /parallel-count: "5"/);
+  assert.match(workflow, /effort: high/);
+  assert.match(workflow, /parallel-count: "7"/);
   assert.match(workflow, /max-turns: "100"/);
   assert.match(workflow, /auto-approve: "false"/);
   assert.match(workflow, /permission_policy: always_allow/);
@@ -102,6 +103,27 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
     /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/,
   );
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
+});
+
+test("automatic AI review waits for successful current-head PR CI", async () => {
+  const workflow = await readFile(reviewWorkflowURL, "utf8");
+  const normalizedWorkflow = workflow.replace(/\s+/g, " ");
+
+  assert.doesNotMatch(workflow, /^\s+pull_request_target:/m);
+  assert.match(workflow, /^\s+workflow_run:/m);
+  assert.match(workflow, /^\s+workflow_dispatch:/m);
+  assert.match(normalizedWorkflow, /workflows: - CI Pull Request types: \[completed\]/);
+  assert.match(
+    normalizedWorkflow,
+    /github\.event_name == 'workflow_dispatch' \|\| \(github\.event\.workflow_run\.event == 'pull_request' && github\.event\.workflow_run\.conclusion == 'success'\)/,
+  );
+  assert.match(workflow, /workflowRun\.event !== "pull_request"/);
+  assert.match(workflow, /workflowRun\.conclusion !== "success"/);
+  assert.match(workflow, /pull\.head\.sha === triggerHeadSha/);
+  assert.match(
+    workflow,
+    /pull\.head\.sha !== triggerHeadSha/,
+  );
 });
 
 test("final review status is fenced by the live pull request head", async () => {

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -136,6 +136,37 @@ test("automatic AI review waits for successful current-head PR CI", async () => 
   );
 });
 
+test("AI review status identity remains scoped to the resolved pull request", async () => {
+  const workflow = await readFile(reviewWorkflowURL, "utf8");
+  const normalizedWorkflow = workflow.replace(/\s+/g, " ");
+  const statusWrites =
+    workflow.match(/context: process\.env\.REVIEW_STATUS_CONTEXT/g) ?? [];
+
+  assert.match(workflow, /REVIEW_STATUS_CONTEXT_PREFIX: AI PR review/);
+  assert.match(
+    workflow,
+    /review_status_context: \$\{\{ steps\.resolve\.outputs\.review_status_context \}\}/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /const reviewStatusContext = `\$\{process\.env\.REVIEW_STATUS_CONTEXT_PREFIX\} \/ PR #\$\{pull\.number\}`/,
+  );
+  assert.match(workflow, /status\.context === reviewStatusContext/);
+  assert.match(
+    workflow,
+    /core\.setOutput\("review_status_context", reviewStatusContext\)/,
+  );
+  assert.match(
+    workflow,
+    /REVIEW_STATUS_CONTEXT: \$\{\{ needs\.resolve\.outputs\.review_status_context \}\}/,
+  );
+  assert.equal(statusWrites.length, 2);
+  assert.doesNotMatch(
+    workflow,
+    /status\.context === process\.env\.REVIEW_STATUS_CONTEXT/,
+  );
+});
+
 test("final review status is fenced by the live pull request head", async () => {
   const workflow = await readFile(reviewWorkflowURL, "utf8");
   const finalStatusStep = workflow.slice(


### PR DESCRIPTION
## Summary

- Wait for successful `CI Pull Request` completion before automatic AI review.
- Preserve manual dispatch, current-head fencing, draft filtering, and review-status deduplication.
- Run all seven review goals concurrently with `effort: high`.
- Add policy coverage for the trigger, successful-CI gate, effort, and parallelism.

## Why

The prior `pull_request_target` path could start review before CI, then the successful `workflow_run` path could initiate another cycle for the same head. Gating the automatic review on successful CI removes that duplicate source of cancellations and review-loop turns.

## Risk

A head with failing CI will not receive automatic AI review until CI succeeds. CI already blocks that head, and manual dispatch remains available for an explicit review attempt. Seven concurrent goals also increase provider concurrency, but the fan-out is bounded to the existing seven review goals.

## Validation

- `./scripts/ci-check.sh`