### PR TITLE
ci: add manual staging deployment workflow

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -1,0 +1,197 @@
+name: Deploy staging
+
+run-name: Deploy staging · ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Dense-Mem image tag to deploy."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
+concurrency:
+  group: dense-mem-staging-deployment
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize staging deployment
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: docker-runner
+    outputs:
+      expected_revision: ${{ steps.authorize.outputs.expected_revision }}
+      tag: ${{ steps.authorize.outputs.tag }}
+
+    steps:
+      - name: Authorize actor and resolve image source
+        id: authorize
+        uses: actions/github-script@v9
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          IMAGE_TAG: ${{ inputs.tag }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        with:
+          script: |
+            const actor = "Z-M-Huang";
+            const tag = process.env.IMAGE_TAG;
+            if (context.actor !== actor || process.env.TRIGGERING_ACTOR !== actor) {
+              throw new Error("Only Z-M-Huang may deploy staging.");
+            }
+            if (process.env.DISPATCH_REF !== "refs/heads/main") {
+              throw new Error("Staging deployments must be dispatched from main.");
+            }
+
+            const preview = /^test-([1-9][0-9]*)$/.exec(tag);
+            if (!preview && !/^v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?$/.test(tag)) {
+              throw new Error("tag must be test-N, vX.Y.Z-rc.N, or vX.Y.Z");
+            }
+
+            let revision;
+            if (preview) {
+              const pullNumber = Number(preview[1]);
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              });
+              const repository = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+              if (
+                pull.state !== "open" ||
+                pull.base.ref !== "main" ||
+                pull.head.repo?.full_name.toLowerCase() !== repository ||
+                !pull.labels.some((label) => label.name === "deploy-test-image")
+              ) {
+                throw new Error(`PR #${pullNumber} is not an eligible staging source.`);
+              }
+              revision = pull.head.sha;
+            } else {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: tag,
+              });
+              revision = commit.sha;
+            }
+
+            if (!/^[0-9a-f]{40}$/.test(revision)) {
+              throw new Error("The image source did not resolve to a commit SHA.");
+            }
+            core.setOutput("expected_revision", revision);
+            core.setOutput("tag", tag);
+
+  deploy-staging:
+    name: Synchronize and deploy staging
+    needs: authorize
+    permissions:
+      contents: read
+      packages: read
+    runs-on: [home-server, bash, non-root]
+    timeout-minutes: 90
+    environment: staging
+
+    steps:
+      - name: Synchronize production copy and deploy image
+        shell: bash
+        env:
+          EXPECTED_REVISION: ${{ needs.authorize.outputs.expected_revision }}
+          GHCR_TOKEN: ${{ github.token }}
+          IMAGE_TAG: ${{ needs.authorize.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          stage_dir="${HOME}/dense-mem-stage"
+          sync_script="${HOME}/dense-mem-stage/sync.sh"
+          if [[ ! -d "${stage_dir}" || ! -x "${sync_script}" ]]; then
+            echo "::error::The staging directory or executable sync.sh is missing"
+            exit 1
+          fi
+
+          cd "${stage_dir}"
+          probe_images="$(
+            DENSE_MEM_IMAGE_TAG=stage-contract-probe \
+              docker compose config --images
+          )"
+          if ! grep -Fxq \
+            'ghcr.io/markhuangai/dense-mem:stage-contract-probe' \
+            <<< "${probe_images}"; then
+            echo "::error::The server image must interpolate DENSE_MEM_IMAGE_TAG"
+            exit 1
+          fi
+          if ! DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose config --quiet; then
+            echo "::error::The staging Compose configuration is invalid"
+            exit 1
+          fi
+          compose_services="$(
+            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose config --services
+          )"
+          if ! grep -Fxq server <<< "${compose_services}"; then
+            echo "::error::The staging Compose configuration is missing server"
+            exit 1
+          fi
+
+          docker_config="${RUNNER_TEMP}/dense-mem-staging-docker"
+          mkdir -p "${docker_config}"
+          export DOCKER_CONFIG="${docker_config}"
+          printf '%s' "${GHCR_TOKEN}" |
+            docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+          unset GHCR_TOKEN
+
+          exec 9>"${HOME}/dense-mem-stage/migration-rehearsal.lock"
+          if ! flock --wait 600 9; then
+            echo "::error::Timed out waiting for the staging migration lock"
+            exit 1
+          fi
+
+          timeout --signal=TERM --kill-after=30s 10m "${sync_script}"
+          DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" \
+            docker compose up -d \
+            --pull always \
+            --no-deps \
+            --wait \
+            --wait-timeout 3000 \
+            server
+
+          container_id="$(
+            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose ps -q server
+          )"
+          revision="$(
+            docker inspect \
+              --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+              "${container_id}"
+          )"
+          health="$(docker inspect --format '{{.State.Health.Status}}' "${container_id}")"
+          image_id="$(docker inspect --format '{{.Image}}' "${container_id}")"
+          digest="$(
+            docker image inspect --format '{{index .RepoDigests 0}}' "${image_id}"
+          )"
+
+          if [[ "${revision}" != "${EXPECTED_REVISION}" ]]; then
+            echo "::error::Deployed revision ${revision} does not match ${EXPECTED_REVISION}"
+            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose stop --timeout 30 server
+            exit 1
+          fi
+          if [[ "${health}" != "healthy" ]]; then
+            echo "::error::The staging server health is ${health}"
+            exit 1
+          fi
+          if [[ ! "${digest}" =~ ^ghcr\.io/markhuangai/dense-mem@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::The deployed GHCR digest is invalid"
+            exit 1
+          fi
+
+          {
+            echo "## Staging deployment"
+            echo
+            echo "- Tag: \`${IMAGE_TAG}\`"
+            echo "- Digest: \`${digest}\`"
+            echo "- Revision: \`${revision}\`"
+            echo "- Health: ${health}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -11,46 +11,26 @@ on:
         type: string
 
 permissions:
-  actions: read
   contents: read
   packages: read
-  pull-requests: read
-  statuses: read
 
 concurrency:
   group: dense-mem-staging-deployment
   cancel-in-progress: false
 
 jobs:
-  deploy-staging:
-    name: Synchronize and deploy staging
-    if: >-
-      ${{
-        github.actor == 'Z-M-Huang' &&
-        github.triggering_actor == 'Z-M-Huang' &&
-        github.ref == 'refs/heads/main'
-      }}
+  authorize:
+    name: Authorize staging deployment
     permissions:
-      actions: read
       contents: read
-      packages: read
-      pull-requests: read
-      statuses: read
-    runs-on: [home-server, bash, non-root]
-    timeout-minutes: 90
-    environment: staging
+    runs-on: docker-runner
+    outputs:
+      revision: ${{ steps.authorize.outputs.revision }}
+      tag: ${{ steps.authorize.outputs.tag }}
 
     steps:
-      - name: Checkout trusted image policy
-        uses: actions/checkout@v7
-        with:
-          clean: true
-          persist-credentials: false
-          ref: ${{ github.sha }}
-          sparse-checkout: .github/scripts
-
-      - name: Validate current image source and staging contract
-        id: source
+      - name: Authorize actor and resolve rehearsal revision
+        id: authorize
         uses: actions/github-script@v9
         env:
           DISPATCH_REF: ${{ github.ref }}
@@ -59,7 +39,6 @@ jobs:
         with:
           script: |
             const actor = "Z-M-Huang";
-            const policy = require("./.github/scripts/image-release-policy.cjs");
             const tag = process.env.IMAGE_TAG;
             if (context.actor !== actor || process.env.TRIGGERING_ACTOR !== actor) {
               throw new Error("Only Z-M-Huang may deploy staging.");
@@ -69,107 +48,45 @@ jobs:
             }
 
             const preview = /^test-([1-9][0-9]*)$/.exec(tag);
-            if (!preview && !/^v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?$/.test(tag)) {
-              throw new Error("tag must be test-N, vX.Y.Z-rc.N, or vX.Y.Z");
-            }
-
-            let revision;
-            if (preview) {
-              const pullNumber = Number(preview[1]);
-              const { data: pull } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pullNumber,
-              });
-              const repository = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
-              const hasPreviewLabel = pull.labels.some(
-                (label) => label.name === policy.PREVIEW_LABEL,
-              );
-              if (
-                pull.state !== "open" ||
-                pull.base.ref !== "main" ||
-                pull.head.repo?.full_name.toLowerCase() !== repository
-              ) {
-                throw new Error(`PR #${pullNumber} is not an eligible staging source.`);
-              }
-
-              const statuses = await github.paginate(
-                github.rest.repos.listCommitStatusesForRef,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: pull.head.sha,
-                  per_page: 100,
-                },
-              );
-              const receipt = policy.parseSuccessfulPolicyStatus({
-                statuses,
-                pullNumber,
-                serverUrl: context.serverUrl,
-                repository: `${context.repo.owner}/${context.repo.repo}`,
-              });
-              let workflowRun = null;
-              if (receipt.status) {
-                ({ data: workflowRun } = await github.rest.actions.getWorkflowRun({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: Number(receipt.status.runId),
-                }));
-              }
-              const eligibility = policy.decideRcPreview({
-                pull,
-                hasPreviewLabel,
-                policyStatus: receipt.status,
-                workflowRun,
-              });
-              if (!eligibility.eligible) {
-                throw new Error(`PR #${pullNumber} is not deployable: ${eligibility.reason}.`);
-              }
-              revision = pull.head.sha;
-            } else {
-              const { data: commit } = await github.rest.repos.getCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `tags/${tag}`,
-              });
-              revision = commit.sha;
-            }
-
-            if (!/^[0-9a-f]{40}$/.test(revision)) {
-              throw new Error("The image source did not resolve to a commit SHA.");
-            }
-
-            const expectedImage = `ghcr.io/markhuangai/dense-mem:${tag}`;
-            const configResult = await exec.getExecOutput(
-              "docker",
-              ["compose", "config", "--format", "json", "--no-env-resolution"],
-              {
-                cwd: `${process.env.HOME}/dense-mem-stage`,
-                env: { ...process.env, DENSE_MEM_IMAGE_TAG: tag },
-                silent: true,
-              },
-            );
-            const compose = JSON.parse(configResult.stdout);
-            if (compose.services?.server?.image !== expectedImage) {
-              throw new Error(`The staging server image must resolve to ${expectedImage}.`);
-            }
-
-            core.setOutput("expected_revision", revision);
+            const revision = preview ? `refs/pull/${preview[1]}/head` : tag;
+            core.setOutput("revision", revision);
             core.setOutput("tag", tag);
 
-      - name: Synchronize production copy and deploy image
+  staging-migration-rehearsal:
+    name: Restore production copy and rehearse migrations
+    needs: authorize
+    uses: ./.github/workflows/staging-migration-rehearsal.yml
+    with:
+      revision: ${{ needs.authorize.outputs.revision }}
+    secrets: inherit
+
+  deploy-staging:
+    name: Deploy staging image
+    needs: [authorize, staging-migration-rehearsal]
+    if: >-
+      ${{
+        needs.authorize.result == 'success' &&
+        needs.staging-migration-rehearsal.result == 'success'
+      }}
+    permissions:
+      contents: read
+      packages: read
+    runs-on: [home-server, bash, non-root]
+    timeout-minutes: 60
+    environment: staging
+
+    steps:
+      - name: Pull and deploy requested image
         shell: bash
         env:
-          EXPECTED_REVISION: ${{ steps.source.outputs.expected_revision }}
           GHCR_TOKEN: ${{ github.token }}
-          IMAGE_TAG: ${{ steps.source.outputs.tag }}
+          IMAGE_TAG: ${{ needs.authorize.outputs.tag }}
         run: |
           set -euo pipefail
 
           stage_dir="${HOME}/dense-mem-stage"
-          sync_script="${HOME}/dense-mem-stage/sync.sh"
-          if [[ ! -d "${stage_dir}" || ! -x "${sync_script}" ]]; then
-            echo "::error::The staging directory or executable sync.sh is missing"
+          if [[ ! -d "${stage_dir}" ]]; then
+            echo "::error::The staging directory is missing"
             exit 1
           fi
           cd "${stage_dir}"
@@ -187,7 +104,6 @@ jobs:
             exit 1
           fi
 
-          timeout --signal=TERM --kill-after=30s 10m "${sync_script}"
           DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" \
             docker compose up -d \
             --pull always \
@@ -196,39 +112,8 @@ jobs:
             --wait-timeout 3000 \
             server
 
-          container_id="$(
-            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose ps -q server
-          )"
-          revision="$(
-            docker inspect \
-              --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
-              "${container_id}"
-          )"
-          health="$(docker inspect --format '{{.State.Health.Status}}' "${container_id}")"
-          image_id="$(docker inspect --format '{{.Image}}' "${container_id}")"
-          digest="$(
-            docker image inspect --format '{{index .RepoDigests 0}}' "${image_id}"
-          )"
-
-          if [[ "${revision}" != "${EXPECTED_REVISION}" ]]; then
-            echo "::error::Deployed revision ${revision} does not match ${EXPECTED_REVISION}"
-            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose stop --timeout 30 server
-            exit 1
-          fi
-          if [[ "${health}" != "healthy" ]]; then
-            echo "::error::The staging server health is ${health}"
-            exit 1
-          fi
-          if [[ ! "${digest}" =~ ^ghcr\.io/markhuangai/dense-mem@sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::The deployed GHCR digest is invalid"
-            exit 1
-          fi
-
           {
             echo "## Staging deployment"
             echo
             echo "- Tag: \`${IMAGE_TAG}\`"
-            echo "- Digest: \`${digest}\`"
-            echo "- Revision: \`${revision}\`"
-            echo "- Health: ${health}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -11,28 +11,46 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   packages: read
   pull-requests: read
+  statuses: read
 
 concurrency:
   group: dense-mem-staging-deployment
   cancel-in-progress: false
 
 jobs:
-  authorize:
-    name: Authorize staging deployment
+  deploy-staging:
+    name: Synchronize and deploy staging
+    if: >-
+      ${{
+        github.actor == 'Z-M-Huang' &&
+        github.triggering_actor == 'Z-M-Huang' &&
+        github.ref == 'refs/heads/main'
+      }}
     permissions:
+      actions: read
       contents: read
+      packages: read
       pull-requests: read
-    runs-on: docker-runner
-    outputs:
-      expected_revision: ${{ steps.authorize.outputs.expected_revision }}
-      tag: ${{ steps.authorize.outputs.tag }}
+      statuses: read
+    runs-on: [home-server, bash, non-root]
+    timeout-minutes: 90
+    environment: staging
 
     steps:
-      - name: Authorize actor and resolve image source
-        id: authorize
+      - name: Checkout trusted image policy
+        uses: actions/checkout@v7
+        with:
+          clean: true
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/scripts
+
+      - name: Validate current image source and staging contract
+        id: source
         uses: actions/github-script@v9
         env:
           DISPATCH_REF: ${{ github.ref }}
@@ -41,6 +59,7 @@ jobs:
         with:
           script: |
             const actor = "Z-M-Huang";
+            const policy = require("./.github/scripts/image-release-policy.cjs");
             const tag = process.env.IMAGE_TAG;
             if (context.actor !== actor || process.env.TRIGGERING_ACTOR !== actor) {
               throw new Error("Only Z-M-Huang may deploy staging.");
@@ -63,20 +82,55 @@ jobs:
                 pull_number: pullNumber,
               });
               const repository = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+              const hasPreviewLabel = pull.labels.some(
+                (label) => label.name === policy.PREVIEW_LABEL,
+              );
               if (
                 pull.state !== "open" ||
                 pull.base.ref !== "main" ||
-                pull.head.repo?.full_name.toLowerCase() !== repository ||
-                !pull.labels.some((label) => label.name === "deploy-test-image")
+                pull.head.repo?.full_name.toLowerCase() !== repository
               ) {
                 throw new Error(`PR #${pullNumber} is not an eligible staging source.`);
+              }
+
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: pull.head.sha,
+                  per_page: 100,
+                },
+              );
+              const receipt = policy.parseSuccessfulPolicyStatus({
+                statuses,
+                pullNumber,
+                serverUrl: context.serverUrl,
+                repository: `${context.repo.owner}/${context.repo.repo}`,
+              });
+              let workflowRun = null;
+              if (receipt.status) {
+                ({ data: workflowRun } = await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: Number(receipt.status.runId),
+                }));
+              }
+              const eligibility = policy.decideRcPreview({
+                pull,
+                hasPreviewLabel,
+                policyStatus: receipt.status,
+                workflowRun,
+              });
+              if (!eligibility.eligible) {
+                throw new Error(`PR #${pullNumber} is not deployable: ${eligibility.reason}.`);
               }
               revision = pull.head.sha;
             } else {
               const { data: commit } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: tag,
+                ref: `tags/${tag}`,
               });
               revision = commit.sha;
             }
@@ -84,26 +138,31 @@ jobs:
             if (!/^[0-9a-f]{40}$/.test(revision)) {
               throw new Error("The image source did not resolve to a commit SHA.");
             }
+
+            const expectedImage = `ghcr.io/markhuangai/dense-mem:${tag}`;
+            const configResult = await exec.getExecOutput(
+              "docker",
+              ["compose", "config", "--format", "json", "--no-env-resolution"],
+              {
+                cwd: `${process.env.HOME}/dense-mem-stage`,
+                env: { ...process.env, DENSE_MEM_IMAGE_TAG: tag },
+                silent: true,
+              },
+            );
+            const compose = JSON.parse(configResult.stdout);
+            if (compose.services?.server?.image !== expectedImage) {
+              throw new Error(`The staging server image must resolve to ${expectedImage}.`);
+            }
+
             core.setOutput("expected_revision", revision);
             core.setOutput("tag", tag);
 
-  deploy-staging:
-    name: Synchronize and deploy staging
-    needs: authorize
-    permissions:
-      contents: read
-      packages: read
-    runs-on: [home-server, bash, non-root]
-    timeout-minutes: 90
-    environment: staging
-
-    steps:
       - name: Synchronize production copy and deploy image
         shell: bash
         env:
-          EXPECTED_REVISION: ${{ needs.authorize.outputs.expected_revision }}
+          EXPECTED_REVISION: ${{ steps.source.outputs.expected_revision }}
           GHCR_TOKEN: ${{ github.token }}
-          IMAGE_TAG: ${{ needs.authorize.outputs.tag }}
+          IMAGE_TAG: ${{ steps.source.outputs.tag }}
         run: |
           set -euo pipefail
 
@@ -113,29 +172,7 @@ jobs:
             echo "::error::The staging directory or executable sync.sh is missing"
             exit 1
           fi
-
           cd "${stage_dir}"
-          probe_images="$(
-            DENSE_MEM_IMAGE_TAG=stage-contract-probe \
-              docker compose config --images
-          )"
-          if ! grep -Fxq \
-            'ghcr.io/markhuangai/dense-mem:stage-contract-probe' \
-            <<< "${probe_images}"; then
-            echo "::error::The server image must interpolate DENSE_MEM_IMAGE_TAG"
-            exit 1
-          fi
-          if ! DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose config --quiet; then
-            echo "::error::The staging Compose configuration is invalid"
-            exit 1
-          fi
-          compose_services="$(
-            DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" docker compose config --services
-          )"
-          if ! grep -Fxq server <<< "${compose_services}"; then
-            echo "::error::The staging Compose configuration is missing server"
-            exit 1
-          fi
 
           docker_config="${RUNNER_TEMP}/dense-mem-staging-docker"
           mkdir -p "${docker_config}"

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -144,6 +144,60 @@ test("staging migration rehearsal supports manual and reusable execution", async
   );
 });
 
+test("staging deployment is owner-gated and manual-only", async () => {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/deploy-stage.yml", import.meta.url),
+    "utf8",
+  );
+  const authorize = workflowJob(workflow, "authorize");
+  const deploy = workflowJob(workflow, "deploy-staging");
+
+  assert.match(workflow, /^  workflow_dispatch:\n    inputs:/m);
+  assert.match(
+    workflow,
+    /^      tag:\n        description: "Dense-Mem image tag to deploy\."\n        required: true\n        type: string$/m,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /^  (?:pull_request|pull_request_target|push|workflow_call|workflow_run):/m,
+  );
+  assert.match(authorize, /^    runs-on: docker-runner$/m);
+  assert.match(authorize, /Z-M-Huang/);
+  assert.match(authorize, /github\.triggering_actor/);
+  assert.match(authorize, /refs\/heads\/main/);
+  assert.match(deploy, /^    needs: authorize$/m);
+  assert.match(deploy, /^    runs-on: \[home-server, bash, non-root\]$/m);
+  assert.match(deploy, /^    environment: staging$/m);
+  assert.doesNotMatch(deploy, /actions\/checkout/);
+});
+
+test("staging deployment synchronizes before an always-pull healthy startup", async () => {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/deploy-stage.yml", import.meta.url),
+    "utf8",
+  );
+  const deploy = workflowJob(workflow, "deploy-staging");
+  const sync = 'timeout --signal=TERM --kill-after=30s 10m "${sync_script}"';
+  const up = "docker compose up -d";
+
+  assert.match(workflow, /^  packages: read$/m);
+  assert.match(deploy, /"\$\{HOME\}\/dense-mem-stage\/sync\.sh"/);
+  assert.match(deploy, /migration-rehearsal\.lock/);
+  assert.match(deploy, /flock --wait 600 9/);
+  assert.match(deploy, /DENSE_MEM_IMAGE_TAG/);
+  assert.match(deploy, /docker compose up -d[\s\\]*--pull always/);
+  assert.match(deploy, /--pull always[\s\\]*--no-deps/);
+  assert.match(deploy, /--wait[\s\\]*--wait-timeout 3000/);
+  assert.match(deploy, /org\.opencontainers\.image\.revision/);
+  assert.match(deploy, /EXPECTED_REVISION/);
+  assert.doesNotMatch(deploy, /docker (?:image )?pull|docker compose pull|--pull never/);
+  assert.doesNotMatch(deploy, /docker compose logs/);
+  assert.ok(
+    deploy.indexOf(sync) < deploy.indexOf(up),
+    "the production copy must finish restoring before Compose pulls and starts the image",
+  );
+});
+
 test("same-repository pushes rebuild while the preview label remains", () => {
   assert.deepEqual(decidePreviewEvent(baseEvent), {
     mode: "attempt",

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -149,7 +149,6 @@ test("staging deployment is owner-gated and manual-only", async () => {
     new URL("../../.github/workflows/deploy-stage.yml", import.meta.url),
     "utf8",
   );
-  const authorize = workflowJob(workflow, "authorize");
   const deploy = workflowJob(workflow, "deploy-staging");
 
   assert.match(workflow, /^  workflow_dispatch:\n    inputs:/m);
@@ -161,14 +160,16 @@ test("staging deployment is owner-gated and manual-only", async () => {
     workflow,
     /^  (?:pull_request|pull_request_target|push|workflow_call|workflow_run):/m,
   );
-  assert.match(authorize, /^    runs-on: docker-runner$/m);
-  assert.match(authorize, /Z-M-Huang/);
-  assert.match(authorize, /github\.triggering_actor/);
-  assert.match(authorize, /refs\/heads\/main/);
-  assert.match(deploy, /^    needs: authorize$/m);
+  assert.doesNotMatch(workflow, /^  authorize:/m);
+  assert.match(deploy, /github\.actor == 'Z-M-Huang'/);
+  assert.match(deploy, /github\.triggering_actor == 'Z-M-Huang'/);
+  assert.match(deploy, /github\.ref == 'refs\/heads\/main'/);
   assert.match(deploy, /^    runs-on: \[home-server, bash, non-root\]$/m);
   assert.match(deploy, /^    environment: staging$/m);
-  assert.doesNotMatch(deploy, /actions\/checkout/);
+  assert.match(deploy, /uses: actions\/checkout@v7/);
+  assert.match(deploy, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(deploy, /persist-credentials: false/);
+  assert.match(deploy, /sparse-checkout: \.github\/scripts/);
 });
 
 test("staging deployment synchronizes before an always-pull healthy startup", async () => {
@@ -177,10 +178,19 @@ test("staging deployment synchronizes before an always-pull healthy startup", as
     "utf8",
   );
   const deploy = workflowJob(workflow, "deploy-staging");
+  const sourceValidation = "policy.parseSuccessfulPolicyStatus";
   const sync = 'timeout --signal=TERM --kill-after=30s 10m "${sync_script}"';
   const up = "docker compose up -d";
 
+  assert.match(workflow, /^  actions: read$/m);
   assert.match(workflow, /^  packages: read$/m);
+  assert.match(workflow, /^  statuses: read$/m);
+  assert.match(deploy, /policy\.parseSuccessfulPolicyStatus/);
+  assert.match(deploy, /policy\.decideRcPreview/);
+  assert.match(deploy, /ref: `tags\/\$\{tag\}`/);
+  assert.match(deploy, /compose\.services\?\.server\?\.image/);
+  assert.match(deploy, /silent: true/);
+  assert.doesNotMatch(deploy, /docker compose config --images/);
   assert.match(deploy, /"\$\{HOME\}\/dense-mem-stage\/sync\.sh"/);
   assert.match(deploy, /migration-rehearsal\.lock/);
   assert.match(deploy, /flock --wait 600 9/);
@@ -192,6 +202,10 @@ test("staging deployment synchronizes before an always-pull healthy startup", as
   assert.match(deploy, /EXPECTED_REVISION/);
   assert.doesNotMatch(deploy, /docker (?:image )?pull|docker compose pull|--pull never/);
   assert.doesNotMatch(deploy, /docker compose logs/);
+  assert.ok(
+    deploy.indexOf(sourceValidation) < deploy.indexOf(sync),
+    "preview eligibility and the exact server image must be checked after the job wait",
+  );
   assert.ok(
     deploy.indexOf(sync) < deploy.indexOf(up),
     "the production copy must finish restoring before Compose pulls and starts the image",

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -149,6 +149,8 @@ test("staging deployment is owner-gated and manual-only", async () => {
     new URL("../../.github/workflows/deploy-stage.yml", import.meta.url),
     "utf8",
   );
+  const authorize = workflowJob(workflow, "authorize");
+  const rehearsal = workflowJob(workflow, "staging-migration-rehearsal");
   const deploy = workflowJob(workflow, "deploy-staging");
 
   assert.match(workflow, /^  workflow_dispatch:\n    inputs:/m);
@@ -160,56 +162,58 @@ test("staging deployment is owner-gated and manual-only", async () => {
     workflow,
     /^  (?:pull_request|pull_request_target|push|workflow_call|workflow_run):/m,
   );
-  assert.doesNotMatch(workflow, /^  authorize:/m);
-  assert.match(deploy, /github\.actor == 'Z-M-Huang'/);
-  assert.match(deploy, /github\.triggering_actor == 'Z-M-Huang'/);
-  assert.match(deploy, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(authorize, /^    runs-on: docker-runner$/m);
+  assert.match(authorize, /const actor = "Z-M-Huang"/);
+  assert.match(authorize, /context\.actor !== actor/);
+  assert.match(authorize, /process\.env\.TRIGGERING_ACTOR !== actor/);
+  assert.match(authorize, /refs\/heads\/main/);
+  assert.match(authorize, /refs\/pull\/\$\{preview\[1\]\}\/head/);
+  assert.match(authorize, /core\.setOutput\("revision", revision\)/);
+  assert.match(authorize, /core\.setOutput\("tag", tag\)/);
+  assert.doesNotMatch(workflow, /actions\/checkout|image-release-policy/);
+  assert.match(rehearsal, /^    needs: authorize$/m);
+  assert.match(
+    rehearsal,
+    /^    uses: \.\/\.github\/workflows\/staging-migration-rehearsal\.yml$/m,
+  );
+  assert.match(
+    rehearsal,
+    /^      revision: \$\{\{ needs\.authorize\.outputs\.revision \}\}$/m,
+  );
+  assert.match(rehearsal, /^    secrets: inherit$/m);
+  assert.match(
+    deploy,
+    /^    needs: \[authorize, staging-migration-rehearsal\]$/m,
+  );
   assert.match(deploy, /^    runs-on: \[home-server, bash, non-root\]$/m);
   assert.match(deploy, /^    environment: staging$/m);
-  assert.match(deploy, /uses: actions\/checkout@v7/);
-  assert.match(deploy, /ref: \$\{\{ github\.sha \}\}/);
-  assert.match(deploy, /persist-credentials: false/);
-  assert.match(deploy, /sparse-checkout: \.github\/scripts/);
 });
 
-test("staging deployment synchronizes before an always-pull healthy startup", async () => {
+test("staging deployment rehearses before an always-pull healthy startup", async () => {
   const workflow = await readFile(
     new URL("../../.github/workflows/deploy-stage.yml", import.meta.url),
     "utf8",
   );
+  const rehearsal = workflowJob(workflow, "staging-migration-rehearsal");
   const deploy = workflowJob(workflow, "deploy-staging");
-  const sourceValidation = "policy.parseSuccessfulPolicyStatus";
-  const sync = 'timeout --signal=TERM --kill-after=30s 10m "${sync_script}"';
-  const up = "docker compose up -d";
 
-  assert.match(workflow, /^  actions: read$/m);
   assert.match(workflow, /^  packages: read$/m);
-  assert.match(workflow, /^  statuses: read$/m);
-  assert.match(deploy, /policy\.parseSuccessfulPolicyStatus/);
-  assert.match(deploy, /policy\.decideRcPreview/);
-  assert.match(deploy, /ref: `tags\/\$\{tag\}`/);
-  assert.match(deploy, /compose\.services\?\.server\?\.image/);
-  assert.match(deploy, /silent: true/);
-  assert.doesNotMatch(deploy, /docker compose config --images/);
-  assert.match(deploy, /"\$\{HOME\}\/dense-mem-stage\/sync\.sh"/);
+  assert.doesNotMatch(workflow, /^  (?:actions|pull-requests|statuses): read$/m);
+  assert.match(rehearsal, /^    needs: authorize$/m);
+  assert.match(deploy, /needs\.staging-migration-rehearsal\.result == 'success'/);
+  assert.doesNotMatch(workflow, /sync_script|sync\.sh|go test/);
   assert.match(deploy, /migration-rehearsal\.lock/);
   assert.match(deploy, /flock --wait 600 9/);
-  assert.match(deploy, /DENSE_MEM_IMAGE_TAG/);
+  assert.match(
+    deploy,
+    /IMAGE_TAG: \$\{\{ needs\.authorize\.outputs\.tag \}\}/,
+  );
   assert.match(deploy, /docker compose up -d[\s\\]*--pull always/);
   assert.match(deploy, /--pull always[\s\\]*--no-deps/);
   assert.match(deploy, /--wait[\s\\]*--wait-timeout 3000/);
-  assert.match(deploy, /org\.opencontainers\.image\.revision/);
-  assert.match(deploy, /EXPECTED_REVISION/);
+  assert.doesNotMatch(deploy, /EXPECTED_REVISION|org\.opencontainers\.image\.revision/);
   assert.doesNotMatch(deploy, /docker (?:image )?pull|docker compose pull|--pull never/);
   assert.doesNotMatch(deploy, /docker compose logs/);
-  assert.ok(
-    deploy.indexOf(sourceValidation) < deploy.indexOf(sync),
-    "preview eligibility and the exact server image must be checked after the job wait",
-  );
-  assert.ok(
-    deploy.indexOf(sync) < deploy.indexOf(up),
-    "the production copy must finish restoring before Compose pulls and starts the image",
-  );
 });
 
 test("same-repository pushes rebuild while the preview label remains", () => {


### PR DESCRIPTION
## Summary

- add a manual, main-only staging deployment workflow restricted to Z-M-Huang
- validate test image or release tag provenance before the home-server job runs
- serialize with the migration rehearsal lock, run the production-copy sync, then deploy the server with `docker compose up --pull always --no-deps`
- wait for health and verify the running image revision and GHCR digest
- add UAT coverage for authorization, ordering, and pull policy

## Validation

- `node --test tests/uat/image_release_policy.test.mjs`
- Actionlint v1.7.12 against `deploy-stage.yml`
- `git diff --check`
- `./scripts/ci-check.sh` passed at the 90.0% coverage gate on the final tree and in the pre-push hook

No deterministic evaluation was run because this changes deployment orchestration only.

## Host prerequisites

Before the first dispatch, change the remote staging Compose server image to:

```yaml
image: ghcr.io/markhuangai/dense-mem:${DENSE_MEM_IMAGE_TAG:?DENSE_MEM_IMAGE_TAG must be set}
```

After merge, add `deploy-stage.yml` on `main` to the home-server runner group's selected-workflow execution list.

## Risk

- A registry failure occurs after the staging database sync because the requested behavior performs no separate pull. The run fails visibly and a retry performs a fresh sync and deployment.
- A mutable `test-N` tag may move. Compose always pulls it, and the workflow stops the server if the deployed OCI revision differs from the authorized current PR head.
- `--no-deps` prevents the always-pull policy from unexpectedly refreshing PostgreSQL or Redis images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered staging deployment workflow requiring an image tag.
  * Added authorization checks and a migration rehearsal before deployment.
  * Added safeguards to coordinate migrations and staging startup.
  * Deployment details, including the selected image tag, are recorded in the workflow summary.

* **Tests**
  * Expanded coverage for deployment authorization, migration gating, permissions, and image tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->