### PR TITLE
ci: run AI review alongside PR checks

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Resolve and fence pull request head
         id: resolve
         uses: actions/github-script@v9
+        env:
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -78,23 +80,28 @@ jobs:
               core.setOutput("should_run", "false");
             };
 
+            const trustedActor = "Z-M-Huang";
             const eventName = context.eventName;
             let pullNumber;
             let triggerHeadSha;
+            let workflowRunActor;
+            let workflowRunTriggeringActor;
 
             if (eventName === "pull_request_target") {
               const eventPull = context.payload.pull_request;
               if (!eventPull) {
                 throw new Error("The pull_request_target payload has no pull request.");
               }
-              const eventPullIsDependabot =
-                eventPull.user?.login?.toLowerCase() === "dependabot[bot]";
+              const eventPullIsTrusted =
+                eventPull.user?.login === trustedActor &&
+                context.actor === trustedActor &&
+                process.env.TRIGGERING_ACTOR === trustedActor;
               const eventHeadRepositoryId = eventPull.head?.repo?.id;
               const eventBaseRepositoryId = eventPull.base?.repo?.id;
               const eventPullIsSameRepository =
                 Number.isSafeInteger(eventHeadRepositoryId) &&
                 eventHeadRepositoryId === eventBaseRepositoryId;
-              if (eventPullIsDependabot || !eventPullIsSameRepository) {
+              if (!eventPullIsTrusted || !eventPullIsSameRepository) {
                 skip(`Pull request #${eventPull.number} will use the trusted CI completion path.`);
                 return;
               }
@@ -118,6 +125,8 @@ jobs:
                 );
                 return;
               }
+              workflowRunActor = workflowRun.actor?.login;
+              workflowRunTriggeringActor = workflowRun.triggering_actor?.login;
               triggerHeadSha = workflowRun.head_sha;
               const triggerHeadRef = workflowRun.head_branch;
               const triggerHeadRepositoryId = workflowRun.head_repository?.id;
@@ -194,17 +203,19 @@ jobs:
               );
               return;
             }
-            const pullIsDependabot =
-              pull.user?.login?.toLowerCase() === "dependabot[bot]";
             const pullHeadRepositoryId = pull.head.repo?.id;
             const pullBaseRepositoryId = pull.base.repo?.id;
             const pullIsSameRepository =
               Number.isSafeInteger(pullHeadRepositoryId) &&
               pullHeadRepositoryId === pullBaseRepositoryId;
+            const pullUsesDirectReview =
+              pull.user?.login === trustedActor &&
+              pullIsSameRepository &&
+              workflowRunActor === trustedActor &&
+              workflowRunTriggeringActor === trustedActor;
             if (
               eventName === "workflow_run" &&
-              !pullIsDependabot &&
-              pullIsSameRepository
+              pullUsesDirectReview
             ) {
               skip(`Pull request #${pullNumber} uses the direct pull request review path.`);
               return;

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -8,8 +8,6 @@ on:
   workflow_run:
     workflows:
       - CI Pull Request
-    branches:
-      - dependabot/**
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -89,7 +87,14 @@ jobs:
               if (!eventPull) {
                 throw new Error("The pull_request_target payload has no pull request.");
               }
-              if (eventPull.user?.login?.toLowerCase() === "dependabot[bot]") {
+              const eventPullIsDependabot =
+                eventPull.user?.login?.toLowerCase() === "dependabot[bot]";
+              const eventHeadRepositoryId = eventPull.head?.repo?.id;
+              const eventBaseRepositoryId = eventPull.base?.repo?.id;
+              const eventPullIsSameRepository =
+                Number.isSafeInteger(eventHeadRepositoryId) &&
+                eventHeadRepositoryId === eventBaseRepositoryId;
+              if (eventPullIsDependabot || !eventPullIsSameRepository) {
                 skip(`Pull request #${eventPull.number} will use the trusted CI completion path.`);
                 return;
               }
@@ -189,9 +194,17 @@ jobs:
               );
               return;
             }
+            const pullIsDependabot =
+              pull.user?.login?.toLowerCase() === "dependabot[bot]";
+            const pullHeadRepositoryId = pull.head.repo?.id;
+            const pullBaseRepositoryId = pull.base.repo?.id;
+            const pullIsSameRepository =
+              Number.isSafeInteger(pullHeadRepositoryId) &&
+              pullHeadRepositoryId === pullBaseRepositoryId;
             if (
               eventName === "workflow_run" &&
-              pull.user?.login?.toLowerCase() !== "dependabot[bot]"
+              !pullIsDependabot &&
+              pullIsSameRepository
             ) {
               skip(`Pull request #${pullNumber} uses the direct pull request review path.`);
               return;

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,9 +1,15 @@
 name: AI Pull Request Review
 
 on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_run:
     workflows:
       - CI Pull Request
+    branches:
+      - dependabot/**
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -51,6 +57,7 @@ jobs:
     name: Resolve pull request
     runs-on: docker-runner
     if: >-
+      github.event_name == 'pull_request_target' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success')
@@ -77,7 +84,24 @@ jobs:
             let pullNumber;
             let triggerHeadSha;
 
-            if (eventName === "workflow_run") {
+            if (eventName === "pull_request_target") {
+              const eventPull = context.payload.pull_request;
+              if (!eventPull) {
+                throw new Error("The pull_request_target payload has no pull request.");
+              }
+              if (eventPull.user?.login?.toLowerCase() === "dependabot[bot]") {
+                skip(`Pull request #${eventPull.number} will use the trusted CI completion path.`);
+                return;
+              }
+              pullNumber = eventPull.number;
+              triggerHeadSha = eventPull.head?.sha;
+              if (
+                typeof triggerHeadSha !== "string" ||
+                !/^[0-9a-f]{40}$/.test(triggerHeadSha)
+              ) {
+                throw new Error("The pull_request_target payload has no valid head SHA.");
+              }
+            } else if (eventName === "workflow_run") {
               const workflowRun = context.payload.workflow_run;
               if (!workflowRun || workflowRun.event !== "pull_request") {
                 skip("The completed CI run was not triggered by a pull request.");
@@ -165,10 +189,17 @@ jobs:
               );
               return;
             }
+            if (
+              eventName === "workflow_run" &&
+              pull.user?.login?.toLowerCase() !== "dependabot[bot]"
+            ) {
+              skip(`Pull request #${pullNumber} uses the direct pull request review path.`);
+              return;
+            }
 
             const reviewStatusContext =
               `${process.env.REVIEW_STATUS_CONTEXT_PREFIX} / PR #${pull.number}`;
-            if (eventName === "workflow_run") {
+            if (eventName !== "workflow_dispatch") {
               const statuses = await github.paginate(
                 github.rest.repos.listCommitStatusesForRef,
                 {

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,7 +104,7 @@ jobs:
             exit 1
           fi
 
-          DENSE_MEM_IMAGE_TAG="${IMAGE_TAG}" \
+          DENSE_MEM_IMAGE="ghcr.io/markhuangai/dense-mem:${IMAGE_TAG}" \
             docker compose up -d \
             --pull always \
             --no-deps \

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,7 +104,7 @@ jobs:
             exit 1
           fi
 
-          DENSE_MEM_IMAGE="ghcr.io/markhuangai/dense-mem:${IMAGE_TAG}" \
+          DENSE_MEM_IMAGE="${IMAGE_TAG}" \
             docker compose up -d \
             --pull always \
             --no-deps \

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -7,6 +7,10 @@ const reviewWorkflowURL = new URL(
   "../../.github/workflows/ai-pr-review.yml",
   import.meta.url,
 );
+const prCIWorkflowURL = new URL(
+  "../../.github/workflows/ci-pr.yml",
+  import.meta.url,
+);
 const sharedWorkflowURL = new URL(
   "../../.github/workflows/ci-shared.yml",
   import.meta.url,
@@ -152,35 +156,56 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
 });
 
-test("automatic AI review waits for successful current-head PR CI", async () => {
-  const workflow = await readFile(reviewWorkflowURL, "utf8");
-  const normalizedWorkflow = workflow.replace(/\s+/g, " ");
+test("automatic AI review starts with PR CI while Dependabot keeps its secret-safe fallback", async () => {
+  const [reviewWorkflow, ciWorkflow] = await Promise.all([
+    readFile(reviewWorkflowURL, "utf8"),
+    readFile(prCIWorkflowURL, "utf8"),
+  ]);
+  const normalizedReviewWorkflow = reviewWorkflow.replace(/\s+/g, " ");
+  const normalizedCIWorkflow = ciWorkflow.replace(/\s+/g, " ");
 
-  assert.doesNotMatch(workflow, /^\s+pull_request_target:/m);
-  assert.match(workflow, /^\s+workflow_run:/m);
-  assert.match(workflow, /^\s+workflow_dispatch:/m);
-  assert.match(normalizedWorkflow, /workflows: - CI Pull Request types: \[completed\]/);
+  assert.match(reviewWorkflow, /^\s+pull_request_target:/m);
+  assert.match(reviewWorkflow, /^\s+workflow_run:/m);
+  assert.match(reviewWorkflow, /^\s+workflow_dispatch:/m);
   assert.match(
-    normalizedWorkflow,
-    /github\.event_name == 'workflow_dispatch' \|\| \(github\.event\.workflow_run\.event == 'pull_request' && github\.event\.workflow_run\.conclusion == 'success'\)/,
+    normalizedReviewWorkflow,
+    /pull_request_target: branches: - main types: \[opened, synchronize, reopened, ready_for_review\]/,
   );
-  assert.match(workflow, /workflowRun\.event !== "pull_request"/);
-  assert.match(workflow, /workflowRun\.conclusion !== "success"/);
-  assert.match(workflow, /const triggerHeadRef = workflowRun\.head_branch/);
   assert.match(
-    workflow,
+    normalizedCIWorkflow,
+    /pull_request: branches: - main types: \[opened, synchronize, reopened, ready_for_review\]/,
+  );
+  assert.match(
+    normalizedReviewWorkflow,
+    /workflows: - CI Pull Request branches: - dependabot\/\*\* types: \[completed\]/,
+  );
+  assert.match(reviewWorkflow, /github\.event_name == 'pull_request_target'/);
+  assert.match(reviewWorkflow, /eventName === "pull_request_target"/);
+  assert.match(reviewWorkflow, /const eventPull = context\.payload\.pull_request/);
+  assert.match(
+    reviewWorkflow,
+    /eventPull\.user\?\.login\?\.toLowerCase\(\) === "dependabot\[bot\]"/,
+  );
+  assert.match(reviewWorkflow, /pullNumber = eventPull\.number/);
+  assert.match(reviewWorkflow, /triggerHeadSha = eventPull\.head\?\.sha/);
+  assert.match(reviewWorkflow, /typeof triggerHeadSha !== "string"/);
+  assert.match(reviewWorkflow, /workflowRun\.conclusion !== "success"/);
+  assert.match(reviewWorkflow, /const triggerHeadRef = workflowRun\.head_branch/);
+  assert.match(
+    reviewWorkflow,
     /const triggerHeadRepositoryId = workflowRun\.head_repository\?\.id/,
   );
-  assert.match(workflow, /typeof triggerHeadRef !== "string"/);
-  assert.match(workflow, /!Number\.isSafeInteger\(triggerHeadRepositoryId\)/);
+  assert.match(reviewWorkflow, /typeof triggerHeadRef !== "string"/);
+  assert.match(reviewWorkflow, /!Number\.isSafeInteger\(triggerHeadRepositoryId\)/);
   assert.match(
-    normalizedWorkflow,
+    normalizedReviewWorkflow,
     /pull\.head\.sha === triggerHeadSha && pull\.head\.ref === triggerHeadRef && pull\.head\.repo\?\.id === triggerHeadRepositoryId/,
   );
   assert.match(
-    workflow,
-    /pull\.head\.sha !== triggerHeadSha/,
+    normalizedReviewWorkflow,
+    /eventName === "workflow_run" && pull\.user\?\.login\?\.toLowerCase\(\) !== "dependabot\[bot\]"/,
   );
+  assert.match(reviewWorkflow, /pull\.head\.sha !== triggerHeadSha/);
 });
 
 test("AI review status identity remains scoped to the resolved pull request", async () => {

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -156,7 +156,7 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
 });
 
-test("same-repository AI review starts with PR CI while untrusted heads use the CI fallback", async () => {
+test("owner-controlled AI review starts with PR CI while untrusted heads use the CI fallback", async () => {
   const [reviewWorkflow, ciWorkflow] = await Promise.all([
     readFile(reviewWorkflowURL, "utf8"),
     readFile(prCIWorkflowURL, "utf8"),
@@ -180,11 +180,16 @@ test("same-repository AI review starts with PR CI while untrusted heads use the 
     /workflows: - CI Pull Request types: \[completed\]/,
   );
   assert.match(reviewWorkflow, /github\.event_name == 'pull_request_target'/);
+  assert.match(
+    reviewWorkflow,
+    /TRIGGERING_ACTOR: \$\{\{ github\.triggering_actor \}\}/,
+  );
+  assert.match(reviewWorkflow, /const trustedActor = "Z-M-Huang"/);
   assert.match(reviewWorkflow, /eventName === "pull_request_target"/);
   assert.match(reviewWorkflow, /const eventPull = context\.payload\.pull_request/);
   assert.match(
-    reviewWorkflow,
-    /eventPull\.user\?\.login\?\.toLowerCase\(\) === "dependabot\[bot\]"/,
+    normalizedReviewWorkflow,
+    /eventPull\.user\?\.login === trustedActor && context\.actor === trustedActor && process\.env\.TRIGGERING_ACTOR === trustedActor/,
   );
   assert.match(reviewWorkflow, /const eventHeadRepositoryId = eventPull\.head\?\.repo\?\.id/);
   assert.match(reviewWorkflow, /const eventBaseRepositoryId = eventPull\.base\?\.repo\?\.id/);
@@ -196,6 +201,11 @@ test("same-repository AI review starts with PR CI while untrusted heads use the 
   assert.match(reviewWorkflow, /triggerHeadSha = eventPull\.head\?\.sha/);
   assert.match(reviewWorkflow, /typeof triggerHeadSha !== "string"/);
   assert.match(reviewWorkflow, /workflowRun\.conclusion !== "success"/);
+  assert.match(reviewWorkflow, /workflowRunActor = workflowRun\.actor\?\.login/);
+  assert.match(
+    reviewWorkflow,
+    /workflowRunTriggeringActor = workflowRun\.triggering_actor\?\.login/,
+  );
   assert.match(reviewWorkflow, /const triggerHeadRef = workflowRun\.head_branch/);
   assert.match(
     reviewWorkflow,
@@ -209,7 +219,11 @@ test("same-repository AI review starts with PR CI while untrusted heads use the 
   );
   assert.match(
     normalizedReviewWorkflow,
-    /eventName === "workflow_run" && !pullIsDependabot && pullIsSameRepository/,
+    /pull\.user\?\.login === trustedActor && pullIsSameRepository && workflowRunActor === trustedActor && workflowRunTriggeringActor === trustedActor/,
+  );
+  assert.match(
+    normalizedReviewWorkflow,
+    /eventName === "workflow_run" && pullUsesDirectReview/,
   );
   assert.match(reviewWorkflow, /pull\.head\.sha !== triggerHeadSha/);
 });

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -156,7 +156,7 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
 });
 
-test("automatic AI review starts with PR CI while Dependabot keeps its secret-safe fallback", async () => {
+test("same-repository AI review starts with PR CI while untrusted heads use the CI fallback", async () => {
   const [reviewWorkflow, ciWorkflow] = await Promise.all([
     readFile(reviewWorkflowURL, "utf8"),
     readFile(prCIWorkflowURL, "utf8"),
@@ -177,7 +177,7 @@ test("automatic AI review starts with PR CI while Dependabot keeps its secret-sa
   );
   assert.match(
     normalizedReviewWorkflow,
-    /workflows: - CI Pull Request branches: - dependabot\/\*\* types: \[completed\]/,
+    /workflows: - CI Pull Request types: \[completed\]/,
   );
   assert.match(reviewWorkflow, /github\.event_name == 'pull_request_target'/);
   assert.match(reviewWorkflow, /eventName === "pull_request_target"/);
@@ -185,6 +185,12 @@ test("automatic AI review starts with PR CI while Dependabot keeps its secret-sa
   assert.match(
     reviewWorkflow,
     /eventPull\.user\?\.login\?\.toLowerCase\(\) === "dependabot\[bot\]"/,
+  );
+  assert.match(reviewWorkflow, /const eventHeadRepositoryId = eventPull\.head\?\.repo\?\.id/);
+  assert.match(reviewWorkflow, /const eventBaseRepositoryId = eventPull\.base\?\.repo\?\.id/);
+  assert.match(
+    normalizedReviewWorkflow,
+    /Number\.isSafeInteger\(eventHeadRepositoryId\) && eventHeadRepositoryId === eventBaseRepositoryId/,
   );
   assert.match(reviewWorkflow, /pullNumber = eventPull\.number/);
   assert.match(reviewWorkflow, /triggerHeadSha = eventPull\.head\?\.sha/);
@@ -203,7 +209,7 @@ test("automatic AI review starts with PR CI while Dependabot keeps its secret-sa
   );
   assert.match(
     normalizedReviewWorkflow,
-    /eventName === "workflow_run" && pull\.user\?\.login\?\.toLowerCase\(\) !== "dependabot\[bot\]"/,
+    /eventName === "workflow_run" && !pullIsDependabot && pullIsSameRepository/,
   );
   assert.match(reviewWorkflow, /pull\.head\.sha !== triggerHeadSha/);
 });

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -210,8 +210,9 @@ test("staging deployment rehearses before an always-pull healthy startup", async
   );
   assert.match(
     deploy,
-    /DENSE_MEM_IMAGE="ghcr\.io\/markhuangai\/dense-mem:\$\{IMAGE_TAG\}"[\s\\]*docker compose up -d/,
+    /DENSE_MEM_IMAGE="\$\{IMAGE_TAG\}"[\s\\]*docker compose up -d/,
   );
+  assert.doesNotMatch(deploy, /DENSE_MEM_IMAGE="ghcr\.io\/markhuangai\/dense-mem:/);
   assert.doesNotMatch(deploy, /DENSE_MEM_IMAGE_TAG/);
   assert.match(deploy, /docker compose up -d[\s\\]*--pull always/);
   assert.match(deploy, /--pull always[\s\\]*--no-deps/);

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -208,6 +208,11 @@ test("staging deployment rehearses before an always-pull healthy startup", async
     deploy,
     /IMAGE_TAG: \$\{\{ needs\.authorize\.outputs\.tag \}\}/,
   );
+  assert.match(
+    deploy,
+    /DENSE_MEM_IMAGE="ghcr\.io\/markhuangai\/dense-mem:\$\{IMAGE_TAG\}"[\s\\]*docker compose up -d/,
+  );
+  assert.doesNotMatch(deploy, /DENSE_MEM_IMAGE_TAG/);
   assert.match(deploy, /docker compose up -d[\s\\]*--pull always/);
   assert.match(deploy, /--pull always[\s\\]*--no-deps/);
   assert.match(deploy, /--wait[\s\\]*--wait-timeout 3000/);


### PR DESCRIPTION
Close #292 

## Summary

- Start AI PR Review from `pull_request_target` on the same pull request lifecycle events as `CI Pull Request`.
- Keep the successful-CI `workflow_run` path only for `dependabot/**`, because Dependabot-triggered workflows cannot access the required Actions secrets.
- Reject non-Dependabot CI-completion events before review and retain exact PR/head fencing, PR-scoped status deduplication, and cancellation of stale review work.
- Update the AI review policy test to cover parallel triggering and the Dependabot fallback.

## Why

Normal pull request pushes currently start AI review only after PR CI succeeds. After this change, CI and AI review start independently from the same PR event. Dependabot remains on the existing post-CI path because no matching Dependabot secrets are configured.

## Risk

- `pull_request_target` is privileged and now starts before CI. The workflow definition still comes from the base branch, resolves the PR and event head through the GitHub API, checks out only the fenced SHA without persisted credentials, and rechecks the live head before publishing status.
- Keeping two trigger types could create duplicate reviews. The `workflow_run` trigger is restricted to `dependabot/**`, the resolver rejects non-Dependabot PR authors on that path, and PR-scoped status and concurrency controls prevent repeated work for one head.

## Validation

- `node --test tests/uat/ai_pr_review_policy.test.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ai-pr-review.yml`
- `./scripts/ci-check.sh` (coverage: 90.1%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-powered pull request reviews now begin directly when a pull request is opened, updated, reopened, or marked ready for review.
  * Dependabot pull requests continue using a secure fallback review process after CI completion.

* **Bug Fixes**
  * Improved review triggering and duplicate-review prevention across supported workflow events.

* **Tests**
  * Added coverage for direct pull request reviews and the Dependabot-specific fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->