### PR TITLE
Configure selectable AI review executor

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -284,6 +284,35 @@ jobs:
                 `/actions/runs/${context.runId}`,
             });
 
+      - name: Validate AI reviewer configuration
+        shell: bash
+        env:
+          AI_REVIEWER_SDK: ${{ vars.AI_REVIEWER_SDK }}
+          LOCAL_AI_ENDPOINT: ${{ secrets.LOCAL_AI_ENDPOINT }}
+          LOCAL_OPENAI_AI_ENDPOINT: ${{ secrets.LOCAL_OPENAI_AI_ENDPOINT }}
+        run: |
+          set -euo pipefail
+
+          case "${AI_REVIEWER_SDK}" in
+            codex)
+              endpoint="${LOCAL_OPENAI_AI_ENDPOINT}"
+              endpoint_name="LOCAL_OPENAI_AI_ENDPOINT"
+              ;;
+            claude)
+              endpoint="${LOCAL_AI_ENDPOINT}"
+              endpoint_name="LOCAL_AI_ENDPOINT"
+              ;;
+            *)
+              echo "::error::AI_REVIEWER_SDK must be exactly 'codex' or 'claude'"
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "${endpoint}" ]]; then
+            echo "::error::${endpoint_name} must be configured for ${AI_REVIEWER_SDK}"
+            exit 1
+          fi
+
       - name: Checkout pull request head
         uses: actions/checkout@v7
         with:
@@ -313,7 +342,8 @@ jobs:
         with:
           pull-request-url: ${{ format('{0}/{1}/pull/{2}', github.server_url, github.repository, needs.resolve.outputs.pr_number) }}
           github-pat: ${{ secrets.PR_REVIEW_PAT }}
-          ai-base-url: ${{ secrets.LOCAL_OPENAI_AI_ENDPOINT }}
+          executor: ${{ vars.AI_REVIEWER_SDK }}
+          ai-base-url: ${{ vars.AI_REVIEWER_SDK == 'codex' && secrets.LOCAL_OPENAI_AI_ENDPOINT || secrets.LOCAL_AI_ENDPOINT }}
           ai-secret: ${{ secrets.LOCAL_AI_SECRET }}
           model: auto
           effort: high

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -156,6 +156,36 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
 });
 
+test("AI review selects the configured executor and matching endpoint", async () => {
+  const workflow = await readFile(reviewWorkflowURL, "utf8");
+  const validationStart = workflow.indexOf(
+    "      - name: Validate AI reviewer configuration",
+  );
+  const validationEnd = workflow.indexOf(
+    "      - name: Checkout pull request head",
+    validationStart,
+  );
+
+  assert.notEqual(validationStart, -1);
+  assert.notEqual(validationEnd, -1);
+
+  const validationStep = workflow.slice(validationStart, validationEnd);
+  assert.match(validationStep, /AI_REVIEWER_SDK: \$\{\{ vars\.AI_REVIEWER_SDK \}\}/);
+  assert.match(
+    validationStep,
+    /codex\)\s+endpoint="\$\{LOCAL_OPENAI_AI_ENDPOINT\}"/,
+  );
+  assert.match(validationStep, /claude\)\s+endpoint="\$\{LOCAL_AI_ENDPOINT\}"/);
+  assert.match(validationStep, /AI_REVIEWER_SDK must be exactly 'codex' or 'claude'/);
+  assert.match(validationStep, /\[\[ -z "\$\{endpoint\}" \]\]/);
+  assert.ok(workflow.includes("executor: ${{ vars.AI_REVIEWER_SDK }}"));
+  assert.ok(
+    workflow.includes(
+      "ai-base-url: ${{ vars.AI_REVIEWER_SDK == 'codex' && secrets.LOCAL_OPENAI_AI_ENDPOINT || secrets.LOCAL_AI_ENDPOINT }}",
+    ),
+  );
+});
+
 test("owner-controlled AI review starts with PR CI while untrusted heads use the CI fallback", async () => {
   const [reviewWorkflow, ciWorkflow] = await Promise.all([
     readFile(reviewWorkflowURL, "utf8"),


### PR DESCRIPTION
## Summary

- pass the organization-level `AI_REVIEWER_SDK` variable to the reviewer `executor` input
- route `codex` to `LOCAL_OPENAI_AI_ENDPOINT` and `claude` to `LOCAL_AI_ENDPOINT`
- reject invalid SDK values and missing selected endpoints before checkout
- lock the selector and endpoint mapping in the existing AI review policy test

## Validation

- `node --test tests/uat/ai_pr_review_policy.test.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -config-file .github/actionlint.yaml .github/workflows/ai-pr-review.yml`
- six-case execution matrix for the embedded configuration guard
- `scripts/ci-check.sh` through the repository pre-push hook

## Risk

An empty or invalid organization variable can otherwise let the reviewer default to Codex while the endpoint expression selects the Claude endpoint. The new guard accepts only exact `codex` or `claude` values and requires the matching endpoint before the action runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between Codex and Claude review executors.
  * Added configuration validation to ensure the selected executor and corresponding endpoint are configured correctly.

* **Bug Fixes**
  * Review requests now use the endpoint associated with the selected executor instead of always using the OpenAI endpoint.

* **Tests**
  * Added coverage for executor selection, endpoint mapping, and invalid or missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->