### PR TITLE
Improve AI reviewer fix audits

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -35,11 +35,25 @@ env:
     do not invent context; continue with verified repository evidence and omit
     memory-only claims. When sources conflict, explicit user direction,
     AGENTS.md, the linked issue, and the current PR head, diff, callers,
-    migrations, docs, and real tests govern. Confirm every reported defect
-    against changed code on a supported reachable path. For each changed field,
-    state, identifier, configuration value, or contract owned by this goal,
-    trace all supported inputs and writers through validation, persistence or
-    serialization, asynchronous work, and every reader or consumer. Flag any
+    migrations, docs, and real tests govern. Use prior discussion as a change
+    ledger. First perform a fix-focused pass. When the conversation identifies
+    an earlier completed review head, inspect findings in this goal claimed
+    fixed after that head; otherwise inspect the most recent claimed fixes.
+    Read the complete relevant threads, then treat each fix as new code and
+    inspect its current implementation, affected callers, consumers, and tests.
+    Do not merely confirm that the original defect is gone. Derive the invariant
+    the fix intended to restore and construct adjacent counterexamples across
+    the same state machine, decision table, boundary, or authoritative-value
+    path to find incomplete fixes, contradictions, and newly introduced failure
+    modes. This is not an exact commit-range diff unless a tool supplies one;
+    never claim coverage of an unread range. Then independently sweep the full
+    merge-base-to-head change for this goal, including relevant areas with no
+    prior discussion. Prior review silence and resolved threads are not negative
+    evidence. Complete both passes before deciding. Confirm every reported
+    defect against changed code on a supported reachable path. For each changed
+    field, state, identifier, configuration value, or contract owned by this
+    goal, trace all supported inputs and writers through validation, persistence
+    or serialization, asynchronous work, and every reader or consumer. Flag any
     path that drops, defaults, overwrites, mis-scopes, or retains a stale
     authoritative value. Report only root causes owned by this goal, combine
     their downstream symptoms, and leave other finding classes to their
@@ -284,35 +298,6 @@ jobs:
                 `/actions/runs/${context.runId}`,
             });
 
-      - name: Validate AI reviewer configuration
-        shell: bash
-        env:
-          AI_REVIEWER_SDK: ${{ vars.AI_REVIEWER_SDK }}
-          LOCAL_AI_ENDPOINT: ${{ secrets.LOCAL_AI_ENDPOINT }}
-          LOCAL_OPENAI_AI_ENDPOINT: ${{ secrets.LOCAL_OPENAI_AI_ENDPOINT }}
-        run: |
-          set -euo pipefail
-
-          case "${AI_REVIEWER_SDK}" in
-            codex)
-              endpoint="${LOCAL_OPENAI_AI_ENDPOINT}"
-              endpoint_name="LOCAL_OPENAI_AI_ENDPOINT"
-              ;;
-            claude)
-              endpoint="${LOCAL_AI_ENDPOINT}"
-              endpoint_name="LOCAL_AI_ENDPOINT"
-              ;;
-            *)
-              echo "::error::AI_REVIEWER_SDK must be exactly 'codex' or 'claude'"
-              exit 1
-              ;;
-          esac
-
-          if [[ -z "${endpoint}" ]]; then
-            echo "::error::${endpoint_name} must be configured for ${AI_REVIEWER_SDK}"
-            exit 1
-          fi
-
       - name: Checkout pull request head
         uses: actions/checkout@v7
         with:
@@ -342,8 +327,7 @@ jobs:
         with:
           pull-request-url: ${{ format('{0}/{1}/pull/{2}', github.server_url, github.repository, needs.resolve.outputs.pr_number) }}
           github-pat: ${{ secrets.PR_REVIEW_PAT }}
-          executor: ${{ vars.AI_REVIEWER_SDK }}
-          ai-base-url: ${{ vars.AI_REVIEWER_SDK == 'codex' && secrets.LOCAL_OPENAI_AI_ENDPOINT || secrets.LOCAL_AI_ENDPOINT }}
+          ai-base-url: ${{ secrets.LOCAL_AI_ENDPOINT }}
           ai-secret: ${{ secrets.LOCAL_AI_SECRET }}
           model: auto
           effort: high

--- a/tests/uat/ai_pr_review_policy.test.mjs
+++ b/tests/uat/ai_pr_review_policy.test.mjs
@@ -111,6 +111,33 @@ test("AI review uses six ownership-driven goals and one memory-first protocol", 
   }
 });
 
+test("AI review re-audits fixes before an independent cumulative sweep", async () => {
+  const workflow = await readFile(reviewWorkflowURL, "utf8");
+  const normalizedWorkflow = workflow.replace(/\s+/g, " ");
+
+  assert.match(normalizedWorkflow, /First perform a fix-focused pass/);
+  assert.match(
+    normalizedWorkflow,
+    /Do not merely confirm that the original defect is gone/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /construct adjacent counterexamples across the same state machine, decision table, boundary, or authoritative-value path/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /This is not an exact commit-range diff unless a tool supplies one/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /Then independently sweep the full merge-base-to-head change for this goal/,
+  );
+  assert.match(
+    normalizedWorkflow,
+    /Prior review silence and resolved threads are not negative evidence/,
+  );
+});
+
 test("maintainability review is preventive, bounded, and impact-scored", async () => {
   const workflow = await readFile(reviewWorkflowURL, "utf8");
   const normalizedWorkflow = normalizedReviewPrompt(
@@ -235,32 +262,16 @@ test("review safety controls and CI policy coverage remain enabled", async () =>
   assert.match(ciCheck, /node --test tests\/uat\/ai_pr_review_policy\.test\.mjs/);
 });
 
-test("AI review selects the configured executor and matching endpoint", async () => {
+test("AI review uses the Claude endpoint without obsolete executor routing", async () => {
   const workflow = await readFile(reviewWorkflowURL, "utf8");
-  const validationStart = workflow.indexOf(
-    "      - name: Validate AI reviewer configuration",
-  );
-  const validationEnd = workflow.indexOf(
-    "      - name: Checkout pull request head",
-    validationStart,
-  );
 
-  assert.notEqual(validationStart, -1);
-  assert.notEqual(validationEnd, -1);
-
-  const validationStep = workflow.slice(validationStart, validationEnd);
-  assert.match(validationStep, /AI_REVIEWER_SDK: \$\{\{ vars\.AI_REVIEWER_SDK \}\}/);
-  assert.match(
-    validationStep,
-    /codex\)\s+endpoint="\$\{LOCAL_OPENAI_AI_ENDPOINT\}"/,
-  );
-  assert.match(validationStep, /claude\)\s+endpoint="\$\{LOCAL_AI_ENDPOINT\}"/);
-  assert.match(validationStep, /AI_REVIEWER_SDK must be exactly 'codex' or 'claude'/);
-  assert.match(validationStep, /\[\[ -z "\$\{endpoint\}" \]\]/);
-  assert.ok(workflow.includes("executor: ${{ vars.AI_REVIEWER_SDK }}"));
+  assert.doesNotMatch(workflow, /Validate AI reviewer configuration/);
+  assert.doesNotMatch(workflow, /AI_REVIEWER_SDK/);
+  assert.doesNotMatch(workflow, /LOCAL_OPENAI_AI_ENDPOINT/);
+  assert.doesNotMatch(workflow, /^\s+executor:/m);
   assert.ok(
     workflow.includes(
-      "ai-base-url: ${{ vars.AI_REVIEWER_SDK == 'codex' && secrets.LOCAL_OPENAI_AI_ENDPOINT || secrets.LOCAL_AI_ENDPOINT }}",
+      "ai-base-url: ${{ secrets.LOCAL_AI_ENDPOINT }}",
     ),
   );
 });


### PR DESCRIPTION
## Summary

- Configure the AI reviewer for Claude through LOCAL_AI_ENDPOINT and remove obsolete executor and alternate-endpoint routing.
- Add a fix-focused pass that treats claimed fixes as new code, derives their intended invariants, and tests adjacent counterexamples.
- Follow that pass with an independent merge-base-to-head sweep while stating that prior discussion is not an exact commit-range diff.
- Add policy coverage for the two-pass prompt and Claude-only configuration.

## Validation

- node --test tests/uat/ai_pr_review_policy.test.mjs
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ai-pr-review.yml
- targeted textlint for both changed files
- ./scripts/ci-check.sh (90.0% coverage)
- pre-push repository checks (90.0% coverage)

## Risk

Prior discussion can omit commits or stale threads. The prompt explicitly treats it only as a fix ledger, forbids claiming an unread commit range, and requires a separate full merge-base-to-head review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - AI-assisted pull request reviews now re-check claimed fixes, test nearby edge cases, and perform a complete independent review before confirming results.
  - Review configuration now consistently uses the designated AI endpoint, with obsolete executor selection removed.
- **Tests**
  - Added coverage for fix re-audits, counterexample checks, and the updated endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->