### PR TITLE
ci: skip slow npm cache restore on ephemeral runners

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -39,10 +39,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: |
-            .lint/package-lock.json
-            packages/mcp-proxy/package-lock.json
+          package-manager-cache: false
 
       - name: Install lint dependencies
         run: npm ci --prefix .lint


### PR DESCRIPTION
## Summary

- disable setup-node npm caching in shared CI
- keep automatic package-manager caching explicitly off on ephemeral Docker runners
- avoid downloading the 1.47 GB global npm archive on every job

## Evidence

In https://github.com/markhuangai/dense-mem/actions/runs/33060425093/job/98477540933:

- Node 24.19.0 was found in the runner tool cache in about 120 ms.
- setup-node then spent about 9 minutes restoring a 1,541,495,752-byte npm cache at about 2.8 MB/s.
- the two dependency installation steps completed in under 3 seconds total.
- a local empty-cache falsification test completed both installs in 4.7 seconds total.

## Risk

Registry degradation can lengthen uncached npm installs. The lockfiles remain authoritative, and measured cold installs are far below the current restore time. Caching can be reconsidered if dependency size or runner network behavior changes.

## Validation

- actionlint v1.7.12
- ./scripts/ci-check.sh
- repository pre-push checks
- cold npm installs for .lint and packages/mcp-proxy

Evaluation not run: this CI-only change does not affect retrieval quality, ranking, placement, semantic behavior, embeddings, search documents, or performance of Dense-Mem itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration setup to disable npm dependency caching for Go unit test jobs.
  * No end-user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->