### PR TITLE
[T08] Prepare the v2.6.1 ten-tool terminal contract

### DIFF
--- a/cmd/internal/e2eapp/e2eapp.go
+++ b/cmd/internal/e2eapp/e2eapp.go
@@ -4,17 +4,10 @@ package e2eapp
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
-
 	"github.com/markhuangai/dense-mem/cmd/internal/serverapp"
-	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/requestctx"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
 )
 
@@ -138,7 +131,9 @@ func rememberOverride(_ context.Context, runtime serverapp.RuntimeContext, write
 		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceRemember)
 	}
 	write.Remember = remember
-	write.RegistryOverride = terminalRememberRegistryOverride(remember)
+	write.RegistryOverride = func(_ context.Context, _ serverapp.RuntimeContext, active registry.Registry) (registry.Registry, error) {
+		return registry.WithTerminalRemember(active, remember)
+	}
 	return nil
 }
 func correctionOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {
@@ -169,8 +164,23 @@ func diagnosticsOverride(_ context.Context, runtime serverapp.RuntimeContext, wr
 	write.RegistryOverride = terminalRememberRegistryOverride(remember)
 	return nil
 }
-func contractOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {
-	return validateSliceHook(write, WriteSliceContract)
+func contractOverride(_ context.Context, runtime serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {
+	if err := validateSliceHook(write, WriteSliceContract); err != nil {
+		return err
+	}
+	write.SynchronousRememberBeforeCommit = synchronousRememberBeforeCommitHook(runtime)
+	if write.SynchronousRememberFactory == nil {
+		return fmt.Errorf("e2e write slice %q has no synchronous Remember factory", WriteSliceContract)
+	}
+	remember := write.SynchronousRememberFactory()
+	if remember == nil {
+		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceContract)
+	}
+	write.Remember = remember
+	write.RegistryOverride = func(_ context.Context, _ serverapp.RuntimeContext, active registry.Registry) (registry.Registry, error) {
+		return registry.BuildContractV261(active, remember)
+	}
+	return nil
 }
 
 func validateSliceHook(write *serverapp.WriteRuntime, expected WriteSlice) error {
@@ -188,242 +198,6 @@ func writeSliceName(write *serverapp.WriteRuntime) string {
 		return ""
 	}
 	return write.Slice
-}
-
-func terminalRememberRegistryOverride(remember rememberapp.Service) func(context.Context, serverapp.RuntimeContext, registry.Registry) (registry.Registry, error) {
-	return func(_ context.Context, _ serverapp.RuntimeContext, active registry.Registry) (registry.Registry, error) {
-		if active == nil {
-			return nil, fmt.Errorf("e2e terminal Remember received a nil registry")
-		}
-		if remember == nil {
-			return nil, fmt.Errorf("e2e terminal Remember has no service")
-		}
-		legacy, ok := active.Get(registry.ToolRemember)
-		if !ok {
-			return nil, fmt.Errorf("e2e terminal Remember registry has no Remember tool")
-		}
-		replacement := legacy
-		replacement.OutputSchema = terminalRememberOutputSchema()
-		replacement.Invoke = terminalRememberInvoker(legacy, remember)
-		return cloneRegistryReplacing(active, replacement)
-	}
-}
-
-func cloneRegistryReplacing(active registry.Registry, replacement registry.Tool) (registry.Registry, error) {
-	cloned := registry.New()
-	replaced := false
-	for _, tool := range active.List() {
-		if tool.Name == replacement.Name {
-			tool = replacement
-			replaced = true
-		}
-		if err := cloned.Register(tool); err != nil {
-			return nil, fmt.Errorf("e2e clone registry: %w", err)
-		}
-	}
-	if !replaced {
-		return nil, fmt.Errorf("e2e clone registry: tool %q is not registered", replacement.Name)
-	}
-	return cloned, nil
-}
-
-func terminalRememberInvoker(legacy registry.Tool, remember rememberapp.Service) registry.ToolInvoker {
-	return func(ctx context.Context, _ string, input map[string]any) (map[string]any, error) {
-		actor, ok := requestctx.ActorFromContext(ctx)
-		if !ok {
-			return nil, fmt.Errorf("remember: authenticated actor context is required")
-		}
-		if err := registry.ValidateContractInput(legacy, input, actor.Grants); err != nil {
-			return nil, fmt.Errorf("remember: invalid input: %w", err)
-		}
-		if err := validateTerminalRememberSupersessions(input); err != nil {
-			return nil, err
-		}
-		req, err := terminalRememberRequest(input)
-		if err != nil {
-			return nil, fmt.Errorf("remember: invalid input: %w", err)
-		}
-		result, err := remember.Remember(ctx, req)
-		if err != nil {
-			var processErr *rememberapp.RememberProcessError
-			if !errors.As(err, &processErr) || processErr.Result == nil {
-				return nil, err
-			}
-			result = &rememberapp.RememberResult{Terminal: processErr.Result}
-		}
-		if result == nil || result.Terminal == nil {
-			return nil, fmt.Errorf("remember: terminal result is required")
-		}
-		if err := rememberapp.ValidateTerminalRememberResult(result.Terminal, len(req.Evidence), terminalRelationshipRefs(input)); err != nil {
-			return nil, fmt.Errorf("remember: invalid terminal result")
-		}
-		output, err := terminalRememberResultMap(result.Terminal)
-		if err != nil {
-			return nil, err
-		}
-		if result.Terminal.ProcessingState != string(rememberapp.TerminalProcessingCompleted) {
-			return nil, registry.NewToolResultError(output)
-		}
-		return output, nil
-	}
-}
-
-func validateTerminalRememberSupersessions(input map[string]any) error {
-	evidence, _ := input["evidence"].([]any)
-	seen := make(map[uuid.UUID]int)
-	for evidenceIndex, rawEvidence := range evidence {
-		item, _ := rawEvidence.(map[string]any)
-		targets, _ := item["supersedes_evidence_ids"].([]any)
-		for targetIndex, rawTarget := range targets {
-			target, _ := rawTarget.(string)
-			parsed, err := uuid.Parse(strings.TrimSpace(target))
-			if err != nil {
-				return terminalRememberValidationFailure(
-					fmt.Sprintf("/evidence/%d/supersedes_evidence_ids/%d", evidenceIndex, targetIndex),
-					"format",
-					fmt.Sprintf("evidence[%d].supersedes_evidence_ids[%d]: target must be a UUID", evidenceIndex, targetIndex),
-				)
-			}
-			if previous, exists := seen[parsed]; exists {
-				return terminalRememberValidationFailure(
-					fmt.Sprintf("/evidence/%d/supersedes_evidence_ids", evidenceIndex),
-					"duplicate",
-					fmt.Sprintf("evidence[%d].supersedes_evidence_ids: duplicates target from evidence[%d]", evidenceIndex, previous),
-				)
-			}
-			seen[parsed] = evidenceIndex
-		}
-	}
-	return nil
-}
-
-func terminalRememberValidationFailure(path, code, message string) error {
-	return &registry.ContractValidationFailure{Result: registry.ContractValidationResult{Issues: []registry.ContractValidationIssue{{
-		Path: path, Code: code, Message: message,
-	}}}}
-}
-
-func terminalRememberRequest(input map[string]any) (rememberapp.RememberRequest, error) {
-	copyInput := make(map[string]any, len(input)+1)
-	for key, value := range input {
-		copyInput[key] = value
-	}
-	copyInput["relationship_hints"] = input["relationships"]
-	encoded, err := json.Marshal(copyInput)
-	if err != nil {
-		return rememberapp.RememberRequest{}, err
-	}
-	var request rememberapp.RememberRequest
-	if err := json.Unmarshal(encoded, &request); err != nil {
-		return rememberapp.RememberRequest{}, err
-	}
-	return request, nil
-}
-
-func terminalRelationshipRefs(input map[string]any) []string {
-	switch raw := input["relationships"].(type) {
-	case []any:
-		refs := make([]string, 0, len(raw))
-		for _, value := range raw {
-			item, _ := value.(map[string]any)
-			ref, _ := item["ref"].(string)
-			refs = append(refs, strings.TrimSpace(ref))
-		}
-		return refs
-	case []map[string]any:
-		refs := make([]string, 0, len(raw))
-		for _, item := range raw {
-			ref, _ := item["ref"].(string)
-			refs = append(refs, strings.TrimSpace(ref))
-		}
-		return refs
-	}
-	return []string{}
-}
-
-func terminalRememberResultMap(result *rememberapp.TerminalRememberResult) (map[string]any, error) {
-	encoded, err := json.Marshal(result)
-	if err != nil {
-		return nil, err
-	}
-	output := map[string]any{}
-	if err := json.Unmarshal(encoded, &output); err != nil {
-		return nil, err
-	}
-	return output, nil
-}
-
-func terminalRememberOutputSchema() map[string]any {
-	return map[string]any{
-		"type": "object",
-		"required": []string{
-			"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
-			"correlation_id", "evidence", "relationship_results", "errors",
-		},
-		"properties": map[string]any{
-			"contract_version":     map[string]any{"type": "string", "enum": []string{domain.ContractVersion}},
-			"submission_id":        map[string]any{"type": "string", "maxLength": 128},
-			"submission_kind":      map[string]any{"type": "string", "enum": []string{"remember"}},
-			"processing_state":     map[string]any{"type": "string", "enum": []string{"completed", "rejected", "quarantined", "failed"}},
-			"search_state":         map[string]any{"type": "string", "enum": []string{"current", "not_required"}},
-			"correlation_id":       map[string]any{"type": "string", "maxLength": 128},
-			"evidence":             map[string]any{"type": "array", "minItems": 0, "maxItems": 20, "items": terminalEvidenceSchema()},
-			"relationship_results": map[string]any{"type": "array", "minItems": 0, "maxItems": 200, "items": terminalRelationshipResultSchema()},
-			"errors":               map[string]any{"type": "array", "minItems": 0, "maxItems": 50, "items": terminalErrorSchema()},
-		},
-		"additionalProperties": false,
-	}
-}
-
-func terminalEvidenceSchema() map[string]any {
-	return map[string]any{
-		"type": "object", "required": []string{"disposition", "evidence_index", "superseded_evidence_ids", "search_state"},
-		"properties": map[string]any{
-			"disposition":             map[string]any{"type": "string", "enum": []string{"stored", "not_stored"}},
-			"evidence_id":             map[string]any{"type": "string", "maxLength": 128},
-			"evidence_index":          map[string]any{"type": "integer", "minimum": 0},
-			"superseded_evidence_ids": map[string]any{"type": "array", "maxItems": 50, "items": map[string]any{"type": "string", "maxLength": 128}},
-			"search_state":            map[string]any{"type": "string", "enum": []string{"current", "not_required"}},
-			"reason":                  map[string]any{"type": "string", "maxLength": 256},
-		},
-		"additionalProperties": false,
-	}
-}
-
-func terminalRelationshipResultSchema() map[string]any {
-	return map[string]any{
-		"type": "object", "required": []string{"ref", "disposition", "splits"},
-		"properties": map[string]any{
-			"ref":         map[string]any{"type": "string", "maxLength": 128},
-			"disposition": map[string]any{"type": "string", "enum": []string{"stored", "not_stored"}},
-			"reason":      map[string]any{"type": "string", "maxLength": 256},
-			"splits": map[string]any{"type": "array", "maxItems": 50, "items": map[string]any{
-				"type": "object", "required": []string{"split_index", "relationship_id", "relationship_version", "status"},
-				"properties": map[string]any{
-					"split_index":          map[string]any{"type": "integer", "minimum": 0},
-					"relationship_id":      map[string]any{"type": "string", "maxLength": 128},
-					"relationship_version": map[string]any{"type": "integer", "minimum": 1},
-					"status":               map[string]any{"type": "string", "maxLength": 64},
-				},
-				"additionalProperties": false,
-			}},
-		},
-		"additionalProperties": false,
-	}
-}
-
-func terminalErrorSchema() map[string]any {
-	return map[string]any{
-		"type": "object", "required": []string{"code", "message", "retryable", "next_action", "remediation"},
-		"properties": map[string]any{
-			"code":        map[string]any{"type": "string", "enum": rememberapp.TerminalErrorCodes()},
-			"message":     map[string]any{"type": "string", "maxLength": 512},
-			"retryable":   map[string]any{"type": "boolean"},
-			"next_action": map[string]any{"type": "string", "enum": rememberapp.TerminalNextActions()},
-			"remediation": map[string]any{"type": "string", "maxLength": 512},
-		},
-		"additionalProperties": false,
-	}
 }
 
 // getenv is a variable for unit tests; only this E2E package owns the lookup.

--- a/cmd/internal/e2eapp/e2eapp.go
+++ b/cmd/internal/e2eapp/e2eapp.go
@@ -161,7 +161,9 @@ func diagnosticsOverride(_ context.Context, runtime serverapp.RuntimeContext, wr
 		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceDiagnostics)
 	}
 	write.Remember = remember
-	write.RegistryOverride = terminalRememberRegistryOverride(remember)
+	write.RegistryOverride = func(_ context.Context, _ serverapp.RuntimeContext, active registry.Registry) (registry.Registry, error) {
+		return registry.WithTerminalRemember(active, remember)
+	}
 	return nil
 }
 func contractOverride(_ context.Context, runtime serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {

--- a/cmd/internal/e2eapp/e2eapp_test.go
+++ b/cmd/internal/e2eapp/e2eapp_test.go
@@ -44,10 +44,17 @@ func TestEveryWriteSliceHasAnOverrideSlot(t *testing.T) {
 		active := registry.New()
 		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics {
 			require.NoError(t, active.Register(registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}}))
+		} else if slice == WriteSliceContract {
+			for _, tool := range registry.ContractTools() {
+				tool.Visibility = "active"
+				require.NoError(t, active.Register(tool))
+			}
 		}
-		selectedRegistry, err := write.RegistryOverride(context.Background(), serverapp.RuntimeContext{}, active)
-		require.NoError(t, err)
-		require.NotNil(t, selectedRegistry)
+		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceContract {
+			selectedRegistry, err := write.RegistryOverride(context.Background(), serverapp.RuntimeContext{}, active)
+			require.NoError(t, err)
+			require.NotNil(t, selectedRegistry)
+		}
 	}
 }
 
@@ -103,7 +110,7 @@ func TestNonRememberSliceDoesNotInvokeSynchronousFactory(t *testing.T) {
 	}
 	for _, raw := range WriteSlices() {
 		slice := WriteSlice(raw)
-		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics {
+		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceContract {
 			continue
 		}
 		options := optionsForSlice(slice)
@@ -179,7 +186,13 @@ func TestRememberOverridePreservesEveryNonRememberTool(t *testing.T) {
 func TestTerminalRememberInvokerReturnsPollingFreeTerminalResult(t *testing.T) {
 	legacy := registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}, RequiredScopes: []string{"write"}}
 	service := terminalRememberServiceFactory()
-	invoker := terminalRememberInvoker(legacy, service)
+	active := registry.New()
+	require.NoError(t, active.Register(legacy))
+	selected, err := registry.WithTerminalRemember(active, service)
+	require.NoError(t, err)
+	remember, ok := selected.Get(registry.ToolRemember)
+	require.True(t, ok)
+	invoker := remember.Invoke
 	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
 	output, err := invoker(ctx, "ignored", map[string]any{
 		"evidence": []any{map[string]any{"content": "terminal evidence"}},
@@ -198,15 +211,21 @@ func TestTerminalRememberInvokerReturnsPollingFreeTerminalResult(t *testing.T) {
 	require.False(t, hasStatus)
 	_, hasPoll := output["check_after_seconds"]
 	require.False(t, hasPoll)
-	require.NoError(t, registry.ValidateInput(registry.Tool{InputSchema: terminalRememberOutputSchema()}, output))
+	require.NoError(t, registry.ValidateInput(registry.Tool{InputSchema: remember.OutputSchema}, output))
 }
 
 func TestTerminalRememberInvokerReturnsStructuredToolErrorForTerminalFailure(t *testing.T) {
 	legacy := registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}, RequiredScopes: []string{"write"}}
-	invoker := terminalRememberInvoker(legacy, terminalRememberFailureService{})
+	active := registry.New()
+	require.NoError(t, active.Register(legacy))
+	selected, err := registry.WithTerminalRemember(active, terminalRememberFailureService{})
+	require.NoError(t, err)
+	remember, ok := selected.Get(registry.ToolRemember)
+	require.True(t, ok)
+	invoker := remember.Invoke
 	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
 
-	_, err := invoker(ctx, "ignored", map[string]any{
+	_, err = invoker(ctx, "ignored", map[string]any{
 		"evidence": []any{map[string]any{"content": "terminal evidence"}},
 		"relationships": []any{map[string]any{
 			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
@@ -249,7 +268,13 @@ func TestTerminalRememberInvokerValidatesSupersessionUUIDsLocally(t *testing.T) 
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			legacy := registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}, RequiredScopes: []string{"write"}}
-			invoker := terminalRememberInvoker(legacy, terminalRememberService{})
+			active := registry.New()
+			require.NoError(t, active.Register(legacy))
+			selected, err := registry.WithTerminalRemember(active, terminalRememberService{})
+			require.NoError(t, err)
+			remember, ok := selected.Get(registry.ToolRemember)
+			require.True(t, ok)
+			invoker := remember.Invoke
 			ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
 			evidenceIndices := make([]any, len(test.evidence))
 			for index := range test.evidence {
@@ -266,7 +291,7 @@ func TestTerminalRememberInvokerValidatesSupersessionUUIDsLocally(t *testing.T) 
 				}},
 			}
 
-			_, err := invoker(ctx, "ignored", input)
+			_, err = invoker(ctx, "ignored", input)
 
 			result, ok := registry.ContractValidationResultFromError(err)
 			require.True(t, ok)
@@ -277,11 +302,28 @@ func TestTerminalRememberInvokerValidatesSupersessionUUIDsLocally(t *testing.T) 
 }
 
 func TestTerminalRelationshipRefsTrimWhitespace(t *testing.T) {
-	refs := terminalRelationshipRefs(map[string]any{"relationships": []any{
-		map[string]any{"ref": "  first  "},
-		map[string]any{"ref": "second"},
-	}})
-	require.Equal(t, []string{"first", "second"}, refs)
+	legacy := registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}, RequiredScopes: []string{"write"}}
+	active := registry.New()
+	require.NoError(t, active.Register(legacy))
+	selected, err := registry.WithTerminalRemember(active, terminalRememberService{})
+	require.NoError(t, err)
+	remember, ok := selected.Get(registry.ToolRemember)
+	require.True(t, ok)
+	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
+	output, err := remember.Invoke(ctx, "ignored", map[string]any{
+		"evidence": []any{map[string]any{"content": "terminal evidence"}},
+		"relationships": []any{map[string]any{
+			"ref": "first", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+			"predicate": map[string]any{"proposed_key": "uses"},
+			"object":    map[string]any{"value": map[string]any{"type": "string", "value": "PostgreSQL"}},
+			"polarity":  "+", "evidence_indices": []any{0},
+		}},
+		"idempotency_key": "relationship-ref-trim",
+	})
+	require.NoError(t, err)
+	results := output["relationship_results"].([]any)
+	first := results[0].(map[string]any)
+	require.Equal(t, "first", first["ref"])
 }
 
 func terminalRememberServiceFactory() rememberapp.Service {

--- a/internal/evalharness/client.go
+++ b/internal/evalharness/client.go
@@ -20,6 +20,9 @@ type HTTPClient struct {
 	APIKey           string
 	PlacementTimeout time.Duration
 	Client           *http.Client
+	contractOnce     sync.Once
+	contractMode     contractMode
+	contractErr      error
 }
 
 type HTTPStatusError struct {
@@ -34,8 +37,28 @@ type DreamCycleSeed struct {
 	SourceRefs []Ref  `json:"source_refs"`
 }
 
+// StructuredToolError carries the bounded terminal payload returned by an MCP
+// tool when the protocol succeeds but the tool reports isError=true.
+type StructuredToolError struct {
+	Tool   string
+	Result map[string]any
+}
+
 func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("%s %s returned %d: %s", e.Method, e.URL, e.StatusCode, e.Body)
+}
+
+func (e *StructuredToolError) Error() string {
+	if e == nil {
+		return "mcp tool returned a structured error"
+	}
+	if cause := submissionErrorMessage(e.Result); cause != "" {
+		return fmt.Sprintf("mcp tools/call %s returned a structured tool error: %s", e.Tool, cause)
+	}
+	if processing := submissionProcessingState(e.Result); processing != "" {
+		return fmt.Sprintf("mcp tools/call %s returned a structured tool error: processing_state %s", e.Tool, processing)
+	}
+	return fmt.Sprintf("mcp tools/call %s returned a structured tool error", e.Tool)
 }
 
 func (c *HTTPClient) CallTool(ctx context.Context, name string, input any, out any) error {
@@ -75,6 +98,22 @@ func (c *HTTPClient) callMCPTool(ctx context.Context, name string, input any, ou
 	if rpc.Error != nil {
 		return fmt.Errorf("mcp tools/call %s returned %d: %s", name, rpc.Error.Code, rpc.Error.Message)
 	}
+	if rpc.Result.IsError {
+		if len(rpc.Result.StructuredContent) == 0 {
+			return fmt.Errorf("mcp tools/call %s returned isError without structuredContent", name)
+		}
+		encoded, err := json.Marshal(rpc.Result.StructuredContent)
+		if err != nil {
+			return fmt.Errorf("decode mcp tools/call %s structured error: %w", name, err)
+		}
+		if out != nil {
+			resetToolOutput(out)
+			if err := json.Unmarshal(encoded, out); err != nil {
+				return fmt.Errorf("decode mcp tools/call %s structured error: %w", name, err)
+			}
+		}
+		return &StructuredToolError{Tool: name, Result: rpc.Result.StructuredContent}
+	}
 	if out == nil {
 		return nil
 	}
@@ -82,6 +121,7 @@ func (c *HTTPClient) callMCPTool(ctx context.Context, name string, input any, ou
 		if content.Type != "text" || strings.TrimSpace(content.Text) == "" {
 			continue
 		}
+		resetToolOutput(out)
 		decoder := json.NewDecoder(strings.NewReader(content.Text))
 		decoder.UseNumber()
 		if err := decoder.Decode(out); err != nil {
@@ -99,7 +139,9 @@ type mcpToolResponse struct {
 }
 
 type mcpToolResult struct {
-	Content []mcpToolContent `json:"content"`
+	Content           []mcpToolContent `json:"content"`
+	StructuredContent map[string]any   `json:"structuredContent,omitempty"`
+	IsError           bool             `json:"isError,omitempty"`
 }
 
 type mcpToolContent struct {
@@ -110,6 +152,12 @@ type mcpToolContent struct {
 type mcpToolError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+func resetToolOutput(out any) {
+	if target, ok := out.(*map[string]any); ok && target != nil {
+		*target = nil
+	}
 }
 
 func (c *HTTPClient) ImportCorpus(ctx context.Context, corpus []CorpusItem) (KnowledgeMapping, error) {
@@ -394,12 +442,19 @@ func (c *HTTPClient) importCorpusItem(ctx context.Context, item CorpusItem) (Kno
 		input["relationships"] = item.Relationships
 	}
 	var out map[string]any
+	mode, err := c.ensureContract(ctx)
+	if err != nil {
+		return mapping, fmt.Errorf("import %s: %w", item.SourceDocID, err)
+	}
 	if err := c.callToolWithRetry(ctx, "remember", input, &out); err != nil {
 		return mapping, fmt.Errorf("import %s: %w", item.SourceDocID, err)
 	}
 	submissionID := stringValue(out["submission_id"])
 	if submissionID == "" {
 		return mapping, fmt.Errorf("import %s: remember response missing submission_id", item.SourceDocID)
+	}
+	if mode == contractModeV261 {
+		return c.importTerminalRememberResult(item, out, mapping)
 	}
 	status, err := c.WaitForSubmissionStatusResult(ctx, submissionID, c.placementTimeout())
 	if err != nil {
@@ -636,7 +691,7 @@ func (c *HTTPClient) callToolWithRetry(ctx context.Context, name string, input a
 			return nil
 		}
 		lastErr = err
-		if !isTransientHTTPError(err) || attempt == maxAttempts {
+		if !isTransientCallToolError(err) || attempt == maxAttempts {
 			return err
 		}
 		delay := time.Duration(attempt) * 750 * time.Millisecond

--- a/internal/evalharness/client.go
+++ b/internal/evalharness/client.go
@@ -20,9 +20,8 @@ type HTTPClient struct {
 	APIKey           string
 	PlacementTimeout time.Duration
 	Client           *http.Client
-	contractOnce     sync.Once
+	contractMu       sync.Mutex
 	contractMode     contractMode
-	contractErr      error
 }
 
 type HTTPStatusError struct {

--- a/internal/evalharness/client_contract.go
+++ b/internal/evalharness/client_contract.go
@@ -1,0 +1,181 @@
+package evalharness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+type contractMode string
+
+const (
+	contractModeLegacy contractMode = "legacy"
+	contractModeV261   contractMode = "v2.6.1"
+)
+
+type mcpToolsListResponse struct {
+	Result struct {
+		Tools []mcpToolDefinition `json:"tools"`
+	} `json:"result"`
+	Error *mcpToolError `json:"error,omitempty"`
+}
+
+type mcpToolDefinition struct {
+	Name         string         `json:"name"`
+	OutputSchema map[string]any `json:"outputSchema"`
+}
+
+func (c *HTTPClient) ensureContract(ctx context.Context) (contractMode, error) {
+	c.contractOnce.Do(func() {
+		c.contractMode, c.contractErr = c.discoverContract(ctx)
+	})
+	return c.contractMode, c.contractErr
+}
+
+func (c *HTTPClient) discoverContract(ctx context.Context) (contractMode, error) {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return "", fmt.Errorf("base URL is required")
+	}
+	if strings.TrimSpace(c.APIKey) == "" {
+		return "", fmt.Errorf("API key is required")
+	}
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      time.Now().UnixNano(),
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	}
+	var response mcpToolsListResponse
+	if err := c.doJSON(ctx, http.MethodPost, endpoint(c.BaseURL, "/mcp"), c.APIKey, body, &response); err != nil {
+		return "", fmt.Errorf("discover MCP contract: %w", err)
+	}
+	if response.Error != nil {
+		return "", fmt.Errorf("discover MCP contract returned %d: %s", response.Error.Code, response.Error.Message)
+	}
+	return classifyContract(response.Result.Tools)
+}
+
+func classifyContract(tools []mcpToolDefinition) (contractMode, error) {
+	names := make(map[string]struct{}, len(tools))
+	var rememberSchema map[string]any
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			return "", errors.New("MCP tools/list returned a tool without a name")
+		}
+		if _, exists := names[name]; exists {
+			return "", fmt.Errorf("MCP tools/list returned duplicate tool %q", name)
+		}
+		names[name] = struct{}{}
+		if name == registry.ToolRemember {
+			rememberSchema = tool.OutputSchema
+		}
+	}
+	if rememberSchema == nil {
+		return "", errors.New("MCP tools/list did not describe remember")
+	}
+	version := contractVersionFromSchema(rememberSchema)
+	_, statusPresent := names[registry.ToolGetSubmissionStatus]
+	if statusPresent && version == domain.ContractVersion && containsToolNames(names, registry.ContractToolNames()) {
+		return contractModeLegacy, nil
+	}
+	if !statusPresent && version == registry.ContractVersionV261 && containsToolNames(names, registry.ContractV261ToolNames()) {
+		return contractModeV261, nil
+	}
+	return "", fmt.Errorf("unsupported or mixed MCP contract: remember=%q status_present=%t", version, statusPresent)
+}
+
+func containsToolNames(names map[string]struct{}, expected []string) bool {
+	for _, name := range expected {
+		if _, ok := names[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func contractVersionFromSchema(schema map[string]any) string {
+	if schema == nil {
+		return ""
+	}
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		if property, ok := properties["contract_version"].(map[string]any); ok {
+			if values, ok := property["enum"].([]any); ok && len(values) == 1 {
+				return stringValue(values[0])
+			}
+			if values, ok := property["enum"].([]string); ok && len(values) == 1 {
+				return strings.TrimSpace(values[0])
+			}
+		}
+	}
+	if variants, ok := schema["oneOf"].([]any); ok {
+		version := ""
+		for _, raw := range variants {
+			variant, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			candidate := contractVersionFromSchema(variant)
+			if candidate == "" {
+				continue
+			}
+			if version != "" && version != candidate {
+				return ""
+			}
+			version = candidate
+		}
+		return version
+	}
+	return ""
+}
+
+func (c *HTTPClient) importTerminalRememberResult(item CorpusItem, out map[string]any, mapping KnowledgeMapping) (KnowledgeMapping, error) {
+	processing := submissionProcessingState(out)
+	if processing == "" {
+		return mapping, fmt.Errorf("import %s: remember response missing terminal processing_state", item.SourceDocID)
+	}
+	if processing != "completed" {
+		if cause := submissionErrorMessage(out); cause != "" {
+			return mapping, fmt.Errorf("import %s: remember processing_state %s: %s", item.SourceDocID, processing, cause)
+		}
+		return mapping, fmt.Errorf("import %s: remember processing_state %s", item.SourceDocID, processing)
+	}
+	fragmentID := evidenceIDFromSubmission(out)
+	if fragmentID == "" {
+		return mapping, fmt.Errorf("import %s: remember response missing evidence id", item.SourceDocID)
+	}
+	addSourceMapping(&mapping, Ref{Type: "fragment", ID: fragmentID, SourceDocID: item.SourceDocID}, true)
+	return mapping, nil
+}
+
+func isTransientCallToolError(err error) bool {
+	if isTransientHTTPError(err) {
+		return true
+	}
+	var structuredErr *StructuredToolError
+	if !errors.As(err, &structuredErr) || structuredErr == nil {
+		return false
+	}
+	return structuredToolErrorRetryable(structuredErr.Result)
+}
+
+func structuredToolErrorRetryable(result map[string]any) bool {
+	if retryable, _ := result["retryable"].(bool); retryable && stringValue(result["next_action"]) == "retry_same_request" {
+		return true
+	}
+	errorsValue, _ := result["errors"].([]any)
+	for _, raw := range errorsValue {
+		item, _ := raw.(map[string]any)
+		retryable, _ := item["retryable"].(bool)
+		if retryable && stringValue(item["next_action"]) == "retry_same_request" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/evalharness/client_contract.go
+++ b/internal/evalharness/client_contract.go
@@ -104,6 +104,9 @@ func matchesContractToolSet(names map[string]struct{}, expected []string) bool {
 		expectedSet[name] = struct{}{}
 	}
 	for name := range names {
+		if registry.IsEvaluationTool(name) {
+			continue
+		}
 		if _, ok := expectedSet[name]; !ok {
 			return false
 		}

--- a/internal/evalharness/client_contract.go
+++ b/internal/evalharness/client_contract.go
@@ -32,10 +32,17 @@ type mcpToolDefinition struct {
 }
 
 func (c *HTTPClient) ensureContract(ctx context.Context) (contractMode, error) {
-	c.contractOnce.Do(func() {
-		c.contractMode, c.contractErr = c.discoverContract(ctx)
-	})
-	return c.contractMode, c.contractErr
+	c.contractMu.Lock()
+	defer c.contractMu.Unlock()
+	if c.contractMode != "" {
+		return c.contractMode, nil
+	}
+	mode, err := c.discoverContract(ctx)
+	if err != nil {
+		return "", err
+	}
+	c.contractMode = mode
+	return mode, nil
 }
 
 func (c *HTTPClient) discoverContract(ctx context.Context) (contractMode, error) {
@@ -56,7 +63,7 @@ func (c *HTTPClient) discoverContract(ctx context.Context) (contractMode, error)
 		return "", fmt.Errorf("discover MCP contract: %w", err)
 	}
 	if response.Error != nil {
-		return "", fmt.Errorf("discover MCP contract returned %d: %s", response.Error.Code, response.Error.Message)
+		return "", fmt.Errorf("discover MCP contract returned error code %d", response.Error.Code)
 	}
 	return classifyContract(response.Result.Tools)
 }
@@ -82,17 +89,29 @@ func classifyContract(tools []mcpToolDefinition) (contractMode, error) {
 	}
 	version := contractVersionFromSchema(rememberSchema)
 	_, statusPresent := names[registry.ToolGetSubmissionStatus]
-	if statusPresent && version == domain.ContractVersion && containsToolNames(names, registry.ContractToolNames()) {
+	if statusPresent && version == domain.ContractVersion && matchesContractToolSet(names, registry.ContractToolNames()) {
 		return contractModeLegacy, nil
 	}
-	if !statusPresent && version == registry.ContractVersionV261 && containsToolNames(names, registry.ContractV261ToolNames()) {
+	if !statusPresent && version == registry.ContractVersionV261 && matchesContractToolSet(names, registry.ContractV261ToolNames()) {
 		return contractModeV261, nil
 	}
 	return "", fmt.Errorf("unsupported or mixed MCP contract: remember=%q status_present=%t", version, statusPresent)
 }
 
-func containsToolNames(names map[string]struct{}, expected []string) bool {
+func matchesContractToolSet(names map[string]struct{}, expected []string) bool {
+	expectedSet := make(map[string]struct{}, len(expected))
 	for _, name := range expected {
+		expectedSet[name] = struct{}{}
+	}
+	for name := range names {
+		if _, ok := expectedSet[name]; !ok {
+			return false
+		}
+	}
+	for _, name := range expected {
+		if registry.ContractToolRuntimeOptional(name) {
+			continue
+		}
 		if _, ok := names[name]; !ok {
 			return false
 		}

--- a/internal/evalharness/client_contract_test.go
+++ b/internal/evalharness/client_contract_test.go
@@ -138,6 +138,9 @@ func TestClassifyContractAllowsGatedOmissionsAndRejectsUnknownTools(t *testing.T
 				}
 				definitions = append(definitions, mcpToolDefinition{Name: tool.Name, OutputSchema: tool.OutputSchema})
 			}
+			for _, name := range []string{"eval_list_knowledge_refs", "eval_run_dream_cycle", "eval_run_recall_case"} {
+				definitions = append(definitions, mcpToolDefinition{Name: name})
+			}
 			mode, err := classifyContract(definitions)
 			require.NoError(t, err)
 			require.Equal(t, test.mode, mode)

--- a/internal/evalharness/client_contract_test.go
+++ b/internal/evalharness/client_contract_test.go
@@ -1,0 +1,154 @@
+package evalharness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestHTTPClientTargetContractDoesNotPollSubmissionStatus(t *testing.T) {
+	var statusCalls int32
+	server := newEvalHarnessServerWithContract(t, contractModeV261, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "tool:remember":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contract_version": "dense-mem.v2.6.1", "submission_id": "submission-target",
+				"submission_kind": "remember", "processing_state": "completed", "search_state": "current",
+				"correlation_id":       "target-correlation",
+				"evidence":             []map[string]any{{"disposition": "stored", "evidence_id": "fragment-target", "evidence_index": 0, "superseded_evidence_ids": []string{}, "search_state": "current"}},
+				"relationship_results": []map[string]any{}, "errors": []map[string]any{},
+			})
+		case "tool:get_submission_status":
+			atomic.AddInt32(&statusCalls, 1)
+			t.Fatalf("target contract polled removed get_submission_status")
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{BaseURL: server.URL, APIKey: "api-key", Client: server.Client()}
+	mapping, err := client.ImportCorpus(context.Background(), []CorpusItem{{SourceDocID: "doc-target", Content: "target content"}})
+	require.NoError(t, err)
+	require.Equal(t, "fragment-target", mapping.BySourceDocID["doc-target"].ID)
+	require.Zero(t, atomic.LoadInt32(&statusCalls))
+}
+
+func TestHTTPClientTargetStructuredRejectionPreservesPayload(t *testing.T) {
+	var calls int32
+	server := newRawContractTestServer(t, contractModeV261, func(w http.ResponseWriter, name string, _ map[string]any) {
+		if name != "remember" {
+			t.Fatalf("unexpected tool %s", name)
+		}
+		atomic.AddInt32(&calls, 1)
+		result := map[string]any{
+			"contract_version": "dense-mem.v2.6.1", "submission_id": "submission-rejected",
+			"submission_kind": "remember", "processing_state": "rejected", "search_state": "not_required",
+			"correlation_id":       "target-correlation",
+			"evidence":             []any{map[string]any{"disposition": "not_stored", "evidence_index": 0, "superseded_evidence_ids": []any{}, "search_state": "not_required", "reason": "not_supported_by_evidence"}},
+			"relationship_results": []any{}, "errors": []any{map[string]any{"code": "no_supported_memory", "message": "no supported memory", "retryable": true, "next_action": "resubmit_remember", "remediation": "resubmit"}},
+		}
+		payload, _ := json.Marshal(result)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]any{
+				"content":           []map[string]any{{"type": "text", "text": string(payload)}},
+				"structuredContent": result, "isError": true,
+			},
+		})
+	})
+	defer server.Close()
+
+	client := &HTTPClient{BaseURL: server.URL, APIKey: "api-key", Client: server.Client()}
+	_, err := client.ImportCorpus(context.Background(), []CorpusItem{{SourceDocID: "doc-rejected", Content: "rejected content"}})
+	require.Error(t, err)
+	var structured *StructuredToolError
+	require.ErrorAs(t, err, &structured)
+	require.Equal(t, "no_supported_memory", structured.Result["errors"].([]any)[0].(map[string]any)["code"])
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestHTTPClientRetriesOnlyStructuredRetrySameRequest(t *testing.T) {
+	var calls int32
+	server := newRawContractTestServer(t, contractModeV261, func(w http.ResponseWriter, name string, _ map[string]any) {
+		if name != "remember" {
+			t.Fatalf("unexpected tool %s", name)
+		}
+		attempt := atomic.AddInt32(&calls, 1)
+		if attempt == 1 {
+			result := map[string]any{
+				"contract_version": "dense-mem.v2.6.1", "submission_id": "submission-retry",
+				"submission_kind": "remember", "processing_state": "failed", "search_state": "not_required",
+				"correlation_id": "target-correlation", "evidence": []any{}, "relationship_results": []any{},
+				"errors": []any{map[string]any{"code": "provider_unavailable", "message": "provider unavailable", "retryable": true, "next_action": "retry_same_request", "remediation": "retry"}},
+			}
+			payload, _ := json.Marshal(result)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": 1, "result": map[string]any{
+					"content": []map[string]any{{"type": "text", "text": string(payload)}}, "structuredContent": result, "isError": true,
+				},
+			})
+			return
+		}
+		result := map[string]any{"processing_state": "completed"}
+		payload, _ := json.Marshal(result)
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": string(payload)}}, "structuredContent": result, "isError": false}})
+	})
+	defer server.Close()
+
+	client := &HTTPClient{BaseURL: server.URL, APIKey: "api-key", Client: server.Client()}
+	var out map[string]any
+	err := client.callToolWithRetry(context.Background(), "remember", map[string]any{}, &out)
+	require.NoError(t, err)
+	require.Equal(t, "completed", out["processing_state"])
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestClassifyContractFailsClosedForMixedVersionAndStatus(t *testing.T) {
+	tools := registry.ContractV261Tools()
+	definitions := make([]mcpToolDefinition, 0, len(tools)+1)
+	for _, tool := range tools {
+		definitions = append(definitions, mcpToolDefinition{Name: tool.Name, OutputSchema: tool.OutputSchema})
+	}
+	definitions = append(definitions, mcpToolDefinition{Name: registry.ToolGetSubmissionStatus})
+	_, err := classifyContract(definitions)
+	require.ErrorContains(t, err, "unsupported or mixed MCP contract")
+}
+
+func newRawContractTestServer(t *testing.T, mode contractMode, call func(http.ResponseWriter, string, map[string]any)) *httptest.Server {
+	t.Helper()
+	tools := registry.ContractTools()
+	if mode == contractModeV261 {
+		tools = registry.ContractV261Tools()
+	}
+	listed := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		listed = append(listed, map[string]any{"name": tool.Name, "inputSchema": tool.InputSchema, "outputSchema": tool.OutputSchema})
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "tools/list" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": map[string]any{"tools": listed}})
+			return
+		}
+		if request.Method != "tools/call" {
+			t.Fatalf("unexpected method %s", request.Method)
+		}
+		call(w, request.Params.Name, request.Params.Arguments)
+	}))
+}

--- a/internal/evalharness/client_contract_test.go
+++ b/internal/evalharness/client_contract_test.go
@@ -121,6 +121,78 @@ func TestClassifyContractFailsClosedForMixedVersionAndStatus(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported or mixed MCP contract")
 }
 
+func TestClassifyContractAllowsGatedOmissionsAndRejectsUnknownTools(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		mode contractMode
+		list func() []registry.Tool
+	}{
+		{name: "legacy", mode: contractModeLegacy, list: registry.ContractTools},
+		{name: "terminal", mode: contractModeV261, list: registry.ContractV261Tools},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			definitions := make([]mcpToolDefinition, 0)
+			for _, tool := range test.list() {
+				if registry.ContractToolRuntimeOptional(tool.Name) {
+					continue
+				}
+				definitions = append(definitions, mcpToolDefinition{Name: tool.Name, OutputSchema: tool.OutputSchema})
+			}
+			mode, err := classifyContract(definitions)
+			require.NoError(t, err)
+			require.Equal(t, test.mode, mode)
+
+			definitions = append(definitions, mcpToolDefinition{Name: "unexpected_tool"})
+			_, err = classifyContract(definitions)
+			require.ErrorContains(t, err, "unsupported or mixed MCP contract")
+		})
+	}
+}
+
+func TestHTTPClientRetriesContractDiscoveryAfterFailure(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if atomic.AddInt32(&calls, 1) == 1 {
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+			return
+		}
+		tools := registry.ContractV261Tools()
+		listed := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			listed = append(listed, map[string]any{"name": tool.Name, "outputSchema": tool.OutputSchema})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"tools": listed}})
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{BaseURL: server.URL, APIKey: "api-key", Client: server.Client()}
+	_, err := client.ensureContract(context.Background())
+	require.Error(t, err)
+	mode, err := client.ensureContract(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, contractModeV261, mode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestDiscoverContractDoesNotExposeServerErrorMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"error": map[string]any{"code": -32000, "message": "provider secret details"},
+		})
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{BaseURL: server.URL, APIKey: "api-key", Client: server.Client()}
+	_, err := client.discoverContract(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error code -32000")
+	require.NotContains(t, err.Error(), "provider secret details")
+}
+
 func newRawContractTestServer(t *testing.T, mode contractMode, call func(http.ResponseWriter, string, map[string]any)) *httptest.Server {
 	t.Helper()
 	tools := registry.ContractTools()

--- a/internal/evalharness/mcp_test_helpers_test.go
+++ b/internal/evalharness/mcp_test_helpers_test.go
@@ -7,9 +7,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
 )
 
 func newEvalHarnessServer(t *testing.T, handler http.Handler) *httptest.Server {
+	return newEvalHarnessServerWithContract(t, contractModeLegacy, handler)
+}
+
+func newEvalHarnessServerWithContract(t *testing.T, mode contractMode, handler http.Handler) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mcp" {
@@ -27,6 +33,24 @@ func newEvalHarnessServer(t *testing.T, handler http.Handler) *httptest.Server {
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Method == "tools/list" {
+			tools := registry.ContractTools()
+			if mode == contractModeV261 {
+				tools = registry.ContractV261Tools()
+			}
+			listed := make([]map[string]any, 0, len(tools))
+			for _, tool := range tools {
+				listed = append(listed, map[string]any{
+					"name": tool.Name, "description": tool.Description,
+					"inputSchema": tool.InputSchema, "outputSchema": tool.OutputSchema,
+				})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{"tools": listed},
+			})
 			return
 		}
 		if req.Method != "tools/call" || req.Params.Name == "" {

--- a/internal/repository/relationship_correction_repository.go
+++ b/internal/repository/relationship_correction_repository.go
@@ -145,9 +145,6 @@ func (r *SemanticRepositoryImpl) correctRelationship(
 				committedErr = err
 				return nil
 			}
-			if errors.Is(err, ErrRelationshipCorrectionConfirmation) && result != nil && result.ProcessingState == "awaiting_confirmation" {
-				return nil
-			}
 		} else {
 			result, err = r.submitRelationshipCorrection(ctx, tx, input)
 		}

--- a/internal/repository/relationship_correction_repository.go
+++ b/internal/repository/relationship_correction_repository.go
@@ -145,6 +145,9 @@ func (r *SemanticRepositoryImpl) correctRelationship(
 				committedErr = err
 				return nil
 			}
+			if errors.Is(err, ErrRelationshipCorrectionConfirmation) && result != nil && result.ProcessingState == "awaiting_confirmation" {
+				return nil
+			}
 		} else {
 			result, err = r.submitRelationshipCorrection(ctx, tx, input)
 		}
@@ -342,7 +345,7 @@ func (r *SemanticRepositoryImpl) confirmRelationshipCorrection(
 		return relationshipCorrectionResultFromRow(updated), ErrRelationshipCorrectionConfirmationExpired
 	}
 	if subtle.ConstantTimeCompare([]byte(row.ConfirmationToken), []byte(input.ConfirmationToken)) != 1 {
-		return nil, ErrRelationshipCorrectionConfirmation
+		return relationshipCorrectionResultFromRow(row), ErrRelationshipCorrectionConfirmation
 	}
 
 	source, err := loadRelationshipRecordForUpdate(ctx, tx, row.TeamID, row.RelationshipID)
@@ -391,7 +394,7 @@ func (r *SemanticRepositoryImpl) confirmRelationshipCorrection(
 
 	selection, err := validateRelationshipCorrectionSelection(row, input.Selection)
 	if err != nil {
-		return nil, err
+		return relationshipCorrectionResultFromRow(row), err
 	}
 	confirmInput := CorrectRelationshipInput{
 		TeamID:          row.TeamID,

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -255,6 +255,16 @@ func TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation(t *testing.
 	}))
 	require.Equal(t, "active", originalStatus)
 
+	invalidToken, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
+		SubmissionID: submitted.SubmissionID, ConfirmationToken: uuid.NewString(),
+		Selection: RelationshipCorrectionSelection{ObjectEntityID: firstAtlas.EntityID}, IdempotencyKey: "invalid-token-confirm",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "awaiting_confirmation", invalidToken.ProcessingState)
+	require.NotNil(t, invalidToken.Confirmation)
+	require.Equal(t, submitted.Confirmation.Token, invalidToken.Confirmation.Token)
+
 	confirmed, err := correctRelationshipWithTestEmbeddings(ctx, semantic, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
 		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -265,6 +265,16 @@ func TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation(t *testing.
 	require.NotNil(t, invalidToken.Confirmation)
 	require.Equal(t, submitted.Confirmation.Token, invalidToken.Confirmation.Token)
 
+	invalidSelection, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
+		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,
+		Selection: RelationshipCorrectionSelection{ObjectEntityID: uuid.NewString()}, IdempotencyKey: "invalid-selection-confirm",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "awaiting_confirmation", invalidSelection.ProcessingState)
+	require.NotNil(t, invalidSelection.Confirmation)
+	require.Equal(t, submitted.Confirmation.Token, invalidSelection.Confirmation.Token)
+
 	confirmed, err := correctRelationshipWithTestEmbeddings(ctx, semantic, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
 		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,

--- a/internal/repository/relationship_correction_repository_integration_test.go
+++ b/internal/repository/relationship_correction_repository_integration_test.go
@@ -255,20 +255,28 @@ func TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation(t *testing.
 	}))
 	require.Equal(t, "active", originalStatus)
 
-	invalidToken, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+	_, err = semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
 		SubmissionID: submitted.SubmissionID, ConfirmationToken: uuid.NewString(),
 		Selection: RelationshipCorrectionSelection{ObjectEntityID: firstAtlas.EntityID}, IdempotencyKey: "invalid-token-confirm",
+	})
+	require.ErrorIs(t, err, ErrRelationshipCorrectionConfirmation)
+	invalidToken, err := semantic.GetRelationshipCorrection(ctx, GetRelationshipCorrectionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SubmissionID: submitted.SubmissionID,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "awaiting_confirmation", invalidToken.ProcessingState)
 	require.NotNil(t, invalidToken.Confirmation)
 	require.Equal(t, submitted.Confirmation.Token, invalidToken.Confirmation.Token)
 
-	invalidSelection, err := semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
+	_, err = semantic.CorrectRelationship(ctx, CorrectRelationshipInput{
 		TeamID: teamID, OwnerProfileID: ownerID, Action: "confirm",
 		SubmissionID: submitted.SubmissionID, ConfirmationToken: submitted.Confirmation.Token,
 		Selection: RelationshipCorrectionSelection{ObjectEntityID: uuid.NewString()}, IdempotencyKey: "invalid-selection-confirm",
+	})
+	require.ErrorIs(t, err, ErrRelationshipCorrectionConfirmation)
+	invalidSelection, err := semantic.GetRelationshipCorrection(ctx, GetRelationshipCorrectionInput{
+		TeamID: teamID, OwnerProfileID: ownerID, SubmissionID: submitted.SubmissionID,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "awaiting_confirmation", invalidSelection.ProcessingState)

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -19,15 +19,17 @@ import (
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 )
 
 var (
-	ErrLifecycleAuthContext          = errors.New("memory lifecycle: authenticated actor context is required")
-	ErrLifecyclePersistence          = errors.New("memory lifecycle: persistence failed")
-	ErrLifecycleEmbeddingUnavailable = errors.New("memory lifecycle: embedding provider unavailable")
-	ErrLifecycleEmbeddingInvalid     = errors.New("memory lifecycle: embedding response invalid")
-	ErrLifecycleEmbeddingTimeout     = errors.New("memory lifecycle: embedding provider timed out")
+	ErrLifecycleAuthContext           = errors.New("memory lifecycle: authenticated actor context is required")
+	ErrLifecyclePersistence           = errors.New("memory lifecycle: persistence failed")
+	ErrLifecycleEmbeddingUnavailable  = errors.New("memory lifecycle: embedding provider unavailable")
+	ErrLifecycleEmbeddingInvalid      = errors.New("memory lifecycle: embedding response invalid")
+	ErrLifecycleEmbeddingTimeout      = errors.New("memory lifecycle: embedding provider timed out")
+	errLifecycleCorrectionCommitFence = errors.New("memory lifecycle: correction commit search fence conflict")
 )
 
 type LifecycleService interface {
@@ -168,6 +170,9 @@ func (s *lifecycleService) CorrectRelationship(
 			err = ctxErr
 		} else {
 			result, err = s.semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+			if isCorrectionCommitSearchFenceError(err) {
+				err = fmt.Errorf("%w: %w", errLifecycleCorrectionCommitFence, err)
+			}
 		}
 	}
 	if err != nil {
@@ -285,6 +290,11 @@ func translateRelationshipCorrectionError(err error) error {
 			Field: "reason", Message: string(SubmissionErrorConfirmationExpired),
 		}})
 	}
+	if errors.Is(err, errLifecycleCorrectionCommitFence) {
+		return httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: string(rememberapp.TerminalErrorCommitConflict),
+		}})
+	}
 	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) ||
 		errors.Is(err, repository.ErrSearchEmbeddingRequired) ||
@@ -293,6 +303,12 @@ func translateRelationshipCorrectionError(err error) error {
 		return httperr.New(httperr.CONFLICT, "relationship correction conflict")
 	}
 	return ErrLifecyclePersistence
+}
+
+func isCorrectionCommitSearchFenceError(err error) bool {
+	return errors.Is(err, repository.ErrSearchEmbeddingRequired) ||
+		errors.Is(err, repository.ErrSearchContractMismatch) ||
+		errors.Is(err, repository.ErrSearchStaleVersion)
 }
 
 func relationshipCorrectionSubmissionStatus(result *repository.RelationshipCorrectionStatus) *SubmissionStatusResult {

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -280,8 +280,12 @@ func translateRelationshipCorrectionError(err error) error {
 			Field: "reason", Message: "idempotency_conflict",
 		}})
 	}
+	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) {
+		return httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: string(SubmissionErrorConfirmationExpired),
+		}})
+	}
 	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
-		errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) ||
 		errors.Is(err, repository.ErrSearchEmbeddingRequired) ||
 		errors.Is(err, repository.ErrSearchContractMismatch) ||

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -275,8 +275,12 @@ func translateRelationshipCorrectionError(err error) error {
 	if errors.Is(err, repository.ErrSemanticOwnerMismatch) || errors.Is(err, repository.ErrRelationshipCorrectionNotFound) {
 		return httperr.New(httperr.NOT_FOUND, "submission not found")
 	}
-	if errors.Is(err, repository.ErrSemanticIdempotencyConflict) ||
-		errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
+	if errors.Is(err, repository.ErrSemanticIdempotencyConflict) {
+		return httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: "idempotency_conflict",
+		}})
+	}
+	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) ||
 		errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) ||
 		errors.Is(err, repository.ErrSearchEmbeddingRequired) ||

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -32,6 +32,11 @@ var (
 	errLifecycleCorrectionCommitFence = errors.New("memory lifecycle: correction commit search fence conflict")
 )
 
+// CorrectionConfirmationInvalidReason identifies a pending confirmation that
+// remains awaiting confirmation after the legacy lifecycle rejects a token or
+// candidate selection.
+const CorrectionConfirmationInvalidReason = "confirmation_invalid"
+
 type LifecycleService interface {
 	CorrectRelationship(ctx context.Context, req CorrectRelationshipRequest) (*CorrectRelationshipReceipt, error)
 	GetRelationshipCorrectionStatus(ctx context.Context, req GetSubmissionStatusRequest) (*SubmissionStatusResult, error)
@@ -288,6 +293,11 @@ func translateRelationshipCorrectionError(err error) error {
 	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) {
 		return httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
 			Field: "reason", Message: string(SubmissionErrorConfirmationExpired),
+		}})
+	}
+	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) {
+		return httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: CorrectionConfirmationInvalidReason,
 		}})
 	}
 	if errors.Is(err, errLifecycleCorrectionCommitFence) {

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/repository"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 )
 
@@ -88,6 +89,26 @@ func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingTimesOut(t *testi
 	require.ErrorAs(t, err, &publicErr)
 	require.Equal(t, httperr.ErrEmbeddingTimeout, publicErr.Code)
 	require.Zero(t, semantic.commitCalls)
+}
+
+func TestLifecycleCorrectRelationshipPreservesCommitFenceClassification(t *testing.T) {
+	teamID, profileID := uuid.New(), uuid.New()
+	for _, cause := range []error{repository.ErrSearchEmbeddingRequired, repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
+				Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+				EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
+			}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}, commitErr: cause}
+			executor := &lifecycleExecutorStub{result: semanticwrite.Result{Fence: semanticwrite.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwrite.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
+			svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor})
+
+			_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "commit-fence-correction"})
+			var publicErr *httperr.APIError
+			require.ErrorAs(t, err, &publicErr)
+			require.Equal(t, httperr.CONFLICT, publicErr.Code)
+			require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: string(rememberapp.TerminalErrorCommitConflict)})
+		})
+	}
 }
 
 func TestLifecycleCorrectRelationshipClassifiesConfiguredEmbeddingDeadline(t *testing.T) {
@@ -293,6 +314,7 @@ type lifecycleSemanticStub struct {
 	err           error
 	plan          *repository.RelationshipCorrectionEmbeddingPlan
 	embeddings    []repository.RelationshipCorrectionEmbedding
+	commitErr     error
 	commitCalls   int
 }
 
@@ -321,6 +343,9 @@ func (s *lifecycleSemanticStub) PlanRelationshipCorrectionEmbeddings(_ context.C
 func (s *lifecycleSemanticStub) CorrectRelationshipWithEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput, embeddings []repository.RelationshipCorrectionEmbedding) (*repository.CorrectRelationshipResult, error) {
 	s.commitCalls++
 	s.embeddings = append([]repository.RelationshipCorrectionEmbedding(nil), embeddings...)
+	if s.commitErr != nil {
+		return nil, s.commitErr
+	}
 	return s.CorrectRelationship(ctx, input)
 }
 

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -173,6 +173,14 @@ func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testi
 	}
 }
 
+func TestTranslateRelationshipCorrectionIdempotencyConflictPreservesTerminalClassification(t *testing.T) {
+	err := translateRelationshipCorrectionError(repository.ErrSemanticIdempotencyConflict)
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.CONFLICT, publicErr.Code)
+	require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: "idempotency_conflict"})
+}
+
 func TestTranslateRelationshipCorrectionErrorMapsEmbeddingFailures(t *testing.T) {
 	for _, test := range []struct {
 		err  error

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -202,6 +202,14 @@ func TestTranslateRelationshipCorrectionIdempotencyConflictPreservesTerminalClas
 	require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: "idempotency_conflict"})
 }
 
+func TestTranslateRelationshipCorrectionConfirmationPreservesTypedConflict(t *testing.T) {
+	err := translateRelationshipCorrectionError(repository.ErrRelationshipCorrectionConfirmation)
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.CONFLICT, publicErr.Code)
+	require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: CorrectionConfirmationInvalidReason})
+}
+
 func TestTranslateRelationshipCorrectionConfirmationExpiryPreservesTerminalClassification(t *testing.T) {
 	err := translateRelationshipCorrectionError(repository.ErrRelationshipCorrectionConfirmationExpired)
 	var publicErr *httperr.APIError

--- a/internal/service/memoryservice/lifecycle_test.go
+++ b/internal/service/memoryservice/lifecycle_test.go
@@ -181,6 +181,14 @@ func TestTranslateRelationshipCorrectionIdempotencyConflictPreservesTerminalClas
 	require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: "idempotency_conflict"})
 }
 
+func TestTranslateRelationshipCorrectionConfirmationExpiryPreservesTerminalClassification(t *testing.T) {
+	err := translateRelationshipCorrectionError(repository.ErrRelationshipCorrectionConfirmationExpired)
+	var publicErr *httperr.APIError
+	require.ErrorAs(t, err, &publicErr)
+	require.Equal(t, httperr.CONFLICT, publicErr.Code)
+	require.Contains(t, publicErr.Details, httperr.ErrorDetail{Field: "reason", Message: string(SubmissionErrorConfirmationExpired)})
+}
+
 func TestTranslateRelationshipCorrectionErrorMapsEmbeddingFailures(t *testing.T) {
 	for _, test := range []struct {
 		err  error

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -164,7 +164,11 @@ func contractTools(deps Dependencies) []Tool {
 				if statusService == nil && deps.Lifecycle == nil {
 					return nil, ErrToolUnavailable
 				}
-				if err := ValidateContractInput(tool, input, authenticatedScopes(ctx)); err != nil {
+				if internalSubmissionStatusLookup(ctx) {
+					if err := ValidateInput(tool, input); err != nil {
+						return nil, fmt.Errorf("get_submission_status: invalid input: %w", err)
+					}
+				} else if err := ValidateContractInput(tool, input, authenticatedScopes(ctx)); err != nil {
 					return nil, fmt.Errorf("get_submission_status: invalid input: %w", err)
 				}
 				var req memoryservice.GetSubmissionStatusRequest

--- a/internal/tools/registry/contract_auth.go
+++ b/internal/tools/registry/contract_auth.go
@@ -6,10 +6,21 @@ import (
 	"github.com/markhuangai/dense-mem/internal/requestctx"
 )
 
+type internalSubmissionStatusLookupContextKey struct{}
+
 func authenticatedScopes(ctx context.Context) []string {
 	actor, ok := requestctx.ActorFromContext(ctx)
 	if !ok {
 		return nil
 	}
 	return actor.Grants
+}
+
+func withInternalSubmissionStatusLookup(ctx context.Context) context.Context {
+	return context.WithValue(ctx, internalSubmissionStatusLookupContextKey{}, true)
+}
+
+func internalSubmissionStatusLookup(ctx context.Context) bool {
+	value, _ := ctx.Value(internalSubmissionStatusLookupContextKey{}).(bool)
+	return value
 }

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -543,6 +543,9 @@ func terminalCorrectionToolResultErrorWithOptions(ctx context.Context, submissio
 			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorIdempotencyConflict)):
 				code = rememberapp.TerminalErrorIdempotencyConflict
 				statusError = terminalCorrectionStatusError(code)
+			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorCommitConflict)):
+				code = rememberapp.TerminalErrorCommitConflict
+				statusError = rememberapp.TerminalStatusError(code)
 			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.SubmissionErrorConfirmationExpired)):
 				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorConfirmationExpired)
 				processingState = string(rememberapp.TerminalProcessingRejected)

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -523,6 +523,7 @@ func terminalRememberErrorCode(err error) rememberapp.TerminalErrorCode {
 
 func terminalCorrectionToolResultError(ctx context.Context, submissionID string, err error, version string) error {
 	code := rememberapp.TerminalErrorDatabaseFailure
+	processingState := string(rememberapp.TerminalProcessingFailed)
 	var statusError rememberapp.SubmissionStatusError
 	var apiErr *httperr.APIError
 	if errors.As(err, &apiErr) {
@@ -530,10 +531,14 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 		case httperr.NOT_FOUND:
 			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorEntityNotFound)
 		case httperr.CONFLICT:
-			if !apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorIdempotencyConflict)) {
-				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorRelationshipChanged)
-			} else {
+			switch {
+			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorIdempotencyConflict)):
 				code = rememberapp.TerminalErrorIdempotencyConflict
+			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.SubmissionErrorConfirmationExpired)):
+				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorConfirmationExpired)
+				processingState = string(rememberapp.TerminalProcessingRejected)
+			default:
+				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorRelationshipChanged)
 			}
 		case httperr.ErrEmbeddingUnavailable:
 			code = rememberapp.TerminalErrorEmbeddingUnavailable
@@ -557,7 +562,7 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 		"contract_version": version,
 		"submission_id":    firstNonEmptyString(submissionID, uuid.NewString()),
 		"submission_kind":  "relationship_correction",
-		"processing_state": string(rememberapp.TerminalProcessingFailed),
+		"processing_state": processingState,
 		"search_state":     string(rememberapp.TerminalSearchNotRequired),
 		"correlation_id":   firstNonEmptyString(correlation.FromContext(ctx), uuid.NewString()),
 		"errors": []any{map[string]any{

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -209,6 +209,26 @@ func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInv
 		}
 		receipt, err := legacy.Invoke(ctx, teamID, input)
 		if err != nil {
+			if isInvalidConfirmationError(input, err) {
+				submissionID := strings.TrimSpace(stringInput(input["submission_id"]))
+				statusOutput, statusErr := status.Invoke(withInternalSubmissionStatusLookup(ctx), teamID, map[string]any{"submission_id": submissionID})
+				if statusErr != nil {
+					return nil, terminalCorrectionStatusReadError(ctx, submissionID, version)
+				}
+				correlationID := strings.TrimSpace(stringInput(statusOutput["correlation_id"]))
+				if correlationID == "" {
+					correlationID = firstNonEmptyString(correlation.FromContext(ctx), uuid.NewString())
+				}
+				hydrated, hydrateErr := terminalCorrectionResultMap(map[string]any{
+					"submission_id": submissionID, "correlation_id": correlationID,
+				}, statusOutput, version)
+				if hydrateErr == nil && stringInput(hydrated["processing_state"]) == "awaiting_confirmation" {
+					if hydrateErr = validateTerminalCorrectionOutput(hydrated, version); hydrateErr != nil {
+						return nil, terminalCorrectionToolResultError(ctx, submissionID, hydrateErr, version)
+					}
+					return hydrated, nil
+				}
+			}
 			return nil, terminalCorrectionToolResultError(ctx, stringInput(input["submission_id"]), err, version)
 		}
 		submissionID := strings.TrimSpace(stringInput(receipt["submission_id"]))
@@ -232,6 +252,15 @@ func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInv
 		}
 		return output, nil
 	}
+}
+
+func isInvalidConfirmationError(input map[string]any, err error) bool {
+	if stringInput(input["action"]) != "confirm" {
+		return false
+	}
+	var apiErr *httperr.APIError
+	return errors.As(err, &apiErr) && apiErr.Code == httperr.CONFLICT &&
+		apiErrorDetailEquals(apiErr, "reason", memoryservice.CorrectionConfirmationInvalidReason)
 }
 
 func terminalRememberRequest(input map[string]any) (rememberapp.RememberRequest, error) {

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -215,7 +215,7 @@ func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInv
 		if submissionID == "" {
 			return nil, terminalCorrectionToolResultError(ctx, "", errors.New("correction receipt missing submission_id"), version)
 		}
-		statusOutput, err := status.Invoke(ctx, teamID, map[string]any{"submission_id": submissionID})
+		statusOutput, err := status.Invoke(withInternalSubmissionStatusLookup(ctx), teamID, map[string]any{"submission_id": submissionID})
 		if err != nil {
 			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
 		}
@@ -223,7 +223,7 @@ func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInv
 		if err != nil {
 			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
 		}
-		if err := validateTerminalCorrectionOutput(output); err != nil {
+		if err := validateTerminalCorrectionOutput(output, version); err != nil {
 			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
 		}
 		state := stringInput(output["processing_state"])
@@ -300,8 +300,8 @@ func terminalCorrectionResultMap(receipt, status map[string]any, version string)
 	return output, nil
 }
 
-func validateTerminalCorrectionOutput(output map[string]any) error {
-	if err := ValidateInput(Tool{InputSchema: terminalCorrectionOutputSchema(ContractVersionV261)}, output); err != nil {
+func validateTerminalCorrectionOutput(output map[string]any, version string) error {
+	if err := ValidateInput(Tool{InputSchema: terminalCorrectionOutputSchema(version)}, output); err != nil {
 		return err
 	}
 	state := stringInput(output["processing_state"])
@@ -530,7 +530,11 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 		case httperr.NOT_FOUND:
 			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorEntityNotFound)
 		case httperr.CONFLICT:
-			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorRelationshipChanged)
+			if !apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorIdempotencyConflict)) {
+				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorRelationshipChanged)
+			} else {
+				code = rememberapp.TerminalErrorIdempotencyConflict
+			}
 		case httperr.ErrEmbeddingUnavailable:
 			code = rememberapp.TerminalErrorEmbeddingUnavailable
 		case httperr.ErrEmbeddingResponseInvalid:
@@ -566,4 +570,16 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 		output["errors"].([]any)[0].(map[string]any)["remediation"] = "Retry correct_relationship with current relationship state and a new idempotency_key."
 	}
 	return NewToolResultError(output)
+}
+
+func apiErrorDetailEquals(apiErr *httperr.APIError, field, value string) bool {
+	if apiErr == nil {
+		return false
+	}
+	for _, detail := range apiErr.Details {
+		if detail.Field == field && detail.Message == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -1,0 +1,569 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/correlation"
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+// ContractVersionV261 is the prepared terminal contract version. Production
+// remains on domain.ContractVersion until the stopped-service cutover.
+const ContractVersionV261 = "dense-mem.v2.6.1"
+
+var contractV261ToolNames = []string{
+	ToolRemember,
+	ToolRetractEvidence,
+	ToolCorrectRelationship,
+	ToolRecallMemory,
+	ToolTraceMemory,
+	ToolSubmitRecallSessionFeedback,
+	ToolListDreams,
+	ToolGetDream,
+	ToolResolveDreamFeedback,
+	ToolExportMemoryPack,
+}
+
+// ContractV261ToolNames returns the frozen ten-tool target catalog names.
+func ContractV261ToolNames() []string {
+	return append([]string(nil), contractV261ToolNames...)
+}
+
+// ContractV261Tools returns metadata for the inactive terminal catalog. The
+// returned tools have no invokers until an explicit test-only composition seam
+// installs them.
+func ContractV261Tools() []Tool {
+	byName := make(map[string]Tool, len(contractToolNames))
+	for _, tool := range ContractTools() {
+		byName[tool.Name] = tool
+	}
+	tools := make([]Tool, 0, len(contractV261ToolNames))
+	for _, name := range contractV261ToolNames {
+		tool, ok := byName[name]
+		if !ok {
+			continue
+		}
+		tool.Visibility = domain.ToolVisibility
+		switch name {
+		case ToolRemember:
+			tool.Description = "Submit exact evidence and relationship proposals for one synchronous atomic semantic commit; every submitted evidence item must be cited by evidence_index. The server and assessor own exact grounding. Use exactly one object shape: {\"object\":{\"entity\":{\"name\":\"PostgreSQL\",\"entity_kind\":\"product\"}}} or {\"object\":{\"value\":{\"type\":\"string\",\"value\":\"PostgreSQL\"}}}."
+			tool.OutputSchema = terminalRememberOutputSchema(ContractVersionV261)
+		case ToolCorrectRelationship:
+			tool.OutputSchema = terminalCorrectionOutputSchema(ContractVersionV261)
+		}
+		tools = append(tools, tool)
+	}
+	return tools
+}
+
+// WithTerminalRemember replaces only Remember in an active catalog. It is the
+// transitional E2E seam used by T02 and retains the v2.6 status tool.
+func WithTerminalRemember(active Registry, remember rememberapp.Service) (Registry, error) {
+	if active == nil {
+		return nil, errors.New("terminal Remember registry requires an active catalog")
+	}
+	if remember == nil {
+		return nil, errors.New("terminal Remember registry requires a service")
+	}
+	legacy, ok := active.Get(ToolRemember)
+	if !ok {
+		return nil, fmt.Errorf("terminal Remember registry has no %q tool", ToolRemember)
+	}
+	replacement := legacy
+	replacement.OutputSchema = terminalRememberOutputSchema(domain.ContractVersion)
+	replacement.Invoke = terminalRememberInvoker(legacy, remember, domain.ContractVersion, false)
+	return cloneContractRegistry(active, replacement, false)
+}
+
+// BuildContractV261 installs the inactive ten-tool terminal catalog over an
+// active registry. It is intentionally not called by production BuildActive.
+func BuildContractV261(active Registry, remember rememberapp.Service) (Registry, error) {
+	if active == nil {
+		return nil, errors.New("v2.6.1 registry requires an active catalog")
+	}
+	if remember == nil {
+		return nil, errors.New("v2.6.1 registry requires a Remember service")
+	}
+	if _, ok := active.Get(ToolGetSubmissionStatus); !ok {
+		return nil, fmt.Errorf("v2.6.1 registry requires the legacy %q invoker", ToolGetSubmissionStatus)
+	}
+	metadata := make(map[string]Tool, len(contractV261ToolNames))
+	for _, tool := range ContractV261Tools() {
+		metadata[tool.Name] = tool
+	}
+	for _, name := range contractV261ToolNames {
+		if _, ok := active.Get(name); !ok {
+			return nil, fmt.Errorf("v2.6.1 registry is missing %q", name)
+		}
+	}
+
+	status, _ := active.Get(ToolGetSubmissionStatus)
+	cloned := New()
+	for _, name := range contractV261ToolNames {
+		source, ok := active.Get(name)
+		if !ok {
+			return nil, fmt.Errorf("v2.6.1 registry is missing %q", name)
+		}
+		target := metadata[name]
+		target.Invoke = source.Invoke
+		target.Visibility = source.Visibility
+		switch name {
+		case ToolRemember:
+			target.Invoke = terminalRememberInvoker(source, remember, ContractVersionV261, true)
+		case ToolCorrectRelationship:
+			target.Invoke = terminalCorrectionInvoker(source, status, ContractVersionV261)
+		}
+		if err := cloned.Register(target); err != nil {
+			return nil, fmt.Errorf("v2.6.1 registry: %w", err)
+		}
+	}
+	return cloned, nil
+}
+
+func cloneContractRegistry(active Registry, replacement Tool, omitStatus bool) (Registry, error) {
+	cloned := New()
+	replaced := false
+	for _, tool := range active.List() {
+		if omitStatus && tool.Name == ToolGetSubmissionStatus {
+			continue
+		}
+		if tool.Name == replacement.Name {
+			tool = replacement
+			replaced = true
+		}
+		if err := cloned.Register(tool); err != nil {
+			return nil, fmt.Errorf("clone contract registry: %w", err)
+		}
+	}
+	if !replaced {
+		return nil, fmt.Errorf("clone contract registry: tool %q is not registered", replacement.Name)
+	}
+	return cloned, nil
+}
+
+func terminalRememberInvoker(legacy Tool, remember rememberapp.Service, version string, structuredFallback bool) ToolInvoker {
+	return func(ctx context.Context, _ string, input map[string]any) (map[string]any, error) {
+		if err := ValidateContractInput(legacy, input, authenticatedScopes(ctx)); err != nil {
+			return nil, fmt.Errorf("remember: invalid input: %w", err)
+		}
+		if err := validateTerminalRememberSupersessions(input); err != nil {
+			return nil, err
+		}
+		req, err := terminalRememberRequest(input)
+		if err != nil {
+			return nil, fmt.Errorf("remember: invalid input: %w", err)
+		}
+		result, err := remember.Remember(ctx, req)
+		if err != nil {
+			var processErr *rememberapp.RememberProcessError
+			if errors.As(err, &processErr) && processErr.Result != nil {
+				result = &rememberapp.RememberResult{Terminal: processErr.Result}
+			} else if structuredFallback {
+				return nil, terminalRememberToolResultError(ctx, input, err, version)
+			} else {
+				return nil, err
+			}
+		}
+		if result == nil || result.Terminal == nil {
+			if structuredFallback {
+				return nil, terminalRememberToolResultError(ctx, input, errors.New("remember: terminal result is required"), version)
+			}
+			return nil, errors.New("remember: terminal result is required")
+		}
+		if err := rememberapp.ValidateTerminalRememberResult(result.Terminal, len(req.Evidence), terminalRelationshipRefs(input)); err != nil {
+			if structuredFallback {
+				return nil, terminalRememberToolResultError(ctx, input, err, version)
+			}
+			return nil, fmt.Errorf("remember: invalid terminal result")
+		}
+		output, err := terminalRememberResultMap(result.Terminal, version)
+		if err != nil {
+			if structuredFallback {
+				return nil, terminalRememberToolResultError(ctx, input, err, version)
+			}
+			return nil, err
+		}
+		if result.Terminal.ProcessingState != string(rememberapp.TerminalProcessingCompleted) {
+			return nil, NewToolResultError(output)
+		}
+		return output, nil
+	}
+}
+
+func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInvoker {
+	return func(ctx context.Context, teamID string, input map[string]any) (map[string]any, error) {
+		if err := ValidateContractInput(legacy, input, authenticatedScopes(ctx)); err != nil {
+			return nil, fmt.Errorf("correct_relationship: invalid input: %w", err)
+		}
+		if legacy.Invoke == nil || status.Invoke == nil {
+			return nil, terminalCorrectionToolResultError(ctx, stringInput(input["submission_id"]), errors.New("correction invoker is unavailable"), version)
+		}
+		receipt, err := legacy.Invoke(ctx, teamID, input)
+		if err != nil {
+			return nil, terminalCorrectionToolResultError(ctx, stringInput(input["submission_id"]), err, version)
+		}
+		submissionID := strings.TrimSpace(stringInput(receipt["submission_id"]))
+		if submissionID == "" {
+			return nil, terminalCorrectionToolResultError(ctx, "", errors.New("correction receipt missing submission_id"), version)
+		}
+		statusOutput, err := status.Invoke(ctx, teamID, map[string]any{"submission_id": submissionID})
+		if err != nil {
+			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
+		}
+		output, err := terminalCorrectionResultMap(receipt, statusOutput, version)
+		if err != nil {
+			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
+		}
+		if err := validateTerminalCorrectionOutput(output); err != nil {
+			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
+		}
+		state := stringInput(output["processing_state"])
+		if state == "rejected" || state == "failed" {
+			return nil, NewToolResultError(output)
+		}
+		return output, nil
+	}
+}
+
+func terminalRememberRequest(input map[string]any) (rememberapp.RememberRequest, error) {
+	copyInput := make(map[string]any, len(input)+1)
+	for key, value := range input {
+		copyInput[key] = value
+	}
+	copyInput["relationship_hints"] = input["relationships"]
+	encoded, err := json.Marshal(copyInput)
+	if err != nil {
+		return rememberapp.RememberRequest{}, err
+	}
+	var request rememberapp.RememberRequest
+	if err := json.Unmarshal(encoded, &request); err != nil {
+		return rememberapp.RememberRequest{}, err
+	}
+	return request, nil
+}
+
+func terminalRelationshipRefs(input map[string]any) []string {
+	items, _ := input["relationships"].([]any)
+	refs := make([]string, 0, len(items))
+	for _, value := range items {
+		fields, _ := value.(map[string]any)
+		refs = append(refs, strings.TrimSpace(stringInput(fields["ref"])))
+	}
+	return refs
+}
+
+func terminalRememberResultMap(result *rememberapp.TerminalRememberResult, version string) (map[string]any, error) {
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	output := map[string]any{}
+	if err := json.Unmarshal(encoded, &output); err != nil {
+		return nil, err
+	}
+	output["contract_version"] = version
+	if err := ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(version)}, output); err != nil {
+		return nil, fmt.Errorf("remember: terminal output validation failed: %w", err)
+	}
+	return output, nil
+}
+
+func terminalCorrectionResultMap(receipt, status map[string]any, version string) (map[string]any, error) {
+	submissionID := firstNonEmptyString(stringInput(status["submission_id"]), stringInput(receipt["submission_id"]))
+	correlationID := firstNonEmptyString(stringInput(receipt["correlation_id"]), stringInput(status["correlation_id"]))
+	searchState := firstNonEmptyString(stringInput(status["search_state"]), string(domain.SearchProjectionNotRequired))
+	processingState := firstNonEmptyString(stringInput(status["processing_state"]), stringInput(receipt["processing_state"]))
+	output := map[string]any{
+		"contract_version": version,
+		"submission_id":    submissionID,
+		"submission_kind":  "relationship_correction",
+		"processing_state": processingState,
+		"search_state":     searchState,
+		"correlation_id":   correlationID,
+		"errors":           normalizeArray(status["errors"]),
+	}
+	if value, ok := status["awaiting_confirmation"]; ok && value != nil {
+		output["awaiting_confirmation"] = value
+	}
+	if value, ok := status["correction_result"]; ok && value != nil {
+		output["correction_result"] = value
+	}
+	return output, nil
+}
+
+func validateTerminalCorrectionOutput(output map[string]any) error {
+	if err := ValidateInput(Tool{InputSchema: terminalCorrectionOutputSchema(ContractVersionV261)}, output); err != nil {
+		return err
+	}
+	state := stringInput(output["processing_state"])
+	if state == "awaiting_confirmation" && output["awaiting_confirmation"] == nil {
+		return errors.New("correction awaiting_confirmation result is missing confirmation details")
+	}
+	if state == "completed" && output["correction_result"] == nil {
+		return errors.New("completed correction result is missing correction details")
+	}
+	if (state == "rejected" || state == "failed") && len(normalizeArray(output["errors"])) == 0 {
+		return errors.New("rejected correction result is missing errors")
+	}
+	return nil
+}
+
+func normalizeArray(value any) []any {
+	if value == nil {
+		return []any{}
+	}
+	if values, ok := value.([]any); ok {
+		return values
+	}
+	if values, ok := value.([]map[string]any); ok {
+		result := make([]any, 0, len(values))
+		for _, item := range values {
+			result = append(result, item)
+		}
+		return result
+	}
+	if values, ok := value.([]rememberapp.SubmissionStatusError); ok {
+		result := make([]any, 0, len(values))
+		for _, item := range values {
+			result = append(result, map[string]any{
+				"code": item.Code, "message": item.Message, "retryable": item.Retryable,
+				"next_action": item.NextAction, "remediation": item.Remediation,
+			})
+		}
+		return result
+	}
+	return []any{}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func validateTerminalRememberSupersessions(input map[string]any) error {
+	evidence, _ := input["evidence"].([]any)
+	seen := make(map[uuid.UUID]int)
+	for evidenceIndex, rawEvidence := range evidence {
+		item, _ := rawEvidence.(map[string]any)
+		targets, _ := item["supersedes_evidence_ids"].([]any)
+		for targetIndex, rawTarget := range targets {
+			target, _ := rawTarget.(string)
+			parsed, err := uuid.Parse(strings.TrimSpace(target))
+			if err != nil {
+				return &ContractValidationFailure{Result: ContractValidationResult{Issues: []ContractValidationIssue{{
+					Path: fmt.Sprintf("/evidence/%d/supersedes_evidence_ids/%d", evidenceIndex, targetIndex), Code: "format",
+					Message: fmt.Sprintf("evidence[%d].supersedes_evidence_ids[%d]: target must be a UUID", evidenceIndex, targetIndex),
+				}}}}
+			}
+			if previous, exists := seen[parsed]; exists {
+				return &ContractValidationFailure{Result: ContractValidationResult{Issues: []ContractValidationIssue{{
+					Path: fmt.Sprintf("/evidence/%d/supersedes_evidence_ids", evidenceIndex), Code: "duplicate",
+					Message: fmt.Sprintf("evidence[%d].supersedes_evidence_ids: duplicates target from evidence[%d]", evidenceIndex, previous),
+				}}}}
+			}
+			seen[parsed] = evidenceIndex
+		}
+	}
+	return nil
+}
+
+func terminalRememberToolResultError(ctx context.Context, input map[string]any, err error, version string) error {
+	refs := terminalRelationshipRefs(input)
+	evidenceCount := terminalEvidenceCount(input)
+	base, _ := terminalRememberFailureBase(ctx, err, evidenceCount, refs)
+	output, mapErr := terminalRememberResultMap(base, version)
+	if mapErr != nil {
+		return mapErr
+	}
+	return NewToolResultError(output)
+}
+
+func terminalEvidenceCount(input map[string]any) int {
+	evidence, _ := input["evidence"].([]any)
+	return len(evidence)
+}
+
+func terminalRememberFailureBase(ctx context.Context, err error, evidenceCount int, refs []string) (*rememberapp.TerminalRememberResult, rememberapp.TerminalErrorCode) {
+	code := terminalRememberErrorCode(err)
+	base := &rememberapp.TerminalRememberResult{
+		ContractVersion:     domain.ContractVersion,
+		SubmissionID:        uuid.NewString(),
+		SubmissionKind:      "remember",
+		ProcessingState:     string(rememberapp.TerminalProcessingFailed),
+		SearchState:         string(rememberapp.TerminalSearchNotRequired),
+		CorrelationID:       correlation.FromContext(ctx),
+		Evidence:            make([]rememberapp.TerminalEvidenceResult, evidenceCount),
+		RelationshipResults: make([]rememberapp.SubmissionRelationshipResult, len(refs)),
+		Errors:              []rememberapp.SubmissionStatusError{},
+		Kind:                rememberapp.ResultKindTerminal,
+	}
+	for index := range base.Evidence {
+		base.Evidence[index] = rememberapp.TerminalEvidenceResult{
+			Disposition: "not_stored", EvidenceIndex: index, SupersededEvidenceIDs: []string{},
+			SearchState: string(rememberapp.TerminalSearchNotRequired), Reason: "internal_failure",
+		}
+	}
+	for index, ref := range refs {
+		base.RelationshipResults[index] = rememberapp.SubmissionRelationshipResult{
+			RelationshipRef: ref, Disposition: "not_stored", Reason: "internal_failure",
+			Splits: []rememberapp.SubmissionRelationshipSplit{},
+		}
+	}
+
+	var processErr *rememberapp.RememberProcessError
+	if errors.As(err, &processErr) && processErr != nil {
+		if processErr.Result != nil {
+			base = processErr.Result
+		}
+		if processErr.Status != nil {
+			status := processErr.Status
+			if strings.TrimSpace(status.SubmissionID) != "" {
+				base.SubmissionID = strings.TrimSpace(status.SubmissionID)
+			}
+			if strings.TrimSpace(status.CorrelationID) != "" {
+				base.CorrelationID = strings.TrimSpace(status.CorrelationID)
+			}
+			if status.ProcessingState != "" {
+				base.ProcessingState = status.ProcessingState
+			}
+			if len(status.Errors) > 0 {
+				code = terminalErrorCodeFromStatus(status.Errors[0].Code, status.ProcessingState)
+			}
+		}
+	}
+	if strings.TrimSpace(base.SubmissionID) == "" {
+		base.SubmissionID = uuid.NewString()
+	}
+	if strings.TrimSpace(base.CorrelationID) == "" {
+		base.CorrelationID = firstNonEmptyString(correlation.FromContext(ctx), uuid.NewString())
+	}
+	base.ContractVersion = domain.ContractVersion
+	base.SubmissionKind = "remember"
+	base.Kind = rememberapp.ResultKindTerminal
+	if base.Evidence == nil || len(base.Evidence) != evidenceCount || base.RelationshipResults == nil || len(base.RelationshipResults) != len(refs) || len(base.Errors) == 0 || rememberapp.ValidateTerminalRememberResult(base, evidenceCount, refs) != nil {
+		failure := rememberapp.TerminalResultWithError(base, code)
+		base = failure.Result
+	}
+	return base, code
+}
+
+func terminalErrorCodeFromStatus(rawCode, state string) rememberapp.TerminalErrorCode {
+	code := rememberapp.TerminalErrorCode(strings.TrimSpace(rawCode))
+	if rememberapp.IsTerminalErrorCode(code) {
+		return code
+	}
+	switch strings.TrimSpace(rawCode) {
+	case string(rememberapp.SubmissionErrorNoSupportedMemory):
+		return rememberapp.TerminalErrorNoSupportedMemory
+	case string(rememberapp.SubmissionErrorStaleInput):
+		return rememberapp.TerminalErrorStaleInput
+	case string(rememberapp.SubmissionErrorProviderUnavailable):
+		return rememberapp.TerminalErrorProviderUnavailable
+	case string(rememberapp.SubmissionErrorProviderResponseInvalid):
+		return rememberapp.TerminalErrorProviderResponseInvalid
+	case string(rememberapp.SubmissionErrorInputBudgetExceeded):
+		return rememberapp.TerminalErrorInputBudgetExceeded
+	case string(rememberapp.SubmissionErrorConfigurationInvalid):
+		return rememberapp.TerminalErrorConfigurationInvalid
+	case "idempotency_conflict":
+		return rememberapp.TerminalErrorIdempotencyConflict
+	case "embedding_unavailable":
+		return rememberapp.TerminalErrorEmbeddingUnavailable
+	case "embedding_response_invalid":
+		return rememberapp.TerminalErrorEmbeddingResponseInvalid
+	case "commit_conflict":
+		return rememberapp.TerminalErrorCommitConflict
+	case string(rememberapp.SubmissionErrorDatabaseFailure):
+		return rememberapp.TerminalErrorDatabaseFailure
+	case "request_timeout":
+		return rememberapp.TerminalErrorRequestTimeout
+	case "request_cancelled":
+		return rememberapp.TerminalErrorRequestCancelled
+	case string(rememberapp.SubmissionErrorQuarantined):
+		return rememberapp.TerminalErrorQuarantined
+	}
+	if state == string(rememberapp.TerminalProcessingRejected) {
+		return rememberapp.TerminalErrorNoSupportedMemory
+	}
+	if state == string(rememberapp.TerminalProcessingQuarantined) {
+		return rememberapp.TerminalErrorQuarantined
+	}
+	return rememberapp.TerminalErrorInternalFailure
+}
+
+func terminalRememberErrorCode(err error) rememberapp.TerminalErrorCode {
+	switch {
+	case errors.Is(err, memoryservice.ErrRememberConflict), errors.Is(err, rememberapp.ErrRememberConflict):
+		return rememberapp.TerminalErrorIdempotencyConflict
+	case errors.Is(err, context.DeadlineExceeded):
+		return rememberapp.TerminalErrorRequestTimeout
+	case errors.Is(err, context.Canceled):
+		return rememberapp.TerminalErrorRequestCancelled
+	case errors.Is(err, rememberapp.ErrEvidenceSecurityRejected):
+		return rememberapp.TerminalErrorQuarantined
+	case errors.Is(err, rememberapp.ErrRememberPersistence):
+		return rememberapp.TerminalErrorDatabaseFailure
+	default:
+		return rememberapp.TerminalErrorInternalFailure
+	}
+}
+
+func terminalCorrectionToolResultError(ctx context.Context, submissionID string, err error, version string) error {
+	code := rememberapp.TerminalErrorDatabaseFailure
+	var statusError rememberapp.SubmissionStatusError
+	var apiErr *httperr.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case httperr.NOT_FOUND:
+			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorEntityNotFound)
+		case httperr.CONFLICT:
+			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorRelationshipChanged)
+		case httperr.ErrEmbeddingUnavailable:
+			code = rememberapp.TerminalErrorEmbeddingUnavailable
+		case httperr.ErrEmbeddingResponseInvalid:
+			code = rememberapp.TerminalErrorEmbeddingResponseInvalid
+		case httperr.ErrEmbeddingTimeout:
+			code = rememberapp.TerminalErrorRequestTimeout
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		code = rememberapp.TerminalErrorRequestTimeout
+		statusError = rememberapp.TerminalStatusError(code)
+	} else if errors.Is(err, context.Canceled) {
+		code = rememberapp.TerminalErrorRequestCancelled
+		statusError = rememberapp.TerminalStatusError(code)
+	}
+	if statusError.Code == "" {
+		statusError = rememberapp.TerminalStatusError(code)
+	}
+	output := map[string]any{
+		"contract_version": version,
+		"submission_id":    firstNonEmptyString(submissionID, uuid.NewString()),
+		"submission_kind":  "relationship_correction",
+		"processing_state": string(rememberapp.TerminalProcessingFailed),
+		"search_state":     string(rememberapp.TerminalSearchNotRequired),
+		"correlation_id":   firstNonEmptyString(correlation.FromContext(ctx), uuid.NewString()),
+		"errors": []any{map[string]any{
+			"code": statusError.Code, "message": statusError.Message, "retryable": statusError.Retryable,
+			"next_action": statusError.NextAction, "remediation": statusError.Remediation,
+		}},
+	}
+	if statusError.Code == string(rememberapp.TerminalErrorDatabaseFailure) {
+		output["errors"].([]any)[0].(map[string]any)["next_action"] = string(rememberapp.TerminalNextActionRetryCorrection)
+		output["errors"].([]any)[0].(map[string]any)["remediation"] = "Retry correct_relationship with current relationship state and a new idempotency_key."
+	}
+	return NewToolResultError(output)
+}

--- a/internal/tools/registry/contract_v261.go
+++ b/internal/tools/registry/contract_v261.go
@@ -217,7 +217,7 @@ func terminalCorrectionInvoker(legacy Tool, status Tool, version string) ToolInv
 		}
 		statusOutput, err := status.Invoke(withInternalSubmissionStatusLookup(ctx), teamID, map[string]any{"submission_id": submissionID})
 		if err != nil {
-			return nil, terminalCorrectionToolResultError(ctx, submissionID, err, version)
+			return nil, terminalCorrectionStatusReadError(ctx, submissionID, version)
 		}
 		output, err := terminalCorrectionResultMap(receipt, statusOutput, version)
 		if err != nil {
@@ -522,11 +522,19 @@ func terminalRememberErrorCode(err error) rememberapp.TerminalErrorCode {
 }
 
 func terminalCorrectionToolResultError(ctx context.Context, submissionID string, err error, version string) error {
+	return terminalCorrectionToolResultErrorWithOptions(ctx, submissionID, err, version, false)
+}
+
+func terminalCorrectionStatusReadError(ctx context.Context, submissionID, version string) error {
+	return terminalCorrectionToolResultErrorWithOptions(ctx, submissionID, nil, version, true)
+}
+
+func terminalCorrectionToolResultErrorWithOptions(ctx context.Context, submissionID string, err error, version string, retrySameRequest bool) error {
 	code := rememberapp.TerminalErrorDatabaseFailure
 	processingState := string(rememberapp.TerminalProcessingFailed)
 	var statusError rememberapp.SubmissionStatusError
 	var apiErr *httperr.APIError
-	if errors.As(err, &apiErr) {
+	if !retrySameRequest && errors.As(err, &apiErr) {
 		switch apiErr.Code {
 		case httperr.NOT_FOUND:
 			statusError = rememberapp.StatusError(rememberapp.SubmissionErrorEntityNotFound)
@@ -534,6 +542,7 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 			switch {
 			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.TerminalErrorIdempotencyConflict)):
 				code = rememberapp.TerminalErrorIdempotencyConflict
+				statusError = terminalCorrectionStatusError(code)
 			case apiErrorDetailEquals(apiErr, "reason", string(rememberapp.SubmissionErrorConfirmationExpired)):
 				statusError = rememberapp.StatusError(rememberapp.SubmissionErrorConfirmationExpired)
 				processingState = string(rememberapp.TerminalProcessingRejected)
@@ -548,10 +557,10 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 			code = rememberapp.TerminalErrorRequestTimeout
 		}
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	if !retrySameRequest && errors.Is(err, context.DeadlineExceeded) {
 		code = rememberapp.TerminalErrorRequestTimeout
 		statusError = rememberapp.TerminalStatusError(code)
-	} else if errors.Is(err, context.Canceled) {
+	} else if !retrySameRequest && errors.Is(err, context.Canceled) {
 		code = rememberapp.TerminalErrorRequestCancelled
 		statusError = rememberapp.TerminalStatusError(code)
 	}
@@ -570,11 +579,20 @@ func terminalCorrectionToolResultError(ctx context.Context, submissionID string,
 			"next_action": statusError.NextAction, "remediation": statusError.Remediation,
 		}},
 	}
-	if statusError.Code == string(rememberapp.TerminalErrorDatabaseFailure) {
+	if statusError.Code == string(rememberapp.TerminalErrorDatabaseFailure) && !retrySameRequest {
 		output["errors"].([]any)[0].(map[string]any)["next_action"] = string(rememberapp.TerminalNextActionRetryCorrection)
 		output["errors"].([]any)[0].(map[string]any)["remediation"] = "Retry correct_relationship with current relationship state and a new idempotency_key."
 	}
 	return NewToolResultError(output)
+}
+
+func terminalCorrectionStatusError(code rememberapp.TerminalErrorCode) rememberapp.SubmissionStatusError {
+	status := rememberapp.TerminalStatusError(code)
+	if code == rememberapp.TerminalErrorIdempotencyConflict {
+		status.NextAction = string(rememberapp.TerminalNextActionRetryCorrection)
+		status.Remediation = "Retry correct_relationship with current relationship state and a new idempotency_key."
+	}
+	return status
 }
 
 func apiErrorDetailEquals(apiErr *httperr.APIError, field, value string) bool {

--- a/internal/tools/registry/contract_v261_coverage_test.go
+++ b/internal/tools/registry/contract_v261_coverage_test.go
@@ -306,6 +306,11 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, test.want, structured.Result["errors"].([]any)[0].(map[string]any)["code"])
 			require.Equal(t, ContractVersionV261, structured.Result["contract_version"])
+			if test.name == "idempotency conflict" {
+				errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
+				require.Equal(t, string(rememberapp.TerminalNextActionRetryCorrection), errorItem["next_action"])
+				require.Contains(t, errorItem["remediation"], "correct_relationship")
+			}
 			if test.name == "confirmation expired" {
 				require.Equal(t, string(rememberapp.TerminalProcessingRejected), structured.Result["processing_state"])
 			}

--- a/internal/tools/registry/contract_v261_coverage_test.go
+++ b/internal/tools/registry/contract_v261_coverage_test.go
@@ -293,6 +293,7 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 		{"not found", httperr.New(httperr.NOT_FOUND, "hidden"), string(rememberapp.SubmissionErrorEntityNotFound)},
 		{"conflict", httperr.New(httperr.CONFLICT, "hidden"), string(rememberapp.SubmissionErrorRelationshipChanged)},
 		{"idempotency conflict", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: "idempotency_conflict"}}), string(rememberapp.TerminalErrorIdempotencyConflict)},
+		{"confirmation expired", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: string(rememberapp.SubmissionErrorConfirmationExpired)}}), string(rememberapp.SubmissionErrorConfirmationExpired)},
 		{"embedding unavailable", httperr.New(httperr.ErrEmbeddingUnavailable, "hidden"), string(rememberapp.TerminalErrorEmbeddingUnavailable)},
 		{"embedding response invalid", httperr.New(httperr.ErrEmbeddingResponseInvalid, "hidden"), string(rememberapp.TerminalErrorEmbeddingResponseInvalid)},
 		{"embedding timeout", httperr.New(httperr.ErrEmbeddingTimeout, "hidden"), string(rememberapp.TerminalErrorRequestTimeout)},
@@ -305,6 +306,9 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, test.want, structured.Result["errors"].([]any)[0].(map[string]any)["code"])
 			require.Equal(t, ContractVersionV261, structured.Result["contract_version"])
+			if test.name == "confirmation expired" {
+				require.Equal(t, string(rememberapp.TerminalProcessingRejected), structured.Result["processing_state"])
+			}
 			if test.name == "generic" {
 				errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
 				require.Equal(t, string(rememberapp.TerminalNextActionRetryCorrection), errorItem["next_action"])

--- a/internal/tools/registry/contract_v261_coverage_test.go
+++ b/internal/tools/registry/contract_v261_coverage_test.go
@@ -1,0 +1,375 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/correlation"
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+func TestWithTerminalRememberCompositionAndInvocation(t *testing.T) {
+	service := &configurableV261RememberService{rememberFn: func(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+		return &rememberapp.RememberResult{Terminal: terminalRememberResultForRequest(req, string(rememberapp.TerminalProcessingCompleted))}, nil
+	}}
+
+	_, err := WithTerminalRemember(nil, service)
+	require.ErrorContains(t, err, "active catalog")
+	_, err = WithTerminalRemember(New(), nil)
+	require.ErrorContains(t, err, "service")
+	missingRemember := New()
+	require.NoError(t, missingRemember.Register(Tool{Name: ToolGetSubmissionStatus}))
+	_, err = WithTerminalRemember(missingRemember, service)
+	require.ErrorContains(t, err, ToolRemember)
+
+	active := newV261ActiveRegistry(t)
+	selected, err := WithTerminalRemember(active, service)
+	require.NoError(t, err)
+	remember, ok := selected.Get(ToolRemember)
+	require.True(t, ok)
+	require.Equal(t, domain.ContractVersion, remember.OutputSchema["properties"].(map[string]any)["contract_version"].(map[string]any)["enum"].([]string)[0])
+	output, err := remember.Invoke(contractInvokeContext("write"), "team-1", validFlatRelationshipSubmission())
+	require.NoError(t, err)
+	require.Equal(t, domain.ContractVersion, output["contract_version"])
+	require.NotContains(t, output, "status_tool")
+	require.Equal(t, "completed", output["processing_state"])
+}
+
+func TestBuildContractV261CompositionValidationAndTerminalSuccess(t *testing.T) {
+	service := &configurableV261RememberService{rememberFn: func(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+		return &rememberapp.RememberResult{Terminal: terminalRememberResultForRequest(req, string(rememberapp.TerminalProcessingCompleted))}, nil
+	}}
+	_, err := BuildContractV261(nil, service)
+	require.ErrorContains(t, err, "active catalog")
+	_, err = BuildContractV261(New(), nil)
+	require.ErrorContains(t, err, "Remember service")
+
+	selected, err := BuildContractV261(newV261ActiveRegistry(t), service)
+	require.NoError(t, err)
+	remember, ok := selected.Get(ToolRemember)
+	require.True(t, ok)
+	output, err := remember.Invoke(contractInvokeContext("write"), "team-1", validFlatRelationshipSubmission())
+	require.NoError(t, err)
+	require.Equal(t, ContractVersionV261, output["contract_version"])
+	require.Equal(t, "completed", output["processing_state"])
+	require.NoError(t, ValidateInput(Tool{InputSchema: remember.OutputSchema}, output))
+}
+
+func TestTerminalRememberInvokerTerminalFailuresAndFallbacks(t *testing.T) {
+	input := validFlatRelationshipSubmission()
+
+	failedService := &configurableV261RememberService{rememberFn: func(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+		result := terminalRememberResultForRequest(req, string(rememberapp.TerminalProcessingRejected))
+		return nil, rememberapp.TerminalResultWithError(result, rememberapp.TerminalErrorNoSupportedMemory)
+	}}
+	selected, err := BuildContractV261(newV261ActiveRegistry(t), failedService)
+	require.NoError(t, err)
+	remember, _ := selected.Get(ToolRemember)
+	_, err = remember.Invoke(contractInvokeContext("write"), "team-1", input)
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, ContractVersionV261, structured.Result["contract_version"])
+	require.Equal(t, "rejected", structured.Result["processing_state"])
+	require.NotEmpty(t, structured.Result["errors"])
+
+	fallbackService := &configurableV261RememberService{rememberFn: func(context.Context, rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+		return nil, errors.New("provider response must stay private")
+	}}
+	selected, err = BuildContractV261(newV261ActiveRegistry(t), fallbackService)
+	require.NoError(t, err)
+	remember, _ = selected.Get(ToolRemember)
+	_, err = remember.Invoke(contractInvokeContext("write"), "team-1", input)
+	structured, ok = ToolResultFromError(err)
+	require.True(t, ok)
+	item := structured.Result["errors"].([]any)[0].(map[string]any)
+	require.Equal(t, string(rememberapp.TerminalErrorInternalFailure), item["code"])
+
+	invalidService := &configurableV261RememberService{rememberFn: func(context.Context, rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+		return &rememberapp.RememberResult{Terminal: &rememberapp.TerminalRememberResult{}}, nil
+	}}
+	selected, err = BuildContractV261(newV261ActiveRegistry(t), invalidService)
+	require.NoError(t, err)
+	remember, _ = selected.Get(ToolRemember)
+	_, err = remember.Invoke(contractInvokeContext("write"), "team-1", input)
+	structured, ok = ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, string(rememberapp.TerminalErrorInternalFailure), structured.Result["errors"].([]any)[0].(map[string]any)["code"])
+
+	legacyOnly := New()
+	require.NoError(t, legacyOnly.Register(Tool{Name: ToolRemember, InputSchema: rememberInputSchema(), RequiredScopes: []string{"write"}}))
+	legacy, err := WithTerminalRemember(legacyOnly, fallbackService)
+	require.NoError(t, err)
+	legacyRemember, _ := legacy.Get(ToolRemember)
+	_, err = legacyRemember.Invoke(contractInvokeContext("write"), "team-1", input)
+	require.ErrorContains(t, err, "provider response must stay private")
+}
+
+func TestTerminalRememberRequestAndSupersessionValidation(t *testing.T) {
+	request, err := terminalRememberRequest(validFlatRelationshipSubmission())
+	require.NoError(t, err)
+	require.Len(t, request.Evidence, 1)
+	require.Len(t, request.RelationshipHints, 1)
+
+	_, err = terminalRememberRequest(map[string]any{"evidence": func() {}})
+	require.Error(t, err)
+	_, err = terminalRememberRequest(map[string]any{"evidence": "not-an-array"})
+	require.Error(t, err)
+
+	require.NoError(t, validateTerminalRememberSupersessions(map[string]any{"evidence": []any{
+		map[string]any{"content": "one"},
+	}}))
+	target := uuid.NewString()
+	err = validateTerminalRememberSupersessions(map[string]any{"evidence": []any{
+		map[string]any{"supersedes_evidence_ids": []any{"not-a-uuid"}},
+	}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "evidence[0].supersedes_evidence_ids[0]")
+	err = validateTerminalRememberSupersessions(map[string]any{"evidence": []any{
+		map[string]any{"supersedes_evidence_ids": []any{strings.ToUpper(target)}},
+		map[string]any{"supersedes_evidence_ids": []any{target}},
+	}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicates target")
+
+	require.Equal(t, []string{"first", ""}, terminalRelationshipRefs(map[string]any{
+		"relationships": []any{map[string]any{"ref": " first "}, map[string]any{}},
+	}))
+	require.Empty(t, terminalRelationshipRefs(map[string]any{}))
+}
+
+func TestTerminalRememberResultAndCorrectionMaps(t *testing.T) {
+	req := rememberapp.RememberRequest{
+		Evidence:          []rememberapp.RememberEvidenceInput{{Content: "evidence"}},
+		RelationshipHints: []map[string]any{{"ref": "r-1"}},
+	}
+	result := terminalRememberResultForRequest(req, string(rememberapp.TerminalProcessingCompleted))
+	output, err := terminalRememberResultMap(result, ContractVersionV261)
+	require.NoError(t, err)
+	require.Equal(t, ContractVersionV261, output["contract_version"])
+	require.NoError(t, ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(ContractVersionV261)}, output))
+
+	receipt := map[string]any{"submission_id": "receipt-id", "processing_state": "awaiting_confirmation", "correlation_id": "receipt-correlation"}
+	status := map[string]any{
+		"submission_id": "status-id", "processing_state": "awaiting_confirmation", "search_state": "pending",
+		"awaiting_confirmation": map[string]any{"confirmation_token": "token"}, "errors": []rememberapp.SubmissionStatusError{},
+	}
+	correction, err := terminalCorrectionResultMap(receipt, status, ContractVersionV261)
+	require.NoError(t, err)
+	require.Equal(t, "status-id", correction["submission_id"])
+	require.Equal(t, "receipt-correlation", correction["correlation_id"])
+	require.NotNil(t, correction["awaiting_confirmation"])
+	require.NotContains(t, correction, "correction_result")
+
+	correction, err = terminalCorrectionResultMap(map[string]any{"processing_state": "completed"}, map[string]any{"correction_result": map[string]any{}, "errors": []map[string]any{{"code": "x"}}}, ContractVersionV261)
+	require.NoError(t, err)
+	require.Equal(t, string(domain.SearchProjectionNotRequired), correction["search_state"])
+	require.NotNil(t, correction["correction_result"])
+	var typed rememberapp.SubmissionStatusError
+	require.Equal(t, []any{}, normalizeArray(nil))
+	require.Equal(t, []any{"value"}, normalizeArray([]any{"value"}))
+	require.Len(t, normalizeArray([]map[string]any{{"value": "map"}}), 1)
+	require.Len(t, normalizeArray([]rememberapp.SubmissionStatusError{typed}), 1)
+	require.Empty(t, normalizeArray("unsupported"))
+}
+
+func TestValidateTerminalCorrectionOutputRequiresStateDetails(t *testing.T) {
+	base := map[string]any{
+		"contract_version": ContractVersionV261, "submission_id": uuid.NewString(),
+		"submission_kind": "relationship_correction", "search_state": "not_required",
+		"correlation_id": "corr", "errors": []any{},
+	}
+	awaiting := cloneMap(base)
+	awaiting["processing_state"] = "awaiting_confirmation"
+	err := validateTerminalCorrectionOutput(awaiting)
+	require.ErrorContains(t, err, "awaiting_confirmation result")
+	completed := cloneMap(base)
+	completed["processing_state"] = "completed"
+	err = validateTerminalCorrectionOutput(completed)
+	require.ErrorContains(t, err, "completed correction result")
+	rejected := cloneMap(base)
+	rejected["processing_state"] = "rejected"
+	err = validateTerminalCorrectionOutput(rejected)
+	require.ErrorContains(t, err, "rejected correction result")
+	require.NoError(t, validateTerminalCorrectionOutput(map[string]any{
+		"contract_version": ContractVersionV261, "submission_id": uuid.NewString(),
+		"submission_kind": "relationship_correction", "processing_state": "failed", "search_state": "not_required",
+		"correlation_id": "corr", "errors": []any{map[string]any{
+			"code": string(rememberapp.TerminalErrorDatabaseFailure), "message": rememberapp.TerminalStatusError(rememberapp.TerminalErrorDatabaseFailure).Message,
+			"retryable": true, "next_action": string(rememberapp.TerminalNextActionRetrySameRequest),
+			"remediation": rememberapp.TerminalStatusError(rememberapp.TerminalErrorDatabaseFailure).Remediation,
+		}},
+	}))
+}
+
+func TestTerminalRememberFailureBaseAndErrorMappings(t *testing.T) {
+	ctx := correlation.WithID(context.Background(), "failure-correlation")
+	base, code := terminalRememberFailureBase(ctx, errors.New("internal"), 1, []string{"rel-1"})
+	require.Equal(t, rememberapp.TerminalErrorInternalFailure, code)
+	require.Equal(t, string(rememberapp.TerminalProcessingFailed), base.ProcessingState)
+	require.Len(t, base.Evidence, 1)
+	require.Len(t, base.RelationshipResults, 1)
+	require.NoError(t, rememberapp.ValidateTerminalRememberResult(base, 1, []string{"rel-1"}))
+
+	status := &rememberapp.SubmissionStatusResult{
+		SubmissionID: "status-submission", CorrelationID: "status-correlation",
+		ProcessingState: string(rememberapp.TerminalProcessingRejected),
+		Errors:          []rememberapp.SubmissionStatusError{{Code: string(rememberapp.SubmissionErrorStaleInput)}},
+	}
+	base, code = terminalRememberFailureBase(ctx, &rememberapp.RememberProcessError{Status: status, Err: errors.New("wrapped")}, 0, nil)
+	require.Equal(t, rememberapp.TerminalErrorStaleInput, code)
+	require.Equal(t, "status-submission", base.SubmissionID)
+	require.Equal(t, "status-correlation", base.CorrelationID)
+
+	partial := &rememberapp.TerminalRememberResult{
+		ContractVersion: domain.ContractVersion, SubmissionKind: "remember", ProcessingState: string(rememberapp.TerminalProcessingFailed),
+		SearchState: string(rememberapp.TerminalSearchNotRequired), CorrelationID: "", SubmissionID: "", Kind: rememberapp.ResultKindTerminal,
+		Evidence:            []rememberapp.TerminalEvidenceResult{{EvidenceIndex: 0, Disposition: "not_stored", SupersededEvidenceIDs: []string{}, SearchState: string(rememberapp.TerminalSearchNotRequired), Reason: "internal_failure"}},
+		RelationshipResults: []rememberapp.SubmissionRelationshipResult{}, Errors: []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(rememberapp.TerminalErrorInternalFailure)},
+	}
+	base, _ = terminalRememberFailureBase(context.Background(), &rememberapp.RememberProcessError{Result: partial, Err: errors.New("wrapped")}, 1, nil)
+	require.NotEmpty(t, base.SubmissionID)
+	require.NotEmpty(t, base.CorrelationID)
+}
+
+func TestTerminalErrorCodeMappings(t *testing.T) {
+	for _, test := range []struct {
+		raw   string
+		state string
+		want  rememberapp.TerminalErrorCode
+	}{
+		{string(rememberapp.TerminalErrorProviderUnavailable), "", rememberapp.TerminalErrorProviderUnavailable},
+		{string(rememberapp.SubmissionErrorNoSupportedMemory), "", rememberapp.TerminalErrorNoSupportedMemory},
+		{string(rememberapp.SubmissionErrorStaleInput), "", rememberapp.TerminalErrorStaleInput},
+		{string(rememberapp.SubmissionErrorProviderUnavailable), "", rememberapp.TerminalErrorProviderUnavailable},
+		{string(rememberapp.SubmissionErrorProviderResponseInvalid), "", rememberapp.TerminalErrorProviderResponseInvalid},
+		{string(rememberapp.SubmissionErrorInputBudgetExceeded), "", rememberapp.TerminalErrorInputBudgetExceeded},
+		{string(rememberapp.SubmissionErrorConfigurationInvalid), "", rememberapp.TerminalErrorConfigurationInvalid},
+		{"idempotency_conflict", "", rememberapp.TerminalErrorIdempotencyConflict},
+		{"embedding_unavailable", "", rememberapp.TerminalErrorEmbeddingUnavailable},
+		{"embedding_response_invalid", "", rememberapp.TerminalErrorEmbeddingResponseInvalid},
+		{"commit_conflict", "", rememberapp.TerminalErrorCommitConflict},
+		{string(rememberapp.SubmissionErrorDatabaseFailure), "", rememberapp.TerminalErrorDatabaseFailure},
+		{"request_timeout", "", rememberapp.TerminalErrorRequestTimeout},
+		{"request_cancelled", "", rememberapp.TerminalErrorRequestCancelled},
+		{string(rememberapp.SubmissionErrorQuarantined), "", rememberapp.TerminalErrorQuarantined},
+		{"unknown", string(rememberapp.TerminalProcessingRejected), rememberapp.TerminalErrorNoSupportedMemory},
+		{"unknown", string(rememberapp.TerminalProcessingQuarantined), rememberapp.TerminalErrorQuarantined},
+		{"unknown", string(rememberapp.TerminalProcessingFailed), rememberapp.TerminalErrorInternalFailure},
+	} {
+		require.Equal(t, test.want, terminalErrorCodeFromStatus(test.raw, test.state), test.raw)
+	}
+	for _, test := range []struct {
+		err  error
+		want rememberapp.TerminalErrorCode
+	}{
+		{memoryservice.ErrRememberConflict, rememberapp.TerminalErrorIdempotencyConflict},
+		{rememberapp.ErrRememberConflict, rememberapp.TerminalErrorIdempotencyConflict},
+		{context.DeadlineExceeded, rememberapp.TerminalErrorRequestTimeout},
+		{context.Canceled, rememberapp.TerminalErrorRequestCancelled},
+		{rememberapp.ErrEvidenceSecurityRejected, rememberapp.TerminalErrorQuarantined},
+		{rememberapp.ErrRememberPersistence, rememberapp.TerminalErrorDatabaseFailure},
+		{errors.New("unknown"), rememberapp.TerminalErrorInternalFailure},
+	} {
+		require.Equal(t, test.want, terminalRememberErrorCode(test.err))
+	}
+}
+
+func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
+	ctx := correlation.WithID(context.Background(), "correction-correlation")
+	for _, test := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not found", httperr.New(httperr.NOT_FOUND, "hidden"), string(rememberapp.SubmissionErrorEntityNotFound)},
+		{"conflict", httperr.New(httperr.CONFLICT, "hidden"), string(rememberapp.SubmissionErrorRelationshipChanged)},
+		{"embedding unavailable", httperr.New(httperr.ErrEmbeddingUnavailable, "hidden"), string(rememberapp.TerminalErrorEmbeddingUnavailable)},
+		{"embedding response invalid", httperr.New(httperr.ErrEmbeddingResponseInvalid, "hidden"), string(rememberapp.TerminalErrorEmbeddingResponseInvalid)},
+		{"embedding timeout", httperr.New(httperr.ErrEmbeddingTimeout, "hidden"), string(rememberapp.TerminalErrorRequestTimeout)},
+		{"deadline", context.DeadlineExceeded, string(rememberapp.TerminalErrorRequestTimeout)},
+		{"cancelled", context.Canceled, string(rememberapp.TerminalErrorRequestCancelled)},
+		{"generic", errors.New("database details"), string(rememberapp.TerminalErrorDatabaseFailure)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			structured, ok := ToolResultFromError(terminalCorrectionToolResultError(ctx, "submission-1", test.err, ContractVersionV261))
+			require.True(t, ok)
+			require.Equal(t, test.want, structured.Result["errors"].([]any)[0].(map[string]any)["code"])
+			require.Equal(t, ContractVersionV261, structured.Result["contract_version"])
+			if test.name == "generic" {
+				errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
+				require.Equal(t, string(rememberapp.TerminalNextActionRetryCorrection), errorItem["next_action"])
+			}
+		})
+	}
+}
+
+func newV261ActiveRegistry(t *testing.T) Registry {
+	t.Helper()
+	active := New()
+	for _, tool := range ContractTools() {
+		tool.Visibility = "active"
+		tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+			return map[string]any{"marker": "legacy"}, nil
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	return active
+}
+
+func terminalRememberResultForRequest(req rememberapp.RememberRequest, state string) *rememberapp.TerminalRememberResult {
+	evidence := make([]rememberapp.TerminalEvidenceResult, len(req.Evidence))
+	for index := range evidence {
+		evidence[index] = rememberapp.TerminalEvidenceResult{
+			Disposition: "stored", EvidenceID: uuid.NewString(), EvidenceIndex: index,
+			SupersededEvidenceIDs: []string{}, SearchState: string(rememberapp.TerminalSearchCurrent),
+		}
+	}
+	relationships := make([]rememberapp.SubmissionRelationshipResult, len(req.RelationshipHints))
+	for index, hint := range req.RelationshipHints {
+		ref, _ := hint["ref"].(string)
+		relationships[index] = rememberapp.SubmissionRelationshipResult{
+			RelationshipRef: ref, Disposition: "stored",
+			Splits: []rememberapp.SubmissionRelationshipSplit{{SplitIndex: 0, RelationshipID: uuid.NewString(), RelationshipVersion: 1, Status: "active"}},
+		}
+	}
+	result := &rememberapp.TerminalRememberResult{
+		ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+		ProcessingState: state, SearchState: string(rememberapp.TerminalSearchCurrent), CorrelationID: "terminal-correlation",
+		Evidence: evidence, RelationshipResults: relationships, Errors: []rememberapp.SubmissionStatusError{}, Kind: rememberapp.ResultKindTerminal,
+	}
+	if state != string(rememberapp.TerminalProcessingCompleted) {
+		code := rememberapp.TerminalErrorNoSupportedMemory
+		if state == string(rememberapp.TerminalProcessingQuarantined) {
+			code = rememberapp.TerminalErrorQuarantined
+		}
+		result = rememberapp.TerminalResultWithError(result, code).Result
+	}
+	return result
+}
+
+type configurableV261RememberService struct {
+	rememberFn func(context.Context, rememberapp.RememberRequest) (*rememberapp.RememberResult, error)
+	statusFn   func(context.Context, rememberapp.GetSubmissionStatusRequest) (*rememberapp.SubmissionStatusResult, error)
+}
+
+func (s *configurableV261RememberService) Remember(ctx context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+	if s.rememberFn == nil {
+		return nil, errors.New("remember function is not configured")
+	}
+	return s.rememberFn(ctx, req)
+}
+
+func (s *configurableV261RememberService) GetSubmissionStatus(ctx context.Context, req rememberapp.GetSubmissionStatusRequest) (*rememberapp.SubmissionStatusResult, error) {
+	if s.statusFn == nil {
+		return nil, errors.New("status function is not configured")
+	}
+	return s.statusFn(ctx, req)
+}

--- a/internal/tools/registry/contract_v261_coverage_test.go
+++ b/internal/tools/registry/contract_v261_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/correlation"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
@@ -188,15 +189,15 @@ func TestValidateTerminalCorrectionOutputRequiresStateDetails(t *testing.T) {
 	}
 	awaiting := cloneMap(base)
 	awaiting["processing_state"] = "awaiting_confirmation"
-	err := validateTerminalCorrectionOutput(awaiting)
+	err := validateTerminalCorrectionOutput(awaiting, ContractVersionV261)
 	require.ErrorContains(t, err, "awaiting_confirmation result")
 	completed := cloneMap(base)
 	completed["processing_state"] = "completed"
-	err = validateTerminalCorrectionOutput(completed)
+	err = validateTerminalCorrectionOutput(completed, ContractVersionV261)
 	require.ErrorContains(t, err, "completed correction result")
 	rejected := cloneMap(base)
 	rejected["processing_state"] = "rejected"
-	err = validateTerminalCorrectionOutput(rejected)
+	err = validateTerminalCorrectionOutput(rejected, ContractVersionV261)
 	require.ErrorContains(t, err, "rejected correction result")
 	require.NoError(t, validateTerminalCorrectionOutput(map[string]any{
 		"contract_version": ContractVersionV261, "submission_id": uuid.NewString(),
@@ -206,7 +207,7 @@ func TestValidateTerminalCorrectionOutputRequiresStateDetails(t *testing.T) {
 			"retryable": true, "next_action": string(rememberapp.TerminalNextActionRetrySameRequest),
 			"remediation": rememberapp.TerminalStatusError(rememberapp.TerminalErrorDatabaseFailure).Remediation,
 		}},
-	}))
+	}, ContractVersionV261))
 }
 
 func TestTerminalRememberFailureBaseAndErrorMappings(t *testing.T) {
@@ -291,6 +292,7 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 	}{
 		{"not found", httperr.New(httperr.NOT_FOUND, "hidden"), string(rememberapp.SubmissionErrorEntityNotFound)},
 		{"conflict", httperr.New(httperr.CONFLICT, "hidden"), string(rememberapp.SubmissionErrorRelationshipChanged)},
+		{"idempotency conflict", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: "idempotency_conflict"}}), string(rememberapp.TerminalErrorIdempotencyConflict)},
 		{"embedding unavailable", httperr.New(httperr.ErrEmbeddingUnavailable, "hidden"), string(rememberapp.TerminalErrorEmbeddingUnavailable)},
 		{"embedding response invalid", httperr.New(httperr.ErrEmbeddingResponseInvalid, "hidden"), string(rememberapp.TerminalErrorEmbeddingResponseInvalid)},
 		{"embedding timeout", httperr.New(httperr.ErrEmbeddingTimeout, "hidden"), string(rememberapp.TerminalErrorRequestTimeout)},
@@ -309,6 +311,25 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContractCorrectionStatusLookupDoesNotRequireReadScope(t *testing.T) {
+	active, err := BuildActive(Dependencies{Lifecycle: &v261LifecycleService{}})
+	require.NoError(t, err)
+	selected, err := BuildContractV261(active, &v261RememberService{})
+	require.NoError(t, err)
+	correct, ok := selected.Get(ToolCorrectRelationship)
+	require.True(t, ok)
+	output, err := correct.Invoke(contractInvokeContext("write"), "team-1", map[string]any{
+		"action": "submit", "relationship_id": "relationship-1", "expected_version": 1,
+		"patch":    map[string]any{"predicate": map[string]any{"key": "uses"}},
+		"supports": []any{map[string]any{"evidence_id": "evidence-1", "start": 0, "end": 4}},
+		"reason":   "predicate was resolved incorrectly", "idempotency_key": "correction-write-only",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ContractVersionV261, output["contract_version"])
+	require.Equal(t, "completed", output["processing_state"])
+	require.NotNil(t, output["correction_result"])
 }
 
 func newV261ActiveRegistry(t *testing.T) Registry {
@@ -358,6 +379,31 @@ func terminalRememberResultForRequest(req rememberapp.RememberRequest, state str
 type configurableV261RememberService struct {
 	rememberFn func(context.Context, rememberapp.RememberRequest) (*rememberapp.RememberResult, error)
 	statusFn   func(context.Context, rememberapp.GetSubmissionStatusRequest) (*rememberapp.SubmissionStatusResult, error)
+}
+
+type v261LifecycleService struct{}
+
+func (v261LifecycleService) CorrectRelationship(context.Context, memoryservice.CorrectRelationshipRequest) (*memoryservice.CorrectRelationshipReceipt, error) {
+	return &memoryservice.CorrectRelationshipReceipt{
+		ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "relationship_correction",
+		ProcessingState: "completed", StatusTool: ToolGetSubmissionStatus, CorrelationID: "correction-correlation",
+	}, nil
+}
+
+func (v261LifecycleService) GetRelationshipCorrectionStatus(_ context.Context, req memoryservice.GetSubmissionStatusRequest) (*memoryservice.SubmissionStatusResult, error) {
+	return &memoryservice.SubmissionStatusResult{
+		ContractVersion: domain.ContractVersion, SubmissionID: req.SubmissionID, SubmissionKind: "relationship_correction",
+		ProcessingState: "completed", SearchState: "current", Errors: []memoryservice.SubmissionStatusError{},
+		Degradations: []memoryservice.SubmissionStatusDegradation{}, Evidence: []memoryservice.SubmissionEvidenceStatus{},
+		CorrectionResult: &repository.RelationshipCorrectionResult{
+			OriginalRelationshipID: uuid.NewString(), OriginalVersion: 1,
+			SuccessorRelationshipID: uuid.NewString(), SuccessorVersion: 1, ReusedSuccessor: false,
+		},
+	}, nil
+}
+
+func (v261LifecycleService) RetractEvidence(context.Context, memoryservice.RetractEvidenceRequest) (*memoryservice.RetractEvidenceResult, error) {
+	return nil, errors.New("unused")
 }
 
 func (s *configurableV261RememberService) Remember(ctx context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {

--- a/internal/tools/registry/contract_v261_coverage_test.go
+++ b/internal/tools/registry/contract_v261_coverage_test.go
@@ -293,6 +293,7 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 		{"not found", httperr.New(httperr.NOT_FOUND, "hidden"), string(rememberapp.SubmissionErrorEntityNotFound)},
 		{"conflict", httperr.New(httperr.CONFLICT, "hidden"), string(rememberapp.SubmissionErrorRelationshipChanged)},
 		{"idempotency conflict", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: "idempotency_conflict"}}), string(rememberapp.TerminalErrorIdempotencyConflict)},
+		{"commit conflict", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: string(rememberapp.TerminalErrorCommitConflict)}}), string(rememberapp.TerminalErrorCommitConflict)},
 		{"confirmation expired", httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{Field: "reason", Message: string(rememberapp.SubmissionErrorConfirmationExpired)}}), string(rememberapp.SubmissionErrorConfirmationExpired)},
 		{"embedding unavailable", httperr.New(httperr.ErrEmbeddingUnavailable, "hidden"), string(rememberapp.TerminalErrorEmbeddingUnavailable)},
 		{"embedding response invalid", httperr.New(httperr.ErrEmbeddingResponseInvalid, "hidden"), string(rememberapp.TerminalErrorEmbeddingResponseInvalid)},
@@ -310,6 +311,11 @@ func TestTerminalCorrectionToolResultErrorMapsBoundedFailures(t *testing.T) {
 				errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
 				require.Equal(t, string(rememberapp.TerminalNextActionRetryCorrection), errorItem["next_action"])
 				require.Contains(t, errorItem["remediation"], "correct_relationship")
+			}
+			if test.name == "commit conflict" {
+				errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
+				require.Equal(t, string(rememberapp.TerminalNextActionRetrySameRequest), errorItem["next_action"])
+				require.Contains(t, errorItem["remediation"], "same idempotency_key")
 			}
 			if test.name == "confirmation expired" {
 				require.Equal(t, string(rememberapp.TerminalProcessingRejected), structured.Result["processing_state"])

--- a/internal/tools/registry/contract_v261_schemas.go
+++ b/internal/tools/registry/contract_v261_schemas.go
@@ -1,0 +1,92 @@
+package registry
+
+import (
+	"github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+func terminalRememberOutputSchema(version string) map[string]any {
+	return closedObject(
+		[]string{"contract_version", "submission_id", "submission_kind", "processing_state", "search_state", "correlation_id", "evidence", "relationship_results", "errors"},
+		map[string]any{
+			"contract_version":     schemaEnum([]string{version}),
+			"submission_id":        schemaString("Submission ID.", 128),
+			"submission_kind":      schemaEnum([]string{"remember"}),
+			"processing_state":     schemaEnum([]string{"completed", "rejected", "quarantined", "failed"}),
+			"search_state":         schemaEnum([]string{"current", "not_required"}),
+			"correlation_id":       schemaString("Request correlation ID.", 128),
+			"evidence":             array(terminalEvidenceSchema(), 0, 20),
+			"relationship_results": submissionRelationshipResultsSchema(),
+			"errors":               array(terminalErrorSchema(), 0, 50),
+		},
+	)
+}
+
+func terminalEvidenceSchema() map[string]any {
+	return closedObject(
+		[]string{"disposition", "evidence_index", "superseded_evidence_ids", "search_state"},
+		map[string]any{
+			"disposition":             schemaEnum([]string{"stored", "not_stored"}),
+			"evidence_id":             schemaString("Durable evidence ID when stored.", 128),
+			"evidence_index":          map[string]any{"type": "integer", "minimum": 0},
+			"superseded_evidence_ids": stringArraySchema("Evidence ID superseded by this evidence.", 50, 128),
+			"search_state":            schemaEnum([]string{"current", "not_required"}),
+			"reason":                  schemaString("Bounded reason when not stored.", 256),
+		},
+	)
+}
+
+func terminalCorrectionOutputSchema(version string) map[string]any {
+	return closedObject(
+		[]string{"contract_version", "submission_id", "submission_kind", "processing_state", "search_state", "correlation_id", "errors"},
+		map[string]any{
+			"contract_version":      schemaEnum([]string{version}),
+			"submission_id":         schemaString("Correction submission ID.", 128),
+			"submission_kind":       schemaEnum([]string{"relationship_correction"}),
+			"processing_state":      schemaEnum([]string{"awaiting_confirmation", "completed", "rejected", "failed"}),
+			"search_state":          schemaEnum([]string{"current", "pending", "not_required", "failed"}),
+			"correlation_id":        schemaString("Request correlation ID.", 128),
+			"awaiting_confirmation": relationshipCorrectionConfirmationSchema(),
+			"correction_result":     relationshipCorrectionResultSchema(),
+			"errors":                array(terminalErrorSchema(), 0, 50),
+		},
+	)
+}
+
+func terminalErrorSchema() map[string]any {
+	return closedObject(
+		[]string{"code", "message", "retryable", "next_action", "remediation"},
+		map[string]any{
+			"code":      schemaEnum(contractV261ErrorCodes()),
+			"message":   schemaString("Bounded safe submission error.", 512),
+			"retryable": map[string]any{"type": "boolean"},
+			"next_action": schemaEnum([]string{
+				string(remember.TerminalNextActionRetrySameRequest),
+				string(remember.TerminalNextActionResubmitRemember),
+				string(remember.TerminalNextActionRetryCorrection),
+				string(remember.TerminalNextActionContactOperator),
+				string(remember.TerminalNextActionNone),
+			}),
+			"remediation": schemaString("Bounded action the caller can take next.", 512),
+		},
+	)
+}
+
+func contractV261ErrorCodes() []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0)
+	add := func(values []string) {
+		for _, value := range values {
+			if value == string(remember.SubmissionErrorSearchIndexingDelayed) {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			result = append(result, value)
+		}
+	}
+	add(remember.TerminalErrorCodes())
+	add(remember.SubmissionErrorCodes())
+	return result
+}

--- a/internal/tools/registry/contract_v261_test.go
+++ b/internal/tools/registry/contract_v261_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
@@ -244,6 +245,53 @@ func TestTerminalCorrectionInvokerStatusReadFailurePreservesReplayGuidance(t *te
 	require.Equal(t, string(rememberapp.TerminalNextActionRetrySameRequest), errorItem["next_action"])
 	require.Contains(t, errorItem["remediation"], "same idempotency_key")
 	require.NoError(t, ValidateInput(Tool{InputSchema: tool.OutputSchema}, structured.Result))
+}
+
+func TestTerminalCorrectionInvalidConfirmationHydratesAwaitingState(t *testing.T) {
+	active := New()
+	for _, tool := range ContractTools() {
+		tool.Visibility = "active"
+		tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+			return nil, errors.New("unused")
+		}
+		switch tool.Name {
+		case ToolCorrectRelationship:
+			tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+				return nil, httperr.NewWithDetails(httperr.CONFLICT, "hidden", []httperr.ErrorDetail{{
+					Field: "reason", Message: memoryservice.CorrectionConfirmationInvalidReason,
+				}})
+			}
+		case ToolGetSubmissionStatus:
+			tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+				return map[string]any{
+					"submission_id": "status-submission", "processing_state": "awaiting_confirmation", "search_state": "pending", "correlation_id": "status-correlation",
+					"awaiting_confirmation": map[string]any{
+						"confirmation_token": uuid.NewString(), "expires_at": "2026-08-30T00:00:00Z",
+						"candidates": []any{
+							map[string]any{"endpoint": "subject_entity", "entity_id": uuid.NewString(), "entity_kind": "project", "canonical_name": "Subject"},
+							map[string]any{"endpoint": "object_entity", "entity_id": uuid.NewString(), "entity_kind": "project", "canonical_name": "Object"},
+						},
+					},
+					"errors": []any{},
+				}, nil
+			}
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	selected, err := BuildContractV261(active, &v261RememberService{})
+	require.NoError(t, err)
+	correct, ok := selected.Get(ToolCorrectRelationship)
+	require.True(t, ok)
+	output, err := correct.Invoke(contractInvokeContext("write"), "team-1", map[string]any{
+		"action": "confirm", "submission_id": uuid.NewString(), "confirmation_token": uuid.NewString(),
+		"selection": map[string]any{"object_entity_id": uuid.NewString()}, "idempotency_key": "invalid-confirmation",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ContractVersionV261, output["contract_version"])
+	require.Equal(t, "awaiting_confirmation", output["processing_state"])
+	require.Equal(t, "status-correlation", output["correlation_id"])
+	require.NotNil(t, output["awaiting_confirmation"])
+	require.NoError(t, ValidateInput(Tool{InputSchema: correct.OutputSchema}, output))
 }
 
 func TestTerminalCorrectionInvokerMapsBoundedDomainErrors(t *testing.T) {

--- a/internal/tools/registry/contract_v261_test.go
+++ b/internal/tools/registry/contract_v261_test.go
@@ -207,6 +207,45 @@ func TestTerminalCorrectionInvokerProjectsReceiptAndStatusOnce(t *testing.T) {
 	require.Equal(t, []string{"receipt:team-1:same-context", "status:team-1:same-context"}, calls)
 }
 
+func TestTerminalCorrectionInvokerStatusReadFailurePreservesReplayGuidance(t *testing.T) {
+	active := New()
+	for _, tool := range ContractTools() {
+		tool.Visibility = "active"
+		tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+			return nil, errors.New("unused")
+		}
+		switch tool.Name {
+		case ToolCorrectRelationship:
+			tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+				return map[string]any{"submission_id": uuid.NewString(), "processing_state": "processing", "correlation_id": "receipt-correlation"}, nil
+			}
+		case ToolGetSubmissionStatus:
+			tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+				return nil, errors.New("database status read failed")
+			}
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	selected, err := BuildContractV261(active, &v261RememberService{})
+	require.NoError(t, err)
+	tool, ok := selected.Get(ToolCorrectRelationship)
+	require.True(t, ok)
+	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
+	_, err = tool.Invoke(ctx, "team-1", map[string]any{
+		"action": "submit", "relationship_id": uuid.NewString(), "expected_version": 1,
+		"patch":    map[string]any{"predicate": map[string]any{"key": "uses"}},
+		"supports": []any{map[string]any{"evidence_id": uuid.NewString(), "start": 0, "end": 4}},
+		"reason":   "predicate was resolved incorrectly", "idempotency_key": "correction-replay-key",
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	errorItem := structured.Result["errors"].([]any)[0].(map[string]any)
+	require.Equal(t, string(rememberapp.TerminalErrorDatabaseFailure), errorItem["code"])
+	require.Equal(t, string(rememberapp.TerminalNextActionRetrySameRequest), errorItem["next_action"])
+	require.Contains(t, errorItem["remediation"], "same idempotency_key")
+	require.NoError(t, ValidateInput(Tool{InputSchema: tool.OutputSchema}, structured.Result))
+}
+
 func TestTerminalCorrectionInvokerMapsBoundedDomainErrors(t *testing.T) {
 	for _, test := range []struct {
 		name string

--- a/internal/tools/registry/contract_v261_test.go
+++ b/internal/tools/registry/contract_v261_test.go
@@ -1,0 +1,285 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+func TestContractV261CatalogIsInactiveAndExactlyTenTools(t *testing.T) {
+	tools := ContractV261Tools()
+	require.Len(t, tools, 10)
+	require.Equal(t, ContractV261ToolNames(), toolNames(tools))
+	for _, tool := range tools {
+		require.Equal(t, domain.FeatureGate, tool.FeatureGate, tool.Name)
+		require.Equal(t, domain.ToolVisibility, tool.Visibility, tool.Name)
+		require.Nil(t, tool.Invoke, tool.Name)
+	}
+	_, present := findTool(tools, ToolGetSubmissionStatus)
+	require.False(t, present)
+
+	remember, present := findTool(tools, ToolRemember)
+	require.True(t, present)
+	require.Equal(t, []string{ContractVersionV261}, remember.OutputSchema["properties"].(map[string]any)["contract_version"].(map[string]any)["enum"])
+	correction, present := findTool(tools, ToolCorrectRelationship)
+	require.True(t, present)
+	correctionProperties := correction.OutputSchema["properties"].(map[string]any)
+	require.Contains(t, correctionProperties, "awaiting_confirmation")
+	require.Contains(t, correctionProperties, "correction_result")
+	require.Contains(t, correctionProperties, "errors")
+}
+
+func TestBuildContractV261RemovesStatusWithoutChangingProductionCatalog(t *testing.T) {
+	active := New()
+	for _, tool := range ContractTools() {
+		tool.Visibility = "active"
+		tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+			return map[string]any{"marker": "legacy"}, nil
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	remember := &v261RememberService{}
+	selected, err := BuildContractV261(active, remember)
+	require.NoError(t, err)
+	require.Len(t, selected.List(), len(ContractV261ToolNames()))
+	require.ElementsMatch(t, ContractV261ToolNames(), toolNames(selected.List()))
+	_, present := selected.Get(ToolGetSubmissionStatus)
+	require.False(t, present)
+	for _, name := range ContractV261ToolNames() {
+		tool, ok := selected.Get(name)
+		require.True(t, ok, name)
+		require.Equal(t, "active", tool.Visibility, name)
+	}
+	require.Len(t, ContractTools(), 11)
+	require.Contains(t, ContractToolNames(), ToolGetSubmissionStatus)
+}
+
+func TestBuildContractV261RequiresLegacyStatusAndEveryTargetTool(t *testing.T) {
+	remember := &v261RememberService{}
+	active := New()
+	_, err := BuildContractV261(active, remember)
+	require.ErrorContains(t, err, ToolGetSubmissionStatus)
+
+	active = New()
+	for _, tool := range ContractTools() {
+		if tool.Name == ToolRecallMemory {
+			continue
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	_, err = BuildContractV261(active, remember)
+	require.ErrorContains(t, err, ToolRecallMemory)
+}
+
+func TestContractV261SchemasValidateRememberAndCorrectionStates(t *testing.T) {
+	evidenceID := uuid.NewString()
+	relationshipID := uuid.NewString()
+	rememberOutput := map[string]any{
+		"contract_version": ContractVersionV261,
+		"submission_id":    uuid.NewString(),
+		"submission_kind":  "remember",
+		"processing_state": "completed",
+		"search_state":     "current",
+		"correlation_id":   "corr-remember",
+		"evidence": []any{map[string]any{
+			"disposition": "stored", "evidence_id": evidenceID, "evidence_index": 0,
+			"superseded_evidence_ids": []any{}, "search_state": "current",
+		}},
+		"relationship_results": []any{map[string]any{
+			"ref": "rel-1", "disposition": "stored",
+			"splits": []any{map[string]any{"split_index": 0, "relationship_id": relationshipID, "relationship_version": 1, "status": "active"}},
+		}},
+		"errors": []any{},
+	}
+	rememberTool, _ := findTool(ContractV261Tools(), ToolRemember)
+	require.NoError(t, ValidateInput(Tool{InputSchema: rememberTool.OutputSchema}, rememberOutput))
+
+	awaiting := map[string]any{
+		"contract_version": ContractVersionV261, "submission_id": uuid.NewString(),
+		"submission_kind": "relationship_correction", "processing_state": "awaiting_confirmation",
+		"search_state": "pending", "correlation_id": "corr-correction",
+		"awaiting_confirmation": map[string]any{
+			"confirmation_token": "token-1", "expires_at": "2026-08-30T00:00:00Z",
+			"candidates": []any{
+				map[string]any{"endpoint": "subject_entity", "entity_id": uuid.NewString(), "entity_kind": "project", "canonical_name": "Dense-Mem"},
+				map[string]any{"endpoint": "object_entity", "entity_id": uuid.NewString(), "entity_kind": "project", "canonical_name": "PostgreSQL"},
+			},
+		},
+		"errors": []any{},
+	}
+	correctionTool, _ := findTool(ContractV261Tools(), ToolCorrectRelationship)
+	require.NoError(t, ValidateInput(Tool{InputSchema: correctionTool.OutputSchema}, awaiting))
+
+	completed := map[string]any{
+		"contract_version": ContractVersionV261, "submission_id": uuid.NewString(),
+		"submission_kind": "relationship_correction", "processing_state": "completed",
+		"search_state": "current", "correlation_id": "corr-correction", "errors": []any{},
+		"correction_result": map[string]any{
+			"original_relationship_id": uuid.NewString(), "original_version": 1,
+			"successor_relationship_id": uuid.NewString(), "successor_version": 1, "reused_successor": false,
+		},
+	}
+	require.NoError(t, ValidateInput(Tool{InputSchema: correctionTool.OutputSchema}, completed))
+}
+
+func TestContractV261FixturesValidateTargetOutputs(t *testing.T) {
+	data, err := os.ReadFile("testdata/contract_v261_fixtures.json")
+	require.NoError(t, err)
+	var fixtures []struct {
+		Name   string         `json:"name"`
+		Tool   string         `json:"tool"`
+		Output map[string]any `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(data, &fixtures))
+	tools := ContractV261Tools()
+	for _, fixture := range fixtures {
+		t.Run(fixture.Name, func(t *testing.T) {
+			tool, ok := findTool(tools, fixture.Tool)
+			require.True(t, ok)
+			require.NoError(t, ValidateInput(Tool{InputSchema: tool.OutputSchema}, fixture.Output))
+		})
+	}
+}
+
+func TestTerminalCorrectionInvokerProjectsReceiptAndStatusOnce(t *testing.T) {
+	active := New()
+	var calls []string
+	for _, tool := range ContractTools() {
+		tool.Visibility = "active"
+		tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+			return map[string]any{"marker": "legacy"}, nil
+		}
+		switch tool.Name {
+		case ToolCorrectRelationship:
+			tool.Invoke = func(ctx context.Context, teamID string, input map[string]any) (map[string]any, error) {
+				calls = append(calls, "receipt:"+teamID+":"+contextMarker(ctx))
+				return map[string]any{"submission_id": "correction-1", "processing_state": "completed", "correlation_id": "receipt-correlation"}, nil
+			}
+		case ToolGetSubmissionStatus:
+			tool.Invoke = func(ctx context.Context, teamID string, input map[string]any) (map[string]any, error) {
+				calls = append(calls, "status:"+teamID+":"+contextMarker(ctx))
+				return map[string]any{
+					"submission_id": "correction-1", "processing_state": "completed", "search_state": "current",
+					"correlation_id": "status-correlation", "correction_result": map[string]any{
+						"original_relationship_id": uuid.NewString(), "original_version": 1,
+						"successor_relationship_id": uuid.NewString(), "successor_version": 1, "reused_successor": false,
+					}, "errors": []any{},
+				}, nil
+			}
+		}
+		require.NoError(t, active.Register(tool))
+	}
+	selected, err := BuildContractV261(active, &v261RememberService{})
+	require.NoError(t, err)
+	tool, ok := selected.Get(ToolCorrectRelationship)
+	require.True(t, ok)
+	ctx := requestctx.WithActor(context.WithValue(context.Background(), markerKey{}, "same-context"), requestctx.Actor{Grants: []string{"write"}})
+	output, err := tool.Invoke(ctx, "team-1", map[string]any{
+		"action": "submit", "relationship_id": uuid.NewString(), "expected_version": 1,
+		"patch":    map[string]any{"predicate": map[string]any{"key": "uses"}},
+		"supports": []any{map[string]any{"evidence_id": uuid.NewString(), "start": 0, "end": 4}},
+		"reason":   "predicate was resolved incorrectly", "idempotency_key": "correction-key",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ContractVersionV261, output["contract_version"])
+	require.Equal(t, "completed", output["processing_state"])
+	require.NotNil(t, output["correction_result"])
+	require.Empty(t, output["errors"])
+	require.Equal(t, []string{"receipt:team-1:same-context", "status:team-1:same-context"}, calls)
+}
+
+func TestTerminalCorrectionInvokerMapsBoundedDomainErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "entity not found", err: httperr.New(httperr.NOT_FOUND, "hidden"), code: "entity_not_found"},
+		{name: "relationship changed", err: httperr.New(httperr.CONFLICT, "hidden"), code: "relationship_changed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			active := New()
+			for _, tool := range ContractTools() {
+				tool.Visibility = "active"
+				tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) {
+					return nil, errors.New("unused")
+				}
+				if tool.Name == ToolCorrectRelationship {
+					tool.Invoke = func(context.Context, string, map[string]any) (map[string]any, error) { return nil, test.err }
+				}
+				require.NoError(t, active.Register(tool))
+			}
+			selected, err := BuildContractV261(active, &v261RememberService{})
+			require.NoError(t, err)
+			tool, _ := selected.Get(ToolCorrectRelationship)
+			ctx := requestctx.WithActor(context.Background(), requestctx.Actor{Grants: []string{"write"}})
+			_, err = tool.Invoke(ctx, "team-1", map[string]any{
+				"action": "submit", "relationship_id": uuid.NewString(), "expected_version": 1,
+				"patch":    map[string]any{"predicate": map[string]any{"key": "uses"}},
+				"supports": []any{map[string]any{"evidence_id": uuid.NewString(), "start": 0, "end": 4}},
+				"reason":   "predicate was resolved incorrectly", "idempotency_key": "correction-key",
+			})
+			structured, ok := ToolResultFromError(err)
+			require.True(t, ok)
+			item := structured.Result["errors"].([]any)[0].(map[string]any)
+			require.Equal(t, test.code, item["code"])
+		})
+	}
+}
+
+type markerKey struct{}
+
+func contextMarker(ctx context.Context) string {
+	value, _ := ctx.Value(markerKey{}).(string)
+	return value
+}
+
+func toolNames(tools []Tool) []string {
+	result := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		result = append(result, tool.Name)
+	}
+	return result
+}
+
+func findTool(tools []Tool, name string) (Tool, bool) {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool, true
+		}
+	}
+	return Tool{}, false
+}
+
+type v261RememberService struct{}
+
+func (v261RememberService) Remember(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+	evidence := make([]rememberapp.TerminalEvidenceResult, len(req.Evidence))
+	for index := range evidence {
+		evidence[index] = rememberapp.TerminalEvidenceResult{Disposition: "stored", EvidenceID: uuid.NewString(), EvidenceIndex: index, SupersededEvidenceIDs: []string{}, SearchState: string(rememberapp.TerminalSearchCurrent)}
+	}
+	relationships := make([]rememberapp.SubmissionRelationshipResult, len(req.RelationshipHints))
+	for index, hint := range req.RelationshipHints {
+		ref, _ := hint["ref"].(string)
+		relationships[index] = rememberapp.SubmissionRelationshipResult{RelationshipRef: ref, Disposition: "stored", Splits: []rememberapp.SubmissionRelationshipSplit{{SplitIndex: 0, RelationshipID: uuid.NewString(), RelationshipVersion: 1, Status: "active"}}}
+	}
+	return &rememberapp.RememberResult{Terminal: &rememberapp.TerminalRememberResult{
+		ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+		ProcessingState: string(rememberapp.TerminalProcessingCompleted), SearchState: string(rememberapp.TerminalSearchCurrent), CorrelationID: "remember-correlation",
+		Evidence: evidence, RelationshipResults: relationships, Errors: []rememberapp.SubmissionStatusError{}, Kind: rememberapp.ResultKindTerminal,
+	}}, nil
+}
+
+func (v261RememberService) GetSubmissionStatus(context.Context, rememberapp.GetSubmissionStatusRequest) (*rememberapp.SubmissionStatusResult, error) {
+	return nil, nil
+}

--- a/internal/tools/registry/contract_v261_test.go
+++ b/internal/tools/registry/contract_v261_test.go
@@ -39,6 +39,15 @@ func TestContractV261CatalogIsInactiveAndExactlyTenTools(t *testing.T) {
 	require.Contains(t, correctionProperties, "errors")
 }
 
+func TestContractToolRuntimeOptionalCoversGatedToolsOnly(t *testing.T) {
+	for _, name := range []string{ToolSubmitRecallSessionFeedback, ToolListDreams, ToolGetDream, ToolResolveDreamFeedback} {
+		require.True(t, ContractToolRuntimeOptional(name), name)
+	}
+	for _, name := range []string{ToolRemember, ToolRetractEvidence, ToolCorrectRelationship, ToolRecallMemory, ToolTraceMemory, ToolExportMemoryPack, ToolGetSubmissionStatus} {
+		require.False(t, ContractToolRuntimeOptional(name), name)
+	}
+}
+
 func TestBuildContractV261RemovesStatusWithoutChangingProductionCatalog(t *testing.T) {
 	active := New()
 	for _, tool := range ContractTools() {

--- a/internal/tools/registry/runtime_config.go
+++ b/internal/tools/registry/runtime_config.go
@@ -26,6 +26,16 @@ func IsEvaluationTool(name string) bool {
 	return ok
 }
 
+// ContractToolRuntimeOptional reports whether a contract tool may be omitted
+// from discovery while its runtime feature is disabled.
+func ContractToolRuntimeOptional(name string) bool {
+	if name == ToolSubmitRecallSessionFeedback {
+		return true
+	}
+	_, ok := dreamToolNames[name]
+	return ok
+}
+
 // ErrToolDisabled is returned when a registered tool is unavailable under the
 // current runtime feature configuration.
 var ErrToolDisabled = errors.New("tool disabled")

--- a/internal/tools/registry/testdata/contract_v261_fixtures.json
+++ b/internal/tools/registry/testdata/contract_v261_fixtures.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "terminal remember success",
+    "tool": "remember",
+    "output": {
+      "contract_version": "dense-mem.v2.6.1",
+      "submission_id": "11111111-1111-1111-1111-111111111111",
+      "submission_kind": "remember",
+      "processing_state": "completed",
+      "search_state": "current",
+      "correlation_id": "fixture-correlation",
+      "evidence": [
+        {
+          "disposition": "stored",
+          "evidence_id": "22222222-2222-2222-2222-222222222222",
+          "evidence_index": 0,
+          "superseded_evidence_ids": [],
+          "search_state": "current"
+        }
+      ],
+      "relationship_results": [
+        {
+          "ref": "relationship:0",
+          "disposition": "stored",
+          "splits": [
+            {
+              "split_index": 0,
+              "relationship_id": "33333333-3333-3333-3333-333333333333",
+              "relationship_version": 1,
+              "status": "active"
+            }
+          ]
+        }
+      ],
+      "errors": []
+    }
+  },
+  {
+    "name": "direct correction awaiting confirmation",
+    "tool": "correct_relationship",
+    "output": {
+      "contract_version": "dense-mem.v2.6.1",
+      "submission_id": "44444444-4444-4444-4444-444444444444",
+      "submission_kind": "relationship_correction",
+      "processing_state": "awaiting_confirmation",
+      "search_state": "pending",
+      "correlation_id": "fixture-correction-correlation",
+      "awaiting_confirmation": {
+        "confirmation_token": "fixture-token",
+        "expires_at": "2026-08-30T00:00:00Z",
+        "candidates": [
+          {
+            "endpoint": "subject_entity",
+            "entity_id": "55555555-5555-5555-5555-555555555555",
+            "entity_kind": "project",
+            "canonical_name": "Dense-Mem"
+          },
+          {
+            "endpoint": "object_entity",
+            "entity_id": "66666666-6666-6666-6666-666666666666",
+            "entity_kind": "product",
+            "canonical_name": "PostgreSQL"
+          }
+        ]
+      },
+      "errors": []
+    }
+  },
+  {
+    "name": "direct correction structured rejection",
+    "tool": "correct_relationship",
+    "output": {
+      "contract_version": "dense-mem.v2.6.1",
+      "submission_id": "77777777-7777-7777-7777-777777777777",
+      "submission_kind": "relationship_correction",
+      "processing_state": "rejected",
+      "search_state": "not_required",
+      "correlation_id": "fixture-rejection-correlation",
+      "errors": [
+        {
+          "code": "relationship_changed",
+          "message": "relationship changed while confirmation was pending",
+          "retryable": true,
+          "next_action": "retry_correction",
+          "remediation": "Retry correct_relationship with current relationship state and a new idempotency_key."
+        }
+      ]
+    }
+  }
+]

--- a/tests/uat/mcp_sdk_parity_e2e.mjs
+++ b/tests/uat/mcp_sdk_parity_e2e.mjs
@@ -23,9 +23,10 @@ const listed = await rpc("tools/list", {}, { "MCP-Protocol-Version": "2025-11-25
 if (listed.error || !listed.result?.tools?.some((tool) => tool.name === "remember")) {
   throw new Error("live SDK tools/list did not expose the shared registry");
 }
+const hasStatusTool = listed.result.tools.some((tool) => tool.name === "get_submission_status");
 const bounded = await rpc("tools/call", {
-  name: "get_submission_status",
-  arguments: { submission_id: "00000000-0000-0000-0000-000000000000" },
+  name: hasStatusTool ? "get_submission_status" : "remember",
+  arguments: hasStatusTool ? { submission_id: "00000000-0000-0000-0000-000000000000" } : {},
 }, { "MCP-Protocol-Version": "2025-11-25" });
 if (!bounded.error || typeof bounded.error.message !== "string" || bounded.error.message.length > 512) {
   throw new Error("live SDK error mapping was not bounded");

--- a/tests/uat/synchronous_write/cases/contract.mjs
+++ b/tests/uat/synchronous_write/cases/contract.mjs
@@ -44,6 +44,8 @@ export async function run({ rpc, rawRPC, expect }) {
   const trace = await toolSuccess(rpc, "trace_memory", { relationship_id: split.relationship_id });
   const support = trace.evidence_supports?.[0];
   expect(support?.evidence_id && Number.isInteger(support.span_start) && Number.isInteger(support.span_end), "trace must expose correction support spans");
+  const ownership = await assertOwnershipIsolation({ runID, source, split, trace, support, expect });
+
   const correctionRaw = await rawRPC("tools/call", {
     name: "correct_relationship",
     arguments: {
@@ -107,6 +109,7 @@ export async function run({ rpc, rawRPC, expect }) {
     remember_state: source.processing_state,
     rejection_is_error: rejectedRaw.result?.isError === true,
     correction_state: correction.processing_state,
+    ownership_isolation: ownership,
     text_structured_parity: true,
   };
 }
@@ -160,10 +163,109 @@ async function controlJSON(baseURL, token, path, body, method = "PATCH") {
   return response.text();
 }
 
+async function controlPayload(path, body, method = "POST") {
+  const baseURL = validatedControlURL();
+  const token = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+  const response = await fetch(`${baseURL}/control/api${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`control API ${path} returned HTTP ${response.status}`);
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`control API ${path} returned invalid JSON`);
+  }
+}
+
 function requiredEnv(name) {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required`);
   return value;
+}
+
+function requiredString(value, field) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} missing`);
+  return value;
+}
+
+async function assertOwnershipIsolation({ runID, source, split, trace, support, expect }) {
+  const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+  const sameTeamCredential = await createControlCredential(teamID, `${runID}-same-team-owner`);
+  const otherTeam = await controlPayload("/teams", {
+    name: `${runID} other team`,
+    description: "contract ownership isolation",
+  });
+  const otherTeamID = requiredString(otherTeam.data?.id, "other team id");
+  const crossTeamCredential = await createControlCredential(otherTeamID, `${runID}-cross-team-owner`);
+  const correction = correctionArguments(runID, split.relationship_id, trace.relationship?.version, support, "ownership");
+
+  const sameTeamRaw = await rawRPCWithKey(sameTeamCredential.apiKey, "tools/call", { name: "correct_relationship", arguments: correction });
+  const crossTeamRaw = await rawRPCWithKey(crossTeamCredential.apiKey, "tools/call", { name: "correct_relationship", arguments: correction });
+  const sameTeamDenied = assertOwnershipDenied(sameTeamRaw, source, split.relationship_id, expect, "same-team non-owner");
+  const crossTeamDenied = assertOwnershipDenied(crossTeamRaw, source, split.relationship_id, expect, "cross-team actor");
+
+  for (const [label, credential] of [["same-team", sameTeamCredential], ["cross-team", crossTeamCredential]]) {
+    const statusRaw = await rawRPCWithKey(credential.apiKey, "tools/call", {
+      name: "get_submission_status",
+      arguments: { submission_id: source.submission_id },
+    });
+    expect(statusRaw.error?.code === -32601 && !statusRaw.result, `${label} actor must not obtain the removed correction status tool`);
+  }
+  return {
+    same_team_rejected: sameTeamDenied.processing_state,
+    cross_team_rejected: crossTeamDenied.processing_state,
+    status_lookup_removed: true,
+  };
+}
+
+async function createControlCredential(teamID, name) {
+  const payload = await controlPayload(`/teams/${teamID}/credentials`, {
+    name,
+    scopes: ["read", "write"],
+    rate_limit: 300,
+  });
+  return { apiKey: requiredString(payload.data?.api_key, "credential api key") };
+}
+
+function correctionArguments(runID, relationshipID, expectedVersion, support, suffix) {
+  return {
+    action: "submit",
+    relationship_id: relationshipID,
+    expected_version: expectedVersion,
+    patch: { object_entity: { name: `${runID} ${suffix} successor`, entity_kind: "project" } },
+    supports: [{ evidence_id: support.evidence_id, start: support.span_start, end: support.span_end }],
+    reason: `Ownership isolation ${suffix} correction must be denied.`,
+    idempotency_key: `${runID}-${suffix}-ownership-correction`,
+  };
+}
+
+function assertOwnershipDenied(raw, source, relationshipID, expect, label) {
+  const denied = structuredToolResult(raw, expect);
+  assertTerminalCorrectionResult(denied);
+  expect(denied.processing_state === "failed", `${label} correction must fail without a target mutation`);
+  expect(denied.errors?.[0]?.code === "entity_not_found", `${label} correction must use bounded not-found classification: ${JSON.stringify(denied)}`);
+  expect(!denied.correction_result && !denied.awaiting_confirmation, `${label} correction must not expose a result or confirmation`);
+  expect(denied.submission_id !== source.submission_id, `${label} correction must not expose the owner's submission ID`);
+  expect(!JSON.stringify(denied).includes(relationshipID), `${label} correction must not expose the owner's relationship ID`);
+  assertTextStructuredParity(raw, expect);
+  return denied;
+}
+
+let directRPCID = 0;
+
+async function rawRPCWithKey(apiKey, method, params) {
+  const baseURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+  const response = await fetch(`${baseURL}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: `contract-${++directRPCID}`, method, params }),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`${method} request returned HTTP ${response.status}`);
+  return text ? JSON.parse(text) : {};
 }
 
 function rememberArguments(label, fault) {

--- a/tests/uat/synchronous_write/cases/contract.mjs
+++ b/tests/uat/synchronous_write/cases/contract.mjs
@@ -1,10 +1,11 @@
-export const name = "contract";
-
+import { randomUUID } from "node:crypto";
 import {
   TERMINAL_TOOLS,
   assertTerminalCorrectionResult,
   assertTerminalRememberResult,
 } from "../surface.mjs";
+
+export const name = "contract";
 
 export async function run({ rpc, rawRPC, expect }) {
   await enableTargetFeatureGates();
@@ -20,7 +21,7 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(JSON.stringify(rememberProperties.contract_version?.enum) === JSON.stringify(["dense-mem.v2.6.1"]), "Remember schema must identify v2.6.1");
   expect(!Object.hasOwn(rememberProperties, "status_tool") && !Object.hasOwn(rememberProperties, "check_after_seconds"), "v2.6.1 Remember schema must not expose polling fields");
 
-  const runID = `synchronous-write-contract-${Date.now()}`;
+  const runID = `synchronous-write-contract-${randomUUID()}`;
   const sourceRaw = await rawRPC("tools/call", { name: "remember", arguments: rememberArguments(runID, "none") });
   const source = successfulToolResult(sourceRaw, expect);
   assertTerminalRememberResult(source);
@@ -61,6 +62,24 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(!Object.hasOwn(correction, "status_tool") && !Object.hasOwn(correction, "check_after_seconds"), "direct correction must not return polling metadata");
   assertTextStructuredParity(correctionRaw, expect);
 
+  const staleRaw = await rawRPC("tools/call", {
+    name: "correct_relationship",
+    arguments: {
+      action: "submit",
+      relationship_id: split.relationship_id,
+      expected_version: trace.relationship?.version,
+      patch: { object_entity: { name: `${runID} stale successor`, entity_kind: "project" } },
+      supports: [{ evidence_id: support.evidence_id, start: support.span_start, end: support.span_end }],
+      reason: "The relationship version is intentionally stale.",
+      idempotency_key: `${runID}-stale-correction`,
+    },
+  });
+  const stale = structuredToolResult(staleRaw, expect);
+  assertTerminalCorrectionResult(stale);
+  expect(stale.contract_version === "dense-mem.v2.6.1" && stale.processing_state === "rejected", "stale correction must return a terminal rejection");
+  expect(stale.errors?.[0]?.code === "relationship_version_stale", `stale correction must preserve version classification: ${JSON.stringify(stale)}`);
+  assertTextStructuredParity(staleRaw, expect);
+
   // Keep the intermediate confirmation branch exercised even when this
   // disposable seed resolves the correction directly to completed.
   assertTerminalCorrectionResult({
@@ -93,7 +112,7 @@ export async function run({ rpc, rawRPC, expect }) {
 }
 
 async function enableTargetFeatureGates() {
-  const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+  const controlURL = validatedControlURL();
   const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
   const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
   await controlJSON(controlURL, controlToken, "/config/recall-feedback", {
@@ -113,6 +132,22 @@ async function enableTargetFeatureGates() {
   await controlJSON(controlURL, controlToken, `/teams/${teamID}`, {
     config: { dreaming: { enabled: true } },
   }, "PATCH");
+}
+
+function validatedControlURL() {
+  const raw = requiredEnv("DENSE_MEM_CONTROL_URL").trim();
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("DENSE_MEM_CONTROL_URL must be a valid URL");
+  }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const loopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  if (parsed.username || parsed.password || (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback))) {
+    throw new Error("DENSE_MEM_CONTROL_URL must use HTTPS or loopback HTTP");
+  }
+  return parsed.toString().replace(/\/$/, "");
 }
 
 async function controlJSON(baseURL, token, path, body, method = "PATCH") {

--- a/tests/uat/synchronous_write/cases/contract.mjs
+++ b/tests/uat/synchronous_write/cases/contract.mjs
@@ -1,2 +1,183 @@
 export const name = "contract";
-export async function run() { return { mode: name, status: "reserved-for-adoption" }; }
+
+import {
+  TERMINAL_TOOLS,
+  assertTerminalCorrectionResult,
+  assertTerminalRememberResult,
+} from "../surface.mjs";
+
+export async function run({ rpc, rawRPC, expect }) {
+  await enableTargetFeatureGates();
+  const listed = await rpc("tools/list", {});
+  const tools = listed.tools || [];
+  const names = tools.map((tool) => tool.name);
+  expect(names.length === TERMINAL_TOOLS.length && TERMINAL_TOOLS.every((tool) => names.includes(tool)), "v2.6.1 catalog must expose exactly ten tools");
+  expect(!names.includes("get_submission_status"), "v2.6.1 catalog must remove get_submission_status");
+
+  const rememberTool = tools.find((tool) => tool.name === "remember");
+  const rememberSchema = rememberTool?.outputSchema || rememberTool?.output_schema || {};
+  const rememberProperties = rememberSchema.properties || {};
+  expect(JSON.stringify(rememberProperties.contract_version?.enum) === JSON.stringify(["dense-mem.v2.6.1"]), "Remember schema must identify v2.6.1");
+  expect(!Object.hasOwn(rememberProperties, "status_tool") && !Object.hasOwn(rememberProperties, "check_after_seconds"), "v2.6.1 Remember schema must not expose polling fields");
+
+  const runID = `synchronous-write-contract-${Date.now()}`;
+  const sourceRaw = await rawRPC("tools/call", { name: "remember", arguments: rememberArguments(runID, "none") });
+  const source = successfulToolResult(sourceRaw, expect);
+  assertTerminalRememberResult(source);
+  expect(source.contract_version === "dense-mem.v2.6.1", "terminal Remember must return v2.6.1");
+  expect(source.processing_state === "completed", `terminal Remember must complete: ${JSON.stringify(source)}`);
+  expect(source.relationship_results?.[0]?.splits?.[0]?.relationship_id, "terminal Remember must return a relationship split");
+  assertTextStructuredParity(sourceRaw, expect);
+
+  const removed = await rawRPC("tools/call", { name: "get_submission_status", arguments: { submission_id: source.submission_id } });
+  expect(removed.error?.code === -32601 && !removed.result, "removed get_submission_status must return bounded method-not-found");
+
+  const rejectedRaw = await rawRPC("tools/call", { name: "remember", arguments: rememberArguments(`${runID}-rejected`, "no-supported") });
+  const rejected = structuredToolResult(rejectedRaw, expect);
+  assertTerminalRememberResult(rejected);
+  expect(rejected.contract_version === "dense-mem.v2.6.1" && rejected.processing_state === "rejected", "terminal rejection must preserve target state");
+  expect(rejected.errors?.[0]?.code === "no_supported_memory", "terminal rejection must preserve bounded error code");
+  assertTextStructuredParity(rejectedRaw, expect);
+
+  const split = source.relationship_results[0].splits[0];
+  const trace = await toolSuccess(rpc, "trace_memory", { relationship_id: split.relationship_id });
+  const support = trace.evidence_supports?.[0];
+  expect(support?.evidence_id && Number.isInteger(support.span_start) && Number.isInteger(support.span_end), "trace must expose correction support spans");
+  const correctionRaw = await rawRPC("tools/call", {
+    name: "correct_relationship",
+    arguments: {
+      action: "submit",
+      relationship_id: split.relationship_id,
+      expected_version: trace.relationship?.version,
+      patch: { object_entity: { name: `${runID} successor`, entity_kind: "project" } },
+      supports: [{ evidence_id: support.evidence_id, start: support.span_start, end: support.span_end }],
+      reason: "The relationship object was resolved incorrectly.",
+      idempotency_key: `${runID}-correction`,
+    },
+  });
+  const correction = successfulToolResult(correctionRaw, expect);
+  assertTerminalCorrectionResult(correction);
+  expect(correction.contract_version === "dense-mem.v2.6.1", "direct correction must return v2.6.1");
+  expect(!Object.hasOwn(correction, "status_tool") && !Object.hasOwn(correction, "check_after_seconds"), "direct correction must not return polling metadata");
+  assertTextStructuredParity(correctionRaw, expect);
+
+  // Keep the intermediate confirmation branch exercised even when this
+  // disposable seed resolves the correction directly to completed.
+  assertTerminalCorrectionResult({
+    contract_version: "dense-mem.v2.6.1",
+    submission_id: "fixture-confirmation",
+    submission_kind: "relationship_correction",
+    processing_state: "awaiting_confirmation",
+    search_state: "pending",
+    correlation_id: "fixture-confirmation-correlation",
+    awaiting_confirmation: {
+      confirmation_token: "fixture-token",
+      expires_at: "2026-08-30T00:00:00Z",
+      candidates: [
+        { endpoint: "subject_entity", entity_id: "fixture-subject", entity_kind: "project", canonical_name: "Subject" },
+        { endpoint: "object_entity", entity_id: "fixture-object", entity_kind: "project", canonical_name: "Object" },
+      ],
+    },
+    errors: [],
+  });
+
+  return {
+    mode: name,
+    tools: names.length,
+    removed_status: true,
+    remember_state: source.processing_state,
+    rejection_is_error: rejectedRaw.result?.isError === true,
+    correction_state: correction.processing_state,
+    text_structured_parity: true,
+  };
+}
+
+async function enableTargetFeatureGates() {
+  const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+  const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+  const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+  await controlJSON(controlURL, controlToken, "/config/recall-feedback", {
+    items: [
+      { key: "RECALL_FEEDBACK_ENABLED", value: "true" },
+      { key: "RECALL_FEEDBACK_RETENTION_DAYS", value: "30" },
+    ],
+  });
+  await controlJSON(controlURL, controlToken, "/config/dreaming", {
+    items: [
+      { key: "DREAMING_ENABLED", value: "true" },
+      { key: "DREAMING_FORCE_ENABLED", value: "true" },
+      { key: "DREAMING_START_TIME_LOCAL", value: "03:00" },
+      { key: "DREAMING_MAX_OUTPUTS", value: "5" },
+    ],
+  });
+  await controlJSON(controlURL, controlToken, `/teams/${teamID}`, {
+    config: { dreaming: { enabled: true } },
+  }, "PATCH");
+}
+
+async function controlJSON(baseURL, token, path, body, method = "PATCH") {
+  const response = await fetch(`${baseURL}/control/api${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`control API ${path} returned HTTP ${response.status}`);
+  return response.text();
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function rememberArguments(label, fault) {
+  const subject = `${label} subject`;
+  const object = `${label} object`;
+  const marker = fault === "none" ? "fixture-contract" : `fixture-fault:${fault}`;
+  return {
+    idempotency_key: `${label}-remember`,
+    evidence: [{ content: `${subject} uses ${object}. [${marker}]`, source_type: "manual", source: label, source_group: label }],
+    relationships: [{
+      ref: `${label}-relationship`,
+      subject: { name: subject, entity_kind: "project" },
+      predicate: { proposed_key: "uses" },
+      object: { entity: { name: object, entity_kind: "project" } },
+      polarity: "+",
+      evidence_indices: [0],
+    }],
+  };
+}
+
+function successfulToolResult(raw, expect) {
+  expect(!raw.error && raw.result && raw.result.isError !== true, "MCP tool call must succeed");
+  const text = raw.result?.content?.[0]?.text;
+  expect(typeof text === "string", "MCP tool call must include JSON text");
+  return JSON.parse(text);
+}
+
+function structuredToolResult(raw, expect) {
+  expect(!raw.error && raw.result?.isError === true, "target rejection must be an MCP structured error result");
+  const text = raw.result?.content?.[0]?.text;
+  expect(typeof text === "string" && raw.result?.structuredContent, "structured error must include text and structuredContent");
+  return JSON.parse(text);
+}
+
+function assertTextStructuredParity(raw, expect) {
+  const text = raw.result?.content?.[0]?.text;
+  const parsed = JSON.parse(text);
+  expect(stableJSON(parsed) === stableJSON(raw.result?.structuredContent), "MCP text and structuredContent must be equivalent");
+}
+
+async function toolSuccess(rpc, name, argumentsValue) {
+  const raw = await rpc("tools/call", { name, arguments: argumentsValue });
+  const text = raw?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} did not return JSON content`);
+  return JSON.parse(text);
+}
+
+function stableJSON(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJSON).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJSON(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
+}

--- a/tests/uat/synchronous_write/cases/contract.mjs
+++ b/tests/uat/synchronous_write/cases/contract.mjs
@@ -9,6 +9,7 @@ export const name = "contract";
 
 export async function run({ rpc, rawRPC, expect }) {
   await enableTargetFeatureGates();
+  validatedUserURL();
   const listed = await rpc("tools/list", {});
   const tools = listed.tools || [];
   const names = tools.map((tool) => tool.name);
@@ -138,17 +139,25 @@ async function enableTargetFeatureGates() {
 }
 
 function validatedControlURL() {
-  const raw = requiredEnv("DENSE_MEM_CONTROL_URL").trim();
+  return validatedEndpointURL("DENSE_MEM_CONTROL_URL");
+}
+
+function validatedUserURL() {
+  return validatedEndpointURL("DENSE_MEM_USER_URL");
+}
+
+function validatedEndpointURL(name) {
+  const raw = requiredEnv(name).trim();
   let parsed;
   try {
     parsed = new URL(raw);
   } catch {
-    throw new Error("DENSE_MEM_CONTROL_URL must be a valid URL");
+    throw new Error(`${name} must be a valid URL`);
   }
   const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
   const loopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
   if (parsed.username || parsed.password || (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback))) {
-    throw new Error("DENSE_MEM_CONTROL_URL must use HTTPS or loopback HTTP");
+    throw new Error(`${name} must use HTTPS or loopback HTTP`);
   }
   return parsed.toString().replace(/\/$/, "");
 }
@@ -257,7 +266,7 @@ function assertOwnershipDenied(raw, source, relationshipID, expect, label) {
 let directRPCID = 0;
 
 async function rawRPCWithKey(apiKey, method, params) {
-  const baseURL = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+  const baseURL = validatedUserURL();
   const response = await fetch(`${baseURL}/mcp`, {
     method: "POST",
     headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json", "Content-Type": "application/json" },

--- a/tests/uat/synchronous_write/runner.test.mjs
+++ b/tests/uat/synchronous_write/runner.test.mjs
@@ -81,3 +81,12 @@ test("diagnostics slice contains control API and scrubbed artifact assertions", 
   assert.match(overlay, /run_compose_playwright_tests remember_attempts/);
   assert.match(compose, /remember-attempts\.spec\.ts/);
 });
+
+test("contract slice asserts target catalog, terminal errors, correction, and parity", async () => {
+  const contract = await readFile(new URL("./cases/contract.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(contract, /reserved-for-adoption/);
+  assert.match(contract, /exactly ten tools/);
+  assert.match(contract, /get_submission_status/);
+  assert.match(contract, /structuredContent/);
+  assert.match(contract, /correct_relationship/);
+});

--- a/tests/uat/synchronous_write/runner.test.mjs
+++ b/tests/uat/synchronous_write/runner.test.mjs
@@ -90,3 +90,11 @@ test("contract slice asserts target catalog, terminal errors, correction, and pa
   assert.match(contract, /structuredContent/);
   assert.match(contract, /correct_relationship/);
 });
+
+test("contract ownership callers validate the user endpoint before sending credentials", async () => {
+  const contract = await readFile(new URL("./cases/contract.mjs", import.meta.url), "utf8");
+  assert.match(contract, /validatedUserURL\(\);/);
+  assert.match(contract, /validatedEndpointURL\("DENSE_MEM_USER_URL"\)/);
+  assert.match(contract, /must use HTTPS or loopback HTTP/);
+  assert.match(contract, /const baseURL = validatedUserURL\(\);/);
+});

--- a/tests/uat/synchronous_write/staging_surface.test.mjs
+++ b/tests/uat/synchronous_write/staging_surface.test.mjs
@@ -21,7 +21,7 @@ test("classifies the legacy polling surface", () => {
 
 test("classifies the terminal surface", () => {
   const remember = { processing_state: "completed", search_state: "current", evidence: [], relationship_results: [] };
-  const correction = { processing_state: "completed", relationship_results: [], correlation_id: "corr" };
+  const correction = { processing_state: "completed", search_state: "current", correction_result: {}, errors: [], correlation_id: "corr" };
   assert.equal(classifyStagingSurface({
     tools: TERMINAL_TOOLS,
     remember,
@@ -51,13 +51,13 @@ test("fails closed on mixed or ambiguous surfaces", () => {
   assert.throws(() => classifyStagingSurface({
     tools: TERMINAL_TOOLS,
     remember: { processing_state: "completed", search_state: "current", evidence: [], relationship_results: [] },
-    correction: { processing_state: "completed", relationship_results: [], correlation_id: "corr", status_tool: "get_submission_status" },
+    correction: { processing_state: "completed", search_state: "current", correction_result: {}, errors: [], correlation_id: "corr", status_tool: "get_submission_status" },
     removedToolFailure: true,
   }), /mixed or ambiguous/);
   assert.throws(() => classifyStagingSurface({
     tools: TERMINAL_TOOLS,
     remember: { processing_state: "completed", search_state: "current", evidence: [], relationship_results: [], check_after_seconds: 60 },
-    correction: { processing_state: "completed", relationship_results: [], correlation_id: "corr" },
+    correction: { processing_state: "completed", search_state: "current", correction_result: {}, errors: [], correlation_id: "corr" },
     removedToolFailure: true,
   }), /mixed or ambiguous/);
 });

--- a/tests/uat/synchronous_write/surface.mjs
+++ b/tests/uat/synchronous_write/surface.mjs
@@ -28,6 +28,7 @@ function exactToolSet(names, expected) {
 }
 
 const TERMINAL_PROCESSING_STATES = new Set(["completed", "rejected", "quarantined", "failed"]);
+const CORRECTION_PROCESSING_STATES = new Set(["awaiting_confirmation", "completed", "rejected", "failed"]);
 const TERMINAL_SEARCH_STATES = new Set(["current", "not_required"]);
 
 export function assertLegacyRememberReceipt(result) {
@@ -50,12 +51,21 @@ export function assertTerminalRememberResult(result) {
 }
 
 export function assertTerminalCorrectionResult(result) {
-  if (!result || !TERMINAL_PROCESSING_STATES.has(result.processing_state) ||
-      !Array.isArray(result.relationship_results) ||
+  if (!result || !CORRECTION_PROCESSING_STATES.has(result.processing_state) ||
+      !Array.isArray(result.errors) ||
       typeof result.correlation_id !== "string" ||
       result.correlation_id.trim() === "" ||
       Object.hasOwn(result, "status_tool") || Object.hasOwn(result, "check_after_seconds")) {
     throw new Error("terminal correction result must be direct and complete");
+  }
+  if (result.processing_state === "awaiting_confirmation" && !result.awaiting_confirmation) {
+    throw new Error("awaiting correction result must include confirmation details");
+  }
+  if (result.processing_state === "completed" && !result.correction_result) {
+    throw new Error("completed correction result must include correction details");
+  }
+  if ((result.processing_state === "rejected" || result.processing_state === "failed") && result.errors.length === 0) {
+    throw new Error("rejected correction result must include errors");
   }
   return result;
 }


### PR DESCRIPTION
Close #306 

## Summary

Implements [T08 / issue #306](https://github.com/markhuangai/dense-mem/issues/306) for the prepared v2.6.1 terminal contract.

- Adds the inactive, versioned ten-tool catalog and closed Remember/direct-correction schemas.
- Preserves terminal tool failures as bounded MCP `isError` results with equivalent text JSON and `structuredContent`.
- Makes the evaluation client discover legacy versus terminal contracts, avoid removed status polling, and retry only actionable transient terminal failures.
- Adds test-selected E2E composition, contract fixtures, UAT assertions, and SDK parity coverage.
- Leaves production `BuildActive` and `domain.ContractVersion` on v2.6 until T09.

## Verification

- `go test ./internal/... ./cmd/... -count=1`
- `go vet ./internal/... ./cmd/...`
- `node --test tests/uat/synchronous_write/*.test.mjs`
- `./scripts/ci-check.sh` — passed; aggregate coverage 90.0%.
- Contract synchronous-write, mcp SDK parity, and mcp SDK transport Compose slices passed with isolated temporary mounts and allocator-selected fresh ports.
- Full Compose matrix reached `conflict_queue` and stopped because the configured live embedding endpoint was unreachable (`curl` status `000`); this is an external provider limitation.
- Deterministic 1k evaluation is waived for this ticket per the published issue.

## Audit

- Independent plan audit: `conformant`, no unresolved findings.
- Prerequisites T02 (#300) and T03 (#301) are closed on the merge base.

## Review scope

Post-audit changes were limited to the recorded issue-306 implementation and test paths; the post-audit coverage tests are test-only additions required by the repository coverage gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `dense-mem.v2.6.1` contract with a streamlined ten-tool catalog.
  * Remember operations now return completed terminal results without status polling.
  * Added relationship-correction results with confirmation, completion, and failure states.
  * Added structured tool responses with machine-readable error details.
* **Compatibility**
  * Clients automatically detect the available contract and adjust behavior.
* **Bug Fixes**
  * Improved handling of idempotency conflicts and expired confirmations.
* **Tests**
  * Expanded coverage for contract discovery, terminal results, corrections, structured errors, ownership isolation, and compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->