### PR TITLE
ci: configure CodeQL and skip metadata-only prereleases

### DIFF
--- a/.github/scripts/prerelease-version.sh
+++ b/.github/scripts/prerelease-version.sh
@@ -68,6 +68,77 @@ latest_rc() {
 	printf '%s\n' "${latest}"
 }
 
+is_version_tag() {
+	local tag="$1"
+
+	[[ "${tag}" =~ ${SEMVER_REGEX} || "${tag}" =~ ${RC_REGEX} ]]
+}
+
+commit_has_version_tag() {
+	local commit="$1"
+	local tag
+
+	while IFS= read -r tag; do
+		is_version_tag "${tag}" && return 0
+	done < <(git tag --points-at "${commit}")
+
+	return 1
+}
+
+nearest_version_commit() {
+	local target="$1"
+	local commit
+
+	while IFS= read -r commit; do
+		if commit_has_version_tag "${commit}"; then
+			printf '%s\n' "${commit}"
+			return
+		fi
+	done < <(git rev-list --first-parent "${target}")
+
+	return 1
+}
+
+release_path_is_ignored() {
+	case "$1" in
+	.github/* | README.md | README.zh-CN.md) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+resolve_should_release() {
+	local target="${1:-}"
+	local parent
+	local baseline
+	local path
+
+	[[ "${target}" =~ ^[0-9a-f]{40}$ ]] || fail "target must be a 40-character commit SHA"
+	git rev-parse --verify "${target}^{commit}" >/dev/null 2>&1 || fail "target commit does not exist: ${target}"
+
+	if commit_has_version_tag "${target}"; then
+		printf 'true\n'
+		return
+	fi
+
+	if ! parent="$(git rev-parse "${target}^" 2>/dev/null)"; then
+		printf 'true\n'
+		return
+	fi
+	if ! baseline="$(nearest_version_commit "${parent}")"; then
+		printf 'true\n'
+		return
+	fi
+
+	while IFS= read -r -d '' path; do
+		if ! release_path_is_ignored "${path}"; then
+			printf 'true\n'
+			return
+		fi
+	done < <(git diff --name-only --no-renames -z "${baseline}" "${target}")
+
+	printf 'false\n'
+}
+
 resolve_next() {
 	local stable
 	local base
@@ -137,6 +208,7 @@ usage() {
 	printf '%s\n' \
 		"usage:" \
 		"  $0 next" \
+		"  $0 should-release TARGET_SHA" \
 		"  $0 start RELEASE_BASE TARGET_SHA" >&2
 	exit 2
 }
@@ -145,6 +217,10 @@ case "${1:-}" in
 next)
 	[[ "$#" -eq 1 ]] || usage
 	resolve_next
+	;;
+should-release)
+	[[ "$#" -eq 2 ]] || usage
+	resolve_should_release "$2"
 	;;
 start)
 	[[ "$#" -eq 3 ]] || usage

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: docker-runner
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26.6"
+          cache: false
+
+      - name: Set up Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     runs-on: docker-runner
 
     strategy:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -18,12 +18,55 @@ concurrency:
   queue: max
 
 jobs:
-  staging-migration-rehearsal:
-    name: Rehearse migrations on staging data
+  classify-release:
+    name: Classify release changes
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push'
+      }}
+    permissions:
+      contents: read
+    runs-on: docker-runner
+    outputs:
+      should_release: ${{ steps.policy.outputs.should_release }}
+
+    steps:
+      - name: Checkout release candidate
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Classify release changes
+        id: policy
+        shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          test "$(git rev-parse HEAD)" = "${HEAD_SHA}"
+          git fetch --tags --force origin '+refs/tags/*:refs/tags/*'
+          should_release="$(.github/scripts/prerelease-version.sh should-release "${HEAD_SHA}")"
+          case "${should_release}" in
+            true | false) ;;
+            *)
+              echo "::error::invalid release classification: ${should_release}"
+              exit 1
+              ;;
+          esac
+          echo "should_release=${should_release}" >> "${GITHUB_OUTPUT}"
+
+  staging-migration-rehearsal:
+    name: Rehearse migrations on staging data
+    needs: classify-release
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        needs.classify-release.outputs.should_release == 'true'
       }}
     uses: ./.github/workflows/staging-migration-rehearsal.yml
     with:
@@ -32,11 +75,14 @@ jobs:
 
   prepare-prerelease:
     name: Prepare prerelease
-    needs: staging-migration-rehearsal
+    needs:
+      - classify-release
+      - staging-migration-rehearsal
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push' &&
+        needs.classify-release.outputs.should_release == 'true' &&
         needs.staging-migration-rehearsal.result == 'success'
       }}
     permissions:

--- a/tests/uat/go_vulnerability_scan_policy.test.mjs
+++ b/tests/uat/go_vulnerability_scan_policy.test.mjs
@@ -18,6 +18,35 @@ const scanner = fileURLToPath(
 );
 const expiry = "2026-09-01";
 
+test("CodeQL checks pull request updates and main on Docker runners", async () => {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/codeql.yml", import.meta.url),
+    "utf8",
+  );
+  const normalized = workflow.replace(/\s+/g, " ");
+
+  assert.match(workflow, /^  push:\n    branches:\n      - main$/m);
+  assert.match(
+    workflow,
+    /^  pull_request:\n    branches:\n      - main\n    types: \[opened, synchronize, reopened, ready_for_review\]$/m,
+  );
+  assert.doesNotMatch(workflow, /^  schedule:/m);
+  assert.match(workflow, /^  security-events: write$/m);
+  assert.match(workflow, /^    runs-on: docker-runner$/m);
+  assert.match(
+    normalized,
+    /include: - language: actions build-mode: none - language: go build-mode: autobuild - language: javascript-typescript build-mode: none/,
+  );
+  assert.match(workflow, /if: matrix\.language == 'go'[\s\S]*go-version: "1\.26\.6"/);
+  assert.match(
+    workflow,
+    /if: matrix\.language == 'javascript-typescript'[\s\S]*node-version: 24/,
+  );
+  assert.match(workflow, /uses: github\/codeql-action\/init@v4/);
+  assert.match(workflow, /uses: github\/codeql-action\/analyze@v4/);
+  assert.match(workflow, /category: "\/language:\$\{\{ matrix\.language \}\}"/);
+});
+
 test("CI wires the date-bounded exception to the Go vulnerability scan", async () => {
   const workflow = await readFile(
     new URL("../../.github/workflows/ci-shared.yml", import.meta.url),

--- a/tests/uat/go_vulnerability_scan_policy.test.mjs
+++ b/tests/uat/go_vulnerability_scan_policy.test.mjs
@@ -18,7 +18,7 @@ const scanner = fileURLToPath(
 );
 const expiry = "2026-09-01";
 
-test("CodeQL checks pull request updates and main on Docker runners", async () => {
+test("CodeQL checks trusted pull request updates and main on Docker runners", async () => {
   const workflow = await readFile(
     new URL("../../.github/workflows/codeql.yml", import.meta.url),
     "utf8",
@@ -32,6 +32,10 @@ test("CodeQL checks pull request updates and main on Docker runners", async () =
   );
   assert.doesNotMatch(workflow, /^  schedule:/m);
   assert.match(workflow, /^  security-events: write$/m);
+  assert.match(
+    workflow,
+    /^    if: >-\n      \$\{\{\n        github\.event_name != 'pull_request' \|\|\n        github\.event\.pull_request\.head\.repo\.full_name == github\.repository\n      \}\}$/m,
+  );
   assert.match(workflow, /^    runs-on: docker-runner$/m);
   assert.match(
     normalized,

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -50,17 +50,24 @@ test("OCI promotion avoids jq 1.6 reserved variable names", async () => {
 });
 
 test("prerelease publication waits for the staging migration rehearsal", async () => {
-  const releaseWorkflow = await readFile(
-    new URL("../../.github/workflows/release-rc.yml", import.meta.url),
-    "utf8",
-  );
-  const rehearsalWorkflow = await readFile(
-    new URL(
-      "../../.github/workflows/staging-migration-rehearsal.yml",
-      import.meta.url,
+  const [releaseWorkflow, rehearsalWorkflow, pushWorkflow] = await Promise.all([
+    readFile(
+      new URL("../../.github/workflows/release-rc.yml", import.meta.url),
+      "utf8",
     ),
-    "utf8",
-  );
+    readFile(
+      new URL(
+        "../../.github/workflows/staging-migration-rehearsal.yml",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../.github/workflows/ci-push.yml", import.meta.url),
+      "utf8",
+    ),
+  ]);
+  const classifier = workflowJob(releaseWorkflow, "classify-release");
   const rehearsalCall = workflowJob(
     releaseWorkflow,
     "staging-migration-rehearsal",
@@ -71,6 +78,22 @@ test("prerelease publication waits for the staging migration rehearsal", async (
   );
   const prepare = workflowJob(releaseWorkflow, "prepare-prerelease");
 
+  assert.doesNotMatch(pushWorkflow, /paths-ignore/);
+  assert.match(classifier, /^    runs-on: docker-runner$/m);
+  assert.match(classifier, /^          fetch-depth: 0$/m);
+  assert.match(classifier, /^          persist-credentials: false$/m);
+  assert.match(
+    classifier,
+    /^          ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}$/m,
+  );
+  assert.match(
+    classifier,
+    /prerelease-version\.sh should-release "\$\{HEAD_SHA\}"/,
+  );
+  assert.match(
+    rehearsalCall,
+    /^    needs: classify-release$[\s\S]*needs\.classify-release\.outputs\.should_release == 'true'/m,
+  );
   assert.match(
     rehearsalCall,
     /^    uses: \.\/\.github\/workflows\/staging-migration-rehearsal\.yml$/m,
@@ -104,7 +127,11 @@ test("prerelease publication waits for the staging migration rehearsal", async (
       rehearsal.indexOf("go test -tags=staging_rehearsal"),
     "the production copy must finish restoring before migrations run",
   );
-  assert.match(prepare, /^    needs: staging-migration-rehearsal$/m);
+  assert.match(
+    prepare,
+    /^    needs:\n      - classify-release\n      - staging-migration-rehearsal$/m,
+  );
+  assert.match(prepare, /needs\.classify-release\.outputs\.should_release == 'true'/);
   assert.match(prepare, /needs\.staging-migration-rehearsal\.result == 'success'/);
 
   for (const jobName of [

--- a/tests/uat/prerelease_version.test.mjs
+++ b/tests/uat/prerelease_version.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { devNull, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -60,6 +60,17 @@ function tag(repository, ...tags) {
   }
 }
 
+function commitFiles(repository, message, files) {
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(repository, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  git(repository, "add", "--", ...Object.keys(files));
+  git(repository, "commit", "--quiet", "-m", message);
+  return git(repository, "rev-parse", "HEAD");
+}
+
 test("temporary repositories ignore configured global hooks", (t) => {
   const home = mkdtempSync(join(tmpdir(), "dense-mem-prerelease-home-"));
   const hooks = join(home, "hooks");
@@ -115,6 +126,88 @@ test("next returns to patch allocation after the active line becomes stable", (t
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), "v2.5.1-rc.0");
+});
+
+test("should-release skips accumulated GitHub and root README changes", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.6.1-rc.0");
+  const head = commitFiles(repository, "update repository metadata", {
+    ".github/workflows/ci.yml": "name: CI\n",
+    "README.md": "English\n",
+    "README.zh-CN.md": "Chinese\n",
+  });
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "false");
+});
+
+test("should-release skips an empty untagged commit", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.6.1-rc.0");
+  git(repository, "commit", "--quiet", "--allow-empty", "-m", "empty");
+  const head = git(repository, "rev-parse", "HEAD");
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "false");
+});
+
+test("should-release includes untagged code before a README-only commit", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.6.1-rc.0");
+  commitFiles(repository, "change code", {
+    "internal/service.go": "package internal\n",
+  });
+  const head = commitFiles(repository, "update docs", {
+    "README.md": "Documentation\n",
+  });
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "true");
+});
+
+test("should-release includes a code file renamed into an ignored path", (t) => {
+  const repository = createRepository(t);
+  commitFiles(repository, "add code", {
+    "internal/config.go": "package internal\n",
+  });
+  tag(repository, "v2.6.1-rc.0");
+  git(repository, "mv", "internal/config.go", "README.md");
+  git(repository, "commit", "--quiet", "-m", "rename code");
+  const head = git(repository, "rev-parse", "HEAD");
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "true");
+});
+
+test("should-release keeps tagged-head publication retries eligible", (t) => {
+  const repository = createRepository(t);
+  tag(repository, "v2.6.1-rc.0");
+  const head = git(repository, "rev-parse", "HEAD");
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "true");
+});
+
+test("should-release publishes when no version baseline exists", (t) => {
+  const repository = createRepository(t);
+  const head = commitFiles(repository, "initial docs", {
+    "README.md": "Documentation\n",
+  });
+
+  const result = resolve(repository, "should-release", head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "true");
 });
 
 test("start accepts any canonical SemVer base newer than known lines", (t) => {


### PR DESCRIPTION
## Summary

- replace dynamic CodeQL default setup with a checked-in workflow that analyzes pull request updates and main on docker-runner
- install Node 24 and Go 1.26.6 before the matching CodeQL matrix jobs
- preserve main CI while skipping prerelease rehearsal, tagging, and image publication when accumulated changes are limited to .github and the two root READMEs
- compare release eligibility with the nearest version-tagged first-parent baseline so a later docs commit cannot hide earlier untagged code

## Verification

- node --test tests/uat/prerelease_version.test.mjs tests/uat/image_release_policy.test.mjs tests/uat/go_vulnerability_scan_policy.test.mjs
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 with the existing concurrency.queue diagnostic ignored
- ./scripts/ci-check.sh (90.0% coverage)
- git diff --check

## Operational note

CodeQL default setup was disabled after the branch was pushed and before this pull request was opened. The new advanced CodeQL workflow must pass for Actions, Go, and JavaScript/TypeScript before merge.

The deterministic 1k evaluation is not applicable because this change does not affect retrieval or semantic quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CodeQL security analysis for supported languages on main branch changes and pull requests.
  * Added prerelease classification to determine when code changes warrant a release.
* **Release Improvements**
  * Prerelease preparation and staging migration rehearsals now run only when release conditions are met.
  * Documentation-only and workflow-only changes can be excluded from prerelease publication.
  * Release retries and untagged code changes are handled more reliably.
* **Tests**
  * Added coverage validating security scanning and prerelease decision rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->