### PR TITLE
feat: make relationship correction synchronous (#301)

### DIFF
--- a/cmd/internal/serverapp/provider_adapters.go
+++ b/cmd/internal/serverapp/provider_adapters.go
@@ -5,8 +5,44 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/conflictassessment"
 	"github.com/markhuangai/dense-mem/internal/dreamgeneration"
+	"github.com/markhuangai/dense-mem/internal/embedding"
+	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 	"github.com/markhuangai/dense-mem/internal/verifier"
 )
+
+// semanticWriteProvider adapts the existing ordered embedding port to T01's
+// index-explicit batch executor at the composition boundary.
+type semanticWriteProvider struct {
+	provider embedding.EmbeddingProviderInterface
+}
+
+func (p semanticWriteProvider) EmbedBatch(ctx context.Context, texts []string) ([]semanticwrite.IndexedEmbedding, string, error) {
+	vectors, model, err := p.provider.EmbedBatch(ctx, texts)
+	if err != nil {
+		return nil, model, err
+	}
+	result := make([]semanticwrite.IndexedEmbedding, len(vectors))
+	for index, vector := range vectors {
+		result[index] = semanticwrite.IndexedEmbedding{Index: index, Vector: append([]float32(nil), vector...)}
+	}
+	return result, model, nil
+}
+
+func (p semanticWriteProvider) ModelName() string {
+	if p.provider == nil {
+		return ""
+	}
+	return p.provider.ModelName()
+}
+func (p semanticWriteProvider) Dimensions() int {
+	if p.provider == nil {
+		return 0
+	}
+	return p.provider.Dimensions()
+}
+func (p semanticWriteProvider) IsAvailable() bool {
+	return p.provider != nil && p.provider.IsAvailable()
+}
 
 // legacyConflictProvider keeps the transitional Conflict protocol on its own
 // application port until the conflict capability issue owns its provider.

--- a/cmd/internal/serverapp/provider_adapters.go
+++ b/cmd/internal/serverapp/provider_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/markhuangai/dense-mem/internal/conflictassessment"
+	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/dreamgeneration"
 	"github.com/markhuangai/dense-mem/internal/embedding"
 	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
@@ -19,13 +20,26 @@ type semanticWriteProvider struct {
 func (p semanticWriteProvider) EmbedBatch(ctx context.Context, texts []string) ([]semanticwrite.IndexedEmbedding, string, error) {
 	vectors, model, err := p.provider.EmbedBatch(ctx, texts)
 	if err != nil {
-		return nil, model, err
+		return nil, model, translateSemanticWriteEmbeddingError(err)
 	}
 	result := make([]semanticwrite.IndexedEmbedding, len(vectors))
 	for index, vector := range vectors {
 		result[index] = semanticwrite.IndexedEmbedding{Index: index, Vector: append([]float32(nil), vector...)}
 	}
 	return result, model, nil
+}
+
+func translateSemanticWriteEmbeddingError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch embedding.ClassifyFailure(err).Code {
+	case string(domain.EmbeddingFailureProviderResponseInvalid):
+		return semanticwrite.ErrProviderResponseInvalid
+	case string(domain.EmbeddingFailureProviderTimeout):
+		return semanticwrite.ErrProviderTimeout
+	}
+	return err
 }
 
 func (p semanticWriteProvider) ModelName() string {

--- a/cmd/internal/serverapp/provider_adapters_test.go
+++ b/cmd/internal/serverapp/provider_adapters_test.go
@@ -1,8 +1,12 @@
 package serverapp
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/markhuangai/dense-mem/internal/embedding"
+	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 	"github.com/markhuangai/dense-mem/internal/verifier"
 	"github.com/stretchr/testify/require"
 )
@@ -21,4 +25,42 @@ func TestLegacyDreamGenerationResponsePreservesDiagnostics(t *testing.T) {
 	require.Equal(t, 11, response.InputTokens)
 	require.Equal(t, 7, response.OutputTokens)
 	require.Equal(t, 2, response.ProviderTurns)
+}
+
+type semanticWriteEmbeddingProviderStub struct {
+	err error
+}
+
+func (p semanticWriteEmbeddingProviderStub) Embed(context.Context, string) ([]float32, string, error) {
+	return nil, "", p.err
+}
+
+func (p semanticWriteEmbeddingProviderStub) EmbedBatch(context.Context, []string) ([][]float32, string, error) {
+	return nil, "model", p.err
+}
+
+func (semanticWriteEmbeddingProviderStub) ModelName() string { return "model" }
+func (semanticWriteEmbeddingProviderStub) Dimensions() int   { return 2 }
+func (semanticWriteEmbeddingProviderStub) IsAvailable() bool { return true }
+
+func TestSemanticWriteProviderPreservesMalformedResponseClassification(t *testing.T) {
+	provider := semanticWriteEmbeddingProviderStub{err: &embedding.ProviderError{
+		Provider:     "openai",
+		FailureClass: "provider_action_required",
+		FailureCode:  "provider_response_invalid",
+	}}
+	adapter := semanticWriteProvider{provider: provider}
+	plan := semanticwrite.Plan{
+		Documents: []semanticwrite.Document{{Hash: "hash", Text: "relationship"}},
+		Fence: semanticwrite.Fence{
+			Model: "model", Dimensions: 2, EmbeddingContractID: "contract",
+			SearchGenerationID: "generation", SearchGenerationVersion: 1,
+		},
+		Timeout: time.Second,
+	}
+
+	_, err := semanticwrite.NewExecutor(adapter).Execute(context.Background(), plan)
+
+	require.ErrorIs(t, err, semanticwrite.ErrProviderResponseInvalid)
+	require.NotErrorIs(t, err, semanticwrite.ErrProviderUnavailable)
 }

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -266,7 +266,7 @@ func RunActiveServer(
 		Semantic:                   semanticRepo,
 		Evidence:                   ledgerRepo,
 		CorrectionExecutor:         semanticwrite.NewExecutor(semanticWriteProvider{provider: openaiProvider}),
-		CorrectionEmbeddingTimeout: 10 * time.Second,
+		CorrectionEmbeddingTimeout: time.Duration(cfg.GetAIEmbeddingTimeoutSeconds()) * time.Second,
 	})
 	contextSvc := contextservice.NewSemantic(semanticRepo)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/graphview"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 	"github.com/markhuangai/dense-mem/internal/sse"
 	"github.com/markhuangai/dense-mem/internal/storage/postgres"
@@ -262,8 +263,10 @@ func RunActiveServer(
 		Metrics:   discoverabilityMetrics,
 	})
 	lifecycleSvc := memoryservice.NewLifecycleService(memoryservice.LifecycleDependencies{
-		Semantic: semanticRepo,
-		Evidence: ledgerRepo,
+		Semantic:                   semanticRepo,
+		Evidence:                   ledgerRepo,
+		CorrectionExecutor:         semanticwrite.NewExecutor(semanticWriteProvider{provider: openaiProvider}),
+		CorrectionEmbeddingTimeout: 10 * time.Second,
 	})
 	contextSvc := contextservice.NewSemantic(semanticRepo)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{

--- a/internal/httperr/errors.go
+++ b/internal/httperr/errors.go
@@ -51,6 +51,7 @@ const (
 	ErrVerifierMalformedResponse ErrorCode = "verifier_malformed_response"
 	ErrEmbeddingUnavailable      ErrorCode = "embedding_unavailable"
 	ErrEmbeddingResponseInvalid  ErrorCode = "embedding_response_invalid"
+	ErrEmbeddingTimeout          ErrorCode = "embedding_timeout"
 
 	// Policy / predicate violations (422)
 	ErrPredicateNotPoliced    ErrorCode = "predicate_not_policed"

--- a/internal/httperr/errors.go
+++ b/internal/httperr/errors.go
@@ -49,6 +49,8 @@ const (
 	ErrVerifierTimeout           ErrorCode = "verifier_timeout"
 	ErrVerifierProvider          ErrorCode = "verifier_provider"
 	ErrVerifierMalformedResponse ErrorCode = "verifier_malformed_response"
+	ErrEmbeddingUnavailable      ErrorCode = "embedding_unavailable"
+	ErrEmbeddingResponseInvalid  ErrorCode = "embedding_response_invalid"
 
 	// Policy / predicate violations (422)
 	ErrPredicateNotPoliced    ErrorCode = "predicate_not_policed"

--- a/internal/httperr/errors_test.go
+++ b/internal/httperr/errors_test.go
@@ -273,6 +273,8 @@ func TestKnowledgeErrorCodes(t *testing.T) {
 		{ErrVerifierTimeout, "verifier_timeout", http.StatusGatewayTimeout},
 		{ErrVerifierProvider, "verifier_provider", http.StatusServiceUnavailable},
 		{ErrVerifierMalformedResponse, "verifier_malformed_response", http.StatusBadGateway},
+		{ErrEmbeddingUnavailable, "embedding_unavailable", http.StatusServiceUnavailable},
+		{ErrEmbeddingResponseInvalid, "embedding_response_invalid", http.StatusBadGateway},
 
 		// Policy / predicate violations
 		{ErrPredicateNotPoliced, "predicate_not_policed", http.StatusUnprocessableEntity},

--- a/internal/httperr/errors_test.go
+++ b/internal/httperr/errors_test.go
@@ -275,6 +275,7 @@ func TestKnowledgeErrorCodes(t *testing.T) {
 		{ErrVerifierMalformedResponse, "verifier_malformed_response", http.StatusBadGateway},
 		{ErrEmbeddingUnavailable, "embedding_unavailable", http.StatusServiceUnavailable},
 		{ErrEmbeddingResponseInvalid, "embedding_response_invalid", http.StatusBadGateway},
+		{ErrEmbeddingTimeout, "embedding_timeout", http.StatusGatewayTimeout},
 
 		// Policy / predicate violations
 		{ErrPredicateNotPoliced, "predicate_not_policed", http.StatusUnprocessableEntity},

--- a/internal/httperr/handler.go
+++ b/internal/httperr/handler.go
@@ -37,9 +37,9 @@ func HTTPStatusCode(code ErrorCode) int {
 		return http.StatusTooManyRequests
 	case ErrVerifierTimeout:
 		return http.StatusGatewayTimeout
-	case ErrVerifierProvider:
+	case ErrVerifierProvider, ErrEmbeddingUnavailable:
 		return http.StatusServiceUnavailable
-	case ErrVerifierMalformedResponse:
+	case ErrVerifierMalformedResponse, ErrEmbeddingResponseInvalid:
 		return http.StatusBadGateway
 	case ErrPredicateNotPoliced, ErrUnsupportedPolicy, ErrCommunityGraphTooLarge:
 		return http.StatusUnprocessableEntity

--- a/internal/httperr/handler.go
+++ b/internal/httperr/handler.go
@@ -35,7 +35,7 @@ func HTTPStatusCode(code ErrorCode) int {
 		return http.StatusNotFound
 	case ErrVerifierRateLimit:
 		return http.StatusTooManyRequests
-	case ErrVerifierTimeout:
+	case ErrVerifierTimeout, ErrEmbeddingTimeout:
 		return http.StatusGatewayTimeout
 	case ErrVerifierProvider, ErrEmbeddingUnavailable:
 		return http.StatusServiceUnavailable

--- a/internal/repository/placement_commit_search.go
+++ b/internal/repository/placement_commit_search.go
@@ -85,6 +85,29 @@ func upsertSearchDocumentInTx(
 	contract *ActiveSearchContract,
 	embeddingJobMaxAttempts int,
 ) (*SearchDocumentResult, error) {
+	loaded, err := upsertSearchDocumentRecordInTx(ctx, tx, input, contract)
+	if err != nil {
+		return nil, err
+	}
+	if err := retireSupersededEmbeddingJobs(ctx, tx, *loaded); err != nil {
+		return nil, err
+	}
+	jobID, err := enqueueEmbeddingJob(ctx, tx, *loaded, embeddingJobMaxAttempts)
+	if err != nil {
+		return nil, err
+	}
+	loaded.QueuedJobID = jobID
+	return loaded, nil
+}
+
+// upsertSearchDocumentRecordInTx writes the fenced document record only.
+// Callers that require asynchronous embedding must enqueue separately.
+func upsertSearchDocumentRecordInTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	input UpsertSearchDocumentInput,
+	contract *ActiveSearchContract,
+) (*SearchDocumentResult, error) {
 	metadata, err := marshalSearchJSON(input.Metadata)
 	if err != nil {
 		return nil, err
@@ -165,8 +188,12 @@ func upsertSearchDocumentInTx(
 		return nil, err
 	}
 	if !rows.Next() {
+		err := rows.Err()
 		_ = rows.Close()
-		return nil, rows.Err()
+		if err != nil {
+			return nil, err
+		}
+		return nil, ErrSearchStaleVersion
 	}
 	loaded := SearchDocumentResult{}
 	if err := rows.Scan(
@@ -195,14 +222,6 @@ func upsertSearchDocumentInTx(
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
-	if err := retireSupersededEmbeddingJobs(ctx, tx, loaded); err != nil {
-		return nil, err
-	}
-	jobID, err := enqueueEmbeddingJob(ctx, tx, loaded, embeddingJobMaxAttempts)
-	if err != nil {
-		return nil, err
-	}
-	loaded.QueuedJobID = jobID
 	return &loaded, nil
 }
 

--- a/internal/repository/private_memory_semantic_lineage_integration_test.go
+++ b/internal/repository/private_memory_semantic_lineage_integration_test.go
@@ -95,7 +95,7 @@ func TestPrivateMemoryErasureCleansPrivateSemanticDecisionLineage(t *testing.T) 
 	relationshipID := decision.Relationship.RelationshipID
 	require.Equal(t, target.MemorySpaceID.String(), decision.Relationship.SpaceID)
 
-	correction, err := semantic.CorrectRelationship(semanticCtx, CorrectRelationshipInput{
+	correction, err := correctRelationshipWithTestEmbeddings(semanticCtx, semantic, CorrectRelationshipInput{
 		TeamID:          teamID.String(),
 		OwnerProfileID:  ownerID.String(),
 		Action:          "submit",

--- a/internal/repository/relationship_correction_canonical_projection_integration_test.go
+++ b/internal/repository/relationship_correction_canonical_projection_integration_test.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelationshipCorrectionPlannerUsesCanonicalNameForUniqueSubmitMatch(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-canonical-submit", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-canonical-submit")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Canonical Submit Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Canonical Submit Wrong")
+	canonicalObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Dense-Mem")
+	content := "Canonical Submit Owner works on Dense-Mem."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-canonical-submit", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "canonical-submit", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{Name: "dense-mem", EntityKind: "project"}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity spelling was normalized", IdempotencyKey: "canonical-submit",
+	}
+
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, plan.Documents, 2)
+	successorDocument := plan.Documents[len(plan.Documents)-1].DocumentText
+	require.Contains(t, successorDocument, "object: Dense-Mem")
+	require.NotContains(t, successorDocument, "object: dense-mem")
+
+	result, err := semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+	require.NoError(t, err)
+	require.Equal(t, "completed", result.ProcessingState)
+	require.Equal(t, canonicalObject.EntityID, loadRelationshipObjectEntity(t, ctx, appDB, rls, teamID, ownerID, result.Correction.SuccessorRelationshipID))
+}

--- a/internal/repository/relationship_correction_embedding_plan.go
+++ b/internal/repository/relationship_correction_embedding_plan.go
@@ -111,11 +111,11 @@ func (r *SemanticRepositoryImpl) PlanRelationshipCorrectionEmbeddings(
 		}
 		subjectPatch := effective.Patch.SubjectEntity
 		objectPatch := effective.Patch.ObjectEntity
-		if effective.Action == "confirm" && effective.Selection.SubjectEntityID != "" {
-			subjectPatch = &RelationshipCorrectionEntityPatch{EntityID: effective.Selection.SubjectEntityID}
+		if resolution.Selection.SubjectEntityID != "" {
+			subjectPatch = &RelationshipCorrectionEntityPatch{EntityID: resolution.Selection.SubjectEntityID}
 		}
-		if effective.Action == "confirm" && effective.Selection.ObjectEntityID != "" {
-			objectPatch = &RelationshipCorrectionEntityPatch{EntityID: effective.Selection.ObjectEntityID}
+		if resolution.Selection.ObjectEntityID != "" {
+			objectPatch = &RelationshipCorrectionEntityPatch{EntityID: resolution.Selection.ObjectEntityID}
 		}
 		subjectID, subjectName, err := correctionEndpointProjection(ctx, tx, input.TeamID, source.SubjectEntityID, names.SubjectName, subjectPatch)
 		if err != nil {

--- a/internal/repository/relationship_correction_embedding_plan.go
+++ b/internal/repository/relationship_correction_embedding_plan.go
@@ -1,0 +1,211 @@
+package repository
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+// PlanRelationshipCorrectionEmbeddings renders only the provider work that a
+// currently valid correction needs. It never writes semantic or search state.
+func (r *SemanticRepositoryImpl) PlanRelationshipCorrectionEmbeddings(
+	ctx context.Context,
+	input CorrectRelationshipInput,
+) (*RelationshipCorrectionEmbeddingPlan, error) {
+	input = normalizeCorrectRelationshipInput(input)
+	if err := validateCorrectRelationshipInput(input); err != nil {
+		return nil, err
+	}
+	plan := &RelationshipCorrectionEmbeddingPlan{Documents: []RelationshipCorrectionEmbeddingDocument{}}
+	err := r.withTeamProfileTx(ctx, input.TeamID, input.OwnerProfileID, func(tx *gorm.DB) error {
+		effective := input
+		var pending *relationshipCorrectionSubmissionRow
+		if input.Action == "submit" {
+			requestHash, err := relationshipCorrectionRequestHash(input)
+			if err != nil {
+				return err
+			}
+			existing, err := loadRelationshipCorrectionByIdempotency(ctx, tx, input.TeamID, input.OwnerProfileID, input.IdempotencyKey)
+			if err == nil {
+				if existing.RequestHash != requestHash || existing.ProcessingState != "processing" {
+					return nil
+				}
+				effective.RelationshipID = existing.RelationshipID
+				effective.ExpectedVersion = existing.ExpectedVersion
+				effective.Patch = existing.Patch
+				effective.Supports = append([]RelationshipCorrectionSupport(nil), existing.Supports...)
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+		} else {
+			row, err := loadRelationshipCorrectionSubmission(ctx, tx, input.TeamID, input.OwnerProfileID, input.SubmissionID, false)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			if err != nil || row.ProcessingState != "awaiting_confirmation" {
+				return err
+			}
+			pending = row
+			effective.RelationshipID = row.RelationshipID
+			effective.ExpectedVersion = row.ExpectedVersion
+			effective.Patch = row.Patch
+			effective.Supports = append([]RelationshipCorrectionSupport(nil), row.Supports...)
+			effective.Selection = mergeRelationshipCorrectionSelection(row.Selection, input.Selection)
+		}
+
+		source, err := loadRelationshipRecord(ctx, tx, input.TeamID, effective.RelationshipID)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if source.OwnerProfileID != input.OwnerProfileID || source.Status != string(domain.RelationshipStatusActive) ||
+			source.SupportCount == 0 || source.IdentityAliasOfID != "" || source.Version != effective.ExpectedVersion {
+			return nil
+		}
+		supports, err := loadEffectiveRelationshipCorrectionSupports(ctx, tx, input.TeamID, source.RelationshipID)
+		if err != nil {
+			return err
+		}
+		if !relationshipCorrectionSupportsEqual(effective.Supports, supports) {
+			return nil
+		}
+		for _, support := range supports {
+			if requireSemanticSpaceMatch(source.SpaceID, support.SpaceID) != nil {
+				return nil
+			}
+		}
+
+		resolution, err := resolveRelationshipCorrectionPatch(ctx, tx, effective, source)
+		if err != nil || resolution.RejectionCode != "" || (input.Action == "submit" && len(resolution.Candidates) > 0) {
+			return err
+		}
+		if pending != nil {
+			if pending.ConfirmationExpiresAt == nil || !time.Now().UTC().Before(*pending.ConfirmationExpiresAt) ||
+				subtle.ConstantTimeCompare([]byte(pending.ConfirmationToken), []byte(input.ConfirmationToken)) != 1 {
+				return nil
+			}
+			if _, err := validateRelationshipCorrectionSelection(pending, effective.Selection); err != nil {
+				return nil
+			}
+			resolution.Selection = mergeRelationshipCorrectionSelection(resolution.Selection, effective.Selection)
+			if err := validateSelectedCorrectionEntities(ctx, tx, input.TeamID, pending.Candidates, resolution.Selection); err != nil {
+				if errors.Is(err, errRelationshipCorrectionSelectionUnavailable) {
+					return nil
+				}
+				return err
+			}
+		}
+
+		names, err := loadCorrectionProjectionNames(ctx, tx, input.TeamID, source)
+		if err != nil {
+			return err
+		}
+		subjectPatch := effective.Patch.SubjectEntity
+		objectPatch := effective.Patch.ObjectEntity
+		if effective.Action == "confirm" && effective.Selection.SubjectEntityID != "" {
+			subjectPatch = &RelationshipCorrectionEntityPatch{EntityID: effective.Selection.SubjectEntityID}
+		}
+		if effective.Action == "confirm" && effective.Selection.ObjectEntityID != "" {
+			objectPatch = &RelationshipCorrectionEntityPatch{EntityID: effective.Selection.ObjectEntityID}
+		}
+		subjectID, subjectName, err := correctionEndpointProjection(ctx, tx, input.TeamID, source.SubjectEntityID, names.SubjectName, subjectPatch)
+		if err != nil {
+			return err
+		}
+		objectID, objectName, objectValueID, objectValue, objectUnit, err := correctionObjectProjection(ctx, tx, input.TeamID, source, names, objectPatch)
+		if err != nil {
+			return err
+		}
+		if resolution.Predicate == nil {
+			return nil
+		}
+		if subjectID == source.SubjectEntityID && objectID == source.ObjectEntityID && objectValueID == source.ObjectValueID &&
+			resolution.Predicate.Key == source.PredicateKey && resolution.Predicate.Version == source.PredicateVersion &&
+			resolution.SubjectCreate == nil && resolution.ObjectCreate == nil {
+			return nil
+		}
+		contract, err := loadActiveSearchContractInTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		plan.EmbeddingContractID = contract.EmbeddingContractID
+		plan.EmbeddingDimensions = contract.EmbeddingDimensions
+		plan.EmbeddingModel = contract.EmbeddingModel
+		plan.SearchIndexGenerationID = contract.SearchIndexGenerationID
+		plan.IndexGeneration = contract.IndexGeneration
+		successor := &RelationshipRecord{SubjectEntityID: subjectID, PredicateKey: resolution.Predicate.Key, ObjectEntityID: objectID, ObjectValueID: objectValueID, Polarity: source.Polarity, ScopeKey: source.ScopeKey, ValidFrom: source.ValidFrom, ValidTo: source.ValidTo}
+		appendCorrectionPlanDocument(plan, relationshipProjectionText(source, names))
+		appendCorrectionPlanDocument(plan, relationshipProjectionText(successor, relationshipProjectionNames{SubjectName: subjectName, ObjectName: objectName, ObjectValue: objectValue, ObjectUnit: objectUnit}))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("repository: plan relationship correction embeddings: %w", err)
+	}
+	return plan, nil
+}
+
+func appendCorrectionPlanDocument(plan *RelationshipCorrectionEmbeddingPlan, text string) {
+	text = strings.TrimSpace(text)
+	if plan == nil || text == "" {
+		return
+	}
+	hash := strings.TrimPrefix(sha256Hex(text), "sha256:")
+	for _, document := range plan.Documents {
+		if document.DocumentHash == hash {
+			return
+		}
+	}
+	plan.Documents = append(plan.Documents, RelationshipCorrectionEmbeddingDocument{DocumentHash: hash, DocumentText: text})
+}
+
+func loadCorrectionProjectionNames(ctx context.Context, tx *gorm.DB, teamID string, source *RelationshipRecord) (relationshipProjectionNames, error) {
+	var names relationshipProjectionNames
+	err := tx.WithContext(ctx).Raw(`
+		SELECT COALESCE(NULLIF(subject_name.display_name, ''), relationship.subject_entity_id::text),
+		       COALESCE(NULLIF(object_name.display_name, ''), NULLIF(value_record.display, ''), NULLIF(value_record.canonical_value, ''), relationship.object_entity_id::text, relationship.object_value_id::text, ''),
+		       COALESCE(value_record.value_type, ''), COALESCE(value_record.canonical_value, ''), COALESCE(value_record.unit, '')
+		FROM relationship_records AS relationship
+		LEFT JOIN entity_names AS subject_name ON subject_name.team_id = relationship.team_id AND subject_name.entity_id = relationship.subject_entity_id AND subject_name.name_kind = 'canonical' AND subject_name.valid_to IS NULL
+		LEFT JOIN entity_names AS object_name ON object_name.team_id = relationship.team_id AND object_name.entity_id = relationship.object_entity_id AND object_name.name_kind = 'canonical' AND object_name.valid_to IS NULL
+		LEFT JOIN value_records AS value_record ON value_record.team_id = relationship.team_id AND value_record.value_id = relationship.object_value_id
+		WHERE relationship.team_id = ?::uuid AND relationship.relationship_id = ?::uuid LIMIT 1
+	`, teamID, source.RelationshipID).Row().Scan(&names.SubjectName, &names.ObjectName, &names.ObjectValueType, &names.ObjectValue, &names.ObjectUnit)
+	return names, err
+}
+
+func correctionEndpointProjection(ctx context.Context, tx *gorm.DB, teamID, currentID, currentName string, patch *RelationshipCorrectionEntityPatch) (string, string, error) {
+	if patch == nil {
+		return currentID, currentName, nil
+	}
+	if patch.EntityID == "" {
+		return "", patch.Name, nil
+	}
+	candidate, err := loadActiveCorrectionEntity(ctx, tx, teamID, patch.EntityID)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", patch.EntityID, nil
+	}
+	if err != nil {
+		return "", "", err
+	}
+	return candidate.EntityID, candidate.CanonicalName, nil
+}
+
+func correctionObjectProjection(ctx context.Context, tx *gorm.DB, teamID string, source *RelationshipRecord, names relationshipProjectionNames, patch *RelationshipCorrectionEntityPatch) (string, string, string, string, string, error) {
+	if patch != nil {
+		id, name, err := correctionEndpointProjection(ctx, tx, teamID, source.ObjectEntityID, names.ObjectName, patch)
+		return id, name, "", "", "", err
+	}
+	if source.ObjectEntityID != "" {
+		return source.ObjectEntityID, names.ObjectName, "", "", "", nil
+	}
+	return "", firstNonEmpty(names.ObjectName, names.ObjectValue), source.ObjectValueID, names.ObjectValue, names.ObjectUnit, nil
+}

--- a/internal/repository/relationship_correction_embedding_plan.go
+++ b/internal/repository/relationship_correction_embedding_plan.go
@@ -93,7 +93,7 @@ func (r *SemanticRepositoryImpl) PlanRelationshipCorrectionEmbeddings(
 				subtle.ConstantTimeCompare([]byte(pending.ConfirmationToken), []byte(input.ConfirmationToken)) != 1 {
 				return nil
 			}
-			if _, err := validateRelationshipCorrectionSelection(pending, effective.Selection); err != nil {
+			if _, err := validateRelationshipCorrectionSelection(pending, input.Selection); err != nil {
 				return nil
 			}
 			resolution.Selection = mergeRelationshipCorrectionSelection(resolution.Selection, effective.Selection)

--- a/internal/repository/relationship_correction_fence_integration_test.go
+++ b/internal/repository/relationship_correction_fence_integration_test.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestRelationshipCorrectionRejectsStaleVersionAfterPlan(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-stale-version", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-stale-version")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Stale Version Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Stale Version Wrong")
+	correctObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Stale Version Correct")
+	content := "Stale Version Owner works on Stale Version Correct."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-stale-version", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "stale-version", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: correctObject.EntityID}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity was resolved incorrectly", IdempotencyKey: "stale-version-submit",
+	}
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Documents)
+	sourceDocument, err := NewSearchRepository(appDB, rls).UpsertSearchDocument(ctx, UpsertSearchDocumentInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKind: "relationship", SourceID: original.RelationshipID,
+		SourceVersion: int64(original.Version), ProjectionFormat: 2, DocumentText: plan.Documents[0].DocumentText,
+		SpaceID: original.SpaceID, SpaceGeneration: original.SpaceGeneration,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pending", sourceDocument.SearchState)
+
+	var beforeSearchState, beforeDocumentHash string
+	var beforeJobCount, beforeRelationshipCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&beforeSearchState, &beforeDocumentHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&beforeJobCount).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT COUNT(*) FROM relationship_records WHERE team_id = ?::uuid`, teamID).Scan(&beforeRelationshipCount).Error
+	}))
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		result := tx.Exec(`
+			UPDATE relationship_records SET version = version + 1, updated_at = now()
+			WHERE team_id = ?::uuid AND relationship_id = ?::uuid
+		`, teamID, original.RelationshipID)
+		require.Equal(t, int64(1), result.RowsAffected)
+		return result.Error
+	}))
+
+	result, err := semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+	require.NoError(t, err)
+	require.Equal(t, "rejected", result.ProcessingState)
+	require.Equal(t, "relationship_version_stale", result.ErrorCode)
+	require.Nil(t, result.Correction)
+
+	var afterSearchState, afterDocumentHash, originalStatus string
+	var afterJobCount, afterRelationshipCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&afterSearchState, &afterDocumentHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&afterJobCount).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM relationship_records WHERE team_id = ?::uuid`, teamID).Scan(&afterRelationshipCount).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT status FROM relationship_records WHERE team_id = ?::uuid AND relationship_id = ?::uuid`, teamID, original.RelationshipID).Scan(&originalStatus).Error
+	}))
+	require.Equal(t, "active", originalStatus)
+	require.Equal(t, beforeSearchState, afterSearchState)
+	require.Equal(t, beforeDocumentHash, afterDocumentHash)
+	require.Equal(t, beforeJobCount, afterJobCount)
+	require.Equal(t, beforeRelationshipCount, afterRelationshipCount)
+}

--- a/internal/repository/relationship_correction_fence_integration_test.go
+++ b/internal/repository/relationship_correction_fence_integration_test.go
@@ -101,3 +101,109 @@ func TestRelationshipCorrectionRejectsStaleVersionAfterPlan(t *testing.T) {
 	require.Equal(t, beforeJobCount, afterJobCount)
 	require.Equal(t, beforeRelationshipCount, afterRelationshipCount)
 }
+
+func TestRelationshipCorrectionRejectsSupportRevisionChangeAfterPlan(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-support-revision", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-support-revision")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Support Revision Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Support Revision Wrong")
+	correctObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Support Revision Correct")
+	content := "Support Revision Owner works on Support Revision Correct."
+	const sourceKey = "document://relationship-correction-support-revision"
+	ingest, err := ledger.CreateIngest(ctx, CreateIngestInput{
+		TeamID: teamID, OwnerProfileID: ownerID,
+		Evidence: []EvidenceInput{{
+			Content: content, SourceKey: sourceKey, SourceRevisionToken: "rev-1",
+			SourceRevisionContentHash: sha256Hex(content),
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, ingest.Evidence, 1)
+	support := &EvidenceSupportInput{
+		FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "support-revision",
+		SourceID: ingest.Evidence[0].SourceID, SourceRevisionID: ingest.Evidence[0].SourceRevisionID,
+		SpanStart: 0, SpanEnd: len(content), Authority: "primary",
+	}
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: support,
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: correctObject.EntityID}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity was resolved incorrectly", IdempotencyKey: "support-revision-submit",
+	}
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Documents)
+	sourceDocument, err := NewSearchRepository(appDB, rls).UpsertSearchDocument(ctx, UpsertSearchDocumentInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKind: "relationship", SourceID: original.RelationshipID,
+		SourceVersion: int64(original.Version), ProjectionFormat: 2, DocumentText: plan.Documents[0].DocumentText,
+		SpaceID: original.SpaceID, SpaceGeneration: original.SpaceGeneration,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pending", sourceDocument.SearchState)
+
+	var beforeSearchState, beforeDocumentHash string
+	var beforeJobCount, beforeRelationshipCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&beforeSearchState, &beforeDocumentHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&beforeJobCount).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT COUNT(*) FROM relationship_records WHERE team_id = ?::uuid`, teamID).Scan(&beforeRelationshipCount).Error
+	}))
+
+	_, err = ledger.AdvanceSourceRevision(ctx, AdvanceSourceRevisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKey: sourceKey,
+		RevisionToken: "rev-2", ExpectedPreviousRevisionToken: "rev-1",
+		ContentHash: sha256Hex("Support Revision Owner now works elsewhere."),
+	})
+	require.NoError(t, err)
+
+	result, err := semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+	require.NoError(t, err)
+	require.Equal(t, "rejected", result.ProcessingState)
+	require.Equal(t, "support_set_mismatch", result.ErrorCode)
+	require.Nil(t, result.Correction)
+
+	var afterSearchState, afterDocumentHash, originalStatus string
+	var afterJobCount, afterRelationshipCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&afterSearchState, &afterDocumentHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&afterJobCount).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM relationship_records WHERE team_id = ?::uuid`, teamID).Scan(&afterRelationshipCount).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT status FROM relationship_records WHERE team_id = ?::uuid AND relationship_id = ?::uuid`, teamID, original.RelationshipID).Scan(&originalStatus).Error
+	}))
+	require.Equal(t, "active", originalStatus)
+	require.Equal(t, beforeSearchState, afterSearchState)
+	require.Equal(t, beforeDocumentHash, afterDocumentHash)
+	require.Equal(t, beforeJobCount, afterJobCount)
+	require.Equal(t, beforeRelationshipCount, afterRelationshipCount)
+}

--- a/internal/repository/relationship_correction_helpers.go
+++ b/internal/repository/relationship_correction_helpers.go
@@ -764,11 +764,7 @@ func (r *SemanticRepositoryImpl) applyRelationshipCorrection(
 		reused, string(patchJSON), string(supportsJSON), row.Reason, sourceSpaceID).Error; err != nil {
 		return nil, err
 	}
-	commit := CommitPlacementSemanticInput{TeamID: row.TeamID, OwnerProfileID: row.OwnerProfileID}
-	if _, err := upsertPlacementRelationshipSearchDocument(ctx, tx, commit, original, defaultEmbeddingJobMaxAttempts); err != nil {
-		return nil, err
-	}
-	if _, err := upsertPlacementRelationshipSearchDocument(ctx, tx, commit, successor, defaultEmbeddingJobMaxAttempts); err != nil {
+	if err := applyRelationshipCorrectionSearchDocuments(ctx, tx, row, original, successor); err != nil {
 		return nil, err
 	}
 	selectionJSON, err := json.Marshal(resolution.Selection)

--- a/internal/repository/relationship_correction_inline_embedding.go
+++ b/internal/repository/relationship_correction_inline_embedding.go
@@ -1,0 +1,138 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type relationshipCorrectionEmbeddingsContextKey struct{}
+
+func withRelationshipCorrectionEmbeddings(ctx context.Context, values []RelationshipCorrectionEmbedding) context.Context {
+	copyValues := make([]RelationshipCorrectionEmbedding, len(values))
+	for index, value := range values {
+		copyValues[index] = value
+		copyValues[index].Embedding = append([]float32(nil), value.Embedding...)
+	}
+	return context.WithValue(ctx, relationshipCorrectionEmbeddingsContextKey{}, copyValues)
+}
+
+func relationshipCorrectionEmbeddings(ctx context.Context) ([]RelationshipCorrectionEmbedding, bool) {
+	values, ok := ctx.Value(relationshipCorrectionEmbeddingsContextKey{}).([]RelationshipCorrectionEmbedding)
+	return values, ok
+}
+
+func applyRelationshipCorrectionSearchDocuments(ctx context.Context, tx *gorm.DB, row *relationshipCorrectionSubmissionRow, original, successor *RelationshipRecord) error {
+	values, provided := relationshipCorrectionEmbeddings(ctx)
+	if !provided {
+		return ErrSearchEmbeddingRequired
+	}
+	contract, err := loadActiveSearchContractInTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	byHash := make(map[string][]float32, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value.DocumentHash) == "" || len(value.Embedding) == 0 {
+			return fmt.Errorf("%w: correction embedding requires hash and vector", ErrSearchEmbeddingRequired)
+		}
+		if value.EmbeddingContractID != contract.EmbeddingContractID || value.EmbeddingDimensions != contract.EmbeddingDimensions ||
+			value.EmbeddingModel != contract.EmbeddingModel || value.SearchIndexGenerationID != contract.SearchIndexGenerationID || value.IndexGeneration != contract.IndexGeneration {
+			return ErrSearchContractMismatch
+		}
+		if _, exists := byHash[value.DocumentHash]; exists {
+			return fmt.Errorf("%w: duplicate correction embedding hash", ErrSearchEmbeddingRequired)
+		}
+		byHash[value.DocumentHash] = append([]float32(nil), value.Embedding...)
+	}
+
+	commit := CommitPlacementSemanticInput{TeamID: row.TeamID, OwnerProfileID: row.OwnerProfileID}
+	if _, err := markRelationshipSearchDocumentNotRequired(ctx, tx, commit, original); err != nil {
+		return err
+	}
+	if err := staleCorrectionEmbeddingJobs(ctx, tx, row.TeamID, original.RelationshipID, contract.EmbeddingContractID); err != nil {
+		return err
+	}
+	document, documentHash, err := upsertCorrectionRelationshipSearchDocument(ctx, tx, row, successor, contract)
+	if err != nil {
+		return err
+	}
+	vector, ok := byHash[documentHash]
+	if !ok {
+		return fmt.Errorf("%w: successor document was not embedded", ErrSearchEmbeddingRequired)
+	}
+	if len(vector) != document.EmbeddingDimensions {
+		return ErrSearchContractMismatch
+	}
+	literal, err := vectorLiteral(vector)
+	if err != nil {
+		return err
+	}
+	updated := tx.WithContext(ctx).Exec(`
+		UPDATE search_documents
+		SET embedding = ?::vector, search_state = 'current', embedding_updated_at = now(), embedding_error = '', updated_at = now()
+		WHERE team_id = ?::uuid AND search_document_id = ?::uuid AND owner_profile_id = ?::uuid
+		  AND source_version = ? AND projection_format_version = ?
+		  AND projection_generation_id IS NOT DISTINCT FROM NULLIF(?, '')::uuid
+		  AND document_version = ? AND embedding_contract_id = ?::uuid AND embedding_dimensions = ?
+		  AND space_id = ?::uuid AND space_generation = ? AND document_hash = ?
+	`, literal, row.TeamID, document.SearchDocumentID, row.OwnerProfileID, document.SourceVersion, document.ProjectionFormat,
+		document.ProjectionGenerationID, document.DocumentVersion, contract.EmbeddingContractID, contract.EmbeddingDimensions,
+		document.SpaceID, document.SpaceGeneration, documentHash)
+	if updated.Error != nil {
+		return updated.Error
+	}
+	if updated.RowsAffected != 1 {
+		return ErrSearchStaleVersion
+	}
+	if err := staleCorrectionEmbeddingJobs(ctx, tx, row.TeamID, successor.RelationshipID, contract.EmbeddingContractID); err != nil {
+		return err
+	}
+	if document.ProjectionGenerationID != "" {
+		if err := refreshRelationshipProjectionGeneration(ctx, tx, row.TeamID, document.ProjectionGenerationID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertCorrectionRelationshipSearchDocument(ctx context.Context, tx *gorm.DB, row *relationshipCorrectionSubmissionRow, relationship *RelationshipRecord, contract *ActiveSearchContract) (*SearchDocumentResult, string, error) {
+	if !relationshipSearchEligible(relationship) {
+		return nil, "", errors.New("correction successor is not search eligible")
+	}
+	text, err := placementRelationshipSearchText(ctx, tx, relationship)
+	if err != nil {
+		return nil, "", err
+	}
+	previousGenerationID, err := relationshipSearchDocumentProjectionGenerationID(ctx, tx, row.TeamID, relationship.RelationshipID, contract.EmbeddingContractID)
+	if err != nil {
+		return nil, "", err
+	}
+	metadata, err := relationshipForegroundSearchMetadata(ctx, tx, row.TeamID)
+	if err != nil {
+		return nil, "", err
+	}
+	input := normalizeUpsertSearchDocumentInput(UpsertSearchDocumentInput{TeamID: row.TeamID, OwnerProfileID: row.OwnerProfileID, SourceKind: "relationship", SourceID: relationship.RelationshipID, SourceVersion: int64(relationship.Version), ProjectionFormat: 2, DocumentText: text, Metadata: metadata, SpaceID: relationship.SpaceID, SpaceGeneration: relationship.SpaceGeneration})
+	if err := validateUpsertSearchDocumentInput(input); err != nil {
+		return nil, "", err
+	}
+	document, err := upsertSearchDocumentRecordInTx(ctx, tx, input, contract)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := refreshPreviousRelationshipProjectionGeneration(ctx, tx, row.TeamID, previousGenerationID); err != nil {
+		return nil, "", err
+	}
+	return document, input.DocumentHash, nil
+}
+
+func staleCorrectionEmbeddingJobs(ctx context.Context, tx *gorm.DB, teamID, relationshipID, contractID string) error {
+	return tx.WithContext(ctx).Exec(`
+		UPDATE embedding_jobs SET status = 'stale', error = 'relationship correction completed synchronously', completed_at = COALESCE(completed_at, now()), lease_until = NULL, worker_id = '', updated_at = now()
+		WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid AND embedding_contract_id = ?::uuid
+		  AND status IN ('queued', 'processing', 'failed')
+	`, teamID, relationshipID, contractID).Error
+}

--- a/internal/repository/relationship_correction_repository.go
+++ b/internal/repository/relationship_correction_repository.go
@@ -108,6 +108,26 @@ func (r *SemanticRepositoryImpl) CorrectRelationship(
 	ctx context.Context,
 	input CorrectRelationshipInput,
 ) (*CorrectRelationshipResult, error) {
+	// Corrections cannot fall back to the asynchronous embedding queue. This
+	// compatibility entry point therefore fails a state-changing correction
+	// unless its caller supplies the precomputed provider result.
+	return r.correctRelationship(withRelationshipCorrectionEmbeddings(ctx, nil), input)
+}
+
+// CorrectRelationshipWithEmbeddings commits only provider results produced by
+// PlanRelationshipCorrectionEmbeddings before the transaction began.
+func (r *SemanticRepositoryImpl) CorrectRelationshipWithEmbeddings(
+	ctx context.Context,
+	input CorrectRelationshipInput,
+	embeddings []RelationshipCorrectionEmbedding,
+) (*CorrectRelationshipResult, error) {
+	return r.correctRelationship(withRelationshipCorrectionEmbeddings(ctx, embeddings), input)
+}
+
+func (r *SemanticRepositoryImpl) correctRelationship(
+	ctx context.Context,
+	input CorrectRelationshipInput,
+) (*CorrectRelationshipResult, error) {
 	input = normalizeCorrectRelationshipInput(input)
 	if err := validateCorrectRelationshipInput(input); err != nil {
 		return nil, err

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -600,6 +600,309 @@ func TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp(t *testing.T)
 	require.Equal(t, "inactive_relationship_collision", inactiveCollision.ErrorCode)
 }
 
+func TestRelationshipCorrectionPlannerKeepsStoredResolvedSelection(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-mixed-selection", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-mixed-selection")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	wrongSubject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Wrong Subject")
+	resolvedSubject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Resolved Subject")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Wrong Project")
+	firstAtlas := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Atlas")
+	createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Atlas")
+	content := "Resolved Subject works on Atlas."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-mixed-selection", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: wrongSubject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "mixed-selection", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+
+	submitted, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch: RelationshipCorrectionPatch{
+			SubjectEntity: &RelationshipCorrectionEntityPatch{Name: "Resolved Subject", EntityKind: "person"},
+			ObjectEntity:  &RelationshipCorrectionEntityPatch{Name: "Atlas", EntityKind: "project"},
+		},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "both endpoints were resolved incorrectly", IdempotencyKey: "mixed-selection-submit",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "awaiting_confirmation", submitted.ProcessingState)
+	require.NotNil(t, submitted.Confirmation)
+	require.Len(t, submitted.Confirmation.Candidates, 2)
+
+	confirmed, err := correctRelationshipWithTestEmbeddings(ctx, semantic, CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
+		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,
+		Selection: RelationshipCorrectionSelection{ObjectEntityID: firstAtlas.EntityID}, IdempotencyKey: "mixed-selection-confirm",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "completed", confirmed.ProcessingState)
+	require.Equal(t, firstAtlas.EntityID, loadRelationshipObjectEntity(t, ctx, appDB, rls, teamID, ownerID, confirmed.Correction.SuccessorRelationshipID))
+
+	var successorSubjectID string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT subject_entity_id::text FROM relationship_records
+			WHERE team_id = ?::uuid AND relationship_id = ?::uuid
+		`, teamID, confirmed.Correction.SuccessorRelationshipID).Scan(&successorSubjectID).Error
+	}))
+	require.Equal(t, resolvedSubject.EntityID, successorSubjectID)
+}
+
+func TestRelationshipCorrectionRejectsSearchContractRotationAfterPlan(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-rotation", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-rotation")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Rotation Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Rotation Wrong")
+	correctObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Rotation Correct")
+	content := "Rotation Owner works on Rotation Correct."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-rotation", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "rotation", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: correctObject.EntityID}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity was resolved incorrectly", IdempotencyKey: "rotation-submit",
+	}
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Documents)
+	sourceDocument, err := NewSearchRepository(appDB, rls).UpsertSearchDocument(ctx, UpsertSearchDocumentInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKind: "relationship", SourceID: original.RelationshipID,
+		SourceVersion: int64(original.Version), ProjectionFormat: 2, DocumentText: plan.Documents[0].DocumentText,
+		SpaceID: original.SpaceID, SpaceGeneration: original.SpaceGeneration,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pending", sourceDocument.SearchState)
+
+	var beforeSearchState string
+	var beforeJobCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Scan(&beforeSearchState).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&beforeJobCount).Error
+	}))
+
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-rotation-next", 3, "exact", "")
+	_, err = semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+	require.ErrorIs(t, err, ErrSearchContractMismatch)
+
+	var originalStatus, afterSearchState string
+	var activeRelationships, afterJobCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT status FROM relationship_records
+			WHERE team_id = ?::uuid AND relationship_id = ?::uuid
+		`, teamID, original.RelationshipID).Scan(&originalStatus).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`
+			SELECT COUNT(*) FROM relationship_records
+			WHERE team_id = ?::uuid AND status = 'active'
+		`, teamID).Scan(&activeRelationships).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`
+			SELECT search_state FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Scan(&afterSearchState).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&afterJobCount).Error
+	}))
+	require.Equal(t, "active", originalStatus)
+	require.Equal(t, int64(1), activeRelationships)
+	require.Equal(t, beforeSearchState, afterSearchState)
+	require.Equal(t, beforeJobCount, afterJobCount)
+}
+
+func TestRelationshipCorrectionRejectsInvalidEmbeddingAtomically(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-invalid-embedding", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-invalid-embedding")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Invalid Embedding Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Invalid Embedding Wrong")
+	correctObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Invalid Embedding Correct")
+	content := "Invalid Embedding Owner works on Invalid Embedding Correct."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-invalid-embedding", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "invalid-embedding", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: correctObject.EntityID}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity was resolved incorrectly", IdempotencyKey: "invalid-embedding-submit",
+	}
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Documents)
+	sourceDocument, err := NewSearchRepository(appDB, rls).UpsertSearchDocument(ctx, UpsertSearchDocumentInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKind: "relationship", SourceID: original.RelationshipID,
+		SourceVersion: int64(original.Version), ProjectionFormat: 2, DocumentText: plan.Documents[0].DocumentText,
+		SpaceID: original.SpaceID, SpaceGeneration: original.SpaceGeneration,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pending", sourceDocument.SearchState)
+
+	embeddings := relationshipCorrectionTestEmbeddings(plan)
+	successorHash := plan.Documents[len(plan.Documents)-1].DocumentHash
+	invalidated := false
+	for index := range embeddings {
+		if embeddings[index].DocumentHash == successorHash {
+			embeddings[index].Embedding = []float32{0}
+			invalidated = true
+		}
+	}
+	require.True(t, invalidated)
+
+	var beforeSearchState, beforeDocumentHash string
+	var beforeJobCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&beforeSearchState, &beforeDocumentHash); err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&beforeJobCount).Error
+	}))
+
+	_, err = semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+	require.ErrorIs(t, err, ErrSearchContractMismatch)
+
+	var afterSearchState, afterDocumentHash, originalStatus string
+	var afterJobCount, relationshipCount int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&afterSearchState, &afterDocumentHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM embedding_jobs WHERE team_id = ?::uuid`, teamID).Scan(&afterJobCount).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM relationship_records WHERE team_id = ?::uuid`, teamID).Scan(&relationshipCount).Error; err != nil {
+			return err
+		}
+		return tx.Raw(`SELECT status FROM relationship_records WHERE team_id = ?::uuid AND relationship_id = ?::uuid`, teamID, original.RelationshipID).Scan(&originalStatus).Error
+	}))
+	require.Equal(t, "active", originalStatus)
+	require.Equal(t, beforeSearchState, afterSearchState)
+	require.Equal(t, beforeDocumentHash, afterDocumentHash)
+	require.Equal(t, beforeJobCount, afterJobCount)
+	require.Equal(t, int64(1), relationshipCount)
+}
+
+func TestRelationshipCorrectionEqualHashUsesOneEmbeddingForBothDocumentStates(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	insertSearchTestContract(t, adminDB, rls, "relationship-correction-equal-hash", 3, "exact", "")
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "relationship-correction-equal-hash")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "owner")
+	ledger := NewLedgerRepository(appDB, rls)
+	semantic := NewSemanticRepository(appDB, rls)
+
+	subject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "person", "Equal Hash Owner")
+	wrongObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Atlas")
+	correctObject := createSemanticEntity(t, ctx, semantic, teamID, ownerID, "project", "Atlas")
+	content := "Equal Hash Owner works on Atlas."
+	ingest := createSemanticIngest(t, ctx, ledger, teamID, ownerID, "relationship-correction-equal-hash", content)
+	original := applySemanticDecision(t, ctx, semantic, ApplyRelationshipDecisionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, IngestID: ingest.IngestID,
+		SubjectEntityID: subject.EntityID, PredicateKey: "works_on", ObjectEntityID: wrongObject.EntityID,
+		Support: &EvidenceSupportInput{FragmentID: ingest.Evidence[0].FragmentID, SourceGroupKey: "equal-hash", SpanStart: 0, SpanEnd: len(content), Authority: "primary"},
+	}).Relationship
+	input := CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
+		RelationshipID: original.RelationshipID, ExpectedVersion: original.Version,
+		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: correctObject.EntityID}},
+		Supports: []RelationshipCorrectionSupport{{EvidenceID: ingest.Evidence[0].FragmentID, Start: 0, End: len(content)}},
+		Reason:   "the object Entity identity was resolved incorrectly", IdempotencyKey: "equal-hash-submit",
+	}
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, plan.Documents, 1)
+	sourceDocument, err := NewSearchRepository(appDB, rls).UpsertSearchDocument(ctx, UpsertSearchDocumentInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SourceKind: "relationship", SourceID: original.RelationshipID,
+		SourceVersion: int64(original.Version), ProjectionFormat: 2, DocumentText: plan.Documents[0].DocumentText,
+		SpaceID: original.SpaceID, SpaceGeneration: original.SpaceGeneration,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "pending", sourceDocument.SearchState)
+
+	result, err := semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+	require.NoError(t, err)
+	require.Equal(t, "completed", result.ProcessingState)
+
+	var originalSearchState, successorSearchState, originalHash, successorHash string
+	var successorJobs int64
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, original.RelationshipID).Row().Scan(&originalSearchState, &originalHash); err != nil {
+			return err
+		}
+		if err := tx.Raw(`
+			SELECT search_state, document_hash FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+			ORDER BY updated_at DESC LIMIT 1
+		`, teamID, result.Correction.SuccessorRelationshipID).Row().Scan(&successorSearchState, &successorHash); err != nil {
+			return err
+		}
+		return tx.Raw(`
+			SELECT COUNT(*) FROM embedding_jobs
+			WHERE team_id = ?::uuid AND source_kind = 'relationship' AND source_id = ?::uuid
+		`, teamID, result.Correction.SuccessorRelationshipID).Scan(&successorJobs).Error
+	}))
+	require.Equal(t, "not_required", originalSearchState)
+	require.Equal(t, "current", successorSearchState)
+	require.Equal(t, plan.Documents[0].DocumentHash, originalHash)
+	require.Equal(t, plan.Documents[0].DocumentHash, successorHash)
+	require.Zero(t, successorJobs)
+}
+
 func loadRelationshipObjectEntity(
 	t *testing.T,
 	ctx context.Context,

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -83,6 +83,19 @@ func TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport(t *t
 	_, err = semantic.CorrectRelationship(ctx, crossTeam)
 	require.ErrorIs(t, err, ErrSemanticOwnerMismatch)
 
+	missingEmbedding := request
+	missingEmbedding.IdempotencyKey = "replace-owned-relationship-missing-embedding"
+	_, err = semantic.CorrectRelationship(ctx, missingEmbedding)
+	require.ErrorIs(t, err, ErrSearchEmbeddingRequired)
+	var originalStateAfterFailure string
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamA, ownerA, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT status FROM relationship_records
+			WHERE team_id = ?::uuid AND relationship_id = ?::uuid
+		`, teamA, original.RelationshipID).Row().Scan(&originalStateAfterFailure)
+	}))
+	require.Equal(t, "active", originalStateAfterFailure)
+
 	result, err := correctRelationshipWithTestEmbeddings(ctx, semantic, request)
 	require.NoError(t, err)
 	require.Equal(t, "completed", result.ProcessingState)

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -83,10 +83,10 @@ func TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport(t *t
 	_, err = semantic.CorrectRelationship(ctx, crossTeam)
 	require.ErrorIs(t, err, ErrSemanticOwnerMismatch)
 
-	result, err := semantic.CorrectRelationship(ctx, request)
+	result, err := correctRelationshipWithTestEmbeddings(ctx, semantic, request)
 	require.NoError(t, err)
 	require.Equal(t, "completed", result.ProcessingState)
-	require.Equal(t, "pending", result.SearchState)
+	require.Equal(t, "current", result.SearchState)
 	require.NotNil(t, result.Correction)
 	require.False(t, result.Correction.ReusedSuccessor)
 	require.NotEqual(t, original.RelationshipID, result.Correction.SuccessorRelationshipID)
@@ -101,7 +101,7 @@ func TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport(t *t
 	})
 	require.NoError(t, err)
 	require.Equal(t, "completed", status.ProcessingState)
-	require.Equal(t, "pending", status.SearchState)
+	require.Equal(t, "current", status.SearchState)
 
 	err = rls.WithTeamProfileTx(ctx, appDB, teamA, ownerA, func(tx *gorm.DB) error {
 		var originalStatus, successorStatus string
@@ -131,6 +131,15 @@ func TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport(t *t
 			return err
 		}
 		assert.Equal(t, searchState, status.SearchState)
+		var correctionJobs int64
+		if err := tx.Raw(`
+			SELECT COUNT(*) FROM embedding_jobs
+			WHERE team_id = ?::uuid AND source_kind = 'relationship'
+			  AND source_id = ?::uuid
+		`, teamA, result.Correction.SuccessorRelationshipID).Scan(&correctionJobs).Error; err != nil {
+			return err
+		}
+		assert.Zero(t, correctionJobs)
 
 		var crossReferences, correctionEvents int64
 		if err := tx.Raw(`
@@ -233,7 +242,7 @@ func TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation(t *testing.
 	}))
 	require.Equal(t, "active", originalStatus)
 
-	confirmed, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+	confirmed, err := correctRelationshipWithTestEmbeddings(ctx, semantic, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
 		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,
 		Selection:      RelationshipCorrectionSelection{ObjectEntityID: strings.ToUpper(firstAtlas.EntityID)},
@@ -510,7 +519,7 @@ func TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp(t *testing.T)
 		Support: &EvidenceSupportInput{FragmentID: targetIngest.Evidence[0].FragmentID, SourceGroupKey: "collision:target", SpanStart: 0, SpanEnd: targetSpan, Authority: "primary"},
 	}).Relationship
 
-	reused, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+	reused, err := correctRelationshipWithTestEmbeddings(ctx, semantic, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "submit",
 		RelationshipID: source.RelationshipID, ExpectedVersion: source.Version,
 		Patch:    RelationshipCorrectionPatch{ObjectEntity: &RelationshipCorrectionEntityPatch{EntityID: targetObject.EntityID}},

--- a/internal/repository/search_repository.go
+++ b/internal/repository/search_repository.go
@@ -21,6 +21,7 @@ const (
 var (
 	ErrSearchStaleVersion                   = errors.New("search stale source or document version")
 	ErrSearchContractMismatch               = errors.New("search contract mismatch")
+	ErrSearchEmbeddingRequired              = errors.New("search embedding is required")
 	ErrSearchConvergenceAttentionRequired   = errors.New("search convergence is attention_required")
 	ErrEmbeddingLeaseLost                   = errors.New("embedding lease lost")
 	ErrEmbeddingReconciliationCanarySkipped = errors.New("embedding reconciliation canary was no longer claimable")

--- a/internal/repository/semantic_repository_integration_helpers_test.go
+++ b/internal/repository/semantic_repository_integration_helpers_test.go
@@ -9,6 +9,26 @@ import (
 	"gorm.io/gorm"
 )
 
+func correctRelationshipWithTestEmbeddings(ctx context.Context, semantic *SemanticRepositoryImpl, input CorrectRelationshipInput) (*CorrectRelationshipResult, error) {
+	plan, err := semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	embeddings := make([]RelationshipCorrectionEmbedding, 0, len(plan.Documents))
+	for _, document := range plan.Documents {
+		embeddings = append(embeddings, RelationshipCorrectionEmbedding{
+			DocumentHash:            document.DocumentHash,
+			Embedding:               make([]float32, plan.EmbeddingDimensions),
+			EmbeddingContractID:     plan.EmbeddingContractID,
+			EmbeddingDimensions:     plan.EmbeddingDimensions,
+			EmbeddingModel:          plan.EmbeddingModel,
+			SearchIndexGenerationID: plan.SearchIndexGenerationID,
+			IndexGeneration:         plan.IndexGeneration,
+		})
+	}
+	return semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+}
+
 func assertGraphHasNode(t *testing.T, nodes []SemanticGraphNode, nodeType, id, title string) {
 	t.Helper()
 	for _, node := range nodes {

--- a/internal/repository/semantic_repository_integration_helpers_test.go
+++ b/internal/repository/semantic_repository_integration_helpers_test.go
@@ -14,6 +14,10 @@ func correctRelationshipWithTestEmbeddings(ctx context.Context, semantic *Semant
 	if err != nil {
 		return nil, err
 	}
+	return semantic.CorrectRelationshipWithEmbeddings(ctx, input, relationshipCorrectionTestEmbeddings(plan))
+}
+
+func relationshipCorrectionTestEmbeddings(plan *RelationshipCorrectionEmbeddingPlan) []RelationshipCorrectionEmbedding {
 	embeddings := make([]RelationshipCorrectionEmbedding, 0, len(plan.Documents))
 	for _, document := range plan.Documents {
 		embeddings = append(embeddings, RelationshipCorrectionEmbedding{
@@ -26,7 +30,7 @@ func correctRelationshipWithTestEmbeddings(ctx context.Context, semantic *Semant
 			IndexGeneration:         plan.IndexGeneration,
 		})
 	}
-	return semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+	return embeddings
 }
 
 func assertGraphHasNode(t *testing.T, nodes []SemanticGraphNode, nodeType, id, title string) {

--- a/internal/repository/semantic_types.go
+++ b/internal/repository/semantic_types.go
@@ -13,6 +13,8 @@ type SemanticRepository interface {
 	RetractRelationship(ctx context.Context, input RetractRelationshipInput) (*RelationshipTransitionResult, error)
 	ApplyRelationshipSupportDecision(ctx context.Context, input ApplyRelationshipSupportDecisionInput) (*RelationshipSupportDecisionResult, error)
 	CorrectRelationship(ctx context.Context, input CorrectRelationshipInput) (*CorrectRelationshipResult, error)
+	PlanRelationshipCorrectionEmbeddings(ctx context.Context, input CorrectRelationshipInput) (*RelationshipCorrectionEmbeddingPlan, error)
+	CorrectRelationshipWithEmbeddings(ctx context.Context, input CorrectRelationshipInput, embeddings []RelationshipCorrectionEmbedding) (*CorrectRelationshipResult, error)
 	GetRelationshipCorrection(ctx context.Context, input GetRelationshipCorrectionInput) (*RelationshipCorrectionStatus, error)
 	AppendCrossReference(ctx context.Context, input AppendCrossReferenceInput) (string, error)
 	CreateHypothesis(ctx context.Context, input CreateHypothesisInput) (string, error)
@@ -379,6 +381,34 @@ type CorrectRelationshipResult struct {
 	Correction      *RelationshipCorrectionResult
 	ErrorCode       string
 	ErrorMessage    string
+}
+
+// RelationshipCorrectionEmbeddingPlan is the read-only provider input for a
+// correction. The commit phase identifies final rows by document hash.
+type RelationshipCorrectionEmbeddingPlan struct {
+	Documents               []RelationshipCorrectionEmbeddingDocument
+	EmbeddingContractID     string
+	EmbeddingDimensions     int
+	EmbeddingModel          string
+	SearchIndexGenerationID string
+	IndexGeneration         int
+}
+
+type RelationshipCorrectionEmbeddingDocument struct {
+	DocumentHash string
+	DocumentText string
+}
+
+// RelationshipCorrectionEmbedding is a validated provider result associated
+// with the stable document hash from a correction plan.
+type RelationshipCorrectionEmbedding struct {
+	DocumentHash            string
+	Embedding               []float32
+	EmbeddingContractID     string
+	EmbeddingDimensions     int
+	EmbeddingModel          string
+	SearchIndexGenerationID string
+	IndexGeneration         int
 }
 
 type GetRelationshipCorrectionInput struct {

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -9,19 +9,24 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/markhuangai/dense-mem/internal/correlation"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
+	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 )
 
 var (
-	ErrLifecycleAuthContext = errors.New("memory lifecycle: authenticated actor context is required")
-	ErrLifecyclePersistence = errors.New("memory lifecycle: persistence failed")
+	ErrLifecycleAuthContext          = errors.New("memory lifecycle: authenticated actor context is required")
+	ErrLifecyclePersistence          = errors.New("memory lifecycle: persistence failed")
+	ErrLifecycleEmbeddingUnavailable = errors.New("memory lifecycle: embedding provider unavailable")
+	ErrLifecycleEmbeddingInvalid     = errors.New("memory lifecycle: embedding response invalid")
 )
 
 type LifecycleService interface {
@@ -31,13 +36,20 @@ type LifecycleService interface {
 }
 
 type LifecycleDependencies struct {
-	Semantic LifecycleSemanticRepository
-	Evidence LifecycleEvidenceRepository
+	Semantic                   LifecycleSemanticRepository
+	Evidence                   LifecycleEvidenceRepository
+	CorrectionExecutor         LifecycleCorrectionExecutor
+	CorrectionEmbeddingTimeout time.Duration
 }
 
 type LifecycleSemanticRepository interface {
-	CorrectRelationship(ctx context.Context, input repository.CorrectRelationshipInput) (*repository.CorrectRelationshipResult, error)
+	PlanRelationshipCorrectionEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput) (*repository.RelationshipCorrectionEmbeddingPlan, error)
+	CorrectRelationshipWithEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput, embeddings []repository.RelationshipCorrectionEmbedding) (*repository.CorrectRelationshipResult, error)
 	GetRelationshipCorrection(ctx context.Context, input repository.GetRelationshipCorrectionInput) (*repository.RelationshipCorrectionStatus, error)
+}
+
+type LifecycleCorrectionExecutor interface {
+	Execute(context.Context, semanticwrite.Plan) (semanticwrite.Result, error)
 }
 
 type LifecycleEvidenceRepository interface {
@@ -45,12 +57,18 @@ type LifecycleEvidenceRepository interface {
 }
 
 type lifecycleService struct {
-	semantic LifecycleSemanticRepository
-	evidence LifecycleEvidenceRepository
+	semantic         LifecycleSemanticRepository
+	evidence         LifecycleEvidenceRepository
+	executor         LifecycleCorrectionExecutor
+	embeddingTimeout time.Duration
 }
 
 func NewLifecycleService(deps LifecycleDependencies) LifecycleService {
-	return &lifecycleService{semantic: deps.Semantic, evidence: deps.Evidence}
+	timeout := deps.CorrectionEmbeddingTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &lifecycleService{semantic: deps.Semantic, evidence: deps.Evidence, executor: deps.CorrectionExecutor, embeddingTimeout: timeout}
 }
 
 type CorrectRelationshipRequest struct {
@@ -105,7 +123,7 @@ func (s *lifecycleService) CorrectRelationship(
 	if req.Action != "submit" && req.Action != "confirm" {
 		return nil, errors.New("memory lifecycle: action must be submit or confirm")
 	}
-	result, err := s.semantic.CorrectRelationship(ctx, repository.CorrectRelationshipInput{
+	input := repository.CorrectRelationshipInput{
 		TeamID:            actor.TeamID.String(),
 		OwnerProfileID:    actor.OwnerID.String(),
 		Action:            req.Action,
@@ -118,7 +136,37 @@ func (s *lifecycleService) CorrectRelationship(
 		ConfirmationToken: req.ConfirmationToken,
 		Selection:         req.Selection,
 		IdempotencyKey:    req.IdempotencyKey,
-	})
+	}
+	plan, err := s.semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	if err == nil && plan == nil {
+		err = ErrLifecyclePersistence
+	}
+	var embeddings []repository.RelationshipCorrectionEmbedding
+	if err == nil && len(plan.Documents) > 0 {
+		if s.executor == nil {
+			err = ErrLifecycleEmbeddingUnavailable
+		} else {
+			executionCtx := observability.WithMetricIdentity(ctx, input.TeamID, input.OwnerProfileID)
+			result, executeErr := s.executor.Execute(executionCtx, semanticwrite.Plan{
+				Documents: correctionPlanDocuments(plan.Documents),
+				Fence:     semanticwrite.Fence{Model: plan.EmbeddingModel, Dimensions: plan.EmbeddingDimensions, EmbeddingContractID: plan.EmbeddingContractID, SearchGenerationID: plan.SearchIndexGenerationID, SearchGenerationVersion: int64(plan.IndexGeneration)},
+				Timeout:   s.embeddingTimeout,
+			})
+			if executeErr != nil {
+				err = translateCorrectionEmbeddingError(executeErr)
+			} else {
+				embeddings = correctionEmbeddingsFromResult(result)
+			}
+		}
+	}
+	var result *repository.CorrectRelationshipResult
+	if err == nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		} else {
+			result, err = s.semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+		}
+	}
 	if err != nil {
 		return nil, translateRelationshipCorrectionError(err)
 	}
@@ -131,6 +179,33 @@ func (s *lifecycleService) CorrectRelationship(
 		StatusTool:        rememberStatusTool,
 		CorrelationID:     correlation.FromContext(ctx),
 	}, nil
+}
+
+func correctionPlanDocuments(documents []repository.RelationshipCorrectionEmbeddingDocument) []semanticwrite.Document {
+	result := make([]semanticwrite.Document, 0, len(documents))
+	for _, document := range documents {
+		result = append(result, semanticwrite.Document{Hash: document.DocumentHash, Text: document.DocumentText})
+	}
+	return result
+}
+
+func correctionEmbeddingsFromResult(result semanticwrite.Result) []repository.RelationshipCorrectionEmbedding {
+	embeddings := make([]repository.RelationshipCorrectionEmbedding, 0, len(result.Embeddings))
+	for _, embedding := range result.Embeddings {
+		embeddings = append(embeddings, repository.RelationshipCorrectionEmbedding{DocumentHash: embedding.DocumentHash, Embedding: append([]float32(nil), embedding.Vector...), EmbeddingContractID: result.Fence.EmbeddingContractID, EmbeddingDimensions: result.Fence.Dimensions, EmbeddingModel: result.Fence.Model, SearchIndexGenerationID: result.Fence.SearchGenerationID, IndexGeneration: int(result.Fence.SearchGenerationVersion)})
+	}
+	return embeddings
+}
+
+func translateCorrectionEmbeddingError(err error) error {
+	switch {
+	case errors.Is(err, semanticwrite.ErrProviderUnavailable):
+		return ErrLifecycleEmbeddingUnavailable
+	case errors.Is(err, semanticwrite.ErrProviderResponseInvalid), errors.Is(err, semanticwrite.ErrInvalidPlan):
+		return ErrLifecycleEmbeddingInvalid
+	default:
+		return err
+	}
 }
 
 func (s *lifecycleService) GetRelationshipCorrectionStatus(
@@ -158,6 +233,9 @@ func (s *lifecycleService) GetRelationshipCorrectionStatus(
 }
 
 func translateRelationshipCorrectionError(err error) error {
+	if errors.Is(err, ErrLifecycleEmbeddingUnavailable) || errors.Is(err, ErrLifecycleEmbeddingInvalid) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 	if errors.Is(err, repository.ErrSemanticOwnerMismatch) || errors.Is(err, repository.ErrRelationshipCorrectionNotFound) {
 		return httperr.New(httperr.NOT_FOUND, "submission not found")
 	}

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -233,7 +233,13 @@ func (s *lifecycleService) GetRelationshipCorrectionStatus(
 }
 
 func translateRelationshipCorrectionError(err error) error {
-	if errors.Is(err, ErrLifecycleEmbeddingUnavailable) || errors.Is(err, ErrLifecycleEmbeddingInvalid) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, ErrLifecycleEmbeddingUnavailable) {
+		return httperr.New(httperr.ErrEmbeddingUnavailable, "embedding provider unavailable")
+	}
+	if errors.Is(err, ErrLifecycleEmbeddingInvalid) {
+		return httperr.New(httperr.ErrEmbeddingResponseInvalid, "embedding provider response invalid")
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 	if errors.Is(err, repository.ErrSemanticOwnerMismatch) || errors.Is(err, repository.ErrRelationshipCorrectionNotFound) {

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -27,6 +27,7 @@ var (
 	ErrLifecyclePersistence          = errors.New("memory lifecycle: persistence failed")
 	ErrLifecycleEmbeddingUnavailable = errors.New("memory lifecycle: embedding provider unavailable")
 	ErrLifecycleEmbeddingInvalid     = errors.New("memory lifecycle: embedding response invalid")
+	ErrLifecycleEmbeddingTimeout     = errors.New("memory lifecycle: embedding provider timed out")
 )
 
 type LifecycleService interface {
@@ -147,16 +148,18 @@ func (s *lifecycleService) CorrectRelationship(
 			err = ErrLifecycleEmbeddingUnavailable
 		} else {
 			executionCtx := observability.WithMetricIdentity(ctx, input.TeamID, input.OwnerProfileID)
-			result, executeErr := s.executor.Execute(executionCtx, semanticwrite.Plan{
+			embeddingCtx, cancel := context.WithTimeout(executionCtx, s.embeddingTimeout)
+			result, executeErr := s.executor.Execute(embeddingCtx, semanticwrite.Plan{
 				Documents: correctionPlanDocuments(plan.Documents),
 				Fence:     semanticwrite.Fence{Model: plan.EmbeddingModel, Dimensions: plan.EmbeddingDimensions, EmbeddingContractID: plan.EmbeddingContractID, SearchGenerationID: plan.SearchIndexGenerationID, SearchGenerationVersion: int64(plan.IndexGeneration)},
 				Timeout:   s.embeddingTimeout,
 			})
 			if executeErr != nil {
-				err = translateCorrectionEmbeddingError(executeErr)
+				err = translateCorrectionEmbeddingErrorWithContext(ctx, embeddingCtx, executeErr)
 			} else {
 				embeddings = correctionEmbeddingsFromResult(result)
 			}
+			cancel()
 		}
 	}
 	var result *repository.CorrectRelationshipResult
@@ -203,9 +206,33 @@ func translateCorrectionEmbeddingError(err error) error {
 		return ErrLifecycleEmbeddingUnavailable
 	case errors.Is(err, semanticwrite.ErrProviderResponseInvalid), errors.Is(err, semanticwrite.ErrInvalidPlan):
 		return ErrLifecycleEmbeddingInvalid
+	case errors.Is(err, semanticwrite.ErrProviderTimeout):
+		return ErrLifecycleEmbeddingTimeout
 	default:
 		return err
 	}
+}
+
+func translateCorrectionEmbeddingErrorWithContext(callerCtx, embeddingCtx context.Context, err error) error {
+	if errors.Is(err, context.DeadlineExceeded) && correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx) {
+		return ErrLifecycleEmbeddingTimeout
+	}
+	return translateCorrectionEmbeddingError(err)
+}
+
+func correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx context.Context) bool {
+	if !errors.Is(embeddingCtx.Err(), context.DeadlineExceeded) {
+		return false
+	}
+	callerDeadline, callerHasDeadline := callerCtx.Deadline()
+	embeddingDeadline, embeddingHasDeadline := embeddingCtx.Deadline()
+	if !embeddingHasDeadline {
+		return false
+	}
+	if !callerHasDeadline {
+		return true
+	}
+	return embeddingDeadline.Before(callerDeadline)
 }
 
 func (s *lifecycleService) GetRelationshipCorrectionStatus(
@@ -238,6 +265,9 @@ func translateRelationshipCorrectionError(err error) error {
 	}
 	if errors.Is(err, ErrLifecycleEmbeddingInvalid) {
 		return httperr.New(httperr.ErrEmbeddingResponseInvalid, "embedding provider response invalid")
+	}
+	if errors.Is(err, ErrLifecycleEmbeddingTimeout) {
+		return httperr.New(httperr.ErrEmbeddingTimeout, "embedding provider timed out")
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -242,7 +242,9 @@ func translateRelationshipCorrectionError(err error) error {
 	if errors.Is(err, repository.ErrSemanticIdempotencyConflict) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) ||
-		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) {
+		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) ||
+		errors.Is(err, repository.ErrSearchContractMismatch) ||
+		errors.Is(err, repository.ErrSearchStaleVersion) {
 		return httperr.New(httperr.CONFLICT, "relationship correction conflict")
 	}
 	return ErrLifecyclePersistence

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -279,6 +279,7 @@ func translateRelationshipCorrectionError(err error) error {
 		errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) ||
+		errors.Is(err, repository.ErrSearchEmbeddingRequired) ||
 		errors.Is(err, repository.ErrSearchContractMismatch) ||
 		errors.Is(err, repository.ErrSearchStaleVersion) {
 		return httperr.New(httperr.CONFLICT, "relationship correction conflict")

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -68,7 +68,9 @@ func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingFails(t *testing.
 	}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
 	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwrite.ErrProviderUnavailable}})
 	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "failed-planned-correction"})
-	require.ErrorIs(t, err, ErrLifecycleEmbeddingUnavailable)
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.ErrEmbeddingUnavailable, publicErr.Code)
 	require.Zero(t, semantic.commitCalls)
 }
 
@@ -117,6 +119,21 @@ func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testi
 		var publicErr *httperr.APIError
 		require.ErrorAs(t, err, &publicErr)
 		require.Equal(t, httperr.CONFLICT, publicErr.Code)
+	}
+}
+
+func TestTranslateRelationshipCorrectionErrorMapsEmbeddingFailures(t *testing.T) {
+	for _, test := range []struct {
+		err  error
+		code httperr.ErrorCode
+	}{
+		{ErrLifecycleEmbeddingUnavailable, httperr.ErrEmbeddingUnavailable},
+		{ErrLifecycleEmbeddingInvalid, httperr.ErrEmbeddingResponseInvalid},
+	} {
+		err := translateRelationshipCorrectionError(test.err)
+		var publicErr *httperr.APIError
+		require.ErrorAs(t, err, &publicErr)
+		require.Equal(t, test.code, publicErr.Code)
 	}
 }
 

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -111,6 +111,15 @@ func TestLifecycleRelationshipCorrectionErrorsAreBounded(t *testing.T) {
 	require.NotContains(t, err.Error(), unsafeAction)
 }
 
+func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testing.T) {
+	for _, cause := range []error{repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
+		err := translateRelationshipCorrectionError(cause)
+		var publicErr *httperr.APIError
+		require.ErrorAs(t, err, &publicErr)
+		require.Equal(t, httperr.CONFLICT, publicErr.Code)
+	}
+}
+
 func TestLifecycleCorrectRelationshipRequiresAuthAndRepository(t *testing.T) {
 	ctx := authenticatedRememberContext(uuid.New(), uuid.New(), uuid.New())
 	req := CorrectRelationshipRequest{

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 )
 
 func TestLifecycleCorrectRelationshipUsesAuthenticatedOwner(t *testing.T) {
@@ -40,6 +41,35 @@ func TestLifecycleCorrectRelationshipUsesAuthenticatedOwner(t *testing.T) {
 	require.Equal(t, profileID.String(), semantic.correctInput.OwnerProfileID)
 	require.Equal(t, relationshipID, semantic.correctInput.RelationshipID)
 	require.Equal(t, 3, semantic.correctInput.ExpectedVersion)
+}
+
+func TestLifecycleCorrectRelationshipExecutesOnePlannedBatchBeforeCommit(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	semantic := &lifecycleSemanticStub{
+		plan: &repository.RelationshipCorrectionEmbeddingPlan{
+			Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+			EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+		},
+		correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"},
+	}
+	executor := &lifecycleExecutorStub{result: semanticwrite.Result{Fence: semanticwrite.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwrite.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
+	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "planned-correction"})
+	require.NoError(t, err)
+	require.Equal(t, 1, executor.calls)
+	require.Len(t, semantic.embeddings, 1)
+}
+
+func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingFails(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+	}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
+	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwrite.ErrProviderUnavailable}})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "failed-planned-correction"})
+	require.ErrorIs(t, err, ErrLifecycleEmbeddingUnavailable)
+	require.Zero(t, semantic.commitCalls)
 }
 
 func TestLifecycleRelationshipCorrectionStatusPreservesConfirmationWorkflow(t *testing.T) {
@@ -167,6 +197,9 @@ type lifecycleSemanticStub struct {
 	correctResult *repository.CorrectRelationshipResult
 	statusResult  *repository.RelationshipCorrectionStatus
 	err           error
+	plan          *repository.RelationshipCorrectionEmbeddingPlan
+	embeddings    []repository.RelationshipCorrectionEmbedding
+	commitCalls   int
 }
 
 func (s *lifecycleSemanticStub) CorrectRelationship(_ context.Context, input repository.CorrectRelationshipInput) (*repository.CorrectRelationshipResult, error) {
@@ -178,6 +211,23 @@ func (s *lifecycleSemanticStub) CorrectRelationship(_ context.Context, input rep
 		return nil, errors.New("missing correct result")
 	}
 	return s.correctResult, nil
+}
+
+func (s *lifecycleSemanticStub) PlanRelationshipCorrectionEmbeddings(_ context.Context, input repository.CorrectRelationshipInput) (*repository.RelationshipCorrectionEmbeddingPlan, error) {
+	s.correctInput = input
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.plan != nil {
+		return s.plan, nil
+	}
+	return &repository.RelationshipCorrectionEmbeddingPlan{}, nil
+}
+
+func (s *lifecycleSemanticStub) CorrectRelationshipWithEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput, embeddings []repository.RelationshipCorrectionEmbedding) (*repository.CorrectRelationshipResult, error) {
+	s.commitCalls++
+	s.embeddings = append([]repository.RelationshipCorrectionEmbedding(nil), embeddings...)
+	return s.CorrectRelationship(ctx, input)
 }
 
 func (s *lifecycleSemanticStub) GetRelationshipCorrection(_ context.Context, input repository.GetRelationshipCorrectionInput) (*repository.RelationshipCorrectionStatus, error) {
@@ -195,6 +245,17 @@ type lifecycleEvidenceStub struct {
 	input  repository.RetractEvidenceInput
 	result *repository.EvidenceLifecycleResult
 	err    error
+}
+
+type lifecycleExecutorStub struct {
+	result semanticwrite.Result
+	err    error
+	calls  int
+}
+
+func (s *lifecycleExecutorStub) Execute(_ context.Context, _ semanticwrite.Plan) (semanticwrite.Result, error) {
+	s.calls++
+	return s.result, s.err
 }
 
 func (s *lifecycleEvidenceStub) RetractEvidence(_ context.Context, input repository.RetractEvidenceInput) (*repository.EvidenceLifecycleResult, error) {

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -165,7 +165,7 @@ func TestLifecycleRelationshipCorrectionErrorsAreBounded(t *testing.T) {
 }
 
 func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testing.T) {
-	for _, cause := range []error{repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
+	for _, cause := range []error{repository.ErrSearchEmbeddingRequired, repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
 		err := translateRelationshipCorrectionError(cause)
 		var publicErr *httperr.APIError
 		require.ErrorAs(t, err, &publicErr)

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -74,6 +74,57 @@ func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingFails(t *testing.
 	require.Zero(t, semantic.commitCalls)
 }
 
+func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingTimesOut(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+	}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
+	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwrite.ErrProviderTimeout}})
+
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "timed-out-planned-correction"})
+
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.ErrEmbeddingTimeout, publicErr.Code)
+	require.Zero(t, semantic.commitCalls)
+}
+
+func TestLifecycleCorrectRelationshipClassifiesConfiguredEmbeddingDeadline(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+	}}
+	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{waitForContext: true}, CorrectionEmbeddingTimeout: 10 * time.Millisecond})
+
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "configured-timeout-correction"})
+
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.ErrEmbeddingTimeout, publicErr.Code)
+	require.Zero(t, semantic.commitCalls)
+}
+
+func TestLifecycleCorrectRelationshipPreservesCallerDeadline(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+	}}
+	executor := &lifecycleExecutorStub{waitForContext: true}
+	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor, CorrectionEmbeddingTimeout: time.Second})
+	callerCtx, cancel := context.WithTimeout(authenticatedRememberContext(teamID, profileID, uuid.New()), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := svc.CorrectRelationship(callerCtx, CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "caller-deadline-correction"})
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	var publicErr *httperr.APIError
+	require.NotErrorAs(t, err, &publicErr)
+	require.Zero(t, semantic.commitCalls)
+}
+
 func TestLifecycleRelationshipCorrectionStatusPreservesConfirmationWorkflow(t *testing.T) {
 	teamID := uuid.New()
 	profileID := uuid.New()
@@ -129,6 +180,7 @@ func TestTranslateRelationshipCorrectionErrorMapsEmbeddingFailures(t *testing.T)
 	}{
 		{ErrLifecycleEmbeddingUnavailable, httperr.ErrEmbeddingUnavailable},
 		{ErrLifecycleEmbeddingInvalid, httperr.ErrEmbeddingResponseInvalid},
+		{ErrLifecycleEmbeddingTimeout, httperr.ErrEmbeddingTimeout},
 	} {
 		err := translateRelationshipCorrectionError(test.err)
 		var publicErr *httperr.APIError
@@ -274,13 +326,18 @@ type lifecycleEvidenceStub struct {
 }
 
 type lifecycleExecutorStub struct {
-	result semanticwrite.Result
-	err    error
-	calls  int
+	result         semanticwrite.Result
+	err            error
+	calls          int
+	waitForContext bool
 }
 
-func (s *lifecycleExecutorStub) Execute(_ context.Context, _ semanticwrite.Plan) (semanticwrite.Result, error) {
+func (s *lifecycleExecutorStub) Execute(ctx context.Context, _ semanticwrite.Plan) (semanticwrite.Result, error) {
 	s.calls++
+	if s.waitForContext {
+		<-ctx.Done()
+		return semanticwrite.Result{}, ctx.Err()
+	}
 	return s.result, s.err
 }
 

--- a/internal/service/semanticwrite/executor.go
+++ b/internal/service/semanticwrite/executor.go
@@ -15,6 +15,7 @@ var (
 	ErrInvalidPlan             = errors.New("semantic write: invalid embedding plan")
 	ErrProviderUnavailable     = errors.New("semantic write: embedding provider unavailable")
 	ErrProviderResponseInvalid = errors.New("semantic write: embedding provider response invalid")
+	ErrProviderTimeout         = errors.New("semantic write: embedding provider timed out")
 )
 
 // Document is one rendered search document. Hash is the canonical document
@@ -109,17 +110,23 @@ func (e *Executor) Execute(ctx context.Context, plan Plan) (Result, error) {
 	providerCtx, cancel := context.WithTimeout(ctx, plan.Timeout)
 	defer cancel()
 	if err := providerCtx.Err(); err != nil {
-		return Result{}, err
+		return Result{}, providerContextError(ctx, providerCtx, err)
 	}
 	vectors, model, err := e.provider.EmbedBatch(providerCtx, texts)
 	if err != nil {
 		if providerCtx.Err() != nil {
-			return Result{}, providerCtx.Err()
+			return Result{}, providerContextError(ctx, providerCtx, providerCtx.Err())
+		}
+		if errors.Is(err, ErrProviderResponseInvalid) {
+			return Result{}, ErrProviderResponseInvalid
+		}
+		if errors.Is(err, ErrProviderTimeout) {
+			return Result{}, ErrProviderTimeout
 		}
 		return Result{}, fmt.Errorf("%w: provider call failed", ErrProviderUnavailable)
 	}
 	if err := providerCtx.Err(); err != nil {
-		return Result{}, err
+		return Result{}, providerContextError(ctx, providerCtx, err)
 	}
 	if model != plan.Fence.Model {
 		return Result{}, ErrProviderResponseInvalid
@@ -147,6 +154,28 @@ func (e *Executor) Execute(ctx context.Context, plan Plan) (Result, error) {
 		}
 	}
 	return result, nil
+}
+
+func providerContextError(parent, child context.Context, childErr error) error {
+	if parentErr := parent.Err(); parentErr != nil {
+		if errors.Is(parentErr, context.Canceled) {
+			return parentErr
+		}
+		if errors.Is(parentErr, context.DeadlineExceeded) {
+			parentDeadline, parentHasDeadline := parent.Deadline()
+			childDeadline, childHasDeadline := child.Deadline()
+			if !parentHasDeadline || !childHasDeadline || !childDeadline.Before(parentDeadline) {
+				return parentErr
+			}
+		}
+	}
+	if errors.Is(childErr, context.Canceled) {
+		return childErr
+	}
+	if errors.Is(childErr, context.DeadlineExceeded) {
+		return ErrProviderTimeout
+	}
+	return childErr
 }
 
 func validatePlan(plan Plan) error {

--- a/internal/service/semanticwrite/executor_test.go
+++ b/internal/service/semanticwrite/executor_test.go
@@ -166,6 +166,16 @@ func TestExecutorRejectsProviderAvailabilityAndContractMismatches(t *testing.T) 
 	}
 }
 
+func TestExecutorPreservesTypedProviderResponseErrors(t *testing.T) {
+	provider := validProvider()
+	provider.err = ErrProviderResponseInvalid
+
+	_, err := NewExecutor(provider).Execute(context.Background(), validPlan())
+
+	require.ErrorIs(t, err, ErrProviderResponseInvalid)
+	require.NotErrorIs(t, err, ErrProviderUnavailable)
+}
+
 func TestExecutorRejectsNilExecutorAndProvider(t *testing.T) {
 	var nilExecutor *Executor
 	_, err := nilExecutor.Execute(context.Background(), validPlan())
@@ -187,6 +197,50 @@ func TestExecutorBoundsProviderFailureAndHonorsContextDeadline(t *testing.T) {
 	provider.err = nil
 	_, err = NewExecutor(provider).Execute(ctx, validPlan())
 	require.Error(t, err)
+}
+
+type blockingProvider struct {
+	providerStub
+}
+
+func (p *blockingProvider) EmbedBatch(ctx context.Context, _ []string) ([]IndexedEmbedding, string, error) {
+	<-ctx.Done()
+	return nil, "", ctx.Err()
+}
+
+func TestExecutorClassifiesItsOwnTimeout(t *testing.T) {
+	provider := &blockingProvider{providerStub: *validProvider()}
+	plan := validPlan()
+	plan.Timeout = 10 * time.Millisecond
+
+	_, err := NewExecutor(provider).Execute(context.Background(), plan)
+
+	require.ErrorIs(t, err, ErrProviderTimeout)
+	require.NotErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestExecutorPreservesCallerDeadline(t *testing.T) {
+	provider := &blockingProvider{providerStub: *validProvider()}
+	callerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	plan := validPlan()
+	plan.Timeout = time.Second
+
+	_, err := NewExecutor(provider).Execute(callerCtx, plan)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, ErrProviderTimeout)
+}
+
+func TestExecutorPreservesCallerCancellation(t *testing.T) {
+	provider := &blockingProvider{providerStub: *validProvider()}
+	callerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewExecutor(provider).Execute(callerCtx, validPlan())
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, ErrProviderTimeout)
 }
 
 func TestExecutorAllowsEmptyNotRequiredPlanWithoutProviderCall(t *testing.T) {

--- a/scripts/e2e-compose-synchronous-write.sh
+++ b/scripts/e2e-compose-synchronous-write.sh
@@ -15,14 +15,19 @@ prepare_synchronous_write_files() {
       ;;
   esac
 
+  local provider_dimensions
+  provider_dimensions="$(compose_server_environment_value AI_API_EMBEDDING_DIMENSIONS)"
+  if [[ -z "$provider_dimensions" || ! "$provider_dimensions" =~ ^[1-9][0-9]*$ ]]; then
+    echo "AI_API_EMBEDDING_DIMENSIONS must be a positive integer for the synchronous-write provider fixture." >&2
+    return 1
+  fi
+
   SYNCHRONOUS_WRITE_COMPOSE_OVERLAY_FILE="${ROOT_DIR}/docker-compose.synchronous-write-e2e-${E2E_FILE_ID}.yml"
-  node - "$SYNCHRONOUS_WRITE_COMPOSE_OVERLAY_FILE" "$ROOT_DIR" "$slice" "$E2E_MARKER" <<'NODE'
+  node - "$SYNCHRONOUS_WRITE_COMPOSE_OVERLAY_FILE" "$slice" "$provider_dimensions" "$E2E_MARKER" <<'NODE'
 const fs = require("node:fs");
 
-const [destination, rootDir, slice, marker] = process.argv.slice(2);
+const [destination, slice, providerDimensions, marker] = process.argv.slice(2);
 const quote = (value) => JSON.stringify(value);
-const fixture = `${rootDir}/tests/uat/synchronous_write/provider-fixture.mjs`;
-const fixtureMount = `${fixture}:/e2e/provider-fixture.mjs:ro`;
 const contents = `${marker}
 services:
   server:
@@ -41,13 +46,32 @@ services:
     command: ["node", "/e2e/provider-fixture.mjs"]
     environment:
       DENSE_MEM_E2E_PROVIDER_FAULT: "\${DENSE_MEM_E2E_PROVIDER_FAULT:-none}"
-      DENSE_MEM_E2E_PROVIDER_DIMENSIONS: "\${AI_API_EMBEDDING_DIMENSIONS:-1536}"
+      DENSE_MEM_E2E_WRITE_SLICE: ${quote(slice)}
+      DENSE_MEM_E2E_PROVIDER_DIMENSIONS: ${quote(providerDimensions)}
       DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS: "5000"
     volumes:
-      - ${quote(fixtureMount)}
+      - e2e-synchronous-write-provider-files:/e2e
+volumes:
+  e2e-synchronous-write-provider-files:
 `;
 fs.writeFileSync(destination, contents);
 NODE
+}
+
+prepare_synchronous_write_provider_fixture_volume() {
+  if [[ "$E2E_SCENARIO" != "synchronous_write" ]]; then
+    return
+  fi
+
+  local container_id
+  container_id="$(compose create synchronous-write-provider >/dev/null && compose ps -aq synchronous-write-provider)"
+  if [[ -z "$container_id" ]]; then
+    echo "Failed to create the synchronous-write provider fixture volume." >&2
+    return 1
+  fi
+  docker cp \
+    "$ROOT_DIR/tests/uat/synchronous_write/provider-fixture.mjs" \
+    "${container_id}:/e2e/provider-fixture.mjs"
 }
 
 run_synchronous_write_e2e() {

--- a/scripts/e2e-compose-synchronous-write.sh
+++ b/scripts/e2e-compose-synchronous-write.sh
@@ -60,6 +60,8 @@ run_synchronous_write_e2e() {
   DENSE_MEM_CONTROL_TOKEN="$CONTROL_TOKEN" \
   DENSE_MEM_E2E_TEAM_ID="$team_id" \
   DENSE_MEM_E2E_API_KEY="$api_key" \
+	DENSE_MEM_E2E_COMPOSE_PROJECT="$COMPOSE_PROJECT_NAME" \
+	DENSE_MEM_E2E_COMPOSE_FILE="$COMPOSE_FILE" \
   DENSE_MEM_E2E_WRITE_CASE="$slice" \
   node "$ROOT_DIR/tests/uat/synchronous_write/runner.mjs"
 }

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -839,6 +839,7 @@ fi
 prepare_e2e_prometheus_volume
 prepare_oauth_fixture_volume; prepare_conflict_provider_volume
 prepare_embedding_proxy_volume
+prepare_synchronous_write_provider_fixture_volume
 
 echo "Starting e2e compose stack on ${USER_URL}, ${CONTROL_URL}, and ${PROMETHEUS_URL}."
 compose up -d postgres

--- a/tests/uat/synchronous_write/cases/correction.mjs
+++ b/tests/uat/synchronous_write/cases/correction.mjs
@@ -1,6 +1,7 @@
 export const name = "correction";
 
 const providerFaultMarker = "e2e-correction-provider-fault";
+const providerTimeoutMarker = "e2e-correction-provider-timeout";
 const sourcePlacementTimeoutSeconds = Number(process.env.DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS || 240);
 
 export async function run({ rpc, rawRPC, expect }) {
@@ -31,7 +32,15 @@ export async function run({ rpc, rawRPC, expect }) {
 
   const preserved = await toolSuccess(rpc, "trace_memory", { relationship_id: failedSource.relationshipID });
   expect(preserved.relationship?.relationship_status === "active", "provider failure must preserve the original active relationship");
-  return { mode: name, processing_state: successfulStatus.processing_state, provider_failure_preserved: true };
+
+  const timeoutSource = await createSource(rpc, expect, `${runID}-timeout`);
+  const timedOut = await toolRaw(rawRPC, "correct_relationship", correctionInput(timeoutSource, `${providerTimeoutMarker}-${runID}`));
+  expect(timedOut.error && timedOut.result === undefined, "provider timeout must return a bounded MCP error");
+  expect(String(timedOut.error.message || "").includes("embedding_timeout"), "provider timeout must retain its bounded embedding classification");
+  const timeoutPreserved = await toolSuccess(rpc, "trace_memory", { relationship_id: timeoutSource.relationshipID });
+  expect(timeoutPreserved.relationship?.relationship_status === "active", "provider timeout must preserve the original active relationship");
+
+  return { mode: name, processing_state: successfulStatus.processing_state, provider_failure_preserved: true, provider_timeout_preserved: true };
 }
 
 async function createSource(rpc, expect, label) {

--- a/tests/uat/synchronous_write/cases/correction.mjs
+++ b/tests/uat/synchronous_write/cases/correction.mjs
@@ -1,2 +1,108 @@
 export const name = "correction";
-export async function run() { return { mode: name, status: "reserved-for-adoption" }; }
+
+const providerFaultMarker = "e2e-correction-provider-fault";
+const sourcePlacementTimeoutSeconds = Number(process.env.DENSE_MEM_E2E_PLACEMENT_TIMEOUT_SECONDS || 240);
+
+export async function run({ rpc, rawRPC, expect }) {
+  const listed = await rpc("tools/list", {});
+  const names = new Set((listed.tools || []).map((tool) => tool.name));
+  for (const tool of ["remember", "correct_relationship", "get_submission_status", "trace_memory"]) {
+    expect(names.has(tool), `correction surface must expose ${tool}`);
+  }
+
+  const runID = `synchronous-write-correction-${Date.now()}`;
+  const successfulSource = await createSource(rpc, expect, `${runID}-success`);
+  const successfulCorrection = await correct(rpc, successfulSource, `${runID}-correct`);
+  const successfulStatus = await toolSuccess(rpc, "get_submission_status", { submission_id: successfulCorrection.submission_id });
+  const successorID = String(successfulStatus.correction_result?.successor_relationship_id || "");
+  expect(successfulStatus.processing_state === "completed", "successful correction status must be completed");
+  expect(successfulStatus.search_state === "current", "successful correction search state must be current");
+  expect(successorID && successorID !== successfulSource.relationshipID, "successful correction must return a distinct successor");
+
+  const superseded = await toolSuccess(rpc, "trace_memory", { relationship_id: successfulSource.relationshipID });
+  const successor = await toolSuccess(rpc, "trace_memory", { relationship_id: successorID });
+  expect(superseded.relationship?.relationship_status === "superseded", "successful correction must supersede the original relationship");
+  expect(successor.relationship?.relationship_status === "active", "successful correction must activate the successor relationship");
+
+  const failedSource = await createSource(rpc, expect, `${runID}-failure`);
+  const failed = await toolRaw(rawRPC, "correct_relationship", correctionInput(failedSource, `${providerFaultMarker}-${runID}`));
+  expect(failed.error && failed.result === undefined, "provider failure must return a bounded MCP error");
+  expect(String(failed.error.message || "").includes("embedding_unavailable"), "provider failure must retain its bounded embedding classification");
+
+  const preserved = await toolSuccess(rpc, "trace_memory", { relationship_id: failedSource.relationshipID });
+  expect(preserved.relationship?.relationship_status === "active", "provider failure must preserve the original active relationship");
+  return { mode: name, processing_state: successfulStatus.processing_state, provider_failure_preserved: true };
+}
+
+async function createSource(rpc, expect, label) {
+  const subject = `${label} subject`;
+  const object = `${label} original project`;
+  const evidence = `${subject} uses ${object}.`;
+  const receipt = await toolSuccess(rpc, "remember", {
+    idempotency_key: `${label}-remember`,
+    evidence: [{ content: evidence, source_type: "manual", source: label, source_group: label }],
+    relationships: [{
+      ref: `${label}-relationship`,
+      subject: { name: subject, entity_kind: "project" },
+      predicate: { proposed_key: "uses" },
+      object: { entity: { name: object, entity_kind: "project" } },
+      polarity: "+",
+      evidence_indices: [0],
+    }],
+  });
+  const status = await waitForRemember(rpc, receipt.submission_id);
+  const split = status.relationship_results?.[0]?.splits?.[0];
+  expect(split?.relationship_id, "remember must create a relationship before correction");
+  const trace = await toolSuccess(rpc, "trace_memory", { relationship_id: split.relationship_id });
+  const support = trace.evidence_supports?.[0];
+  expect(trace.relationship?.relationship_status === "active", "remember source relationship must be active");
+  expect(Number.isInteger(trace.relationship?.version) && trace.relationship.version > 0, "remember source relationship must expose its version");
+  expect(support?.evidence_id && Number.isInteger(support.span_start) && Number.isInteger(support.span_end), "trace must expose correction support spans");
+  return {
+    relationshipID: split.relationship_id,
+    version: trace.relationship.version,
+    support: { evidence_id: support.evidence_id, start: support.span_start, end: support.span_end },
+  };
+}
+
+async function correct(rpc, source, target) {
+  return toolSuccess(rpc, "correct_relationship", correctionInput(source, target));
+}
+
+function correctionInput(source, target) {
+  return {
+    action: "submit",
+    relationship_id: source.relationshipID,
+    expected_version: source.version,
+    patch: { object_entity: { name: target, entity_kind: "project" } },
+    supports: [source.support],
+    reason: "The relationship object was resolved incorrectly.",
+    idempotency_key: `${target}-correction`,
+  };
+}
+
+async function waitForRemember(rpc, submissionID) {
+  let last = {};
+  const attempts = Math.ceil((sourcePlacementTimeoutSeconds * 1000) / 2000);
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const status = await toolSuccess(rpc, "get_submission_status", { submission_id: submissionID });
+    last = status;
+    if (status.processing_state === "completed") return status;
+    if (["rejected", "failed", "quarantined"].includes(status.processing_state) || status.search_state === "failed") {
+      throw new Error(`remember source reached ${status.processing_state}/${status.search_state}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error(`timed out waiting for source relationship completion (${last.processing_state || "unknown"}/${last.search_state || "unknown"})`);
+}
+
+async function toolSuccess(rpc, name, args) {
+  const result = await rpc("tools/call", { name, arguments: args });
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} did not return JSON content`);
+  return JSON.parse(text);
+}
+
+async function toolRaw(rawRPC, name, args) {
+  return rawRPC("tools/call", { name, arguments: args });
+}

--- a/tests/uat/synchronous_write/provider-fixture.mjs
+++ b/tests/uat/synchronous_write/provider-fixture.mjs
@@ -5,7 +5,9 @@ import { createServer } from "node:http";
 const port = Number(process.env.PORT || 8787);
 const dimensions = Number(process.env.DENSE_MEM_E2E_PROVIDER_DIMENSIONS || 1536);
 const fault = (process.env.DENSE_MEM_E2E_PROVIDER_FAULT || "none").trim();
+const writeSlice = (process.env.DENSE_MEM_E2E_WRITE_SLICE || "").trim();
 const timeoutDelayMs = Number(process.env.DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS || 30_000);
+const correctionProviderFaultMarker = "e2e-correction-provider-fault";
 
 function vectorFor(text, width) {
   const output = [];
@@ -23,6 +25,80 @@ function sendJSON(response, status, payload) {
   const body = JSON.stringify(payload);
   response.writeHead(status, { "content-type": "application/json", "content-length": Buffer.byteLength(body) });
   response.end(body);
+}
+
+function correctionAssessmentResponse(payload) {
+  const messages = Array.isArray(payload.messages) ? payload.messages : [];
+  let request;
+  for (const message of messages) {
+    if (message?.role !== "user" || typeof message.content !== "string") continue;
+    try {
+      const candidate = JSON.parse(message.content);
+      if (Array.isArray(candidate.submitted_entities) && Array.isArray(candidate.submitted_relationships)) {
+        request = candidate;
+        break;
+      }
+    } catch {
+      continue;
+    }
+  }
+  if (!request || request.submitted_entities.length === 0 || request.submitted_relationships.length === 0) return null;
+
+  const evidenceByID = new Map((request.evidence || []).map((item) => [item.evidence_id, item]));
+  const predicates = Array.isArray(request.predicate_options) ? request.predicate_options : [];
+  const entityResults = request.submitted_entities.map((entity) => {
+    const grounding = Array.isArray(entity.groundings) ? entity.groundings[0] : null;
+    if (!entity?.ref || !grounding?.grounding_ref) return null;
+    const knownID = entity.known_entity_id || null;
+    return {
+      ref: entity.ref,
+      grounding_ref: grounding.grounding_ref,
+      action: knownID ? "reuse" : "create",
+      candidate_entity_id: knownID,
+    };
+  });
+  if (entityResults.some((item) => item === null)) return null;
+
+  const relationshipResults = request.submitted_relationships.map((relationship) => {
+    const evidence = evidenceByID.get((relationship.evidence_ids || [])[0]);
+    const range = fullEvidenceRange(evidence);
+    const predicate = predicates.find((item) => item.predicate_key === (relationship.known_predicate_key || relationship.predicate_hint)) || predicates[0];
+    if (!relationship?.ref || !relationship?.subject_ref || !predicate || !range) return null;
+    return {
+      ref: relationship.ref,
+      disposition: "stored",
+      reason: null,
+      splits: [{
+        split_index: 0,
+        subject_ref: relationship.subject_ref,
+        predicate_range: range,
+        predicate_status: "resolved",
+        predicate_key: predicate.predicate_key,
+        predicate_version: predicate.version,
+        predicate_registration: null,
+        object_ref: relationship.object_ref || null,
+        object_value: relationship.object_value || null,
+        value_range: null,
+        polarity: relationship.polarity,
+        support_ranges: [range],
+        valid_from: relationship.valid_from || null,
+        valid_to: relationship.valid_to || null,
+      }],
+    };
+  });
+  if (relationshipResults.some((item) => item === null)) return null;
+  return {
+    request_id: request.request_id,
+    security_signals: [],
+    entity_results: entityResults,
+    relationship_results: relationshipResults,
+  };
+}
+
+function fullEvidenceRange(evidence) {
+  const refs = [...String(evidence?.boundary_text || "").matchAll(/⟦([^⟧]+)⟧/g)].map((match) => match[1]);
+  if (!evidence?.evidence_id || refs.length < 2) return null;
+  return { evidence_id: evidence.evidence_id, start_ref: refs[0], end_ref: refs.at(-1) };
 }
 
 const server = createServer(async (request, response) => {
@@ -50,6 +126,10 @@ const server = createServer(async (request, response) => {
 
   if (request.url?.endsWith("/embeddings")) {
     const inputs = Array.isArray(payload.input) ? payload.input : [payload.input || ""];
+    if (writeSlice === "correction" && inputs.some((input) => String(input).includes(correctionProviderFaultMarker))) {
+      response.destroy();
+      return;
+    }
     if (fault === "malformed") {
       sendJSON(response, 200, { model: "fixture-wrong-model", data: [{ index: 0, embedding: [0] }] });
       return;
@@ -67,10 +147,9 @@ const server = createServer(async (request, response) => {
       sendJSON(response, 200, { choices: [{ message: { content: "not-json" } }] });
       return;
     }
-    // The legacy scenario only needs a deterministic provider response. The
-    // active verifier will apply its own closed-schema validation.
+    const correctionResponse = writeSlice === "correction" ? correctionAssessmentResponse(payload) : null;
     sendJSON(response, 200, {
-      choices: [{ message: { content: JSON.stringify({ request_id: "fixture", entity_results: [], relationship_results: [], security_signals: [] }) } }],
+      choices: [{ message: { content: JSON.stringify(correctionResponse || { request_id: "fixture", entity_results: [], relationship_results: [], security_signals: [] }) } }],
       usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
     });
     return;

--- a/tests/uat/synchronous_write/provider-fixture.mjs
+++ b/tests/uat/synchronous_write/provider-fixture.mjs
@@ -8,6 +8,7 @@ const fault = (process.env.DENSE_MEM_E2E_PROVIDER_FAULT || "none").trim();
 const writeSlice = (process.env.DENSE_MEM_E2E_WRITE_SLICE || "").trim();
 const timeoutDelayMs = Number(process.env.DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS || 30_000);
 const correctionProviderFaultMarker = "e2e-correction-provider-fault";
+const correctionProviderTimeoutMarker = "e2e-correction-provider-timeout";
 
 function vectorFor(text, width) {
   const output = [];
@@ -126,6 +127,9 @@ const server = createServer(async (request, response) => {
 
   if (request.url?.endsWith("/embeddings")) {
     const inputs = Array.isArray(payload.input) ? payload.input : [payload.input || ""];
+    if (writeSlice === "correction" && inputs.some((input) => String(input).includes(correctionProviderTimeoutMarker))) {
+      await new Promise((resolve) => setTimeout(resolve, timeoutDelayMs));
+    }
     if (writeSlice === "correction" && inputs.some((input) => String(input).includes(correctionProviderFaultMarker))) {
       response.destroy();
       return;

--- a/tests/uat/synchronous_write/runner.mjs
+++ b/tests/uat/synchronous_write/runner.mjs
@@ -17,12 +17,12 @@ export async function discoverCases(directory = casesRoot, filter = requested) {
   return selected.map((name) => pathToFileURL(join(directory, name)).href);
 }
 
-export async function runCases({ rpc = liveRPC, expect = assert } = {}) {
+export async function runCases({ rpc = liveRPC, rawRPC = liveRawRPC, expect = assert } = {}) {
   const modules = [];
   for (const url of await discoverCases()) {
     const module = await import(url);
     if (typeof module.run !== "function" || typeof module.name !== "string") throw new Error(`invalid synchronous-write case ${url}`);
-    modules.push({ name: module.name, result: await module.run({ rpc, expect }) });
+    modules.push({ name: module.name, result: await module.run({ rpc, rawRPC, expect }) });
   }
   return modules;
 }
@@ -37,6 +37,12 @@ function assert(condition, message) {
 }
 
 async function liveRPC(method, params) {
+  const payload = await liveRawRPC(method, params);
+  if (payload.error) throw new Error(`MCP ${method} returned a bounded error`);
+  return payload.result ?? payload;
+}
+
+async function liveRawRPC(method, params) {
   const base = required("DENSE_MEM_USER_URL").replace(/\/$/, "");
   const key = required("DENSE_MEM_E2E_API_KEY");
   const response = await fetch(`${base}/mcp`, {
@@ -47,8 +53,7 @@ async function liveRPC(method, params) {
   const body = await response.text();
   if (!response.ok) throw new Error(`MCP request failed with HTTP ${response.status}`);
   const payload = body ? JSON.parse(body) : {};
-  if (payload.error) throw new Error(`MCP ${method} returned a bounded error`);
-  return payload.result ?? payload;
+  return payload;
 }
 
 function required(name) {

--- a/tests/uat/synchronous_write/runner.test.mjs
+++ b/tests/uat/synchronous_write/runner.test.mjs
@@ -25,7 +25,16 @@ test("provider timeout fault is longer than the pinned E2E request caps", async 
   assert.match(overlay, /AI_VERIFIER_TIMEOUT_SECONDS: "2"/);
   assert.match(overlay, /AI_VERIFIER_API_KEY: dense-mem-e2e-verifier-key/);
   assert.match(overlay, /DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS: "5000"/);
+  assert.match(overlay, /provider_dimensions=.*compose_server_environment_value AI_API_EMBEDDING_DIMENSIONS/);
   assert.match(fixture, /timeoutDelayMs/);
+});
+
+test("provider fixture uses a Compose volume instead of a worktree bind mount", async () => {
+  const overlay = await readFile(new URL("../../../scripts/e2e-compose-synchronous-write.sh", import.meta.url), "utf8");
+  assert.match(overlay, /e2e-synchronous-write-provider-files:\/e2e/);
+  assert.match(overlay, /prepare_synchronous_write_provider_fixture_volume/);
+  assert.match(overlay, /docker cp/);
+  assert.doesNotMatch(overlay, /provider-fixture\.mjs:\/e2e\/provider-fixture\.mjs:ro/);
 });
 
 test("compose runner filters the resolved default slice", async () => {
@@ -35,4 +44,11 @@ test("compose runner filters the resolved default slice", async () => {
   assert.match(overlay, /local api_key="\$2"/);
   assert.match(overlay, /DENSE_MEM_E2E_WRITE_CASE="\$slice"/);
   assert.match(compose, /run_synchronous_write_e2e "\$team_id" "\$api_key"/);
+});
+
+test("correction slice contains executable success and provider-failure assertions", async () => {
+  const correction = await readFile(new URL("./cases/correction.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(correction, /reserved-for-adoption/);
+  assert.match(correction, /correct_relationship/);
+  assert.match(correction, /provider_failure_preserved/);
 });

--- a/tests/uat/synchronous_write/runner.test.mjs
+++ b/tests/uat/synchronous_write/runner.test.mjs
@@ -51,4 +51,6 @@ test("correction slice contains executable success and provider-failure assertio
   assert.doesNotMatch(correction, /reserved-for-adoption/);
   assert.match(correction, /correct_relationship/);
   assert.match(correction, /provider_failure_preserved/);
+  assert.match(correction, /provider_timeout_preserved/);
+  assert.match(correction, /embedding_timeout/);
 });


### PR DESCRIPTION
Summary: plan, embed, and atomically commit relationship corrections; preserve v2.6 correction receipt/status compatibility; prevent correction-owned embedding-job creation.

Verification: focused service and semanticwrite tests; real PostgreSQL relationship correction/evidence/search/embedding subset; Compose submission-status correction scenario; repository CI.

Deterministic 1k evaluation waived by maintainer direction. Staging not run; it remains the completion gate after automation review.

Close #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relationship corrections now generate and validate search embeddings before changes are committed.
  * Corrections can complete with current search results immediately, without waiting for background processing.
  * Added clearer handling for unavailable, invalid, and timed-out embedding services.

* **Bug Fixes**
  * Prevented stale or incomplete search records and embedding jobs after corrections.
  * Improved validation for correction requests, confirmations, versions, and search contracts.
  * Preserved active relationships when embedding operations fail or time out.

* **Tests**
  * Added end-to-end coverage for successful corrections, provider failures, timeouts, and preservation of original relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->