### PR TITLE
Fix Dream terminal Remember consumption

### DIFF
--- a/cmd/internal/e2eapp/e2eapp.go
+++ b/cmd/internal/e2eapp/e2eapp.go
@@ -154,7 +154,9 @@ func dreamOverride(_ context.Context, _ serverapp.RuntimeContext, write *servera
 		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceDream)
 	}
 	write.Remember = remember
-	write.RegistryOverride = terminalRememberRegistryOverride(remember)
+	write.RegistryOverride = func(_ context.Context, _ serverapp.RuntimeContext, active registry.Registry) (registry.Registry, error) {
+		return registry.WithTerminalRemember(active, remember)
+	}
 	return nil
 }
 func reconciliationOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {

--- a/cmd/internal/e2eapp/e2eapp.go
+++ b/cmd/internal/e2eapp/e2eapp.go
@@ -143,7 +143,18 @@ func conflictOverride(_ context.Context, _ serverapp.RuntimeContext, write *serv
 	return validateSliceHook(write, WriteSliceConflict)
 }
 func dreamOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {
-	return validateSliceHook(write, WriteSliceDream)
+	if err := validateSliceHook(write, WriteSliceDream); err != nil {
+		return err
+	}
+	if write.SynchronousRememberFactory == nil {
+		return fmt.Errorf("e2e write slice %q has no synchronous Remember factory", WriteSliceDream)
+	}
+	remember := write.SynchronousRememberFactory()
+	if remember == nil {
+		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceDream)
+	}
+	write.Remember = remember
+	return nil
 }
 func reconciliationOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {
 	return validateSliceHook(write, WriteSliceReconciliation)

--- a/cmd/internal/e2eapp/e2eapp.go
+++ b/cmd/internal/e2eapp/e2eapp.go
@@ -154,6 +154,7 @@ func dreamOverride(_ context.Context, _ serverapp.RuntimeContext, write *servera
 		return fmt.Errorf("e2e write slice %q factory returned nil Remember service", WriteSliceDream)
 	}
 	write.Remember = remember
+	write.RegistryOverride = terminalRememberRegistryOverride(remember)
 	return nil
 }
 func reconciliationOverride(_ context.Context, _ serverapp.RuntimeContext, write *serverapp.WriteRuntime) error {

--- a/cmd/internal/e2eapp/e2eapp_test.go
+++ b/cmd/internal/e2eapp/e2eapp_test.go
@@ -145,6 +145,11 @@ func TestDiagnosticsOverrideInstallsTerminalRememberRuntime(t *testing.T) {
 
 func TestDreamOverrideInstallsSynchronousRemember(t *testing.T) {
 	active := registry.New()
+	require.NoError(t, active.Register(registry.Tool{
+		Name:         registry.ToolRemember,
+		InputSchema:  map[string]any{"type": "object"},
+		OutputSchema: map[string]any{"type": "object", "properties": map[string]any{"status_tool": map[string]any{"type": "string"}}, "additionalProperties": false},
+	}))
 	registryOverride := registryOverrideForSlice(WriteSliceDream)
 	factoryCalls := 0
 	write := &serverapp.WriteRuntime{
@@ -159,7 +164,11 @@ func TestDreamOverrideInstallsSynchronousRemember(t *testing.T) {
 	require.NotNil(t, write.RegistryOverride)
 	selected, err := write.RegistryOverride(context.Background(), serverapp.RuntimeContext{}, active)
 	require.NoError(t, err)
-	require.Same(t, active, selected)
+	replacement, ok := selected.Get(registry.ToolRemember)
+	require.True(t, ok)
+	original, ok := active.Get(registry.ToolRemember)
+	require.True(t, ok)
+	require.NotEqual(t, original.OutputSchema, replacement.OutputSchema)
 }
 
 func TestRememberOverridePreservesEveryNonRememberTool(t *testing.T) {

--- a/cmd/internal/e2eapp/e2eapp_test.go
+++ b/cmd/internal/e2eapp/e2eapp_test.go
@@ -42,7 +42,7 @@ func TestEveryWriteSliceHasAnOverrideSlot(t *testing.T) {
 		require.Equal(t, raw, write.Slice)
 		require.NotNil(t, write.RegistryOverride)
 		active := registry.New()
-		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics {
+		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceDream {
 			require.NoError(t, active.Register(registry.Tool{Name: registry.ToolRemember, InputSchema: map[string]any{"type": "object"}}))
 		} else if slice == WriteSliceContract {
 			for _, tool := range registry.ContractTools() {
@@ -50,7 +50,7 @@ func TestEveryWriteSliceHasAnOverrideSlot(t *testing.T) {
 				require.NoError(t, active.Register(tool))
 			}
 		}
-		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceContract {
+		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceDream || slice == WriteSliceContract {
 			selectedRegistry, err := write.RegistryOverride(context.Background(), serverapp.RuntimeContext{}, active)
 			require.NoError(t, err)
 			require.NotNil(t, selectedRegistry)
@@ -102,7 +102,7 @@ func TestRememberOverrideClonesOnlyRememberWithTerminalInvoker(t *testing.T) {
 	require.Len(t, selected.List(), len(active.List()))
 }
 
-func TestNonRememberSliceDoesNotInvokeSynchronousFactory(t *testing.T) {
+func TestSlicesWithoutSynchronousRememberAdoptionDoNotInvokeFactory(t *testing.T) {
 	calls := 0
 	factory := func() rememberapp.Service {
 		calls++
@@ -110,7 +110,7 @@ func TestNonRememberSliceDoesNotInvokeSynchronousFactory(t *testing.T) {
 	}
 	for _, raw := range WriteSlices() {
 		slice := WriteSlice(raw)
-		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceContract {
+		if slice == WriteSliceRemember || slice == WriteSliceDiagnostics || slice == WriteSliceDream || slice == WriteSliceContract {
 			continue
 		}
 		options := optionsForSlice(slice)
@@ -141,6 +141,25 @@ func TestDiagnosticsOverrideInstallsTerminalRememberRuntime(t *testing.T) {
 	replacement, ok := selected.Get(registry.ToolRemember)
 	require.True(t, ok)
 	require.NotEqual(t, original.OutputSchema, replacement.OutputSchema)
+}
+
+func TestDreamOverrideInstallsSynchronousRemember(t *testing.T) {
+	active := registry.New()
+	registryOverride := registryOverrideForSlice(WriteSliceDream)
+	factoryCalls := 0
+	write := &serverapp.WriteRuntime{
+		Slice:                      string(WriteSliceDream),
+		RegistryOverride:           registryOverride,
+		SynchronousRememberFactory: func() rememberapp.Service { factoryCalls++; return terminalRememberService{} },
+	}
+
+	require.NoError(t, dreamOverride(context.Background(), serverapp.RuntimeContext{}, write))
+	require.Equal(t, 1, factoryCalls)
+	require.NotNil(t, write.Remember)
+	require.NotNil(t, write.RegistryOverride)
+	selected, err := write.RegistryOverride(context.Background(), serverapp.RuntimeContext{}, active)
+	require.NoError(t, err)
+	require.Same(t, active, selected)
 }
 
 func TestRememberOverridePreservesEveryNonRememberTool(t *testing.T) {

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -281,7 +281,7 @@ func RunActiveServer(
 	})
 	contextSvc := contextservice.NewSemantic(semanticRepo)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{
-		Remember:       rememberSvc,
+		Remember:       writeRuntime.Remember,
 		Store:          semanticRepo,
 		ScheduledStore: semanticRepo,
 		AppConfig:      appConfigService,

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -281,7 +281,7 @@ func RunActiveServer(
 	})
 	contextSvc := contextservice.NewSemantic(semanticRepo)
 	dreamSvc := dreamservice.New(dreamservice.Dependencies{
-		Remember:       writeRuntime.Remember,
+		Remember: writeRuntime.Remember, RememberIngests: ledgerRepo,
 		Store:          semanticRepo,
 		ScheduledStore: semanticRepo,
 		AppConfig:      appConfigService,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -680,6 +680,12 @@ func loadWithPostgresDSN(postgresDSN string) (Config, error) {
 			}
 		}
 	}
+	if cfg.PostgresMaxOpenConns < 2 {
+		return cfg, &ValidationError{
+			Field:   "POSTGRES_MAX_OPEN_CONNS",
+			Message: fmt.Sprintf("must be at least 2 for Dream confirmation locking, got %d", cfg.PostgresMaxOpenConns),
+		}
+	}
 	if cfg.EmbeddingJobMaxAttempts > MaxEmbeddingJobMaxAttempts {
 		return cfg, &ValidationError{
 			Field:   "EMBEDDING_JOB_MAX_ATTEMPTS",

--- a/internal/config/postgres_coordination_config_test.go
+++ b/internal/config/postgres_coordination_config_test.go
@@ -112,6 +112,25 @@ func TestLoadValidation_PostgresIdleExceedsOpen(t *testing.T) {
 	}
 }
 
+func TestLoadValidation_PostgresOpenRequiresDreamConfirmationCapacity(t *testing.T) {
+	clearEnv()
+	setRequiredEnv()
+	os.Setenv("POSTGRES_MAX_OPEN_CONNS", "1")
+	os.Setenv("POSTGRES_MAX_IDLE_CONNS", "1")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() expected error for a one-connection postgres pool, got nil")
+	}
+	validationErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("expected *ValidationError, got %T", err)
+	}
+	if validationErr.Field != "POSTGRES_MAX_OPEN_CONNS" {
+		t.Errorf("ValidationError.Field = %q, want %q", validationErr.Field, "POSTGRES_MAX_OPEN_CONNS")
+	}
+}
+
 func TestLoadValidation_PostgresMigrationTimeoutExceedsMaximum(t *testing.T) {
 	clearEnv()
 	setRequiredEnv()

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const dreamConfirmationLockPrefix = "dream-confirmation:"
+
+// WithHypothesisConfirmationLock serializes confirmation workflows for one
+// team-owned Hypothesis without holding the semantic transaction over provider work.
+func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
+	ctx context.Context,
+	teamID string,
+	hypothesisID string,
+	fn func() error,
+) error {
+	if r == nil || r.db == nil {
+		return errors.New("dream confirmation lock: database is required")
+	}
+	teamID = strings.TrimSpace(teamID)
+	hypothesisID = strings.TrimSpace(hypothesisID)
+	if _, err := uuid.Parse(teamID); err != nil {
+		return fmt.Errorf("dream confirmation lock: team_id is required: %w", err)
+	}
+	if _, err := uuid.Parse(hypothesisID); err != nil {
+		return fmt.Errorf("dream confirmation lock: hypothesis_id is required: %w", err)
+	}
+	if fn == nil {
+		return errors.New("dream confirmation lock: callback is required")
+	}
+	key := dreamConfirmationLockPrefix + teamID + ":" + hypothesisID
+	return r.db.WithContext(ctx).Connection(func(conn *gorm.DB) error {
+		if err := conn.WithContext(ctx).Exec("SELECT pg_advisory_lock(hashtext(?))", key).Error; err != nil {
+			return fmt.Errorf("dream confirmation lock acquire: %w", err)
+		}
+		callbackErr := fn()
+		unlockErr := conn.WithContext(ctx).Exec("SELECT pg_advisory_unlock(hashtext(?))", key).Error
+		if callbackErr != nil {
+			return callbackErr
+		}
+		if unlockErr != nil {
+			return fmt.Errorf("dream confirmation lock release: %w", unlockErr)
+		}
+		return nil
+	})
+}

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -13,13 +12,15 @@ import (
 
 const dreamConfirmationLockPrefix = "dream-confirmation:"
 
-// WithHypothesisConfirmationLock serializes confirmation workflows for one
-// team-owned Hypothesis without holding the semantic transaction over provider work.
+var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")
+
+// WithHypothesisConfirmationLock admits one confirmation workflow for a
+// team-owned Hypothesis without retaining pooled connections for lock waiters.
 func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	ctx context.Context,
 	teamID string,
 	hypothesisID string,
-	fn func(DreamRepository) error,
+	fn func() error,
 ) error {
 	if r == nil || r.db == nil {
 		return errors.New("dream confirmation lock: database is required")
@@ -35,27 +36,21 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if fn == nil {
 		return errors.New("dream confirmation lock: callback is required")
 	}
-	key := dreamConfirmationLockPrefix + teamID + ":" + hypothesisID
-	return r.db.WithContext(ctx).Connection(func(conn *gorm.DB) error {
-		lockedRepo := *r
-		lockedRepo.db = conn
-		canonicalID := hypothesisID
-		if record, err := lockedRepo.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
-			canonicalID = record.HypothesisID
-		} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
-			return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
-		}
-		key = dreamConfirmationLockPrefix + teamID + ":" + canonicalID
-		if err := conn.WithContext(ctx).Exec("SELECT pg_advisory_lock(hashtext(?))", key).Error; err != nil {
+	canonicalID := hypothesisID
+	if record, err := r.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
+		canonicalID = record.HypothesisID
+	} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
+		return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
+	}
+	key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var acquired bool
+		if err := tx.WithContext(ctx).Raw("SELECT pg_try_advisory_xact_lock(hashtext(?))", key).Row().Scan(&acquired); err != nil {
 			return fmt.Errorf("dream confirmation lock acquire: %w", err)
 		}
-		callbackErr := fn(&lockedRepo)
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		unlockErr := conn.WithContext(cleanupCtx).Exec("SELECT pg_advisory_unlock(hashtext(?))", key).Error
-		if unlockErr != nil {
-			unlockErr = fmt.Errorf("dream confirmation lock release: %w", unlockErr)
+		if !acquired {
+			return ErrDreamConfirmationBusy
 		}
-		return errors.Join(callbackErr, unlockErr)
+		return fn()
 	})
 }

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"strings"
@@ -92,8 +93,19 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if releaseErr == nil && !released {
 		releaseErr = errors.New("database did not release the advisory lock")
 	}
-	closeErr := lockConn.Close()
-	closed = true
+	var closeErr error
+	if releaseErr != nil {
+		closeErr = discardDreamConfirmationLockConnection(lockConn)
+		if closeErr == nil {
+			closed = true
+		} else {
+			closeErr = errors.Join(closeErr, lockConn.Close())
+			closed = true
+		}
+	} else {
+		closeErr = lockConn.Close()
+		closed = true
+	}
 	if releaseErr != nil {
 		releaseErr = fmt.Errorf("dream confirmation lock release: %w", releaseErr)
 	}
@@ -108,6 +120,22 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 		r.db.Logger.Warn(ctx, "dream confirmation lock cleanup failed", "error_class", "database_cleanup")
 	}
 	return nil
+}
+
+func discardDreamConfirmationLockConnection(lockConn *sql.Conn) error {
+	if lockConn == nil {
+		return nil
+	}
+	err := lockConn.Raw(func(any) error {
+		return driver.ErrBadConn
+	})
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, sql.ErrConnDone) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("dream confirmation lock discard: %w", err)
+	}
+	return errors.New("dream confirmation lock discard: connection was not discarded")
 }
 
 func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -17,8 +17,8 @@ import (
 const (
 	dreamConfirmationLockPrefix         = "dream-confirmation:"
 	dreamConfirmationLockCleanupTimeout = 5 * time.Second
-	// Keep one dedicated session for coordination; the application pool cannot share its session across provider work.
-	dreamConfirmationLockAdmissionLimit = 1
+	// Keep a small dedicated session budget; the application pool cannot share its sessions across provider work.
+	dreamConfirmationLockAdmissionLimit = 4
 )
 
 var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -112,7 +112,10 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if callbackErr != nil {
 		return errors.Join(callbackErr, cleanupErr)
 	}
-	return cleanupErr
+	if cleanupErr != nil && r.db.Logger != nil {
+		r.db.Logger.Warn(ctx, "dream confirmation lock cleanup failed", "error_class", "database_cleanup")
+	}
+	return nil
 }
 
 func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -20,7 +20,7 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	ctx context.Context,
 	teamID string,
 	hypothesisID string,
-	fn func() error,
+	fn func(DreamRepository) error,
 ) error {
 	if r == nil || r.db == nil {
 		return errors.New("dream confirmation lock: database is required")
@@ -36,14 +36,16 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if fn == nil {
 		return errors.New("dream confirmation lock: callback is required")
 	}
-	canonicalID := hypothesisID
-	if record, err := r.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
-		canonicalID = record.HypothesisID
-	} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
-		return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
-	}
-	key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		lockedRepo := *r
+		lockedRepo.db = tx
+		canonicalID := hypothesisID
+		if record, err := lockedRepo.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
+			canonicalID = record.HypothesisID
+		} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
+			return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
+		}
+		key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
 		var acquired bool
 		if err := tx.WithContext(ctx).Raw("SELECT pg_try_advisory_xact_lock(hashtext(?))", key).Row().Scan(&acquired); err != nil {
 			return fmt.Errorf("dream confirmation lock acquire: %w", err)
@@ -51,6 +53,6 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 		if !acquired {
 			return ErrDreamConfirmationBusy
 		}
-		return fn()
+		return fn(&lockedRepo)
 	})
 }

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -10,14 +10,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	gormpostgres "gorm.io/driver/postgres"
-	"gorm.io/gorm"
 )
 
 const (
 	dreamConfirmationLockPrefix         = "dream-confirmation:"
 	dreamConfirmationLockCleanupTimeout = 5 * time.Second
-	// Keep a small dedicated session budget; the application pool cannot share its sessions across provider work.
+	// Keep a small session budget so provider work cannot exhaust the application pool.
 	dreamConfirmationLockAdmissionLimit = 4
 )
 
@@ -29,9 +27,8 @@ type dreamConfirmationLockAdmissionState struct {
 }
 
 // WithHypothesisConfirmationLock admits one confirmation workflow for a
-// team-owned Hypothesis without retaining the application pool while provider
-// work runs. The advisory lock uses a dedicated session that is closed after
-// the callback, so a failed unlock cannot strand a pooled application session.
+// team-owned Hypothesis. The advisory lock uses one application-pool session
+// through the callback, so lock sessions count against the configured pool.
 func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	ctx context.Context,
 	teamID string,
@@ -66,7 +63,7 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 		return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
 	}
 
-	lockConn, lockDB, err := r.openDreamConfirmationLockConnection(ctx)
+	lockConn, err := r.openDreamConfirmationLockConnection(ctx)
 	if err != nil {
 		return err
 	}
@@ -76,7 +73,6 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 			return
 		}
 		_ = lockConn.Close()
-		_ = lockDB.Close()
 	}()
 
 	key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
@@ -97,7 +93,6 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 		releaseErr = errors.New("database did not release the advisory lock")
 	}
 	closeErr := lockConn.Close()
-	lockDBErr := lockDB.Close()
 	closed = true
 	if releaseErr != nil {
 		releaseErr = fmt.Errorf("dream confirmation lock release: %w", releaseErr)
@@ -105,10 +100,7 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if closeErr != nil {
 		closeErr = fmt.Errorf("dream confirmation lock connection close: %w", closeErr)
 	}
-	if lockDBErr != nil {
-		lockDBErr = fmt.Errorf("dream confirmation lock database close: %w", lockDBErr)
-	}
-	cleanupErr := errors.Join(releaseErr, closeErr, lockDBErr)
+	cleanupErr := errors.Join(releaseErr, closeErr)
 	if callbackErr != nil {
 		return errors.Join(callbackErr, cleanupErr)
 	}
@@ -120,7 +112,13 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 
 func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {
 	r.dreamConfirmationLockState.once.Do(func() {
-		r.dreamConfirmationLockState.slots = make(chan struct{}, dreamConfirmationLockAdmissionLimit)
+		limit := dreamConfirmationLockAdmissionLimit
+		if sqlDB, err := r.db.DB(); err == nil {
+			if configured := sqlDB.Stats().MaxOpenConnections; configured > 0 && configured-1 < limit {
+				limit = configured - 1
+			}
+		}
+		r.dreamConfirmationLockState.slots = make(chan struct{}, limit)
 	})
 	select {
 	case <-ctx.Done():
@@ -135,38 +133,17 @@ func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx conte
 	}
 }
 
-func (r *SemanticRepositoryImpl) openDreamConfirmationLockConnection(ctx context.Context) (*sql.Conn, *sql.DB, error) {
+func (r *SemanticRepositoryImpl) openDreamConfirmationLockConnection(ctx context.Context) (*sql.Conn, error) {
 	if r == nil || r.db == nil {
-		return nil, nil, errors.New("dream confirmation lock: database is required")
+		return nil, errors.New("dream confirmation lock: database is required")
 	}
-	dialector, ok := r.db.Dialector.(*gormpostgres.Dialector)
-	if !ok || dialector == nil || dialector.Config == nil || strings.TrimSpace(dialector.DSN) == "" || dialector.Conn != nil {
-		return nil, nil, errors.New("dream confirmation lock: postgres DSN is required for a dedicated lock session")
-	}
-	lockConfig := &gorm.Config{}
-	if r.db.Config != nil {
-		lockConfig.Logger = r.db.Config.Logger
-	}
-	lockDB, err := gorm.Open(gormpostgres.New(gormpostgres.Config{
-		DriverName:           dialector.DriverName,
-		DSN:                  dialector.DSN,
-		WithoutQuotingCheck:  dialector.WithoutQuotingCheck,
-		PreferSimpleProtocol: dialector.PreferSimpleProtocol,
-		WithoutReturning:     dialector.WithoutReturning,
-	}), lockConfig)
+	appDB, err := r.db.DB()
 	if err != nil {
-		return nil, nil, fmt.Errorf("dream confirmation lock: open dedicated database: %w", err)
+		return nil, fmt.Errorf("dream confirmation lock: application database handle: %w", err)
 	}
-	lockSQL, err := lockDB.DB()
+	lockConn, err := appDB.Conn(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("dream confirmation lock: dedicated database handle: %w", err)
+		return nil, fmt.Errorf("dream confirmation lock: acquire application connection: %w", err)
 	}
-	lockSQL.SetMaxOpenConns(1)
-	lockSQL.SetMaxIdleConns(1)
-	lockConn, err := lockSQL.Conn(ctx)
-	if err != nil {
-		_ = lockSQL.Close()
-		return nil, nil, fmt.Errorf("dream confirmation lock: acquire dedicated connection: %w", err)
-	}
-	return lockConn, lockSQL, nil
+	return lockConn, nil
 }

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,6 +22,11 @@ const (
 )
 
 var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")
+
+type dreamConfirmationLockAdmissionState struct {
+	once  sync.Once
+	slots chan struct{}
+}
 
 // WithHypothesisConfirmationLock admits one confirmation workflow for a
 // team-owned Hypothesis without retaining the application pool while provider
@@ -110,8 +116,8 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 }
 
 func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {
-	r.dreamConfirmationLockAdmissionOnce.Do(func() {
-		r.dreamConfirmationLockAdmission = make(chan struct{}, dreamConfirmationLockAdmissionLimit)
+	r.dreamConfirmationLockState.once.Do(func() {
+		r.dreamConfirmationLockState.slots = make(chan struct{}, dreamConfirmationLockAdmissionLimit)
 	})
 	select {
 	case <-ctx.Done():
@@ -119,8 +125,8 @@ func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx conte
 	default:
 	}
 	select {
-	case r.dreamConfirmationLockAdmission <- struct{}{}:
-		return func() { <-r.dreamConfirmationLockAdmission }, nil
+	case r.dreamConfirmationLockState.slots <- struct{}{}:
+		return func() { <-r.dreamConfirmationLockState.slots }, nil
 	default:
 		return nil, ErrDreamConfirmationBusy
 	}

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -18,7 +19,7 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	ctx context.Context,
 	teamID string,
 	hypothesisID string,
-	fn func() error,
+	fn func(DreamRepository) error,
 ) error {
 	if r == nil || r.db == nil {
 		return errors.New("dream confirmation lock: database is required")
@@ -36,17 +37,25 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	}
 	key := dreamConfirmationLockPrefix + teamID + ":" + hypothesisID
 	return r.db.WithContext(ctx).Connection(func(conn *gorm.DB) error {
+		lockedRepo := *r
+		lockedRepo.db = conn
+		canonicalID := hypothesisID
+		if record, err := lockedRepo.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
+			canonicalID = record.HypothesisID
+		} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
+			return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
+		}
+		key = dreamConfirmationLockPrefix + teamID + ":" + canonicalID
 		if err := conn.WithContext(ctx).Exec("SELECT pg_advisory_lock(hashtext(?))", key).Error; err != nil {
 			return fmt.Errorf("dream confirmation lock acquire: %w", err)
 		}
-		callbackErr := fn()
-		unlockErr := conn.WithContext(ctx).Exec("SELECT pg_advisory_unlock(hashtext(?))", key).Error
-		if callbackErr != nil {
-			return callbackErr
-		}
+		callbackErr := fn(&lockedRepo)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		unlockErr := conn.WithContext(cleanupCtx).Exec("SELECT pg_advisory_unlock(hashtext(?))", key).Error
 		if unlockErr != nil {
-			return fmt.Errorf("dream confirmation lock release: %w", unlockErr)
+			unlockErr = fmt.Errorf("dream confirmation lock release: %w", unlockErr)
 		}
-		return nil
+		return errors.Join(callbackErr, unlockErr)
 	})
 }

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -16,6 +16,7 @@ import (
 const (
 	dreamConfirmationLockPrefix         = "dream-confirmation:"
 	dreamConfirmationLockCleanupTimeout = 5 * time.Second
+	dreamConfirmationLockFallbackLimit  = 1
 )
 
 var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")
@@ -44,6 +45,11 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if fn == nil {
 		return errors.New("dream confirmation lock: callback is required")
 	}
+	releaseAdmission, err := r.acquireDreamConfirmationLockAdmission(ctx)
+	if err != nil {
+		return err
+	}
+	defer releaseAdmission()
 	canonicalID := hypothesisID
 	if record, err := r.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
 		if strings.TrimSpace(record.HypothesisID) != "" {
@@ -100,6 +106,35 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 		return errors.Join(callbackErr, cleanupErr)
 	}
 	return cleanupErr
+}
+
+func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {
+	r.dreamConfirmationLockAdmissionOnce.Do(func() {
+		limit := dreamConfirmationLockFallbackLimit
+		if sqlDB, err := r.db.DB(); err == nil {
+			if configured := sqlDB.Stats().MaxOpenConnections; configured > 0 {
+				limit = configured
+			}
+		} else {
+			r.dreamConfirmationLockAdmissionErr = fmt.Errorf("dream confirmation lock: inspect application pool: %w", err)
+			return
+		}
+		r.dreamConfirmationLockAdmission = make(chan struct{}, limit)
+	})
+	if r.dreamConfirmationLockAdmissionErr != nil {
+		return nil, r.dreamConfirmationLockAdmissionErr
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	select {
+	case r.dreamConfirmationLockAdmission <- struct{}{}:
+		return func() { <-r.dreamConfirmationLockAdmission }, nil
+	default:
+		return nil, ErrDreamConfirmationBusy
+	}
 }
 
 func (r *SemanticRepositoryImpl) openDreamConfirmationLockConnection(ctx context.Context) (*sql.Conn, *sql.DB, error) {

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -16,7 +16,8 @@ import (
 const (
 	dreamConfirmationLockPrefix         = "dream-confirmation:"
 	dreamConfirmationLockCleanupTimeout = 5 * time.Second
-	dreamConfirmationLockFallbackLimit  = 1
+	// Keep one dedicated session for coordination; the application pool cannot share its session across provider work.
+	dreamConfirmationLockAdmissionLimit = 1
 )
 
 var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")
@@ -110,20 +111,8 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 
 func (r *SemanticRepositoryImpl) acquireDreamConfirmationLockAdmission(ctx context.Context) (func(), error) {
 	r.dreamConfirmationLockAdmissionOnce.Do(func() {
-		limit := dreamConfirmationLockFallbackLimit
-		if sqlDB, err := r.db.DB(); err == nil {
-			if configured := sqlDB.Stats().MaxOpenConnections; configured > 0 {
-				limit = configured
-			}
-		} else {
-			r.dreamConfirmationLockAdmissionErr = fmt.Errorf("dream confirmation lock: inspect application pool: %w", err)
-			return
-		}
-		r.dreamConfirmationLockAdmission = make(chan struct{}, limit)
+		r.dreamConfirmationLockAdmission = make(chan struct{}, dreamConfirmationLockAdmissionLimit)
 	})
-	if r.dreamConfirmationLockAdmissionErr != nil {
-		return nil, r.dreamConfirmationLockAdmissionErr
-	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/internal/repository/dream_confirmation_lock.go
+++ b/internal/repository/dream_confirmation_lock.go
@@ -2,20 +2,28 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
+	gormpostgres "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-const dreamConfirmationLockPrefix = "dream-confirmation:"
+const (
+	dreamConfirmationLockPrefix         = "dream-confirmation:"
+	dreamConfirmationLockCleanupTimeout = 5 * time.Second
+)
 
 var ErrDreamConfirmationBusy = errors.New("dream confirmation is already in progress")
 
 // WithHypothesisConfirmationLock admits one confirmation workflow for a
-// team-owned Hypothesis without retaining pooled connections for lock waiters.
+// team-owned Hypothesis without retaining the application pool while provider
+// work runs. The advisory lock uses a dedicated session that is closed after
+// the callback, so a failed unlock cannot strand a pooled application session.
 func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	ctx context.Context,
 	teamID string,
@@ -36,23 +44,96 @@ func (r *SemanticRepositoryImpl) WithHypothesisConfirmationLock(
 	if fn == nil {
 		return errors.New("dream confirmation lock: callback is required")
 	}
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		lockedRepo := *r
-		lockedRepo.db = tx
-		canonicalID := hypothesisID
-		if record, err := lockedRepo.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
+	canonicalID := hypothesisID
+	if record, err := r.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); err == nil {
+		if strings.TrimSpace(record.HypothesisID) != "" {
 			canonicalID = record.HypothesisID
-		} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
-			return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
 		}
-		key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
-		var acquired bool
-		if err := tx.WithContext(ctx).Raw("SELECT pg_try_advisory_xact_lock(hashtext(?))", key).Row().Scan(&acquired); err != nil {
-			return fmt.Errorf("dream confirmation lock acquire: %w", err)
+	} else if !errors.Is(err, ErrDreamHypothesisNotFound) {
+		return fmt.Errorf("dream confirmation lock resolve hypothesis: %w", err)
+	}
+
+	lockConn, lockDB, err := r.openDreamConfirmationLockConnection(ctx)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if closed {
+			return
 		}
-		if !acquired {
-			return ErrDreamConfirmationBusy
-		}
-		return fn(&lockedRepo)
-	})
+		_ = lockConn.Close()
+		_ = lockDB.Close()
+	}()
+
+	key := dreamConfirmationLockPrefix + teamID + ":" + canonicalID
+	var acquired bool
+	if err := lockConn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock(hashtext($1))", key).Scan(&acquired); err != nil {
+		return fmt.Errorf("dream confirmation lock acquire: %w", err)
+	}
+	if !acquired {
+		return ErrDreamConfirmationBusy
+	}
+
+	callbackErr := fn(r)
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dreamConfirmationLockCleanupTimeout)
+	var released bool
+	releaseErr := lockConn.QueryRowContext(releaseCtx, "SELECT pg_advisory_unlock(hashtext($1))", key).Scan(&released)
+	cancel()
+	if releaseErr == nil && !released {
+		releaseErr = errors.New("database did not release the advisory lock")
+	}
+	closeErr := lockConn.Close()
+	lockDBErr := lockDB.Close()
+	closed = true
+	if releaseErr != nil {
+		releaseErr = fmt.Errorf("dream confirmation lock release: %w", releaseErr)
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("dream confirmation lock connection close: %w", closeErr)
+	}
+	if lockDBErr != nil {
+		lockDBErr = fmt.Errorf("dream confirmation lock database close: %w", lockDBErr)
+	}
+	cleanupErr := errors.Join(releaseErr, closeErr, lockDBErr)
+	if callbackErr != nil {
+		return errors.Join(callbackErr, cleanupErr)
+	}
+	return cleanupErr
+}
+
+func (r *SemanticRepositoryImpl) openDreamConfirmationLockConnection(ctx context.Context) (*sql.Conn, *sql.DB, error) {
+	if r == nil || r.db == nil {
+		return nil, nil, errors.New("dream confirmation lock: database is required")
+	}
+	dialector, ok := r.db.Dialector.(*gormpostgres.Dialector)
+	if !ok || dialector == nil || dialector.Config == nil || strings.TrimSpace(dialector.DSN) == "" || dialector.Conn != nil {
+		return nil, nil, errors.New("dream confirmation lock: postgres DSN is required for a dedicated lock session")
+	}
+	lockConfig := &gorm.Config{}
+	if r.db.Config != nil {
+		lockConfig.Logger = r.db.Config.Logger
+	}
+	lockDB, err := gorm.Open(gormpostgres.New(gormpostgres.Config{
+		DriverName:           dialector.DriverName,
+		DSN:                  dialector.DSN,
+		WithoutQuotingCheck:  dialector.WithoutQuotingCheck,
+		PreferSimpleProtocol: dialector.PreferSimpleProtocol,
+		WithoutReturning:     dialector.WithoutReturning,
+	}), lockConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dream confirmation lock: open dedicated database: %w", err)
+	}
+	lockSQL, err := lockDB.DB()
+	if err != nil {
+		return nil, nil, fmt.Errorf("dream confirmation lock: dedicated database handle: %w", err)
+	}
+	lockSQL.SetMaxOpenConns(1)
+	lockSQL.SetMaxIdleConns(1)
+	lockConn, err := lockSQL.Conn(ctx)
+	if err != nil {
+		_ = lockSQL.Close()
+		return nil, nil, fmt.Errorf("dream confirmation lock: acquire dedicated connection: %w", err)
+	}
+	return lockConn, lockSQL, nil
 }

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	repo := NewSemanticRepository(appDB, rls)
+	teamID := uuid.NewString()
+	hypothesisID := uuid.NewString()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstErr := make(chan error, 1)
+	secondErr := make(chan error, 1)
+
+	go func() {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	select {
+	case <-firstEntered:
+	case <-ctx.Done():
+		t.Fatal("first confirmation lock callback did not start")
+	}
+
+	go func() {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second confirmation callback ran before the first released the lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+
+	require.NoError(t, <-firstErr)
+	select {
+	case <-secondEntered:
+	case <-ctx.Done():
+		t.Fatal("second confirmation lock callback did not run after release")
+	}
+	require.NoError(t, <-secondErr)
+}

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -151,6 +152,24 @@ func TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity(t *test
 	})
 	require.ErrorIs(t, err, ErrDreamConfirmationBusy)
 	require.False(t, callbackCalled)
+}
+
+func TestHypothesisConfirmationLockDiscardsFailedCleanupConnection(t *testing.T) {
+	_, appDB, _, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	sqlDB, err := appDB.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	lockConn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, discardDreamConfirmationLockConnection(lockConn))
+	require.ErrorIs(t, lockConn.PingContext(ctx), sql.ErrConnDone)
+	require.NoError(t, sqlDB.PingContext(ctx))
 }
 
 func TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget(t *testing.T) {

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -89,14 +89,14 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	require.NoError(t, <-followupErr)
 }
 
-func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *testing.T) {
+func TestHypothesisConfirmationLockAllowsNestedRepositoryUseWithinPoolBudget(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 
 	sqlDB, err := appDB.DB()
 	require.NoError(t, err)
-	sqlDB.SetMaxOpenConns(1)
-	sqlDB.SetMaxIdleConns(1)
+	sqlDB.SetMaxOpenConns(2)
+	sqlDB.SetMaxIdleConns(2)
 	repo := NewSemanticRepository(appDB, rls)
 	teamID := uuid.NewString()
 	hypothesisID := uuid.NewString()
@@ -105,6 +105,7 @@ func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *test
 	firstReady := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	firstErr := make(chan error, 1)
+	secondErr := make(chan error, 1)
 	go func() {
 		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
 			if _, err := store.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); !errors.Is(err, ErrDreamHypothesisNotFound) {
@@ -120,13 +121,19 @@ func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *test
 	case <-ctx.Done():
 		t.Fatal("first confirmation callback did not reach its database operation")
 	}
+	go func() {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, uuid.NewString(), func(DreamRepository) error {
+			return nil
+		})
+	}()
+	require.ErrorIs(t, <-secondErr, ErrDreamConfirmationBusy)
 	close(releaseFirst)
 	require.NoError(t, <-firstErr)
 	followupErr := repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error { return nil })
 	require.NoError(t, followupErr)
 }
 
-func TestHypothesisConfirmationLockBoundsDifferentHypotheses(t *testing.T) {
+func TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 
@@ -134,6 +141,26 @@ func TestHypothesisConfirmationLockBoundsDifferentHypotheses(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB.SetMaxOpenConns(1)
 	sqlDB.SetMaxIdleConns(1)
+	repo := NewSemanticRepository(appDB, rls)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	callbackCalled := false
+	err = repo.WithHypothesisConfirmationLock(ctx, uuid.NewString(), uuid.NewString(), func(DreamRepository) error {
+		callbackCalled = true
+		return nil
+	})
+	require.ErrorIs(t, err, ErrDreamConfirmationBusy)
+	require.False(t, callbackCalled)
+}
+
+func TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	sqlDB, err := appDB.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(dreamConfirmationLockAdmissionLimit + 1)
+	sqlDB.SetMaxIdleConns(dreamConfirmationLockAdmissionLimit + 1)
 	repo := NewSemanticRepository(appDB, rls)
 	teamID := uuid.NewString()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -2,11 +2,13 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
@@ -25,7 +27,7 @@ func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
 	secondErr := make(chan error, 1)
 
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
 			close(firstEntered)
 			<-releaseFirst
 			return nil
@@ -38,7 +40,7 @@ func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
 	}
 
 	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
 			close(secondEntered)
 			return nil
 		})
@@ -55,6 +57,190 @@ func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
 	case <-secondEntered:
 	case <-ctx.Done():
 		t.Fatal("second confirmation lock callback did not run after release")
+	}
+	require.NoError(t, <-secondErr)
+}
+
+func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	repo := NewSemanticRepository(appDB, rls)
+	teamID := uuid.NewString()
+	hypothesisID := uuid.NewString()
+	ctx, cancel := context.WithCancel(context.Background())
+	entered := make(chan struct{})
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
+			close(entered)
+			cancel()
+			return context.Canceled
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("confirmation lock callback did not start")
+	}
+	require.ErrorIs(t, <-firstErr, context.Canceled)
+
+	followupCtx, followupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer followupCancel()
+	followupErr := make(chan error, 1)
+	go func() {
+		followupErr <- repo.WithHypothesisConfirmationLock(followupCtx, teamID, hypothesisID, func(DreamRepository) error {
+			return nil
+		})
+	}()
+	require.NoError(t, <-followupErr)
+}
+
+func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	sqlDB, err := appDB.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(2)
+	sqlDB.SetMaxIdleConns(2)
+	repo := NewSemanticRepository(appDB, rls)
+	teamID := uuid.NewString()
+	hypothesisID := uuid.NewString()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	firstReady := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstErr := make(chan error, 1)
+	secondErr := make(chan error, 1)
+	callback := func(ready chan<- struct{}, release <-chan struct{}, store DreamRepository, entered chan<- struct{}) error {
+		_, err := store.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID})
+		if !errors.Is(err, ErrDreamHypothesisNotFound) {
+			return err
+		}
+		close(ready)
+		if release != nil {
+			<-release
+		}
+		if entered != nil {
+			close(entered)
+		}
+		return nil
+	}
+	go func() {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
+			return callback(firstReady, releaseFirst, store, nil)
+		})
+	}()
+	select {
+	case <-firstReady:
+	case <-ctx.Done():
+		t.Fatal("first confirmation callback did not reach its database operation")
+	}
+	go func() {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
+			return callback(make(chan struct{}), nil, store, secondEntered)
+		})
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second confirmation callback ran before the first released the lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	require.NoError(t, <-firstErr)
+	select {
+	case <-secondEntered:
+	case <-ctx.Done():
+		t.Fatal("second confirmation callback did not run after the first released the lock")
+	}
+	require.NoError(t, <-secondErr)
+}
+
+func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "dream-confirmation-canonical-lock")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "dream-confirmation-owner")
+	semanticRepo := NewSemanticRepository(appDB, rls)
+	subject := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "project", "Canonical lock subject")
+	object := createSemanticEntity(t, ctx, semanticRepo, teamID, ownerID, "product", "Canonical lock object")
+	run, err := semanticRepo.ClaimDreamCycle(ctx, DreamCycleClaimInput{
+		TeamID: teamID, InitiatedByProfileID: ownerID, RunDate: "2026-08-30",
+		WindowKey: "manual:canonical-lock", LeaseToken: uuid.NewString(), LeaseUntil: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+	canonical, inserted, err := semanticRepo.UpsertHypothesis(ctx, UpsertHypothesisInput{
+		TeamID: teamID, CreatedByProfileID: ownerID, RunID: run.RunID,
+		Statement: "Canonical lock aliases share one transition.", SubjectEntityID: subject.EntityID,
+		PredicateKey: "uses", PredicateVersion: 1, ObjectEntityID: object.EntityID,
+		SourceVersions: map[string]int{"seed": 1}, SourceRefs: []map[string]any{},
+		SourceOwnerProfileIDs: []string{ownerID}, ContentHash: "sha256:canonical-lock",
+		GeneratorKind: "evaluation_seed", GeneratorVersion: "test", Payload: map[string]any{},
+	})
+	require.NoError(t, err)
+	require.True(t, inserted)
+	aliasID := uuid.NewString()
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO hypotheses (
+			    team_id, hypothesis_id, space_id, space_generation, created_by_profile_id,
+			    status, statement, rationale, likelihood, confidence, subject_entity_id,
+			    predicate_key, predicate_version, object_entity_id, object_value_id,
+			    source_refs, source_versions, source_owner_profile_ids, content_hash,
+			    target_identity, cycle_run_id, generator_kind, generator_version,
+			    invalidated_reason, submitted_ingest_id, submitted_at, canonical_hypothesis_id, payload
+			)
+			SELECT team_id, ?::uuid, space_id, space_generation, created_by_profile_id,
+			       status, statement, rationale, likelihood, confidence, subject_entity_id,
+			       predicate_key, predicate_version, object_entity_id, object_value_id,
+			       source_refs, source_versions, source_owner_profile_ids, content_hash,
+			       target_identity, cycle_run_id, generator_kind, generator_version,
+			       invalidated_reason, submitted_ingest_id, submitted_at, ?::uuid, payload
+			FROM hypotheses
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, aliasID, canonical.HypothesisID, teamID, canonical.HypothesisID).Error
+	}))
+
+	lockCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstErr := make(chan error, 1)
+	secondErr := make(chan error, 1)
+	go func() {
+		firstErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, aliasID, func(DreamRepository) error {
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	select {
+	case <-firstEntered:
+	case <-lockCtx.Done():
+		t.Fatal("alias confirmation lock callback did not start")
+	}
+	go func() {
+		secondErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, canonical.HypothesisID, func(DreamRepository) error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("canonical confirmation callback ran while alias callback held the lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	require.NoError(t, <-firstErr)
+	select {
+	case <-secondEntered:
+	case <-lockCtx.Done():
+		t.Fatal("canonical confirmation callback did not run after alias lock release")
 	}
 	require.NoError(t, <-secondErr)
 }

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestHypothesisConfirmationLockAdmitsOneCallback(t *testing.T) {
 	secondErr := make(chan error, 1)
 
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
 			close(firstEntered)
 			<-releaseFirst
 			return nil
@@ -38,7 +39,7 @@ func TestHypothesisConfirmationLockAdmitsOneCallback(t *testing.T) {
 	}
 
 	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
 			return nil
 		})
 	}()
@@ -64,7 +65,7 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	entered := make(chan struct{})
 	firstErr := make(chan error, 1)
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
 			close(entered)
 			cancel()
 			return context.Canceled
@@ -81,21 +82,21 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	defer followupCancel()
 	followupErr := make(chan error, 1)
 	go func() {
-		followupErr <- repo.WithHypothesisConfirmationLock(followupCtx, teamID, hypothesisID, func() error {
+		followupErr <- repo.WithHypothesisConfirmationLock(followupCtx, teamID, hypothesisID, func(DreamRepository) error {
 			return nil
 		})
 	}()
 	require.NoError(t, <-followupErr)
 }
 
-func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T) {
+func TestHypothesisConfirmationLockCallbackUsesReservedConnectionAtMaxOpenOne(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 
 	sqlDB, err := appDB.DB()
 	require.NoError(t, err)
-	sqlDB.SetMaxOpenConns(2)
-	sqlDB.SetMaxIdleConns(2)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 	repo := NewSemanticRepository(appDB, rls)
 	teamID := uuid.NewString()
 	hypothesisID := uuid.NewString()
@@ -103,13 +104,10 @@ func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T
 	defer cancel()
 	firstReady := make(chan struct{})
 	releaseFirst := make(chan struct{})
-	secondEntered := make(chan struct{})
 	firstErr := make(chan error, 1)
-	secondErr := make(chan error, 1)
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
-			var value int
-			if err := appDB.WithContext(ctx).Raw("SELECT 1").Scan(&value).Error; err != nil {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
+			if _, err := store.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID}); !errors.Is(err, ErrDreamHypothesisNotFound) {
 				return err
 			}
 			close(firstReady)
@@ -122,26 +120,10 @@ func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T
 	case <-ctx.Done():
 		t.Fatal("first confirmation callback did not reach its database operation")
 	}
-	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
-			close(secondEntered)
-			return nil
-		})
-	}()
-	select {
-	case <-secondEntered:
-	case err := <-secondErr:
-		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
-	case <-ctx.Done():
-		t.Fatal("second confirmation lock admission did not return while the first held the lock")
-	}
 	close(releaseFirst)
 	require.NoError(t, <-firstErr)
-	select {
-	case <-secondEntered:
-		t.Fatal("second confirmation callback ran while the first held the lock")
-	default:
-	}
+	followupErr := repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error { return nil })
+	require.NoError(t, followupErr)
 }
 
 func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
@@ -199,7 +181,7 @@ func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 	firstErr := make(chan error, 1)
 	secondErr := make(chan error, 1)
 	go func() {
-		firstErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, aliasID, func() error {
+		firstErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, aliasID, func(DreamRepository) error {
 			close(firstEntered)
 			<-releaseFirst
 			return nil
@@ -211,7 +193,7 @@ func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 		t.Fatal("alias confirmation lock callback did not start")
 	}
 	go func() {
-		secondErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, canonical.HypothesisID, func() error {
+		secondErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, canonical.HypothesisID, func(DreamRepository) error {
 			close(secondEntered)
 			return nil
 		})

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -126,7 +126,7 @@ func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *test
 	require.NoError(t, followupErr)
 }
 
-func TestHypothesisConfirmationLockBoundsDifferentHypothesesAtMaxOpenOne(t *testing.T) {
+func TestHypothesisConfirmationLockBoundsDifferentHypotheses(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 
@@ -136,44 +136,49 @@ func TestHypothesisConfirmationLockBoundsDifferentHypothesesAtMaxOpenOne(t *test
 	sqlDB.SetMaxIdleConns(1)
 	repo := NewSemanticRepository(appDB, rls)
 	teamID := uuid.NewString()
-	firstHypothesisID := uuid.NewString()
-	secondHypothesisID := uuid.NewString()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstEntered := make(chan struct{})
-	releaseFirst := make(chan struct{})
-	firstErr := make(chan error, 1)
-	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, firstHypothesisID, func(DreamRepository) error {
-			close(firstEntered)
-			<-releaseFirst
-			return nil
-		})
-	}()
-	select {
-	case <-firstEntered:
-	case <-ctx.Done():
-		t.Fatal("first confirmation lock callback did not start")
+	release := make(chan struct{})
+	entered := make(chan struct{}, dreamConfirmationLockAdmissionLimit)
+	errs := make(chan error, dreamConfirmationLockAdmissionLimit)
+	for i := 0; i < dreamConfirmationLockAdmissionLimit; i++ {
+		hypothesisID := uuid.NewString()
+		go func() {
+			errs <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
+				entered <- struct{}{}
+				<-release
+				return nil
+			})
+		}()
+	}
+	for i := 0; i < dreamConfirmationLockAdmissionLimit; i++ {
+		select {
+		case <-entered:
+		case <-ctx.Done():
+			t.Fatal("confirmation lock callback did not start")
+		}
 	}
 
-	secondEntered := make(chan struct{})
-	secondErr := make(chan error, 1)
+	extraEntered := make(chan struct{})
+	extraErr := make(chan error, 1)
 	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, secondHypothesisID, func(DreamRepository) error {
-			close(secondEntered)
+		extraErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, uuid.NewString(), func(DreamRepository) error {
+			close(extraEntered)
 			return nil
 		})
 	}()
 	select {
-	case <-secondEntered:
-		t.Fatal("second confirmation lock callback exceeded the configured admission bound")
-	case err := <-secondErr:
+	case <-extraEntered:
+		t.Fatal("confirmation lock callback exceeded the configured admission bound")
+	case err := <-extraErr:
 		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
 	case <-time.After(5 * time.Second):
-		t.Fatal("second confirmation lock admission did not return while the bound was full")
+		t.Fatal("confirmation lock admission did not return while the bound was full")
 	}
-	close(releaseFirst)
-	require.NoError(t, <-firstErr)
+	close(release)
+	for i := 0; i < dreamConfirmationLockAdmissionLimit; i++ {
+		require.NoError(t, <-errs)
+	}
 }
 
 func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
+func TestHypothesisConfirmationLockAdmitsOneCallback(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 
@@ -22,12 +21,11 @@ func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
 	defer cancel()
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
-	secondEntered := make(chan struct{})
 	firstErr := make(chan error, 1)
 	secondErr := make(chan error, 1)
 
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
 			close(firstEntered)
 			<-releaseFirst
 			return nil
@@ -40,25 +38,19 @@ func TestHypothesisConfirmationLockSerializesCallbacks(t *testing.T) {
 	}
 
 	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
-			close(secondEntered)
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
 			return nil
 		})
 	}()
 	select {
-	case <-secondEntered:
-		t.Fatal("second confirmation callback ran before the first released the lock")
-	case <-time.After(100 * time.Millisecond):
+	case err := <-secondErr:
+		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second confirmation lock admission did not return while the first held the lock")
 	}
 	close(releaseFirst)
 
 	require.NoError(t, <-firstErr)
-	select {
-	case <-secondEntered:
-	case <-ctx.Done():
-		t.Fatal("second confirmation lock callback did not run after release")
-	}
-	require.NoError(t, <-secondErr)
 }
 
 func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T) {
@@ -72,7 +64,7 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	entered := make(chan struct{})
 	firstErr := make(chan error, 1)
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(DreamRepository) error {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
 			close(entered)
 			cancel()
 			return context.Canceled
@@ -89,7 +81,7 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	defer followupCancel()
 	followupErr := make(chan error, 1)
 	go func() {
-		followupErr <- repo.WithHypothesisConfirmationLock(followupCtx, teamID, hypothesisID, func(DreamRepository) error {
+		followupErr <- repo.WithHypothesisConfirmationLock(followupCtx, teamID, hypothesisID, func() error {
 			return nil
 		})
 	}()
@@ -114,23 +106,15 @@ func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T
 	secondEntered := make(chan struct{})
 	firstErr := make(chan error, 1)
 	secondErr := make(chan error, 1)
-	callback := func(ready chan<- struct{}, release <-chan struct{}, store DreamRepository, entered chan<- struct{}) error {
-		_, err := store.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: hypothesisID})
-		if !errors.Is(err, ErrDreamHypothesisNotFound) {
-			return err
-		}
-		close(ready)
-		if release != nil {
-			<-release
-		}
-		if entered != nil {
-			close(entered)
-		}
-		return nil
-	}
 	go func() {
-		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
-			return callback(firstReady, releaseFirst, store, nil)
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+			var value int
+			if err := appDB.WithContext(ctx).Raw("SELECT 1").Scan(&value).Error; err != nil {
+				return err
+			}
+			close(firstReady)
+			<-releaseFirst
+			return nil
 		})
 	}()
 	select {
@@ -139,23 +123,25 @@ func TestHypothesisConfirmationLockCallbacksReuseReservedConnection(t *testing.T
 		t.Fatal("first confirmation callback did not reach its database operation")
 	}
 	go func() {
-		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func(store DreamRepository) error {
-			return callback(make(chan struct{}), nil, store, secondEntered)
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, hypothesisID, func() error {
+			close(secondEntered)
+			return nil
 		})
 	}()
 	select {
 	case <-secondEntered:
-		t.Fatal("second confirmation callback ran before the first released the lock")
-	case <-time.After(100 * time.Millisecond):
+	case err := <-secondErr:
+		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
+	case <-ctx.Done():
+		t.Fatal("second confirmation lock admission did not return while the first held the lock")
 	}
 	close(releaseFirst)
 	require.NoError(t, <-firstErr)
 	select {
 	case <-secondEntered:
-	case <-ctx.Done():
-		t.Fatal("second confirmation callback did not run after the first released the lock")
+		t.Fatal("second confirmation callback ran while the first held the lock")
+	default:
 	}
-	require.NoError(t, <-secondErr)
 }
 
 func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
@@ -213,7 +199,7 @@ func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 	firstErr := make(chan error, 1)
 	secondErr := make(chan error, 1)
 	go func() {
-		firstErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, aliasID, func(DreamRepository) error {
+		firstErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, aliasID, func() error {
 			close(firstEntered)
 			<-releaseFirst
 			return nil
@@ -225,7 +211,7 @@ func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 		t.Fatal("alias confirmation lock callback did not start")
 	}
 	go func() {
-		secondErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, canonical.HypothesisID, func(DreamRepository) error {
+		secondErr <- semanticRepo.WithHypothesisConfirmationLock(lockCtx, teamID, canonical.HypothesisID, func() error {
 			close(secondEntered)
 			return nil
 		})
@@ -233,14 +219,16 @@ func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 	select {
 	case <-secondEntered:
 		t.Fatal("canonical confirmation callback ran while alias callback held the lock")
-	case <-time.After(100 * time.Millisecond):
+	case err := <-secondErr:
+		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
+	case <-time.After(5 * time.Second):
+		t.Fatal("canonical confirmation lock admission did not return while alias lock was held")
 	}
 	close(releaseFirst)
 	require.NoError(t, <-firstErr)
 	select {
 	case <-secondEntered:
-	case <-lockCtx.Done():
-		t.Fatal("canonical confirmation callback did not run after alias lock release")
+		t.Fatal("canonical confirmation callback ran while alias lock was held")
+	default:
 	}
-	require.NoError(t, <-secondErr)
 }

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -126,6 +126,56 @@ func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *test
 	require.NoError(t, followupErr)
 }
 
+func TestHypothesisConfirmationLockBoundsDifferentHypothesesAtMaxOpenOne(t *testing.T) {
+	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	sqlDB, err := appDB.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	repo := NewSemanticRepository(appDB, rls)
+	teamID := uuid.NewString()
+	firstHypothesisID := uuid.NewString()
+	secondHypothesisID := uuid.NewString()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, firstHypothesisID, func(DreamRepository) error {
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	select {
+	case <-firstEntered:
+	case <-ctx.Done():
+		t.Fatal("first confirmation lock callback did not start")
+	}
+
+	secondEntered := make(chan struct{})
+	secondErr := make(chan error, 1)
+	go func() {
+		secondErr <- repo.WithHypothesisConfirmationLock(ctx, teamID, secondHypothesisID, func(DreamRepository) error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second confirmation lock callback exceeded the configured admission bound")
+	case err := <-secondErr:
+		require.ErrorIs(t, err, ErrDreamConfirmationBusy)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second confirmation lock admission did not return while the bound was full")
+	}
+	close(releaseFirst)
+	require.NoError(t, <-firstErr)
+}
+
 func TestHypothesisConfirmationLockUsesCanonicalAlias(t *testing.T) {
 	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()

--- a/internal/repository/dream_confirmation_lock_integration_test.go
+++ b/internal/repository/dream_confirmation_lock_integration_test.go
@@ -89,7 +89,7 @@ func TestHypothesisConfirmationLockReleasesAfterContextCancellation(t *testing.T
 	require.NoError(t, <-followupErr)
 }
 
-func TestHypothesisConfirmationLockCallbackUsesReservedConnectionAtMaxOpenOne(t *testing.T) {
+func TestHypothesisConfirmationLockAllowsNestedRepositoryUseAtMaxOpenOne(t *testing.T) {
 	_, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 

--- a/internal/repository/dream_generation_repository.go
+++ b/internal/repository/dream_generation_repository.go
@@ -146,7 +146,24 @@ func insertHypothesisTx(
 		          ARRAY(SELECT source_owner_id::text FROM unnest(source_owner_profile_ids) AS source_owner(source_owner_id)),
 		          COALESCE(content_hash, ''), COALESCE(target_identity, ''), COALESCE(cycle_run_id::text, ''),
 		          generator_kind, generator_version, invalidated_reason,
-		          COALESCE(submitted_ingest_id::text, ''), submitted_at,
+		          COALESCE(submitted_ingest_id::text, ''),
+		          COALESCE((
+		              SELECT ingest.idempotency_key
+		              FROM knowledge_ingests AS ingest
+		              WHERE ingest.team_id = hypotheses.team_id
+		                AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		              LIMIT 1
+		          ), ''),
+		          COALESCE((
+		              SELECT feedback.decision
+		              FROM hypothesis_feedback_events AS feedback
+		              WHERE feedback.team_id = hypotheses.team_id
+		                AND feedback.hypothesis_id = hypotheses.hypothesis_id
+		                AND feedback.submitted_ingest_id IS NOT NULL
+		              ORDER BY feedback.created_at DESC, feedback.feedback_event_id DESC
+		              LIMIT 1
+		          ), ''),
+		          submitted_at,
 		          payload, created_at, updated_at
 	`, input.TeamID, input.TeamID, input.TeamID, input.CreatedByProfileID, input.Statement, input.Rationale,
 		input.Likelihood, input.Confidence, input.SubjectEntityID, input.PredicateKey,

--- a/internal/repository/dream_generation_repository.go
+++ b/internal/repository/dream_generation_repository.go
@@ -155,6 +155,13 @@ func insertHypothesisTx(
 		              LIMIT 1
 		          ), ''),
 		          COALESCE((
+		              SELECT ingest.request_hash
+		              FROM knowledge_ingests AS ingest
+		              WHERE ingest.team_id = hypotheses.team_id
+		                AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		              LIMIT 1
+		          ), ''),
+		          COALESCE((
 		              SELECT feedback.decision
 		              FROM hypothesis_feedback_events AS feedback
 		              WHERE feedback.team_id = hypotheses.team_id

--- a/internal/repository/dream_repository.go
+++ b/internal/repository/dream_repository.go
@@ -800,6 +800,7 @@ func (r *SemanticRepositoryImpl) SubmitHypothesis(
 			input.ActorProfileID, input.Decision, input.InvalidatedReason, input.SubmittedIngestID); err != nil {
 			return err
 		}
+		loaded.SubmittedDecision = input.Decision
 		record = loaded
 		return nil
 	})

--- a/internal/repository/dream_repository.go
+++ b/internal/repository/dream_repository.go
@@ -768,9 +768,9 @@ func (r *SemanticRepositoryImpl) SubmitHypothesis(
 				        AND space_generation = dense_mem_team_shared_generation(team_id)
 				        AND hypothesis_id = ?::uuid
 			  ), ?::uuid)
-			  AND NOT (status = 'submitted' AND submitted_ingest_id IS NOT NULL AND submitted_ingest_id = ?::uuid)
+			  AND NOT (status = 'submitted' AND submitted_ingest_id IS NOT NULL)
 		`), input.SubmittedIngestID, input.InvalidatedReason, input.InvalidatedReason,
-			input.TeamID, input.TeamID, input.HypothesisID, input.HypothesisID, input.SubmittedIngestID).Rows()
+			input.TeamID, input.TeamID, input.HypothesisID, input.HypothesisID).Rows()
 		if err != nil {
 			return err
 		}

--- a/internal/repository/dream_repository.go
+++ b/internal/repository/dream_repository.go
@@ -577,34 +577,8 @@ func (r *SemanticRepositoryImpl) GetHypothesis(ctx context.Context, input GetHyp
 	}
 	var record *HypothesisRecord
 	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		rows, err := tx.WithContext(ctx).Raw(hypothesisSelectSQL(`
-			WHERE team_id = ?::uuid
-			  AND space_id = dense_mem_team_shared_space(team_id)
-			  AND space_generation = dense_mem_team_shared_generation(team_id)
-			  AND canonical_hypothesis_id IS NULL
-			  AND hypothesis_id = COALESCE((
-			      SELECT canonical_hypothesis_id
-			      FROM hypotheses
-				WHERE team_id = ?::uuid
-				        AND space_id = dense_mem_team_shared_space(team_id)
-				        AND space_generation = dense_mem_team_shared_generation(team_id)
-			        AND hypothesis_id = ?::uuid
-			  ), ?::uuid)
-			LIMIT 1
-		`), input.TeamID, input.TeamID, input.HypothesisID, input.HypothesisID).Rows()
+		loaded, err := loadHypothesisRecordInTx(ctx, tx, input.TeamID, input.HypothesisID)
 		if err != nil {
-			return err
-		}
-		if !rows.Next() {
-			_ = rows.Close()
-			return ErrDreamHypothesisNotFound
-		}
-		loaded, err := scanHypothesisRecord(rows)
-		if err != nil {
-			_ = rows.Close()
-			return err
-		}
-		if err := rows.Close(); err != nil {
 			return err
 		}
 		records := []HypothesisRecord{*loaded}
@@ -618,6 +592,40 @@ func (r *SemanticRepositoryImpl) GetHypothesis(ctx context.Context, input GetHyp
 		return nil, fmt.Errorf("dream: get hypothesis: %w", err)
 	}
 	return record, nil
+}
+
+func loadHypothesisRecordInTx(ctx context.Context, tx *gorm.DB, teamID, hypothesisID string) (*HypothesisRecord, error) {
+	rows, err := tx.WithContext(ctx).Raw(hypothesisSelectSQL(`
+		WHERE team_id = ?::uuid
+		  AND space_id = dense_mem_team_shared_space(team_id)
+		  AND space_generation = dense_mem_team_shared_generation(team_id)
+		  AND canonical_hypothesis_id IS NULL
+		  AND hypothesis_id = COALESCE((
+		      SELECT canonical_hypothesis_id
+		      FROM hypotheses
+			WHERE team_id = ?::uuid
+			        AND space_id = dense_mem_team_shared_space(team_id)
+			        AND space_generation = dense_mem_team_shared_generation(team_id)
+			        AND hypothesis_id = ?::uuid
+		  ), ?::uuid)
+		LIMIT 1
+	`), teamID, teamID, hypothesisID, hypothesisID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		_ = rows.Close()
+		return nil, ErrDreamHypothesisNotFound
+	}
+	loaded, err := scanHypothesisRecord(rows)
+	if err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return loaded, nil
 }
 
 func (r *SemanticRepositoryImpl) RecallHypotheses(ctx context.Context, input RecallHypothesesInput) ([]HypothesisRecord, error) {
@@ -758,16 +766,27 @@ func (r *SemanticRepositoryImpl) SubmitHypothesis(
 				WHERE team_id = ?::uuid
 				        AND space_id = dense_mem_team_shared_space(team_id)
 				        AND space_generation = dense_mem_team_shared_generation(team_id)
-			        AND hypothesis_id = ?::uuid
+				        AND hypothesis_id = ?::uuid
 			  ), ?::uuid)
+			  AND NOT (status = 'submitted' AND submitted_ingest_id IS NOT NULL AND submitted_ingest_id = ?::uuid)
 		`), input.SubmittedIngestID, input.InvalidatedReason, input.InvalidatedReason,
-			input.TeamID, input.TeamID, input.HypothesisID, input.HypothesisID).Rows()
+			input.TeamID, input.TeamID, input.HypothesisID, input.HypothesisID, input.SubmittedIngestID).Rows()
 		if err != nil {
 			return err
 		}
 		if !rows.Next() {
-			_ = rows.Close()
-			return ErrDreamHypothesisNotFound
+			if err := rows.Close(); err != nil {
+				return err
+			}
+			loaded, err := loadHypothesisRecordInTx(ctx, tx, input.TeamID, input.HypothesisID)
+			if err != nil {
+				return err
+			}
+			if loaded.Status != "submitted" || loaded.SubmittedIngestID != input.SubmittedIngestID {
+				return ErrDreamHypothesisNotFound
+			}
+			record = loaded
+			return nil
 		}
 		loaded, err := scanHypothesisRecord(rows)
 		if err != nil {

--- a/internal/repository/dream_repository_integration_test.go
+++ b/internal/repository/dream_repository_integration_test.go
@@ -349,6 +349,25 @@ func TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment(t *t
 	require.NotNil(t, firstSubmitted.SubmittedAt)
 	assert.Equal(t, "dream-submit-replay", firstSubmitted.SubmittedIngestIdempotencyKey)
 	assert.Equal(t, "confirm_true", firstSubmitted.SubmittedDecision)
+	otherSubmittedIngest := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"dream-submit-legacy-other", "A legacy feedback event for a different ingest.")
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			INSERT INTO hypothesis_feedback_events (
+			    team_id, hypothesis_id, actor_profile_id, decision, feedback,
+			    submitted_ingest_id, created_at
+			) VALUES (
+			    ?::uuid, ?::uuid, ?::uuid, 'confirm_false', 'legacy event',
+			    ?::uuid, now() + interval '1 hour'
+			)
+		`, teamID, record.HypothesisID, ownerID, otherSubmittedIngest.IngestID).Error
+	}))
+	loadedWithLegacyEvent, err := semanticRepo.GetHypothesis(ctx, GetHypothesisInput{
+		TeamID: teamID, HypothesisID: record.HypothesisID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, submissionIngest.IngestID, loadedWithLegacyEvent.SubmittedIngestID)
+	assert.Equal(t, "confirm_true", loadedWithLegacyEvent.SubmittedDecision)
 	var eventsAfterFirst int
 	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
 		return tx.Raw(`

--- a/internal/repository/dream_repository_integration_test.go
+++ b/internal/repository/dream_repository_integration_test.go
@@ -335,6 +335,66 @@ func TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment(t *t
 	unassessed, err = semanticRepo.ListUnassessedDreamPaths(ctx, teamID, []DreamPathEvaluationInput{path})
 	require.NoError(t, err)
 	require.Equal(t, []DreamPathEvaluationInput{path}, unassessed, "a source version change permits reassessment")
+
+	submissionIngest := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"dream-submit-replay", "Independent deployment evidence confirms Dense-Mem uses PostgreSQL.")
+	firstSubmitted, err := semanticRepo.SubmitHypothesis(ctx, SubmitHypothesisInput{
+		TeamID:            teamID,
+		ActorProfileID:    ownerID,
+		HypothesisID:      record.HypothesisID,
+		Decision:          "confirm_true",
+		SubmittedIngestID: submissionIngest.IngestID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, firstSubmitted.SubmittedAt)
+	var eventsAfterFirst int
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM hypothesis_feedback_events
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, teamID, record.HypothesisID).Scan(&eventsAfterFirst).Error
+	}))
+
+	secondSubmitted, err := semanticRepo.SubmitHypothesis(ctx, SubmitHypothesisInput{
+		TeamID:            teamID,
+		ActorProfileID:    ownerID,
+		HypothesisID:      record.HypothesisID,
+		Decision:          "confirm_true",
+		SubmittedIngestID: submissionIngest.IngestID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, secondSubmitted.SubmittedAt)
+	assert.Equal(t, *firstSubmitted.SubmittedAt, *secondSubmitted.SubmittedAt)
+	assert.Equal(t, submissionIngest.IngestID, secondSubmitted.SubmittedIngestID)
+	var eventsAfterReplay int
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM hypothesis_feedback_events
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, teamID, record.HypothesisID).Scan(&eventsAfterReplay).Error
+	}))
+	assert.Equal(t, eventsAfterFirst, eventsAfterReplay)
+
+	legacySubmission := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"dream-migrated-submit", "Independent evidence for a migrated Dream.")
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE hypotheses
+			SET status = 'submitted', submitted_ingest_id = NULL, submitted_at = now()
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, teamID, record.HypothesisID).Error
+	}))
+	migratedSubmitted, err := semanticRepo.SubmitHypothesis(ctx, SubmitHypothesisInput{
+		TeamID:            teamID,
+		ActorProfileID:    ownerID,
+		HypothesisID:      record.HypothesisID,
+		Decision:          "confirm_true",
+		SubmittedIngestID: legacySubmission.IngestID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, legacySubmission.IngestID, migratedSubmitted.SubmittedIngestID)
 }
 
 func TestDreamRepositoryPersistsTeamScopedPredicateHypothesis(t *testing.T) {

--- a/internal/repository/dream_repository_integration_test.go
+++ b/internal/repository/dream_repository_integration_test.go
@@ -347,6 +347,8 @@ func TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment(t *t
 	})
 	require.NoError(t, err)
 	require.NotNil(t, firstSubmitted.SubmittedAt)
+	assert.Equal(t, "dream-submit-replay", firstSubmitted.SubmittedIngestIdempotencyKey)
+	assert.Equal(t, "confirm_true", firstSubmitted.SubmittedDecision)
 	var eventsAfterFirst int
 	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
 		return tx.Raw(`

--- a/internal/repository/dream_repository_integration_test.go
+++ b/internal/repository/dream_repository_integration_test.go
@@ -377,6 +377,30 @@ func TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment(t *t
 	}))
 	assert.Equal(t, eventsAfterFirst, eventsAfterReplay)
 
+	differentSubmission := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
+		"dream-submit-different-ingest", "A different committed ingest must not replace the first.")
+	_, err = semanticRepo.SubmitHypothesis(ctx, SubmitHypothesisInput{
+		TeamID:            teamID,
+		ActorProfileID:    ownerID,
+		HypothesisID:      record.HypothesisID,
+		Decision:          "confirm_true",
+		SubmittedIngestID: differentSubmission.IngestID,
+	})
+	require.ErrorIs(t, err, ErrDreamHypothesisNotFound)
+	unchanged, err := semanticRepo.GetHypothesis(ctx, GetHypothesisInput{TeamID: teamID, HypothesisID: record.HypothesisID})
+	require.NoError(t, err)
+	assert.Equal(t, submissionIngest.IngestID, unchanged.SubmittedIngestID)
+	assert.Equal(t, *firstSubmitted.SubmittedAt, *unchanged.SubmittedAt)
+	var eventsAfterDifferent int
+	require.NoError(t, rls.WithTeamProfileTx(ctx, appDB, teamID, ownerID, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM hypothesis_feedback_events
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, teamID, record.HypothesisID).Scan(&eventsAfterDifferent).Error
+	}))
+	assert.Equal(t, eventsAfterReplay, eventsAfterDifferent)
+
 	legacySubmission := createSemanticIngest(t, ctx, ledgerRepo, teamID, ownerID,
 		"dream-migrated-submit", "Independent evidence for a migrated Dream.")
 	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {

--- a/internal/repository/dream_repository_scan.go
+++ b/internal/repository/dream_repository_scan.go
@@ -94,6 +94,13 @@ func hypothesisSelectSQL(where string) string {
 		           LIMIT 1
 		       ), ''),
 		       COALESCE((
+		           SELECT ingest.request_hash
+		           FROM knowledge_ingests AS ingest
+		           WHERE ingest.team_id = hypotheses.team_id
+		             AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		           LIMIT 1
+		       ), ''),
+		       COALESCE((
 		           SELECT feedback.decision
 		           FROM hypothesis_feedback_events AS feedback
 		           WHERE feedback.team_id = hypotheses.team_id
@@ -121,6 +128,13 @@ func hypothesisUpdateReturningSQL(update string) string {
 		          COALESCE(submitted_ingest_id::text, ''),
 		          COALESCE((
 		              SELECT ingest.idempotency_key
+		              FROM knowledge_ingests AS ingest
+		              WHERE ingest.team_id = hypotheses.team_id
+		                AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		              LIMIT 1
+		          ), ''),
+		          COALESCE((
+		              SELECT ingest.request_hash
 		              FROM knowledge_ingests AS ingest
 		              WHERE ingest.team_id = hypotheses.team_id
 		                AND ingest.ingest_id = hypotheses.submitted_ingest_id
@@ -186,6 +200,7 @@ func scanHypothesisRecord(rows *sql.Rows) (*HypothesisRecord, error) {
 		&record.InvalidatedReason,
 		&record.SubmittedIngestID,
 		&record.SubmittedIngestIdempotencyKey,
+		&record.SubmittedIngestRequestHash,
 		&record.SubmittedDecision,
 		&submittedAt,
 		&payloadRaw,

--- a/internal/repository/dream_repository_scan.go
+++ b/internal/repository/dream_repository_scan.go
@@ -105,6 +105,7 @@ func hypothesisSelectSQL(where string) string {
 		           FROM hypothesis_feedback_events AS feedback
 		           WHERE feedback.team_id = hypotheses.team_id
 		             AND feedback.hypothesis_id = hypotheses.hypothesis_id
+		             AND feedback.submitted_ingest_id = hypotheses.submitted_ingest_id
 		             AND feedback.submitted_ingest_id IS NOT NULL
 		           ORDER BY feedback.created_at DESC, feedback.feedback_event_id DESC
 		           LIMIT 1
@@ -145,6 +146,7 @@ func hypothesisUpdateReturningSQL(update string) string {
 		              FROM hypothesis_feedback_events AS feedback
 		              WHERE feedback.team_id = hypotheses.team_id
 		                AND feedback.hypothesis_id = hypotheses.hypothesis_id
+		                AND feedback.submitted_ingest_id = hypotheses.submitted_ingest_id
 		                AND feedback.submitted_ingest_id IS NOT NULL
 		              ORDER BY feedback.created_at DESC, feedback.feedback_event_id DESC
 		              LIMIT 1

--- a/internal/repository/dream_repository_scan.go
+++ b/internal/repository/dream_repository_scan.go
@@ -85,7 +85,24 @@ func hypothesisSelectSQL(where string) string {
 		       ARRAY(SELECT source_owner_id::text FROM unnest(source_owner_profile_ids) AS source_owner(source_owner_id)),
 		       COALESCE(content_hash, ''), COALESCE(target_identity, ''), COALESCE(cycle_run_id::text, ''),
 		       generator_kind, generator_version, invalidated_reason,
-		       COALESCE(submitted_ingest_id::text, ''), submitted_at,
+		       COALESCE(submitted_ingest_id::text, ''),
+		       COALESCE((
+		           SELECT ingest.idempotency_key
+		           FROM knowledge_ingests AS ingest
+		           WHERE ingest.team_id = hypotheses.team_id
+		             AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		           LIMIT 1
+		       ), ''),
+		       COALESCE((
+		           SELECT feedback.decision
+		           FROM hypothesis_feedback_events AS feedback
+		           WHERE feedback.team_id = hypotheses.team_id
+		             AND feedback.hypothesis_id = hypotheses.hypothesis_id
+		             AND feedback.submitted_ingest_id IS NOT NULL
+		           ORDER BY feedback.created_at DESC, feedback.feedback_event_id DESC
+		           LIMIT 1
+		       ), ''),
+		       submitted_at,
 		       payload, created_at, updated_at
 		FROM hypotheses
 	` + where
@@ -101,7 +118,24 @@ func hypothesisUpdateReturningSQL(update string) string {
 		          ARRAY(SELECT source_owner_id::text FROM unnest(source_owner_profile_ids) AS source_owner(source_owner_id)),
 		          COALESCE(content_hash, ''), COALESCE(target_identity, ''), COALESCE(cycle_run_id::text, ''),
 		          generator_kind, generator_version, invalidated_reason,
-		          COALESCE(submitted_ingest_id::text, ''), submitted_at,
+		          COALESCE(submitted_ingest_id::text, ''),
+		          COALESCE((
+		              SELECT ingest.idempotency_key
+		              FROM knowledge_ingests AS ingest
+		              WHERE ingest.team_id = hypotheses.team_id
+		                AND ingest.ingest_id = hypotheses.submitted_ingest_id
+		              LIMIT 1
+		          ), ''),
+		          COALESCE((
+		              SELECT feedback.decision
+		              FROM hypothesis_feedback_events AS feedback
+		              WHERE feedback.team_id = hypotheses.team_id
+		                AND feedback.hypothesis_id = hypotheses.hypothesis_id
+		                AND feedback.submitted_ingest_id IS NOT NULL
+		              ORDER BY feedback.created_at DESC, feedback.feedback_event_id DESC
+		              LIMIT 1
+		          ), ''),
+		          submitted_at,
 		          payload, created_at, updated_at
 	`
 }
@@ -151,6 +185,8 @@ func scanHypothesisRecord(rows *sql.Rows) (*HypothesisRecord, error) {
 		&record.GeneratorVersion,
 		&record.InvalidatedReason,
 		&record.SubmittedIngestID,
+		&record.SubmittedIngestIdempotencyKey,
+		&record.SubmittedDecision,
 		&submittedAt,
 		&payloadRaw,
 		&record.CreatedAt,

--- a/internal/repository/dream_types.go
+++ b/internal/repository/dream_types.go
@@ -235,34 +235,36 @@ type DreamDerivationSource struct {
 }
 
 type HypothesisRecord struct {
-	TeamID                string
-	HypothesisID          string
-	CreatedByProfileID    string
-	Status                string
-	Statement             string
-	Rationale             string
-	Likelihood            *float64
-	Confidence            *float64
-	SubjectEntityID       string
-	PredicateKey          string
-	PredicateVersion      int
-	ObjectEntityID        string
-	ObjectValueID         string
-	SourceRefs            []map[string]any
-	SourceVersions        map[string]int
-	SourceOwnerProfileIDs []string
-	ContentHash           string
-	TargetIdentity        string
-	Derivations           []DreamDerivationSource
-	CycleRunID            string
-	GeneratorKind         string
-	GeneratorVersion      string
-	InvalidatedReason     string
-	SubmittedIngestID     string
-	SubmittedAt           *time.Time
-	Payload               map[string]any
-	CreatedAt             time.Time
-	UpdatedAt             time.Time
+	TeamID                        string
+	HypothesisID                  string
+	CreatedByProfileID            string
+	Status                        string
+	Statement                     string
+	Rationale                     string
+	Likelihood                    *float64
+	Confidence                    *float64
+	SubjectEntityID               string
+	PredicateKey                  string
+	PredicateVersion              int
+	ObjectEntityID                string
+	ObjectValueID                 string
+	SourceRefs                    []map[string]any
+	SourceVersions                map[string]int
+	SourceOwnerProfileIDs         []string
+	ContentHash                   string
+	TargetIdentity                string
+	Derivations                   []DreamDerivationSource
+	CycleRunID                    string
+	GeneratorKind                 string
+	GeneratorVersion              string
+	InvalidatedReason             string
+	SubmittedIngestID             string
+	SubmittedIngestIdempotencyKey string
+	SubmittedDecision             string
+	SubmittedAt                   *time.Time
+	Payload                       map[string]any
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
 }
 
 type ListHypothesesInput struct {

--- a/internal/repository/dream_types.go
+++ b/internal/repository/dream_types.go
@@ -17,7 +17,7 @@ type DreamRepository interface {
 	UpsertHypothesis(ctx context.Context, input UpsertHypothesisInput) (*HypothesisRecord, bool, error)
 	ListHypotheses(ctx context.Context, input ListHypothesesInput) ([]HypothesisRecord, string, error)
 	GetHypothesis(ctx context.Context, input GetHypothesisInput) (*HypothesisRecord, error)
-	WithHypothesisConfirmationLock(ctx context.Context, teamID, hypothesisID string, fn func(DreamRepository) error) error
+	WithHypothesisConfirmationLock(ctx context.Context, teamID, hypothesisID string, fn func() error) error
 	RecallHypotheses(ctx context.Context, input RecallHypothesesInput) ([]HypothesisRecord, error)
 	UpdateHypothesisStatus(ctx context.Context, input UpdateHypothesisStatusInput) (*HypothesisRecord, error)
 	SubmitHypothesis(ctx context.Context, input SubmitHypothesisInput) (*HypothesisRecord, error)

--- a/internal/repository/dream_types.go
+++ b/internal/repository/dream_types.go
@@ -17,6 +17,7 @@ type DreamRepository interface {
 	UpsertHypothesis(ctx context.Context, input UpsertHypothesisInput) (*HypothesisRecord, bool, error)
 	ListHypotheses(ctx context.Context, input ListHypothesesInput) ([]HypothesisRecord, string, error)
 	GetHypothesis(ctx context.Context, input GetHypothesisInput) (*HypothesisRecord, error)
+	WithHypothesisConfirmationLock(ctx context.Context, teamID, hypothesisID string, fn func() error) error
 	RecallHypotheses(ctx context.Context, input RecallHypothesesInput) ([]HypothesisRecord, error)
 	UpdateHypothesisStatus(ctx context.Context, input UpdateHypothesisStatusInput) (*HypothesisRecord, error)
 	SubmitHypothesis(ctx context.Context, input SubmitHypothesisInput) (*HypothesisRecord, error)
@@ -260,6 +261,7 @@ type HypothesisRecord struct {
 	InvalidatedReason             string
 	SubmittedIngestID             string
 	SubmittedIngestIdempotencyKey string
+	SubmittedIngestRequestHash    string
 	SubmittedDecision             string
 	SubmittedAt                   *time.Time
 	Payload                       map[string]any

--- a/internal/repository/dream_types.go
+++ b/internal/repository/dream_types.go
@@ -17,7 +17,7 @@ type DreamRepository interface {
 	UpsertHypothesis(ctx context.Context, input UpsertHypothesisInput) (*HypothesisRecord, bool, error)
 	ListHypotheses(ctx context.Context, input ListHypothesesInput) ([]HypothesisRecord, string, error)
 	GetHypothesis(ctx context.Context, input GetHypothesisInput) (*HypothesisRecord, error)
-	WithHypothesisConfirmationLock(ctx context.Context, teamID, hypothesisID string, fn func() error) error
+	WithHypothesisConfirmationLock(ctx context.Context, teamID, hypothesisID string, fn func(DreamRepository) error) error
 	RecallHypotheses(ctx context.Context, input RecallHypothesesInput) ([]HypothesisRecord, error)
 	UpdateHypothesisStatus(ctx context.Context, input UpdateHypothesisStatusInput) (*HypothesisRecord, error)
 	SubmitHypothesis(ctx context.Context, input SubmitHypothesisInput) (*HypothesisRecord, error)

--- a/internal/repository/remember_attempt_repository.go
+++ b/internal/repository/remember_attempt_repository.go
@@ -57,6 +57,17 @@ type RememberAttemptLookup interface {
 	LoadRememberAttempt(context.Context, RememberAttemptLookupInput) (*RememberAttempt, error)
 }
 
+// RememberIngestLookup is the read-only compatibility port used to detect a
+// team/profile-scoped legacy Remember intake that has not yet produced a
+// terminal attempt.
+type RememberIngestLookup interface {
+	RememberIngestExists(context.Context, RememberIngestLookupInput) (bool, error)
+}
+
+type RememberIngestLookupInput struct {
+	TeamID, OwnerProfileID, IdempotencyKey string
+}
+
 // RememberFailureArtifactInput is intentionally failure-only. Its content must
 // already be scrubbed of credentials, prompts, provider responses, and database
 // errors by the application service.
@@ -149,6 +160,7 @@ type RememberAttemptDiagnosticsRepository interface {
 }
 
 var _ RememberAttemptDiagnosticsRepository = (*LedgerRepositoryImpl)(nil)
+var _ RememberIngestLookup = (*LedgerRepositoryImpl)(nil)
 
 const (
 	maxRememberFailureArtifactBytes       = 256 * 1024
@@ -222,6 +234,39 @@ func (r *LedgerRepositoryImpl) LoadRememberAttempt(ctx context.Context, input Re
 		return nil, ErrRememberAttemptNotFound
 	}
 	return result, err
+}
+
+func (r *LedgerRepositoryImpl) RememberIngestExists(ctx context.Context, input RememberIngestLookupInput) (bool, error) {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.OwnerProfileID = strings.TrimSpace(input.OwnerProfileID)
+	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
+	for label, value := range map[string]string{
+		"team_id":          input.TeamID,
+		"owner_profile_id": input.OwnerProfileID,
+	} {
+		if _, err := uuid.Parse(value); err != nil {
+			return false, fmt.Errorf("remember ingest lookup: %s is required: %w", label, err)
+		}
+	}
+	if input.IdempotencyKey == "" {
+		return false, errors.New("remember ingest lookup: idempotency_key is required")
+	}
+	var exists bool
+	err := r.withTeamProfileTx(ctx, input.TeamID, input.OwnerProfileID, func(tx *gorm.DB) error {
+		return tx.WithContext(ctx).Raw(`
+			SELECT EXISTS (
+				SELECT 1
+				FROM knowledge_ingests
+				WHERE team_id = ?::uuid
+				  AND owner_profile_id = ?::uuid
+				  AND idempotency_key = ?
+			)
+		`, input.TeamID, input.OwnerProfileID, input.IdempotencyKey).Row().Scan(&exists)
+	})
+	if err != nil {
+		return false, fmt.Errorf("remember ingest lookup: %w", err)
+	}
+	return exists, nil
 }
 
 func loadTerminalRememberAttemptInTx(ctx context.Context, tx *gorm.DB, teamID, ownerProfileID, key, requestHash, migratedHash string) (*RememberAttempt, error) {

--- a/internal/repository/remember_ingest_lookup_integration_test.go
+++ b/internal/repository/remember_ingest_lookup_integration_test.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRememberIngestExistsScopesTeamAndOwner(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	teamA := createLedgerTeam(t, adminDB, rls, "remember-ingest-lookup-team-a")
+	ownerA := createLedgerProfile(t, adminDB, rls, teamA, "remember-ingest-lookup-owner-a")
+	ownerB := createLedgerProfile(t, adminDB, rls, teamA, "remember-ingest-lookup-owner-b")
+	teamB := createLedgerTeam(t, adminDB, rls, "remember-ingest-lookup-team-b")
+	ownerC := createLedgerProfile(t, adminDB, rls, teamB, "remember-ingest-lookup-owner-c")
+	repo := NewLedgerRepository(appDB, rls)
+	const key = "dream-feedback:legacy-alias:confirm_true"
+	createSemanticIngest(t, ctx, repo, teamA, ownerA, key, "legacy Dream confirmation evidence")
+
+	exists, err := repo.RememberIngestExists(ctx, RememberIngestLookupInput{TeamID: teamA, OwnerProfileID: ownerA, IdempotencyKey: key})
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	for name, input := range map[string]RememberIngestLookupInput{
+		"same team different owner": {TeamID: teamA, OwnerProfileID: ownerB, IdempotencyKey: key},
+		"different team":            {TeamID: teamB, OwnerProfileID: ownerC, IdempotencyKey: key},
+		"unknown key":               {TeamID: teamA, OwnerProfileID: ownerA, IdempotencyKey: "dream-feedback:missing:confirm_true"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exists, err := repo.RememberIngestExists(ctx, input)
+			require.NoError(t, err)
+			require.False(t, exists)
+		})
+	}
+}

--- a/internal/repository/semantic_repository.go
+++ b/internal/repository/semantic_repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -21,6 +22,10 @@ var ErrSemanticIdentityAlias = errors.New("semantic relationship is a legacy ide
 type SemanticRepositoryImpl struct {
 	db  *gorm.DB
 	rls rLSHelper
+
+	dreamConfirmationLockAdmissionOnce sync.Once
+	dreamConfirmationLockAdmission     chan struct{}
+	dreamConfirmationLockAdmissionErr  error
 }
 
 var _ SemanticRepository = (*SemanticRepositoryImpl)(nil)

--- a/internal/repository/semantic_repository.go
+++ b/internal/repository/semantic_repository.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -23,8 +22,7 @@ type SemanticRepositoryImpl struct {
 	db  *gorm.DB
 	rls rLSHelper
 
-	dreamConfirmationLockAdmissionOnce sync.Once
-	dreamConfirmationLockAdmission     chan struct{}
+	dreamConfirmationLockState dreamConfirmationLockAdmissionState
 }
 
 var _ SemanticRepository = (*SemanticRepositoryImpl)(nil)

--- a/internal/repository/semantic_repository.go
+++ b/internal/repository/semantic_repository.go
@@ -25,7 +25,6 @@ type SemanticRepositoryImpl struct {
 
 	dreamConfirmationLockAdmissionOnce sync.Once
 	dreamConfirmationLockAdmission     chan struct{}
-	dreamConfirmationLockAdmissionErr  error
 }
 
 var _ SemanticRepository = (*SemanticRepositoryImpl)(nil)

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -26,17 +26,26 @@ var (
 	ErrInvalidDreamStatus = errors.New("invalid dream status")
 )
 
-// ConfirmationBusyError reports that another confirmation currently owns the
-// Hypothesis admission slot. The MCP registry translates it into bounded
-// retry guidance without exposing repository details.
-type ConfirmationBusyError struct{}
+// ConfirmationBusyError reports that another Dream feedback operation
+// currently owns the Hypothesis admission slot. The MCP registry translates it
+// into bounded retry guidance without exposing repository details.
+type ConfirmationBusyError struct {
+	Decision string
+}
 
 func (e *ConfirmationBusyError) Error() string {
+	if e.IsLifecycle() {
+		return "dream lifecycle feedback is already in progress"
+	}
 	return "dream confirmation is already in progress"
 }
 
 func (e *ConfirmationBusyError) Unwrap() error {
 	return repository.ErrDreamConfirmationBusy
+}
+
+func (e *ConfirmationBusyError) IsLifecycle() bool {
+	return e != nil && isDreamLifecycleDecision(e.Decision)
 }
 
 type AppConfig interface {

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"gorm.io/gorm"
 )
 
@@ -48,8 +48,12 @@ type Generator interface {
 	Model() string
 }
 
+type RememberService interface {
+	Remember(context.Context, rememberapp.RememberRequest) (*rememberapp.RememberResult, error)
+}
+
 type Dependencies struct {
-	Remember           memoryservice.RememberService
+	Remember           RememberService
 	Store              repository.DreamRepository
 	ScheduledStore     repository.ScheduledDreamRepository
 	AppConfig          AppConfig
@@ -112,19 +116,19 @@ type ListOptions struct {
 }
 
 type ResolveFeedbackRequest struct {
-	DreamID           string                                `json:"dream_id"`
-	Decision          string                                `json:"decision"`
-	Feedback          string                                `json:"feedback,omitempty"`
-	Evidence          []memoryservice.RememberEvidenceInput `json:"evidence,omitempty"`
-	EntityHints       []map[string]any                      `json:"entity_hints,omitempty"`
-	RelationshipHints []map[string]any                      `json:"relationship_hints,omitempty"`
-	IdempotencyKey    string                                `json:"idempotency_key,omitempty"`
+	DreamID           string                              `json:"dream_id"`
+	Decision          string                              `json:"decision"`
+	Feedback          string                              `json:"feedback,omitempty"`
+	Evidence          []rememberapp.RememberEvidenceInput `json:"evidence,omitempty"`
+	EntityHints       []map[string]any                    `json:"entity_hints,omitempty"`
+	RelationshipHints []map[string]any                    `json:"relationship_hints,omitempty"`
+	IdempotencyKey    string                              `json:"idempotency_key,omitempty"`
 }
 
 type ResolveFeedbackResult struct {
-	Dream   *domain.Dream                 `json:"dream"`
-	Memory  *memoryservice.RememberResult `json:"memory,omitempty"`
-	Deleted bool                          `json:"deleted,omitempty"`
+	Dream   *domain.Dream               `json:"dream"`
+	Memory  *rememberapp.RememberResult `json:"memory,omitempty"`
+	Deleted bool                        `json:"deleted,omitempty"`
 }
 
 type StatusResult struct {

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -26,6 +26,19 @@ var (
 	ErrInvalidDreamStatus = errors.New("invalid dream status")
 )
 
+// ConfirmationBusyError reports that another confirmation currently owns the
+// Hypothesis admission slot. The MCP registry translates it into bounded
+// retry guidance without exposing repository details.
+type ConfirmationBusyError struct{}
+
+func (e *ConfirmationBusyError) Error() string {
+	return "dream confirmation is already in progress"
+}
+
+func (e *ConfirmationBusyError) Unwrap() error {
+	return repository.ErrDreamConfirmationBusy
+}
+
 type AppConfig interface {
 	DreamingRuntimeConfig(ctx context.Context) (domain.DreamingRuntimeConfig, error)
 }

--- a/internal/service/dreamservice/types.go
+++ b/internal/service/dreamservice/types.go
@@ -67,6 +67,7 @@ type RememberService interface {
 
 type Dependencies struct {
 	Remember           RememberService
+	RememberIngests    repository.RememberIngestLookup
 	Store              repository.DreamRepository
 	ScheduledStore     repository.ScheduledDreamRepository
 	AppConfig          AppConfig

--- a/internal/service/dreamservice/workflow.go
+++ b/internal/service/dreamservice/workflow.go
@@ -523,6 +523,9 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 	if isDreamConfirmationDecision(decision) {
 		return s.resolveConfirmationWithLock(ctx, teamID, actorProfileID, dreamID, decision, req)
 	}
+	if isDreamLifecycleDecision(decision) {
+		return s.resolveLifecycleFeedbackWithLock(ctx, teamID, actorProfileID, dreamID, decision, req)
+	}
 	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
 		TeamID:       teamID,
 		HypothesisID: dreamID,
@@ -536,36 +539,6 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 	}
 	dream := dreamRecord(record)
 	switch decision {
-	case "reject":
-		updated, err := s.deps.Store.UpdateHypothesisStatus(ctx, repository.UpdateHypothesisStatusInput{
-			TeamID:            teamID,
-			ActorProfileID:    actorProfileID,
-			HypothesisID:      dreamID,
-			Status:            string(domain.DreamStatusRejected),
-			Decision:          decision,
-			InvalidatedReason: req.Feedback,
-		})
-		return s.feedbackResult(ctx, decision, dream, updated, nil, err)
-	case "stale":
-		updated, err := s.deps.Store.UpdateHypothesisStatus(ctx, repository.UpdateHypothesisStatusInput{
-			TeamID:            teamID,
-			ActorProfileID:    actorProfileID,
-			HypothesisID:      dreamID,
-			Status:            string(domain.DreamStatusStale),
-			Decision:          decision,
-			InvalidatedReason: req.Feedback,
-		})
-		return s.feedbackResult(ctx, decision, dream, updated, nil, err)
-	case "reinforce":
-		updated, err := s.deps.Store.UpdateHypothesisStatus(ctx, repository.UpdateHypothesisStatusInput{
-			TeamID:            teamID,
-			ActorProfileID:    actorProfileID,
-			HypothesisID:      dreamID,
-			Status:            string(domain.DreamStatusReinforced),
-			Decision:          decision,
-			InvalidatedReason: req.Feedback,
-		})
-		return s.feedbackResult(ctx, decision, dream, updated, nil, err)
 	case "ignore":
 		s.recordDreamFeedback(ctx, decision, dream, "ok")
 		return &ResolveFeedbackResult{Dream: dream}, nil

--- a/internal/service/dreamservice/workflow.go
+++ b/internal/service/dreamservice/workflow.go
@@ -571,6 +571,10 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, fmt.Errorf("resolve dream feedback: remember service is required")
 		}
+		if !dreamConfirmationReplayMatches(record, req, decision) {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, ErrDreamNotFound
+		}
 		evidence, err := dreamSubmissionEvidence(req, record)
 		if err != nil {
 			s.recordDreamFeedback(ctx, decision, dream, "error")
@@ -923,6 +927,15 @@ func dreamRememberCompletion(result *rememberapp.RememberResult) (bool, string, 
 	default:
 		return false, "", errors.New("resolve dream feedback: Remember result kind is required")
 	}
+}
+
+func dreamConfirmationReplayMatches(record *repository.HypothesisRecord, req ResolveFeedbackRequest, decision string) bool {
+	if record == nil || record.Status != string(domain.DreamStatusSubmitted) || strings.TrimSpace(record.SubmittedIngestID) == "" {
+		return true
+	}
+	return strings.TrimSpace(record.SubmittedIngestIdempotencyKey) != "" &&
+		strings.TrimSpace(record.SubmittedIngestIdempotencyKey) == dreamFeedbackIdempotency(req, record.HypothesisID, decision) &&
+		strings.TrimSpace(record.SubmittedDecision) == decision
 }
 
 func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decision string) string {

--- a/internal/service/dreamservice/workflow.go
+++ b/internal/service/dreamservice/workflow.go
@@ -17,7 +17,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
 var ErrDreamAuthContext = errors.New("dream: authenticated actor context is required")
@@ -576,22 +576,35 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, err
 		}
-		remember, err := s.deps.Remember.Remember(ctx, memoryservice.RememberRequest{
+		remember, err := s.deps.Remember.Remember(ctx, rememberapp.RememberRequest{
 			Evidence:          evidence,
 			EntityHints:       req.EntityHints,
 			RelationshipHints: req.RelationshipHints,
 			IdempotencyKey:    dreamFeedbackIdempotency(req, dreamID, decision),
 		})
 		if err != nil {
+			var processErr *rememberapp.RememberProcessError
+			if !errors.As(err, &processErr) || processErr.Result == nil {
+				s.recordDreamFeedback(ctx, decision, dream, "error")
+				return nil, err
+			}
+			remember = rememberResultFromProcessError(processErr.Result)
+		}
+		completed, ingestID, err := dreamRememberCompletion(remember)
+		if err != nil {
 			s.recordDreamFeedback(ctx, decision, dream, "error")
 			return nil, err
+		}
+		if !completed {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 		}
 		updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
 			TeamID:            teamID,
 			ActorProfileID:    actorProfileID,
 			HypothesisID:      dreamID,
 			Decision:          decision,
-			SubmittedIngestID: remember.IngestID,
+			SubmittedIngestID: ingestID,
 			InvalidatedReason: req.Feedback,
 		})
 		return s.feedbackResult(ctx, decision, dream, updated, remember, err)
@@ -606,7 +619,7 @@ func (s *service) feedbackResult(
 	decision string,
 	original *domain.Dream,
 	updated *repository.HypothesisRecord,
-	remember *memoryservice.RememberResult,
+	remember *rememberapp.RememberResult,
 	err error,
 ) (*ResolveFeedbackResult, error) {
 	if err != nil {
@@ -828,11 +841,11 @@ func hypothesisContentHash(input repository.UpsertHypothesisInput) string {
 func dreamSubmissionEvidence(
 	req ResolveFeedbackRequest,
 	record *repository.HypothesisRecord,
-) ([]memoryservice.RememberEvidenceInput, error) {
+) ([]rememberapp.RememberEvidenceInput, error) {
 	if len(req.Evidence) == 0 {
 		return nil, errors.New("resolve dream feedback: independent evidence is required")
 	}
-	out := make([]memoryservice.RememberEvidenceInput, 0, len(req.Evidence))
+	out := make([]rememberapp.RememberEvidenceInput, 0, len(req.Evidence))
 	for i, item := range req.Evidence {
 		content := strings.TrimSpace(item.Content)
 		if content == "" {
@@ -851,10 +864,65 @@ func dreamSubmissionEvidence(
 			item.Metadata = map[string]any{}
 		}
 		item.Metadata["hypothesis_id"] = record.HypothesisID
-		item.Metadata["hypothesis_status_before"] = record.Status
+		if feedback := strings.TrimSpace(req.Feedback); feedback != "" {
+			item.Metadata["dream_feedback_reason"] = feedback
+		} else {
+			delete(item.Metadata, "dream_feedback_reason")
+		}
 		out = append(out, item)
 	}
 	return out, nil
+}
+
+func rememberResultFromProcessError(terminal *rememberapp.TerminalRememberResult) *rememberapp.RememberResult {
+	if terminal == nil {
+		return nil
+	}
+	return &rememberapp.RememberResult{
+		ContractVersion: terminal.ContractVersion,
+		IngestID:        terminal.SubmissionID,
+		SubmissionID:    terminal.SubmissionID,
+		SubmissionKind:  terminal.SubmissionKind,
+		ProcessingState: terminal.ProcessingState,
+		CorrelationID:   terminal.CorrelationID,
+		Kind:            rememberapp.ResultKindTerminal,
+		Terminal:        terminal,
+	}
+}
+
+func dreamRememberCompletion(result *rememberapp.RememberResult) (bool, string, error) {
+	if result == nil {
+		return false, "", errors.New("resolve dream feedback: Remember result is required")
+	}
+	switch result.Kind {
+	// TODO(#307): remove legacy receipt compatibility when all callers use terminal outcomes.
+	case rememberapp.ResultKindLegacyReceipt:
+		ingestID := strings.TrimSpace(result.IngestID)
+		if _, err := uuid.Parse(ingestID); err != nil {
+			return false, "", errors.New("resolve dream feedback: legacy Remember result has no canonical ingest")
+		}
+		return true, ingestID, nil
+	case rememberapp.ResultKindTerminal:
+		if result.Terminal == nil {
+			return false, "", errors.New("resolve dream feedback: terminal Remember result is required")
+		}
+		switch result.Terminal.ProcessingState {
+		case string(rememberapp.TerminalProcessingCompleted):
+			ingestID := strings.TrimSpace(result.Terminal.SubmissionID)
+			if _, err := uuid.Parse(ingestID); err != nil {
+				return false, "", errors.New("resolve dream feedback: completed Remember result has no canonical ingest")
+			}
+			return true, ingestID, nil
+		case string(rememberapp.TerminalProcessingRejected),
+			string(rememberapp.TerminalProcessingQuarantined),
+			string(rememberapp.TerminalProcessingFailed):
+			return false, "", nil
+		default:
+			return false, "", errors.New("resolve dream feedback: terminal Remember result has an unsupported processing state")
+		}
+	default:
+		return false, "", errors.New("resolve dream feedback: Remember result kind is required")
+	}
 }
 
 func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decision string) string {

--- a/internal/service/dreamservice/workflow.go
+++ b/internal/service/dreamservice/workflow.go
@@ -520,6 +520,9 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 		return nil, fmt.Errorf("resolve dream feedback: dream_id is required")
 	}
 	decision := strings.TrimSpace(req.Decision)
+	if isDreamConfirmationDecision(decision) {
+		return s.resolveConfirmationWithLock(ctx, teamID, actorProfileID, dreamID, decision, req)
+	}
 	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
 		TeamID:       teamID,
 		HypothesisID: dreamID,
@@ -566,52 +569,6 @@ func (s *service) resolveFeedback(ctx context.Context, req ResolveFeedbackReques
 	case "ignore":
 		s.recordDreamFeedback(ctx, decision, dream, "ok")
 		return &ResolveFeedbackResult{Dream: dream}, nil
-	case "confirm_true", "confirm_false", "promote_candidate":
-		if s.deps.Remember == nil {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, fmt.Errorf("resolve dream feedback: remember service is required")
-		}
-		if !dreamConfirmationReplayMatches(record, req, decision) {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, ErrDreamNotFound
-		}
-		evidence, err := dreamSubmissionEvidence(req, record)
-		if err != nil {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, err
-		}
-		remember, err := s.deps.Remember.Remember(ctx, rememberapp.RememberRequest{
-			Evidence:          evidence,
-			EntityHints:       req.EntityHints,
-			RelationshipHints: req.RelationshipHints,
-			IdempotencyKey:    dreamFeedbackIdempotency(req, dreamID, decision),
-		})
-		if err != nil {
-			var processErr *rememberapp.RememberProcessError
-			if !errors.As(err, &processErr) || processErr.Result == nil {
-				s.recordDreamFeedback(ctx, decision, dream, "error")
-				return nil, err
-			}
-			remember = rememberResultFromProcessError(processErr.Result)
-		}
-		completed, ingestID, err := dreamRememberCompletion(remember)
-		if err != nil {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return nil, err
-		}
-		if !completed {
-			s.recordDreamFeedback(ctx, decision, dream, "error")
-			return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
-		}
-		updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
-			TeamID:            teamID,
-			ActorProfileID:    actorProfileID,
-			HypothesisID:      dreamID,
-			Decision:          decision,
-			SubmittedIngestID: ingestID,
-			InvalidatedReason: req.Feedback,
-		})
-		return s.feedbackResult(ctx, decision, dream, updated, remember, err)
 	default:
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return nil, fmt.Errorf("%w: %s", ErrInvalidDreamStatus, decision)
@@ -840,109 +797,6 @@ func hypothesisContentHash(input repository.UpsertHypothesisInput) string {
 	}, "\x00")
 	sum := sha256.Sum256([]byte(raw))
 	return "sha256:" + hex.EncodeToString(sum[:])
-}
-
-func dreamSubmissionEvidence(
-	req ResolveFeedbackRequest,
-	record *repository.HypothesisRecord,
-) ([]rememberapp.RememberEvidenceInput, error) {
-	if len(req.Evidence) == 0 {
-		return nil, errors.New("resolve dream feedback: independent evidence is required")
-	}
-	out := make([]rememberapp.RememberEvidenceInput, 0, len(req.Evidence))
-	for i, item := range req.Evidence {
-		content := strings.TrimSpace(item.Content)
-		if content == "" {
-			return nil, fmt.Errorf("resolve dream feedback: evidence[%d].content is required", i)
-		}
-		if strings.EqualFold(content, strings.TrimSpace(record.Statement)) {
-			return nil, errors.New("resolve dream feedback: hypothesis text cannot be submitted as its own evidence")
-		}
-		if item.SourceType == "" {
-			item.SourceType = "manual"
-		}
-		if item.Source == "" {
-			item.Source = "dream_feedback:" + record.HypothesisID
-		}
-		if item.Metadata == nil {
-			item.Metadata = map[string]any{}
-		}
-		item.Metadata["hypothesis_id"] = record.HypothesisID
-		if feedback := strings.TrimSpace(req.Feedback); feedback != "" {
-			item.Metadata["dream_feedback_reason"] = feedback
-		} else {
-			delete(item.Metadata, "dream_feedback_reason")
-		}
-		out = append(out, item)
-	}
-	return out, nil
-}
-
-func rememberResultFromProcessError(terminal *rememberapp.TerminalRememberResult) *rememberapp.RememberResult {
-	if terminal == nil {
-		return nil
-	}
-	return &rememberapp.RememberResult{
-		ContractVersion: terminal.ContractVersion,
-		IngestID:        terminal.SubmissionID,
-		SubmissionID:    terminal.SubmissionID,
-		SubmissionKind:  terminal.SubmissionKind,
-		ProcessingState: terminal.ProcessingState,
-		CorrelationID:   terminal.CorrelationID,
-		Kind:            rememberapp.ResultKindTerminal,
-		Terminal:        terminal,
-	}
-}
-
-func dreamRememberCompletion(result *rememberapp.RememberResult) (bool, string, error) {
-	if result == nil {
-		return false, "", errors.New("resolve dream feedback: Remember result is required")
-	}
-	switch result.Kind {
-	// TODO(#307): remove legacy receipt compatibility when all callers use terminal outcomes.
-	case rememberapp.ResultKindLegacyReceipt:
-		ingestID := strings.TrimSpace(result.IngestID)
-		if _, err := uuid.Parse(ingestID); err != nil {
-			return false, "", errors.New("resolve dream feedback: legacy Remember result has no canonical ingest")
-		}
-		return true, ingestID, nil
-	case rememberapp.ResultKindTerminal:
-		if result.Terminal == nil {
-			return false, "", errors.New("resolve dream feedback: terminal Remember result is required")
-		}
-		switch result.Terminal.ProcessingState {
-		case string(rememberapp.TerminalProcessingCompleted):
-			ingestID := strings.TrimSpace(result.Terminal.SubmissionID)
-			if _, err := uuid.Parse(ingestID); err != nil {
-				return false, "", errors.New("resolve dream feedback: completed Remember result has no canonical ingest")
-			}
-			return true, ingestID, nil
-		case string(rememberapp.TerminalProcessingRejected),
-			string(rememberapp.TerminalProcessingQuarantined),
-			string(rememberapp.TerminalProcessingFailed):
-			return false, "", nil
-		default:
-			return false, "", errors.New("resolve dream feedback: terminal Remember result has an unsupported processing state")
-		}
-	default:
-		return false, "", errors.New("resolve dream feedback: Remember result kind is required")
-	}
-}
-
-func dreamConfirmationReplayMatches(record *repository.HypothesisRecord, req ResolveFeedbackRequest, decision string) bool {
-	if record == nil || record.Status != string(domain.DreamStatusSubmitted) || strings.TrimSpace(record.SubmittedIngestID) == "" {
-		return true
-	}
-	return strings.TrimSpace(record.SubmittedIngestIdempotencyKey) != "" &&
-		strings.TrimSpace(record.SubmittedIngestIdempotencyKey) == dreamFeedbackIdempotency(req, record.HypothesisID, decision) &&
-		strings.TrimSpace(record.SubmittedDecision) == decision
-}
-
-func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decision string) string {
-	if value := strings.TrimSpace(req.IdempotencyKey); value != "" {
-		return value
-	}
-	return "dream-feedback:" + dreamID + ":" + decision
 }
 
 func optionalProbability(value float64) *float64 {

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -189,6 +189,7 @@ func (s *service) resolveConfirmation(
 		return nil, err
 	}
 	if !completed {
+		applyDreamTerminalRetryGuidance(remember, record.HypothesisID, decision)
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
@@ -351,6 +352,23 @@ func rememberResultFromProcessError(terminal *rememberapp.TerminalRememberResult
 		CorrelationID:   terminal.CorrelationID,
 		Kind:            rememberapp.ResultKindTerminal,
 		Terminal:        terminal,
+	}
+}
+
+func applyDreamTerminalRetryGuidance(result *rememberapp.RememberResult, dreamID, decision string) {
+	if result == nil || result.Terminal == nil {
+		return
+	}
+	retryKey := fmt.Sprintf("dream-feedback:%s:%s:retry:%s", dreamID, decision, result.Terminal.SubmissionID)
+	if len([]rune(retryKey)) > 128 {
+		retryKey = "dream-feedback:" + dreamID + ":" + decision + ":retry"
+	}
+	for index := range result.Terminal.Errors {
+		if result.Terminal.Errors[index].NextAction != string(rememberapp.TerminalNextActionResubmitRemember) {
+			continue
+		}
+		result.Terminal.Errors[index].NextAction = string(rememberapp.TerminalNextActionRetryDreamFeedback)
+		result.Terminal.Errors[index].Remediation = rememberapp.DreamFeedbackRetryRemediation(retryKey)
 	}
 }
 

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -36,6 +36,9 @@ func (s *service) resolveConfirmationWithLock(
 		result, err = s.resolveConfirmation(ctx, store, teamID, actorProfileID, dreamID, decision, req)
 		return err
 	})
+	if errors.Is(err, repository.ErrDreamConfirmationBusy) {
+		return nil, &ConfirmationBusyError{}
+	}
 	return result, err
 }
 
@@ -84,7 +87,7 @@ func (s *service) resolveConfirmation(
 		Evidence:          evidence,
 		EntityHints:       req.EntityHints,
 		RelationshipHints: req.RelationshipHints,
-		IdempotencyKey:    dreamFeedbackIdempotency(req, dreamID, decision),
+		IdempotencyKey:    dreamFeedbackIdempotency(req, record.HypothesisID, decision),
 	})
 	if err != nil {
 		var processErr *rememberapp.RememberProcessError
@@ -100,7 +103,7 @@ func (s *service) resolveConfirmation(
 		return nil, err
 	}
 	if !completed {
-		applyDreamTerminalRetryGuidance(remember, dreamID, decision)
+		applyDreamTerminalRetryGuidance(remember, record.HypothesisID, decision)
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -49,7 +49,7 @@ func (s *service) resolveConfirmationWithLock(
 		return err
 	})
 	if errors.Is(err, repository.ErrDreamConfirmationBusy) {
-		return nil, &ConfirmationBusyError{}
+		return nil, &ConfirmationBusyError{Decision: decision}
 	}
 	return result, err
 }
@@ -69,7 +69,7 @@ func (s *service) resolveLifecycleFeedbackWithLock(
 		return err
 	})
 	if errors.Is(err, repository.ErrDreamConfirmationBusy) {
-		return nil, &ConfirmationBusyError{}
+		return nil, &ConfirmationBusyError{Decision: decision}
 	}
 	return result, err
 }

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -22,6 +22,15 @@ func isDreamConfirmationDecision(decision string) bool {
 	}
 }
 
+func isDreamLifecycleDecision(decision string) bool {
+	switch decision {
+	case "reject", "stale", "reinforce":
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *service) resolveConfirmationWithLock(
 	ctx context.Context,
 	teamID string,
@@ -40,6 +49,70 @@ func (s *service) resolveConfirmationWithLock(
 		return nil, &ConfirmationBusyError{}
 	}
 	return result, err
+}
+
+func (s *service) resolveLifecycleFeedbackWithLock(
+	ctx context.Context,
+	teamID string,
+	actorProfileID string,
+	dreamID string,
+	decision string,
+	req ResolveFeedbackRequest,
+) (*ResolveFeedbackResult, error) {
+	var result *ResolveFeedbackResult
+	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func(store repository.DreamRepository) error {
+		var err error
+		result, err = s.resolveLifecycleFeedback(ctx, store, teamID, actorProfileID, dreamID, decision, req)
+		return err
+	})
+	if errors.Is(err, repository.ErrDreamConfirmationBusy) {
+		return nil, &ConfirmationBusyError{}
+	}
+	return result, err
+}
+
+func (s *service) resolveLifecycleFeedback(
+	ctx context.Context,
+	store repository.DreamRepository,
+	teamID string,
+	actorProfileID string,
+	dreamID string,
+	decision string,
+	req ResolveFeedbackRequest,
+) (*ResolveFeedbackResult, error) {
+	record, err := store.GetHypothesis(ctx, repository.GetHypothesisInput{
+		TeamID:       teamID,
+		HypothesisID: dreamID,
+	})
+	if err != nil {
+		s.recordDreamFeedback(ctx, decision, nil, "error")
+		if errors.Is(err, repository.ErrDreamHypothesisNotFound) {
+			return nil, ErrDreamNotFound
+		}
+		return nil, err
+	}
+	updated, err := store.UpdateHypothesisStatus(ctx, repository.UpdateHypothesisStatusInput{
+		TeamID:            teamID,
+		ActorProfileID:    actorProfileID,
+		HypothesisID:      dreamID,
+		Status:            lifecycleStatus(decision),
+		Decision:          decision,
+		InvalidatedReason: req.Feedback,
+	})
+	return s.feedbackResult(ctx, decision, dreamRecord(record), updated, nil, err)
+}
+
+func lifecycleStatus(decision string) string {
+	switch decision {
+	case "reject":
+		return string(domain.DreamStatusRejected)
+	case "stale":
+		return string(domain.DreamStatusStale)
+	case "reinforce":
+		return string(domain.DreamStatusReinforced)
+	default:
+		return ""
+	}
 }
 
 func (s *service) resolveConfirmation(

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -31,9 +31,9 @@ func (s *service) resolveConfirmationWithLock(
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
 	var result *ResolveFeedbackResult
-	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func(store repository.DreamRepository) error {
+	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func() error {
 		var err error
-		result, err = s.resolveConfirmation(ctx, store, teamID, actorProfileID, dreamID, decision, req)
+		result, err = s.resolveConfirmation(ctx, teamID, actorProfileID, dreamID, decision, req)
 		return err
 	})
 	return result, err
@@ -41,14 +41,13 @@ func (s *service) resolveConfirmationWithLock(
 
 func (s *service) resolveConfirmation(
 	ctx context.Context,
-	store repository.DreamRepository,
 	teamID string,
 	actorProfileID string,
 	dreamID string,
 	decision string,
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
-	record, err := store.GetHypothesis(ctx, repository.GetHypothesisInput{
+	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
 		TeamID:       teamID,
 		HypothesisID: dreamID,
 	})
@@ -104,7 +103,7 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
-	updated, err := store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
+	updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
 		TeamID:            teamID,
 		ActorProfileID:    actorProfileID,
 		HypothesisID:      dreamID,
@@ -226,9 +225,8 @@ func applyDreamTerminalRetryGuidance(result *rememberapp.RememberResult, dreamID
 		if result.Terminal.Errors[index].NextAction != string(rememberapp.TerminalNextActionResubmitRemember) {
 			continue
 		}
-		result.Terminal.Errors[index].Remediation = fmt.Sprintf(
-			"Retry resolve_dream_feedback with corrected evidence and idempotency_key %q.", retryKey,
-		)
+		result.Terminal.Errors[index].NextAction = string(rememberapp.TerminalNextActionRetryDreamFeedback)
+		result.Terminal.Errors[index].Remediation = rememberapp.DreamFeedbackRetryRemediation(retryKey)
 	}
 }
 

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/markhuangai/dense-mem/internal/repository"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
+
+const dreamConfirmationFinalizationTimeout = 5 * time.Second
 
 func isDreamConfirmationDecision(decision string) bool {
 	switch decision {
@@ -180,7 +183,7 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
-	updated, err := store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
+	updated, err := s.submitDreamHypothesisWithRetry(ctx, store, repository.SubmitHypothesisInput{
 		TeamID:            teamID,
 		ActorProfileID:    actorProfileID,
 		HypothesisID:      dreamID,
@@ -189,6 +192,24 @@ func (s *service) resolveConfirmation(
 		InvalidatedReason: req.Feedback,
 	})
 	return s.feedbackResult(ctx, decision, dream, updated, remember, err)
+}
+
+func (s *service) submitDreamHypothesisWithRetry(
+	ctx context.Context,
+	store repository.DreamRepository,
+	input repository.SubmitHypothesisInput,
+) (*repository.HypothesisRecord, error) {
+	updated, err := store.SubmitHypothesis(ctx, input)
+	if err == nil {
+		return updated, nil
+	}
+	retryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dreamConfirmationFinalizationTimeout)
+	defer cancel()
+	retried, retryErr := store.SubmitHypothesis(retryCtx, input)
+	if retryErr == nil {
+		return retried, nil
+	}
+	return nil, errors.Join(err, fmt.Errorf("resolve dream feedback: submit hypothesis retry: %w", retryErr))
 }
 
 func dreamSubmissionEvidence(

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -159,12 +159,22 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "ok")
 		return &ResolveFeedbackResult{Dream: dream, Memory: dreamReplayRememberResult(record)}, nil
 	}
-	remember, err := s.deps.Remember.Remember(ctx, rememberapp.RememberRequest{
+	rememberRequest := rememberapp.RememberRequest{
 		Evidence:          evidence,
 		EntityHints:       req.EntityHints,
 		RelationshipHints: req.RelationshipHints,
 		IdempotencyKey:    dreamFeedbackIdempotency(req, record.HypothesisID, decision),
-	})
+	}
+	remember, err := s.deps.Remember.Remember(ctx, rememberRequest)
+	if ctx.Err() == nil && dreamLegacyReplayConflict(err) {
+		legacyEvidence, legacyErr := dreamSubmissionEvidenceWithStatus(req, record, record.Status, true)
+		if legacyErr != nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, legacyErr
+		}
+		rememberRequest.Evidence = legacyEvidence
+		remember, err = s.deps.Remember.Remember(ctx, rememberRequest)
+	}
 	if err != nil {
 		var processErr *rememberapp.RememberProcessError
 		if !errors.As(err, &processErr) || processErr.Result == nil {
@@ -192,6 +202,22 @@ func (s *service) resolveConfirmation(
 		InvalidatedReason: req.Feedback,
 	})
 	return s.feedbackResult(ctx, decision, dream, updated, remember, err)
+}
+
+func dreamLegacyReplayConflict(err error) bool {
+	if errors.Is(err, rememberapp.ErrRememberConflict) {
+		return true
+	}
+	var processErr *rememberapp.RememberProcessError
+	if !errors.As(err, &processErr) || processErr == nil || processErr.Result == nil {
+		return false
+	}
+	for _, statusErr := range processErr.Result.Errors {
+		if statusErr.Code == string(rememberapp.TerminalErrorIdempotencyConflict) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *service) submitDreamHypothesisWithRetry(

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -382,9 +382,15 @@ func dreamConfirmationReplayMatches(record *repository.HypothesisRecord, req Res
 	if record == nil || record.Status != string(domain.DreamStatusSubmitted) || strings.TrimSpace(record.SubmittedIngestID) == "" {
 		return true
 	}
-	return strings.TrimSpace(record.SubmittedIngestIdempotencyKey) != "" &&
-		strings.TrimSpace(record.SubmittedIngestIdempotencyKey) == dreamFeedbackIdempotency(req, record.HypothesisID, decision) &&
-		strings.TrimSpace(record.SubmittedDecision) == decision
+	storedKey := strings.TrimSpace(record.SubmittedIngestIdempotencyKey)
+	if storedKey == "" || strings.TrimSpace(record.SubmittedDecision) != decision {
+		return false
+	}
+	if storedKey == dreamFeedbackIdempotency(req, record.HypothesisID, decision) {
+		return true
+	}
+	return strings.TrimSpace(req.IdempotencyKey) == "" &&
+		storedKey == dreamFeedbackIdempotency(req, strings.TrimSpace(req.DreamID), decision)
 }
 
 func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decision string) string {

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -203,7 +203,10 @@ func (s *service) submitDreamHypothesisWithRetry(
 	if err == nil {
 		return updated, nil
 	}
-	retryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dreamConfirmationFinalizationTimeout)
+	if ctx.Err() != nil {
+		return nil, err
+	}
+	retryCtx, cancel := context.WithTimeout(ctx, dreamConfirmationFinalizationTimeout)
 	defer cancel()
 	retried, retryErr := store.SubmitHypothesis(retryCtx, input)
 	if retryErr == nil {

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -31,9 +31,9 @@ func (s *service) resolveConfirmationWithLock(
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
 	var result *ResolveFeedbackResult
-	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func() error {
+	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func(store repository.DreamRepository) error {
 		var err error
-		result, err = s.resolveConfirmation(ctx, teamID, actorProfileID, dreamID, decision, req)
+		result, err = s.resolveConfirmation(ctx, store, teamID, actorProfileID, dreamID, decision, req)
 		return err
 	})
 	return result, err
@@ -41,13 +41,14 @@ func (s *service) resolveConfirmationWithLock(
 
 func (s *service) resolveConfirmation(
 	ctx context.Context,
+	store repository.DreamRepository,
 	teamID string,
 	actorProfileID string,
 	dreamID string,
 	decision string,
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
-	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
+	record, err := store.GetHypothesis(ctx, repository.GetHypothesisInput{
 		TeamID:       teamID,
 		HypothesisID: dreamID,
 	})
@@ -103,7 +104,7 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
-	updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
+	updated, err := store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
 		TeamID:            teamID,
 		ActorProfileID:    actorProfileID,
 		HypothesisID:      dreamID,
@@ -145,7 +146,7 @@ func dreamSubmissionEvidenceWithStatus(
 		if item.Source == "" {
 			item.Source = "dream_feedback:" + record.HypothesisID
 		}
-		metadata := make(map[string]any, len(item.Metadata)+2)
+		metadata := make(map[string]any)
 		for key, value := range item.Metadata {
 			metadata[key] = value
 		}

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -1,0 +1,299 @@
+package dreamservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+func isDreamConfirmationDecision(decision string) bool {
+	switch decision {
+	case "confirm_true", "confirm_false", "promote_candidate":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *service) resolveConfirmationWithLock(
+	ctx context.Context,
+	teamID string,
+	actorProfileID string,
+	dreamID string,
+	decision string,
+	req ResolveFeedbackRequest,
+) (*ResolveFeedbackResult, error) {
+	var result *ResolveFeedbackResult
+	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func() error {
+		var err error
+		result, err = s.resolveConfirmation(ctx, teamID, actorProfileID, dreamID, decision, req)
+		return err
+	})
+	return result, err
+}
+
+func (s *service) resolveConfirmation(
+	ctx context.Context,
+	teamID string,
+	actorProfileID string,
+	dreamID string,
+	decision string,
+	req ResolveFeedbackRequest,
+) (*ResolveFeedbackResult, error) {
+	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
+		TeamID:       teamID,
+		HypothesisID: dreamID,
+	})
+	if err != nil {
+		s.recordDreamFeedback(ctx, decision, nil, "error")
+		if errors.Is(err, repository.ErrDreamHypothesisNotFound) {
+			return nil, ErrDreamNotFound
+		}
+		return nil, err
+	}
+	dream := dreamRecord(record)
+	if s.deps.Remember == nil {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, fmt.Errorf("resolve dream feedback: remember service is required")
+	}
+	if !dreamConfirmationReplayMatches(record, req, decision) {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, ErrDreamNotFound
+	}
+	evidence, err := dreamSubmissionEvidence(req, record)
+	if err != nil {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, err
+	}
+	if replay, err := dreamSubmittedConfirmationReplay(record, req, evidence); err != nil {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, err
+	} else if replay {
+		s.recordDreamFeedback(ctx, decision, dream, "ok")
+		return &ResolveFeedbackResult{Dream: dream, Memory: dreamReplayRememberResult(record)}, nil
+	}
+	remember, err := s.deps.Remember.Remember(ctx, rememberapp.RememberRequest{
+		Evidence:          evidence,
+		EntityHints:       req.EntityHints,
+		RelationshipHints: req.RelationshipHints,
+		IdempotencyKey:    dreamFeedbackIdempotency(req, dreamID, decision),
+	})
+	if err != nil {
+		var processErr *rememberapp.RememberProcessError
+		if !errors.As(err, &processErr) || processErr.Result == nil {
+			s.recordDreamFeedback(ctx, decision, dream, "error")
+			return nil, err
+		}
+		remember = rememberResultFromProcessError(processErr.Result)
+	}
+	completed, ingestID, err := dreamRememberCompletion(remember)
+	if err != nil {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, err
+	}
+	if !completed {
+		applyDreamTerminalRetryGuidance(remember, dreamID, decision)
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
+	}
+	updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
+		TeamID:            teamID,
+		ActorProfileID:    actorProfileID,
+		HypothesisID:      dreamID,
+		Decision:          decision,
+		SubmittedIngestID: ingestID,
+		InvalidatedReason: req.Feedback,
+	})
+	return s.feedbackResult(ctx, decision, dream, updated, remember, err)
+}
+
+func dreamSubmissionEvidence(
+	req ResolveFeedbackRequest,
+	record *repository.HypothesisRecord,
+) ([]rememberapp.RememberEvidenceInput, error) {
+	return dreamSubmissionEvidenceWithStatus(req, record, record.Status, false)
+}
+
+func dreamSubmissionEvidenceWithStatus(
+	req ResolveFeedbackRequest,
+	record *repository.HypothesisRecord,
+	statusBefore string,
+	legacy bool,
+) ([]rememberapp.RememberEvidenceInput, error) {
+	if len(req.Evidence) == 0 {
+		return nil, errors.New("resolve dream feedback: independent evidence is required")
+	}
+	out := make([]rememberapp.RememberEvidenceInput, 0, len(req.Evidence))
+	for i, item := range req.Evidence {
+		content := strings.TrimSpace(item.Content)
+		if content == "" {
+			return nil, fmt.Errorf("resolve dream feedback: evidence[%d].content is required", i)
+		}
+		if strings.EqualFold(content, strings.TrimSpace(record.Statement)) {
+			return nil, errors.New("resolve dream feedback: hypothesis text cannot be submitted as its own evidence")
+		}
+		if item.SourceType == "" {
+			item.SourceType = "manual"
+		}
+		if item.Source == "" {
+			item.Source = "dream_feedback:" + record.HypothesisID
+		}
+		metadata := make(map[string]any, len(item.Metadata)+2)
+		for key, value := range item.Metadata {
+			metadata[key] = value
+		}
+		item.Metadata = metadata
+		item.Metadata["hypothesis_id"] = record.HypothesisID
+		if legacy {
+			item.Metadata["hypothesis_status_before"] = strings.TrimSpace(statusBefore)
+			delete(item.Metadata, "dream_feedback_reason")
+		} else if feedback := strings.TrimSpace(req.Feedback); feedback != "" {
+			item.Metadata["dream_feedback_reason"] = feedback
+		} else {
+			delete(item.Metadata, "dream_feedback_reason")
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func dreamSubmittedConfirmationReplay(
+	record *repository.HypothesisRecord,
+	req ResolveFeedbackRequest,
+	evidence []rememberapp.RememberEvidenceInput,
+) (bool, error) {
+	if record == nil || record.Status != string(domain.DreamStatusSubmitted) ||
+		strings.TrimSpace(record.SubmittedIngestID) == "" ||
+		strings.TrimSpace(record.SubmittedIngestRequestHash) == "" ||
+		strings.TrimSpace(record.InvalidatedReason) != strings.TrimSpace(req.Feedback) {
+		return false, nil
+	}
+	requestHash, err := rememberapp.CanonicalRequestBodyHash(evidence, req.EntityHints, req.RelationshipHints)
+	if err != nil {
+		return false, fmt.Errorf("resolve dream feedback: replay request hash: %w", err)
+	}
+	if strings.TrimSpace(record.SubmittedIngestRequestHash) == requestHash {
+		return true, nil
+	}
+	for _, statusBefore := range domain.HypothesisStatuses() {
+		legacyEvidence, err := dreamSubmissionEvidenceWithStatus(req, record, statusBefore, true)
+		if err != nil {
+			return false, err
+		}
+		legacyHash, err := rememberapp.CanonicalRequestBodyHash(legacyEvidence, req.EntityHints, req.RelationshipHints)
+		if err != nil {
+			return false, fmt.Errorf("resolve dream feedback: legacy replay request hash: %w", err)
+		}
+		if strings.TrimSpace(record.SubmittedIngestRequestHash) == legacyHash {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func dreamReplayRememberResult(record *repository.HypothesisRecord) *rememberapp.RememberResult {
+	if record == nil {
+		return nil
+	}
+	return &rememberapp.RememberResult{
+		ContractVersion: domain.ContractVersion,
+		IngestID:        record.SubmittedIngestID,
+		SubmissionID:    record.SubmittedIngestID,
+		SubmissionKind:  "remember",
+		ProcessingState: string(domain.PlacementRunQueued),
+		StatusTool:      "get_submission_status",
+		Kind:            rememberapp.ResultKindLegacyReceipt,
+	}
+}
+
+func applyDreamTerminalRetryGuidance(result *rememberapp.RememberResult, dreamID, decision string) {
+	if result == nil || result.Terminal == nil {
+		return
+	}
+	retryKey := fmt.Sprintf("dream-feedback:%s:%s:retry:%s", dreamID, decision, result.Terminal.SubmissionID)
+	if len([]rune(retryKey)) > 128 {
+		retryKey = "dream-feedback:" + dreamID + ":" + decision + ":retry"
+	}
+	for index := range result.Terminal.Errors {
+		if result.Terminal.Errors[index].NextAction != string(rememberapp.TerminalNextActionResubmitRemember) {
+			continue
+		}
+		result.Terminal.Errors[index].Remediation = fmt.Sprintf(
+			"Retry resolve_dream_feedback with corrected evidence and idempotency_key %q.", retryKey,
+		)
+	}
+}
+
+func rememberResultFromProcessError(terminal *rememberapp.TerminalRememberResult) *rememberapp.RememberResult {
+	if terminal == nil {
+		return nil
+	}
+	return &rememberapp.RememberResult{
+		ContractVersion: terminal.ContractVersion,
+		IngestID:        terminal.SubmissionID,
+		SubmissionID:    terminal.SubmissionID,
+		SubmissionKind:  terminal.SubmissionKind,
+		ProcessingState: terminal.ProcessingState,
+		CorrelationID:   terminal.CorrelationID,
+		Kind:            rememberapp.ResultKindTerminal,
+		Terminal:        terminal,
+	}
+}
+
+func dreamRememberCompletion(result *rememberapp.RememberResult) (bool, string, error) {
+	if result == nil {
+		return false, "", errors.New("resolve dream feedback: Remember result is required")
+	}
+	switch result.Kind {
+	// TODO(#307): remove legacy receipt compatibility when all callers use terminal outcomes.
+	case rememberapp.ResultKindLegacyReceipt:
+		ingestID := strings.TrimSpace(result.IngestID)
+		if _, err := uuid.Parse(ingestID); err != nil {
+			return false, "", errors.New("resolve dream feedback: legacy Remember result has no canonical ingest")
+		}
+		return true, ingestID, nil
+	case rememberapp.ResultKindTerminal:
+		if result.Terminal == nil {
+			return false, "", errors.New("resolve dream feedback: terminal Remember result is required")
+		}
+		switch result.Terminal.ProcessingState {
+		case string(rememberapp.TerminalProcessingCompleted):
+			ingestID := strings.TrimSpace(result.Terminal.SubmissionID)
+			if _, err := uuid.Parse(ingestID); err != nil {
+				return false, "", errors.New("resolve dream feedback: completed Remember result has no canonical ingest")
+			}
+			return true, ingestID, nil
+		case string(rememberapp.TerminalProcessingRejected),
+			string(rememberapp.TerminalProcessingQuarantined),
+			string(rememberapp.TerminalProcessingFailed):
+			return false, "", nil
+		default:
+			return false, "", errors.New("resolve dream feedback: terminal Remember result has an unsupported processing state")
+		}
+	default:
+		return false, "", errors.New("resolve dream feedback: Remember result kind is required")
+	}
+}
+
+func dreamConfirmationReplayMatches(record *repository.HypothesisRecord, req ResolveFeedbackRequest, decision string) bool {
+	if record == nil || record.Status != string(domain.DreamStatusSubmitted) || strings.TrimSpace(record.SubmittedIngestID) == "" {
+		return true
+	}
+	return strings.TrimSpace(record.SubmittedIngestIdempotencyKey) != "" &&
+		strings.TrimSpace(record.SubmittedIngestIdempotencyKey) == dreamFeedbackIdempotency(req, record.HypothesisID, decision) &&
+		strings.TrimSpace(record.SubmittedDecision) == decision
+}
+
+func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decision string) string {
+	if value := strings.TrimSpace(req.IdempotencyKey); value != "" {
+		return value
+	}
+	return "dream-feedback:" + dreamID + ":" + decision
+}

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -251,7 +251,6 @@ func dreamSubmissionEvidenceWithStatus(
 		item.Metadata["hypothesis_id"] = record.HypothesisID
 		if legacy {
 			item.Metadata["hypothesis_status_before"] = strings.TrimSpace(statusBefore)
-			delete(item.Metadata, "dream_feedback_reason")
 		} else if feedback := strings.TrimSpace(req.Feedback); feedback != "" {
 			item.Metadata["dream_feedback_reason"] = feedback
 		} else {

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -31,9 +31,9 @@ func (s *service) resolveConfirmationWithLock(
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
 	var result *ResolveFeedbackResult
-	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func() error {
+	err := s.deps.Store.WithHypothesisConfirmationLock(ctx, teamID, dreamID, func(store repository.DreamRepository) error {
 		var err error
-		result, err = s.resolveConfirmation(ctx, teamID, actorProfileID, dreamID, decision, req)
+		result, err = s.resolveConfirmation(ctx, store, teamID, actorProfileID, dreamID, decision, req)
 		return err
 	})
 	return result, err
@@ -41,13 +41,14 @@ func (s *service) resolveConfirmationWithLock(
 
 func (s *service) resolveConfirmation(
 	ctx context.Context,
+	store repository.DreamRepository,
 	teamID string,
 	actorProfileID string,
 	dreamID string,
 	decision string,
 	req ResolveFeedbackRequest,
 ) (*ResolveFeedbackResult, error) {
-	record, err := s.deps.Store.GetHypothesis(ctx, repository.GetHypothesisInput{
+	record, err := store.GetHypothesis(ctx, repository.GetHypothesisInput{
 		TeamID:       teamID,
 		HypothesisID: dreamID,
 	})
@@ -103,7 +104,7 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
-	updated, err := s.deps.Store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
+	updated, err := store.SubmitHypothesis(ctx, repository.SubmitHypothesisInput{
 		TeamID:            teamID,
 		ActorProfileID:    actorProfileID,
 		HypothesisID:      dreamID,

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -189,7 +189,6 @@ func (s *service) resolveConfirmation(
 		return nil, err
 	}
 	if !completed {
-		applyDreamTerminalRetryGuidance(remember, record.HypothesisID, decision)
 		s.recordDreamFeedback(ctx, decision, dream, "error")
 		return &ResolveFeedbackResult{Dream: dream, Memory: remember}, nil
 	}
@@ -336,23 +335,6 @@ func dreamReplayRememberResult(record *repository.HypothesisRecord) *rememberapp
 		ProcessingState: string(domain.PlacementRunQueued),
 		StatusTool:      "get_submission_status",
 		Kind:            rememberapp.ResultKindLegacyReceipt,
-	}
-}
-
-func applyDreamTerminalRetryGuidance(result *rememberapp.RememberResult, dreamID, decision string) {
-	if result == nil || result.Terminal == nil {
-		return
-	}
-	retryKey := fmt.Sprintf("dream-feedback:%s:%s:retry:%s", dreamID, decision, result.Terminal.SubmissionID)
-	if len([]rune(retryKey)) > 128 {
-		retryKey = "dream-feedback:" + dreamID + ":" + decision + ":retry"
-	}
-	for index := range result.Terminal.Errors {
-		if result.Terminal.Errors[index].NextAction != string(rememberapp.TerminalNextActionResubmitRemember) {
-			continue
-		}
-		result.Terminal.Errors[index].NextAction = string(rememberapp.TerminalNextActionRetryDreamFeedback)
-		result.Terminal.Errors[index].Remediation = rememberapp.DreamFeedbackRetryRemediation(retryKey)
 	}
 }
 

--- a/internal/service/dreamservice/workflow_confirmation.go
+++ b/internal/service/dreamservice/workflow_confirmation.go
@@ -159,11 +159,16 @@ func (s *service) resolveConfirmation(
 		s.recordDreamFeedback(ctx, decision, dream, "ok")
 		return &ResolveFeedbackResult{Dream: dream, Memory: dreamReplayRememberResult(record)}, nil
 	}
+	idempotencyKey, err := s.confirmationIdempotencyKey(ctx, teamID, actorProfileID, req, record, decision)
+	if err != nil {
+		s.recordDreamFeedback(ctx, decision, dream, "error")
+		return nil, err
+	}
 	rememberRequest := rememberapp.RememberRequest{
 		Evidence:          evidence,
 		EntityHints:       req.EntityHints,
 		RelationshipHints: req.RelationshipHints,
-		IdempotencyKey:    dreamFeedbackIdempotency(req, record.HypothesisID, decision),
+		IdempotencyKey:    idempotencyKey,
 	}
 	remember, err := s.deps.Remember.Remember(ctx, rememberRequest)
 	if ctx.Err() == nil && dreamLegacyReplayConflict(err) {
@@ -426,5 +431,44 @@ func dreamFeedbackIdempotency(req ResolveFeedbackRequest, dreamID string, decisi
 	if value := strings.TrimSpace(req.IdempotencyKey); value != "" {
 		return value
 	}
-	return "dream-feedback:" + dreamID + ":" + decision
+	return dreamDefaultFeedbackIdempotency(dreamID, decision)
+}
+
+func dreamDefaultFeedbackIdempotency(dreamID, decision string) string {
+	return "dream-feedback:" + strings.TrimSpace(dreamID) + ":" + strings.TrimSpace(decision)
+}
+
+func (s *service) confirmationIdempotencyKey(
+	ctx context.Context,
+	teamID string,
+	actorProfileID string,
+	req ResolveFeedbackRequest,
+	record *repository.HypothesisRecord,
+	decision string,
+) (string, error) {
+	if record == nil {
+		return "", errors.New("resolve dream feedback: hypothesis record is required")
+	}
+	canonicalKey := dreamFeedbackIdempotency(req, record.HypothesisID, decision)
+	if strings.TrimSpace(req.IdempotencyKey) != "" ||
+		record.Status == string(domain.DreamStatusSubmitted) ||
+		s.deps.RememberIngests == nil {
+		return canonicalKey, nil
+	}
+	requestedID := strings.TrimSpace(req.DreamID)
+	canonicalID := strings.TrimSpace(record.HypothesisID)
+	if requestedID == "" || canonicalID == "" || requestedID == canonicalID {
+		return canonicalKey, nil
+	}
+	legacyKey := dreamDefaultFeedbackIdempotency(requestedID, decision)
+	exists, err := s.deps.RememberIngests.RememberIngestExists(ctx, repository.RememberIngestLookupInput{
+		TeamID: teamID, OwnerProfileID: actorProfileID, IdempotencyKey: legacyKey,
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve dream feedback: legacy Remember lookup: %w", err)
+	}
+	if exists {
+		return legacyKey, nil
+	}
+	return canonicalKey, nil
 }

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -163,6 +163,43 @@ func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {
 	require.Equal(t, remember.requests[0].Evidence, remember.requests[1].Evidence)
 }
 
+func TestResolveFeedbackReplaysPreUpgradeSubmittedRememberWithoutCallingRemember(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	ingestID := uuid.NewString()
+	record := repository.HypothesisRecord{
+		TeamID:                        teamID.String(),
+		HypothesisID:                  hypothesisID,
+		CreatedByProfileID:            ownerID.String(),
+		Status:                        string(domain.DreamStatusSubmitted),
+		Statement:                     "Dense-Mem may use PostgreSQL.",
+		InvalidatedReason:             "legacy confirmation reason",
+		SubmittedIngestID:             ingestID,
+		SubmittedIngestIdempotencyKey: "legacy-dream-replay",
+		SubmittedDecision:             "confirm_true",
+	}
+	request := ResolveFeedbackRequest{
+		DreamID: hypothesisID, Decision: "confirm_true", Feedback: record.InvalidatedReason,
+		IdempotencyKey: record.SubmittedIngestIdempotencyKey,
+		Evidence:       []rememberapp.RememberEvidenceInput{{Content: "Independent legacy deployment evidence."}},
+	}
+	legacyEvidence, err := dreamSubmissionEvidenceWithStatus(request, &record, string(domain.DreamStatusProposed), true)
+	require.NoError(t, err)
+	record.SubmittedIngestRequestHash, err = rememberapp.CanonicalRequestBodyHash(legacyEvidence, request.EntityHints, request.RelationshipHints)
+	require.NoError(t, err)
+	repo := &dreamRepositoryStub{getRecord: record}
+	remember := &rememberServiceStub{err: errors.New("legacy replay must not call Remember")}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
+	require.NoError(t, err)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Empty(t, remember.requests)
+	require.Empty(t, repo.submitInput)
+}
+
 func TestResolveFeedbackRejectsConflictingSubmittedConfirmationBeforeRemember(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()
@@ -189,6 +226,33 @@ func TestResolveFeedbackRejectsConflictingSubmittedConfirmationBeforeRemember(t 
 	require.ErrorIs(t, err, ErrDreamNotFound)
 	require.Empty(t, remember.requests)
 	require.Empty(t, repo.submitInput)
+}
+
+func TestResolveFeedbackAddsDreamRetryIdentityToTerminalResubmission(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	attemptID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID:             teamID.String(),
+		HypothesisID:       hypothesisID,
+		CreatedByProfileID: ownerID.String(),
+		Status:             string(domain.DreamStatusProposed),
+		Statement:          "Dense-Mem may use PostgreSQL.",
+	}}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingRejected), attemptID)}
+	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory)}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID: hypothesisID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent refuting evidence."}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Memory)
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "resolve_dream_feedback")
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "idempotency_key")
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, attemptID)
 }
 
 func dreamTerminalRememberResult(state, submissionID string) *rememberapp.RememberResult {

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -216,7 +216,10 @@ func TestResolveFeedbackReplaysPreUpgradeSubmittedRememberWithoutCallingRemember
 	request := ResolveFeedbackRequest{
 		DreamID: hypothesisID, Decision: "confirm_true", Feedback: record.InvalidatedReason,
 		IdempotencyKey: record.SubmittedIngestIdempotencyKey,
-		Evidence:       []rememberapp.RememberEvidenceInput{{Content: "Independent legacy deployment evidence."}},
+		Evidence: []rememberapp.RememberEvidenceInput{{
+			Content:  "Independent legacy deployment evidence.",
+			Metadata: map[string]any{"dream_feedback_reason": "legacy metadata reason"},
+		}},
 	}
 	legacyEvidence, err := dreamSubmissionEvidenceWithStatus(request, &record, string(domain.DreamStatusProposed), true)
 	require.NoError(t, err)

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -256,6 +256,88 @@ func TestResolveFeedbackAddsDreamRetryIdentityToTerminalResubmission(t *testing.
 	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, attemptID)
 }
 
+func TestResolveFeedbackUsesCanonicalDreamIDForDefaultRetryKey(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	canonicalID := uuid.NewString()
+	aliasID := uuid.NewString()
+	ingestID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: canonicalID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+	}}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), ingestID)}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	_, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID: aliasID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+	require.NoError(t, err)
+	require.Len(t, remember.requests, 1)
+	require.Equal(t, "dream-feedback:"+canonicalID+":confirm_true", remember.requests[0].IdempotencyKey)
+
+	remember.result = dreamTerminalRememberResult(string(rememberapp.TerminalProcessingRejected), uuid.NewString())
+	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{
+		rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory),
+	}
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID: aliasID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+	require.NoError(t, err)
+	require.Len(t, remember.requests, 2)
+	require.Contains(t, remember.requests[1].IdempotencyKey, canonicalID)
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, canonicalID)
+	require.NotContains(t, result.Memory.Terminal.Errors[0].Remediation, aliasID)
+}
+
+func TestResolveFeedbackReplaysAliasWithCanonicalDefaultKey(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	canonicalID := uuid.NewString()
+	aliasID := uuid.NewString()
+	ingestID := uuid.NewString()
+	record := repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: canonicalID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusSubmitted), Statement: "Dense-Mem may use PostgreSQL.",
+		SubmittedIngestID: ingestID, SubmittedIngestIdempotencyKey: "dream-feedback:" + canonicalID + ":confirm_true",
+		SubmittedDecision: "confirm_true",
+	}
+	request := ResolveFeedbackRequest{
+		DreamID: aliasID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	}
+	evidence, err := dreamSubmissionEvidence(request, &record)
+	require.NoError(t, err)
+	record.SubmittedIngestRequestHash, err = rememberapp.CanonicalRequestBodyHash(evidence, request.EntityHints, request.RelationshipHints)
+	require.NoError(t, err)
+	repo := &dreamRepositoryStub{getRecord: record}
+	remember := &rememberServiceStub{err: errors.New("alias replay must not call Remember")}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
+	require.NoError(t, err)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Empty(t, remember.requests)
+	require.Empty(t, repo.submitInput)
+}
+
+func TestResolveFeedbackWrapsConfirmationBusyWithTypedError(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	svc := New(Dependencies{Store: &dreamRepositoryStub{confirmationLockErr: repository.ErrDreamConfirmationBusy}})
+
+	_, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID: uuid.NewString(), Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+	var busy *ConfirmationBusyError
+	require.ErrorAs(t, err, &busy)
+	require.ErrorIs(t, err, repository.ErrDreamConfirmationBusy)
+}
+
 func dreamTerminalRememberResult(state, submissionID string) *rememberapp.RememberResult {
 	terminal := &rememberapp.TerminalRememberResult{
 		ContractVersion: domain.ContractVersion,

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -1,0 +1,182 @@
+package dreamservice
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+func TestResolveFeedbackUsesExplicitRememberResultKind(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	baseRecord := repository.HypothesisRecord{
+		TeamID:             teamID.String(),
+		HypothesisID:       hypothesisID,
+		CreatedByProfileID: ownerID.String(),
+		Status:             string(domain.DreamStatusProposed),
+		Statement:          "Dense-Mem may use PostgreSQL.",
+	}
+
+	tests := []struct {
+		name         string
+		result       *rememberapp.RememberResult
+		rememberErr  error
+		processError bool
+		wantStatus   domain.DreamStatus
+		wantMemory   bool
+		wantSubmit   bool
+		wantError    string
+	}{
+		{
+			name: "legacy receipt preserves queued behavior",
+			result: func() *rememberapp.RememberResult {
+				ingestID := uuid.NewString()
+				return &rememberapp.RememberResult{
+					IngestID: ingestID, SubmissionID: ingestID,
+					ProcessingState: string(domain.PlacementRunQueued),
+					Kind:            rememberapp.ResultKindLegacyReceipt,
+				}
+			}(),
+			wantStatus: domain.DreamStatusSubmitted, wantSubmit: true,
+		},
+		{
+			name:       "terminal completed submits committed ingest",
+			result:     dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), uuid.NewString()),
+			wantStatus: domain.DreamStatusSubmitted,
+			wantSubmit: true,
+		},
+		{
+			name:       "terminal rejected stays reviewable",
+			result:     dreamTerminalRememberResult(string(rememberapp.TerminalProcessingRejected), uuid.NewString()),
+			wantStatus: domain.DreamStatusProposed, wantMemory: true,
+		},
+		{
+			name:       "terminal quarantined stays reviewable",
+			result:     dreamTerminalRememberResult(string(rememberapp.TerminalProcessingQuarantined), uuid.NewString()),
+			wantStatus: domain.DreamStatusProposed, wantMemory: true,
+		},
+		{
+			name:         "operational terminal failure stays reviewable",
+			result:       dreamTerminalRememberResult(string(rememberapp.TerminalProcessingFailed), uuid.NewString()),
+			processError: true,
+			wantStatus:   domain.DreamStatusProposed,
+			wantMemory:   true,
+		},
+		{
+			name:      "unknown kind fails closed",
+			result:    &rememberapp.RememberResult{Kind: rememberapp.ResultKind("future")},
+			wantError: "Remember result kind is required",
+		},
+		{
+			name:      "terminal result is required",
+			result:    &rememberapp.RememberResult{Kind: rememberapp.ResultKindTerminal},
+			wantError: "terminal Remember result is required",
+		},
+		{
+			name:      "completed result needs canonical ingest",
+			result:    dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), "not-a-uuid"),
+			wantError: "completed Remember result has no canonical ingest",
+		},
+		{
+			name:        "process error without terminal result propagates",
+			result:      nil,
+			rememberErr: &rememberapp.RememberProcessError{Result: nil, Err: errors.New("provider unavailable")},
+			wantError:   "remember: processor failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &dreamRepositoryStub{getRecord: baseRecord}
+			rememberErr := tc.rememberErr
+			if tc.processError {
+				rememberErr = &rememberapp.RememberProcessError{Result: tc.result.Terminal, Err: errors.New("provider unavailable")}
+			}
+			remember := &rememberServiceStub{result: tc.result, err: rememberErr}
+			svc := New(Dependencies{Store: repo, Remember: remember})
+			result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+				DreamID: hypothesisID, Decision: "confirm_true",
+				Evidence: []rememberapp.RememberEvidenceInput{{Content: "An independent deployment note."}},
+			})
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				require.Empty(t, repo.submitInput)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, result.Dream)
+			require.Equal(t, tc.wantStatus, result.Dream.Status)
+			if tc.wantMemory {
+				require.NotNil(t, result.Memory)
+			}
+			if tc.wantSubmit {
+				require.NotEmpty(t, repo.submitInput.SubmittedIngestID)
+			} else {
+				require.Empty(t, repo.submitInput)
+			}
+		})
+	}
+}
+
+func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	ingestID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: hypothesisID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+	}}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), ingestID)}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+	request := ResolveFeedbackRequest{
+		DreamID: hypothesisID, Decision: "confirm_true", IdempotencyKey: "dream-replay",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "An independent deployment note."}},
+	}
+
+	first, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
+	require.NoError(t, err)
+	// A completed confirmation changes the durable Hypothesis status. The
+	// retry payload must remain identical so Remember can replay its terminal
+	// result under the same idempotency key.
+	repo.getRecord.Status = string(domain.DreamStatusSubmitted)
+	second, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
+	require.NoError(t, err)
+	require.Equal(t, domain.DreamStatusSubmitted, first.Dream.Status)
+	require.Equal(t, domain.DreamStatusSubmitted, second.Dream.Status)
+	require.Equal(t, ingestID, first.Memory.IngestID)
+	require.Equal(t, ingestID, second.Memory.IngestID)
+	require.Len(t, remember.requests, 2)
+	require.Equal(t, request.IdempotencyKey, remember.requests[0].IdempotencyKey)
+	require.Equal(t, request.IdempotencyKey, remember.requests[1].IdempotencyKey)
+	require.Equal(t, remember.requests[0].Evidence, remember.requests[1].Evidence)
+}
+
+func dreamTerminalRememberResult(state, submissionID string) *rememberapp.RememberResult {
+	terminal := &rememberapp.TerminalRememberResult{
+		ContractVersion: domain.ContractVersion,
+		SubmissionID:    submissionID,
+		SubmissionKind:  "remember",
+		ProcessingState: state,
+		CorrelationID:   "dream-test-correlation",
+		Kind:            rememberapp.ResultKindTerminal,
+	}
+	return &rememberapp.RememberResult{
+		ContractVersion: terminal.ContractVersion,
+		IngestID:        terminal.SubmissionID,
+		SubmissionID:    terminal.SubmissionID,
+		SubmissionKind:  terminal.SubmissionKind,
+		ProcessingState: terminal.ProcessingState,
+		CorrelationID:   terminal.CorrelationID,
+		Kind:            rememberapp.ResultKindTerminal,
+		Terminal:        terminal,
+	}
+}

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -361,6 +361,38 @@ func TestResolveFeedbackReplaysAliasWithCanonicalDefaultKey(t *testing.T) {
 	require.Empty(t, repo.submitInput)
 }
 
+func TestResolveFeedbackReplaysAliasWithLegacyDefaultKey(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	canonicalID := uuid.NewString()
+	aliasID := uuid.NewString()
+	ingestID := uuid.NewString()
+	record := repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: canonicalID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusSubmitted), Statement: "Dense-Mem may use PostgreSQL.",
+		SubmittedIngestID: ingestID, SubmittedIngestIdempotencyKey: "dream-feedback:" + aliasID + ":confirm_true",
+		SubmittedDecision: "confirm_true",
+	}
+	request := ResolveFeedbackRequest{
+		DreamID: aliasID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	}
+	legacyEvidence, err := dreamSubmissionEvidenceWithStatus(request, &record, string(domain.DreamStatusProposed), true)
+	require.NoError(t, err)
+	record.SubmittedIngestRequestHash, err = rememberapp.CanonicalRequestBodyHash(legacyEvidence, request.EntityHints, request.RelationshipHints)
+	require.NoError(t, err)
+	repo := &dreamRepositoryStub{getRecord: record}
+	remember := &rememberServiceStub{err: errors.New("legacy alias replay must not call Remember")}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
+	require.NoError(t, err)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Empty(t, remember.requests)
+	require.Empty(t, repo.submitInput)
+}
+
 func TestResolveFeedbackWrapsConfirmationBusyWithTypedError(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -127,7 +127,7 @@ func TestResolveFeedbackUsesExplicitRememberResultKind(t *testing.T) {
 	}
 }
 
-func TestResolveFeedbackRetriesHypothesisFinalizationAfterCancellation(t *testing.T) {
+func TestResolveFeedbackHonorsCancellationBeforeHypothesisFinalization(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()
 	hypothesisID := uuid.NewString()
@@ -148,6 +148,46 @@ func TestResolveFeedbackRetriesHypothesisFinalizationAfterCancellation(t *testin
 	svc := New(Dependencies{Store: repo, Remember: remember})
 
 	result, err := svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  hypothesisID,
+		Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result)
+	require.Equal(t, 1, repo.submitCalls)
+
+	remember.after = nil
+	retried, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  hypothesisID,
+		Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, retried)
+	require.Equal(t, domain.DreamStatusSubmitted, retried.Dream.Status)
+	require.Equal(t, ingestID, retried.Memory.IngestID)
+	require.Equal(t, 2, repo.submitCalls)
+}
+
+func TestResolveFeedbackRetriesHypothesisFinalizationAfterTransientFailure(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	ingestID := uuid.NewString()
+	repo := &dreamRepositoryStub{
+		getRecord: repository.HypothesisRecord{
+			TeamID: teamID.String(), HypothesisID: hypothesisID, CreatedByProfileID: ownerID.String(),
+			Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+		},
+		submitErrs: []error{errors.New("temporary database failure"), nil},
+	}
+	remember := &rememberServiceStub{
+		result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), ingestID),
+	}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
 		DreamID:  hypothesisID,
 		Decision: "confirm_true",
 		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -200,6 +200,62 @@ func TestResolveFeedbackRetriesHypothesisFinalizationAfterTransientFailure(t *te
 	require.Equal(t, 2, repo.submitCalls)
 }
 
+func TestResolveFeedbackReplaysLegacyRememberForProposedHypothesis(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	ingestID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: hypothesisID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+	}}
+	remember := &sequencedRememberServiceStub{responses: []sequencedRememberResponse{
+		{err: rememberapp.ErrRememberConflict},
+		{result: &rememberapp.RememberResult{
+			IngestID: ingestID, SubmissionID: ingestID,
+			ProcessingState: string(domain.PlacementRunQueued),
+			Kind:            rememberapp.ResultKindLegacyReceipt,
+		}},
+	}}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  hypothesisID,
+		Decision: "confirm_true",
+		Feedback: "legacy feedback",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Len(t, remember.requests, 2)
+	require.NotContains(t, remember.requests[0].Evidence[0].Metadata, "hypothesis_status_before")
+	require.Equal(t, string(domain.DreamStatusProposed), remember.requests[1].Evidence[0].Metadata["hypothesis_status_before"])
+	require.Equal(t, 1, repo.submitCalls)
+}
+
+type sequencedRememberResponse struct {
+	result *rememberapp.RememberResult
+	err    error
+}
+
+type sequencedRememberServiceStub struct {
+	requests  []rememberapp.RememberRequest
+	responses []sequencedRememberResponse
+}
+
+func (s *sequencedRememberServiceStub) Remember(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
+	s.requests = append(s.requests, req)
+	if len(s.responses) == 0 {
+		return nil, errors.New("unexpected Remember call")
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response.result, response.err
+}
+
 func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -361,6 +361,34 @@ func TestResolveFeedbackRejectsConflictingSubmittedConfirmationBeforeRemember(t 
 	require.Empty(t, repo.submitInput)
 }
 
+func TestResolveFeedbackAddsDreamRetryIdentityToTerminalResubmission(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	attemptID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID:             teamID.String(),
+		HypothesisID:       hypothesisID,
+		CreatedByProfileID: ownerID.String(),
+		Status:             string(domain.DreamStatusProposed),
+		Statement:          "Dense-Mem may use PostgreSQL.",
+	}}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingRejected), attemptID)}
+	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory)}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID: hypothesisID, Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent refuting evidence."}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Memory)
+	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), result.Memory.Terminal.Errors[0].NextAction)
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "resolve_dream_feedback")
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "idempotency_key")
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, attemptID)
+}
+
 func TestResolveFeedbackUsesCanonicalDreamIDForDefaultRetryKey(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()
@@ -386,13 +414,15 @@ func TestResolveFeedbackUsesCanonicalDreamIDForDefaultRetryKey(t *testing.T) {
 	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{
 		rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory),
 	}
-	_, err = svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
 		DreamID: aliasID, Decision: "confirm_true",
 		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
 	})
 	require.NoError(t, err)
 	require.Len(t, remember.requests, 2)
 	require.Contains(t, remember.requests[1].IdempotencyKey, canonicalID)
+	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, canonicalID)
+	require.NotContains(t, result.Memory.Terminal.Errors[0].Remediation, aliasID)
 }
 
 func TestResolveFeedbackReplaysAliasWithCanonicalDefaultKey(t *testing.T) {

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -1,6 +1,7 @@
 package dreamservice
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -124,6 +125,39 @@ func TestResolveFeedbackUsesExplicitRememberResultKind(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveFeedbackRetriesHypothesisFinalizationAfterCancellation(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	ingestID := uuid.NewString()
+	ctx, cancel := context.WithCancel(dreamTestContext(teamID, ownerID))
+	defer cancel()
+	repo := &dreamRepositoryStub{
+		getRecord: repository.HypothesisRecord{
+			TeamID: teamID.String(), HypothesisID: hypothesisID, CreatedByProfileID: ownerID.String(),
+			Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+		},
+		submitErrs: []error{context.Canceled, nil},
+	}
+	remember := &rememberServiceStub{
+		result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), ingestID),
+		after:  cancel,
+	}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	result, err := svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  hypothesisID,
+		Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Equal(t, 2, repo.submitCalls)
 }
 
 func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -148,6 +148,9 @@ func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {
 	// retry payload must remain identical so Remember can replay its terminal
 	// result under the same idempotency key.
 	repo.getRecord.Status = string(domain.DreamStatusSubmitted)
+	repo.getRecord.SubmittedIngestID = ingestID
+	repo.getRecord.SubmittedIngestIdempotencyKey = request.IdempotencyKey
+	repo.getRecord.SubmittedDecision = request.Decision
 	second, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", request)
 	require.NoError(t, err)
 	require.Equal(t, domain.DreamStatusSubmitted, first.Dream.Status)
@@ -158,6 +161,34 @@ func TestResolveFeedbackReplaysCompletedRememberResult(t *testing.T) {
 	require.Equal(t, request.IdempotencyKey, remember.requests[0].IdempotencyKey)
 	require.Equal(t, request.IdempotencyKey, remember.requests[1].IdempotencyKey)
 	require.Equal(t, remember.requests[0].Evidence, remember.requests[1].Evidence)
+}
+
+func TestResolveFeedbackRejectsConflictingSubmittedConfirmationBeforeRemember(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	hypothesisID := uuid.NewString()
+	record := repository.HypothesisRecord{
+		TeamID:                        teamID.String(),
+		HypothesisID:                  hypothesisID,
+		CreatedByProfileID:            ownerID.String(),
+		Status:                        string(domain.DreamStatusSubmitted),
+		Statement:                     "Dense-Mem may use PostgreSQL.",
+		SubmittedIngestID:             uuid.NewString(),
+		SubmittedIngestIdempotencyKey: "dream-feedback:" + hypothesisID + ":confirm_true",
+		SubmittedDecision:             "confirm_true",
+	}
+	repo := &dreamRepositoryStub{getRecord: record}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), uuid.NewString())}
+	svc := New(Dependencies{Store: repo, Remember: remember})
+
+	_, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  hypothesisID,
+		Decision: "confirm_false",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent refuting evidence."}},
+	})
+	require.ErrorIs(t, err, ErrDreamNotFound)
+	require.Empty(t, remember.requests)
+	require.Empty(t, repo.submitInput)
 }
 
 func dreamTerminalRememberResult(state, submissionID string) *rememberapp.RememberResult {

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -250,6 +250,7 @@ func TestResolveFeedbackAddsDreamRetryIdentityToTerminalResubmission(t *testing.
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result.Memory)
+	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), result.Memory.Terminal.Errors[0].NextAction)
 	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "resolve_dream_feedback")
 	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "idempotency_key")
 	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, attemptID)

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -489,6 +489,70 @@ func TestResolveFeedbackReplaysAliasWithLegacyDefaultKey(t *testing.T) {
 	require.Empty(t, repo.submitInput)
 }
 
+func TestResolveFeedbackRecoversProposedAliasKeyedRememberOrphan(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	canonicalID := uuid.NewString()
+	aliasID := uuid.NewString()
+	ingestID := uuid.NewString()
+	legacyKey := "dream-feedback:" + aliasID + ":confirm_true"
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: canonicalID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+	}}
+	lookup := &rememberIngestLookupStub{existing: map[string]bool{legacyKey: true}}
+	remember := &sequencedRememberServiceStub{responses: []sequencedRememberResponse{
+		{err: rememberapp.ErrRememberConflict},
+		{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), ingestID)},
+	}}
+	svc := New(Dependencies{Store: repo, Remember: remember, RememberIngests: lookup})
+
+	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  aliasID,
+		Decision: "confirm_true",
+		Feedback: "legacy feedback",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, domain.DreamStatusSubmitted, result.Dream.Status)
+	require.Equal(t, ingestID, result.Memory.IngestID)
+	require.Len(t, lookup.calls, 1)
+	require.Equal(t, legacyKey, lookup.calls[0].IdempotencyKey)
+	require.Len(t, remember.requests, 2)
+	require.Equal(t, legacyKey, remember.requests[0].IdempotencyKey)
+	require.Equal(t, legacyKey, remember.requests[1].IdempotencyKey)
+	require.NotContains(t, remember.requests[0].Evidence[0].Metadata, "hypothesis_status_before")
+	require.Equal(t, string(domain.DreamStatusProposed), remember.requests[1].Evidence[0].Metadata["hypothesis_status_before"])
+	require.Equal(t, ingestID, repo.submitInput.SubmittedIngestID)
+}
+
+func TestResolveFeedbackFailsClosedWhenLegacyRememberLookupFails(t *testing.T) {
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	canonicalID := uuid.NewString()
+	aliasID := uuid.NewString()
+	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
+		TeamID: teamID.String(), HypothesisID: canonicalID, CreatedByProfileID: ownerID.String(),
+		Status: string(domain.DreamStatusProposed), Statement: "Dense-Mem may use PostgreSQL.",
+	}}
+	lookupErr := errors.New("lookup unavailable")
+	lookup := &rememberIngestLookupStub{err: lookupErr}
+	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingCompleted), uuid.NewString())}
+	svc := New(Dependencies{Store: repo, Remember: remember, RememberIngests: lookup})
+
+	_, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+		DreamID:  aliasID,
+		Decision: "confirm_true",
+		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
+	})
+
+	require.ErrorIs(t, err, lookupErr)
+	require.ErrorContains(t, err, "legacy Remember lookup")
+	require.Empty(t, remember.requests)
+}
+
 func TestResolveFeedbackWrapsConfirmationBusyWithTypedError(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()

--- a/internal/service/dreamservice/workflow_terminal_test.go
+++ b/internal/service/dreamservice/workflow_terminal_test.go
@@ -361,34 +361,6 @@ func TestResolveFeedbackRejectsConflictingSubmittedConfirmationBeforeRemember(t 
 	require.Empty(t, repo.submitInput)
 }
 
-func TestResolveFeedbackAddsDreamRetryIdentityToTerminalResubmission(t *testing.T) {
-	teamID := uuid.New()
-	ownerID := uuid.New()
-	hypothesisID := uuid.NewString()
-	attemptID := uuid.NewString()
-	repo := &dreamRepositoryStub{getRecord: repository.HypothesisRecord{
-		TeamID:             teamID.String(),
-		HypothesisID:       hypothesisID,
-		CreatedByProfileID: ownerID.String(),
-		Status:             string(domain.DreamStatusProposed),
-		Statement:          "Dense-Mem may use PostgreSQL.",
-	}}
-	remember := &rememberServiceStub{result: dreamTerminalRememberResult(string(rememberapp.TerminalProcessingRejected), attemptID)}
-	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory)}
-	svc := New(Dependencies{Store: repo, Remember: remember})
-
-	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
-		DreamID: hypothesisID, Decision: "confirm_true",
-		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent refuting evidence."}},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result.Memory)
-	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), result.Memory.Terminal.Errors[0].NextAction)
-	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "resolve_dream_feedback")
-	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, "idempotency_key")
-	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, attemptID)
-}
-
 func TestResolveFeedbackUsesCanonicalDreamIDForDefaultRetryKey(t *testing.T) {
 	teamID := uuid.New()
 	ownerID := uuid.New()
@@ -414,15 +386,13 @@ func TestResolveFeedbackUsesCanonicalDreamIDForDefaultRetryKey(t *testing.T) {
 	remember.result.Terminal.Errors = []rememberapp.SubmissionStatusError{
 		rememberapp.TerminalStatusError(rememberapp.TerminalErrorNoSupportedMemory),
 	}
-	result, err := svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
+	_, err = svc.ResolveFeedback(dreamTestContext(teamID, ownerID), "ignored-profile", ResolveFeedbackRequest{
 		DreamID: aliasID, Decision: "confirm_true",
 		Evidence: []rememberapp.RememberEvidenceInput{{Content: "Independent deployment evidence."}},
 	})
 	require.NoError(t, err)
 	require.Len(t, remember.requests, 2)
 	require.Contains(t, remember.requests[1].IdempotencyKey, canonicalID)
-	require.Contains(t, result.Memory.Terminal.Errors[0].Remediation, canonicalID)
-	require.NotContains(t, result.Memory.Terminal.Errors[0].Remediation, aliasID)
 }
 
 func TestResolveFeedbackReplaysAliasWithCanonicalDefaultKey(t *testing.T) {

--- a/internal/service/dreamservice/workflow_test.go
+++ b/internal/service/dreamservice/workflow_test.go
@@ -647,6 +647,11 @@ func TestResolveFeedbackLifecycleDecisions(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			if isDreamConfirmationDecision(tc.req.Decision) || isDreamLifecycleDecision(tc.req.Decision) {
+				assert.Equal(t, 1, repo.confirmationLockCalls)
+			} else {
+				assert.Zero(t, repo.confirmationLockCalls)
+			}
 			require.NotNil(t, res.Dream)
 			assert.Equal(t, tc.wantStatus, res.Dream.Status)
 			if tc.wantMemory {
@@ -815,6 +820,17 @@ func TestResolveFeedbackErrorBranches(t *testing.T) {
 	})
 	_, err := svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{DreamID: hypothesisID, Decision: "reject"})
 	require.ErrorIs(t, err, ErrDreamNotFound)
+
+	svc = New(Dependencies{
+		Store: &dreamRepositoryStub{
+			getRecord:           record,
+			confirmationLockErr: repository.ErrDreamConfirmationBusy,
+		},
+		AppConfig: cycleAppConfigStub{cfg: domain.DreamingRuntimeConfig{Enabled: true}},
+	})
+	_, err = svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{DreamID: hypothesisID, Decision: "reject"})
+	var busyErr *ConfirmationBusyError
+	require.ErrorAs(t, err, &busyErr)
 
 	svc = New(Dependencies{
 		Store:     &dreamRepositoryStub{getRecord: record},

--- a/internal/service/dreamservice/workflow_test.go
+++ b/internal/service/dreamservice/workflow_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
 func TestRunCycleDoesNotTurnOneCandidateIntoAHeuristicDream(t *testing.T) {
@@ -485,9 +485,11 @@ func TestResolveFeedbackSubmitsIndependentEvidence(t *testing.T) {
 			UpdatedAt:          time.Now().UTC(),
 		},
 	}
-	remember := &rememberServiceStub{result: &memoryservice.RememberResult{
+	remember := &rememberServiceStub{result: &rememberapp.RememberResult{
 		IngestID:        ingestID,
+		SubmissionID:    ingestID,
 		ProcessingState: string(domain.PlacementRunQueued),
+		Kind:            rememberapp.ResultKindLegacyReceipt,
 	}}
 	svc := New(Dependencies{
 		Store:     repo,
@@ -505,7 +507,7 @@ func TestResolveFeedbackSubmitsIndependentEvidence(t *testing.T) {
 	_, err = svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{
 		DreamID:  hypothesisID,
 		Decision: "confirm_true",
-		Evidence: []memoryservice.RememberEvidenceInput{{
+		Evidence: []rememberapp.RememberEvidenceInput{{
 			Content: "Dense-Mem may use PostgreSQL.",
 		}},
 	})
@@ -541,7 +543,7 @@ func TestResolveFeedbackSubmitsIndependentEvidence(t *testing.T) {
 		DreamID:  hypothesisID,
 		Decision: "confirm_true",
 		Feedback: "User confirmed this with a deployment note.",
-		Evidence: []memoryservice.RememberEvidenceInput{{
+		Evidence: []rememberapp.RememberEvidenceInput{{
 			Content: evidenceContent,
 		}},
 		RelationshipHints: []map[string]any{relationshipHint},
@@ -610,7 +612,7 @@ func TestResolveFeedbackLifecycleDecisions(t *testing.T) {
 			req: ResolveFeedbackRequest{
 				DreamID:  hypothesisID,
 				Decision: "confirm_false",
-				Evidence: []memoryservice.RememberEvidenceInput{{
+				Evidence: []rememberapp.RememberEvidenceInput{{
 					Content: "The deployment note says Dense-Mem does not use PostgreSQL.",
 				}},
 			},
@@ -627,9 +629,12 @@ func TestResolveFeedbackLifecycleDecisions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &dreamRepositoryStub{getRecord: baseRecord}
-			remember := &rememberServiceStub{result: &memoryservice.RememberResult{
-				IngestID:        uuid.NewString(),
+			ingestID := uuid.NewString()
+			remember := &rememberServiceStub{result: &rememberapp.RememberResult{
+				IngestID:        ingestID,
+				SubmissionID:    ingestID,
 				ProcessingState: string(domain.PlacementRunQueued),
+				Kind:            rememberapp.ResultKindLegacyReceipt,
 			}}
 			svc := New(Dependencies{
 				Store:     repo,
@@ -818,7 +823,7 @@ func TestResolveFeedbackErrorBranches(t *testing.T) {
 	_, err = svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{
 		DreamID:  hypothesisID,
 		Decision: "confirm_true",
-		Evidence: []memoryservice.RememberEvidenceInput{{
+		Evidence: []rememberapp.RememberEvidenceInput{{
 			Content: "The deployment note says Dense-Mem uses PostgreSQL.",
 		}},
 	})
@@ -842,7 +847,7 @@ func TestResolveFeedbackErrorBranches(t *testing.T) {
 	_, err = svc.ResolveFeedback(ctx, "ignored-profile", ResolveFeedbackRequest{
 		DreamID:  hypothesisID,
 		Decision: "confirm_false",
-		Evidence: []memoryservice.RememberEvidenceInput{{
+		Evidence: []rememberapp.RememberEvidenceInput{{
 			Content: "The deployment note says Dense-Mem does not use PostgreSQL.",
 		}},
 	})

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -24,35 +24,36 @@ func dreamTestContext(teamID uuid.UUID, ownerID uuid.UUID) context.Context {
 }
 
 type dreamRepositoryStub struct {
-	confirmationLock sync.Mutex
-	inputs           []repository.DreamInput
-	predicates       []repository.DreamTargetPredicate
-	unassessedPaths  []repository.DreamPathEvaluationInput
-	pathEvaluations  repository.DreamPathEvaluationRecordInput
-	run              repository.DreamCycleRun
-	getRecord        repository.HypothesisRecord
-	listRecords      []repository.HypothesisRecord
-	recallRecords    []repository.HypothesisRecord
-	listInput        repository.DreamInputListInput
-	claimInput       repository.DreamCycleClaimInput
-	completeInput    repository.DreamCycleCompleteInput
-	missedInput      repository.DreamCycleClaimInput
-	upserts          []repository.UpsertHypothesisInput
-	submitInput      repository.SubmitHypothesisInput
-	updateInput      repository.UpdateHypothesisStatusInput
-	err              error
-	claimErr         error
-	completeErr      error
-	listInputsErr    error
-	targetsErr       error
-	pathAssessErr    error
-	upsertErr        error
-	listErr          error
-	getErr           error
-	recallErr        error
-	updateErr        error
-	submitErr        error
-	latestErr        error
+	confirmationLock    sync.Mutex
+	inputs              []repository.DreamInput
+	predicates          []repository.DreamTargetPredicate
+	unassessedPaths     []repository.DreamPathEvaluationInput
+	pathEvaluations     repository.DreamPathEvaluationRecordInput
+	run                 repository.DreamCycleRun
+	getRecord           repository.HypothesisRecord
+	listRecords         []repository.HypothesisRecord
+	recallRecords       []repository.HypothesisRecord
+	listInput           repository.DreamInputListInput
+	claimInput          repository.DreamCycleClaimInput
+	completeInput       repository.DreamCycleCompleteInput
+	missedInput         repository.DreamCycleClaimInput
+	upserts             []repository.UpsertHypothesisInput
+	submitInput         repository.SubmitHypothesisInput
+	updateInput         repository.UpdateHypothesisStatusInput
+	err                 error
+	claimErr            error
+	completeErr         error
+	listInputsErr       error
+	targetsErr          error
+	pathAssessErr       error
+	upsertErr           error
+	listErr             error
+	getErr              error
+	recallErr           error
+	updateErr           error
+	submitErr           error
+	latestErr           error
+	confirmationLockErr error
 }
 
 func (s *dreamRepositoryStub) ClaimDreamCycle(_ context.Context, input repository.DreamCycleClaimInput) (*repository.DreamCycleRun, error) {
@@ -208,6 +209,9 @@ func (s *dreamRepositoryStub) GetHypothesis(context.Context, repository.GetHypot
 }
 
 func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func(repository.DreamRepository) error) error {
+	if s.confirmationLockErr != nil {
+		return s.confirmationLockErr
+	}
 	s.confirmationLock.Lock()
 	defer s.confirmationLock.Unlock()
 	return fn(s)

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -207,10 +207,10 @@ func (s *dreamRepositoryStub) GetHypothesis(context.Context, repository.GetHypot
 	return &record, nil
 }
 
-func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func(repository.DreamRepository) error) error {
+func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func() error) error {
 	s.confirmationLock.Lock()
 	defer s.confirmationLock.Unlock()
-	return fn(s)
+	return fn()
 }
 
 func (s *dreamRepositoryStub) RecallHypotheses(context.Context, repository.RecallHypothesesInput) ([]repository.HypothesisRecord, error) {

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -207,10 +207,10 @@ func (s *dreamRepositoryStub) GetHypothesis(context.Context, repository.GetHypot
 	return &record, nil
 }
 
-func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func() error) error {
+func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func(repository.DreamRepository) error) error {
 	s.confirmationLock.Lock()
 	defer s.confirmationLock.Unlock()
-	return fn()
+	return fn(s)
 }
 
 func (s *dreamRepositoryStub) RecallHypotheses(context.Context, repository.RecallHypothesesInput) ([]repository.HypothesisRecord, error) {

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -3,6 +3,7 @@ package dreamservice
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,34 +24,35 @@ func dreamTestContext(teamID uuid.UUID, ownerID uuid.UUID) context.Context {
 }
 
 type dreamRepositoryStub struct {
-	inputs          []repository.DreamInput
-	predicates      []repository.DreamTargetPredicate
-	unassessedPaths []repository.DreamPathEvaluationInput
-	pathEvaluations repository.DreamPathEvaluationRecordInput
-	run             repository.DreamCycleRun
-	getRecord       repository.HypothesisRecord
-	listRecords     []repository.HypothesisRecord
-	recallRecords   []repository.HypothesisRecord
-	listInput       repository.DreamInputListInput
-	claimInput      repository.DreamCycleClaimInput
-	completeInput   repository.DreamCycleCompleteInput
-	missedInput     repository.DreamCycleClaimInput
-	upserts         []repository.UpsertHypothesisInput
-	submitInput     repository.SubmitHypothesisInput
-	updateInput     repository.UpdateHypothesisStatusInput
-	err             error
-	claimErr        error
-	completeErr     error
-	listInputsErr   error
-	targetsErr      error
-	pathAssessErr   error
-	upsertErr       error
-	listErr         error
-	getErr          error
-	recallErr       error
-	updateErr       error
-	submitErr       error
-	latestErr       error
+	confirmationLock sync.Mutex
+	inputs           []repository.DreamInput
+	predicates       []repository.DreamTargetPredicate
+	unassessedPaths  []repository.DreamPathEvaluationInput
+	pathEvaluations  repository.DreamPathEvaluationRecordInput
+	run              repository.DreamCycleRun
+	getRecord        repository.HypothesisRecord
+	listRecords      []repository.HypothesisRecord
+	recallRecords    []repository.HypothesisRecord
+	listInput        repository.DreamInputListInput
+	claimInput       repository.DreamCycleClaimInput
+	completeInput    repository.DreamCycleCompleteInput
+	missedInput      repository.DreamCycleClaimInput
+	upserts          []repository.UpsertHypothesisInput
+	submitInput      repository.SubmitHypothesisInput
+	updateInput      repository.UpdateHypothesisStatusInput
+	err              error
+	claimErr         error
+	completeErr      error
+	listInputsErr    error
+	targetsErr       error
+	pathAssessErr    error
+	upsertErr        error
+	listErr          error
+	getErr           error
+	recallErr        error
+	updateErr        error
+	submitErr        error
+	latestErr        error
 }
 
 func (s *dreamRepositoryStub) ClaimDreamCycle(_ context.Context, input repository.DreamCycleClaimInput) (*repository.DreamCycleRun, error) {
@@ -203,6 +205,12 @@ func (s *dreamRepositoryStub) GetHypothesis(context.Context, repository.GetHypot
 	}
 	record := s.getRecord
 	return &record, nil
+}
+
+func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func() error) error {
+	s.confirmationLock.Lock()
+	defer s.confirmationLock.Unlock()
+	return fn()
 }
 
 func (s *dreamRepositoryStub) RecallHypotheses(context.Context, repository.RecallHypothesesInput) ([]repository.HypothesisRecord, error) {

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -54,6 +54,8 @@ type dreamRepositoryStub struct {
 	submitErr           error
 	latestErr           error
 	confirmationLockErr error
+
+	confirmationLockCalls int
 }
 
 func (s *dreamRepositoryStub) ClaimDreamCycle(_ context.Context, input repository.DreamCycleClaimInput) (*repository.DreamCycleRun, error) {
@@ -209,6 +211,7 @@ func (s *dreamRepositoryStub) GetHypothesis(context.Context, repository.GetHypot
 }
 
 func (s *dreamRepositoryStub) WithHypothesisConfirmationLock(_ context.Context, _, _ string, fn func(repository.DreamRepository) error) error {
+	s.confirmationLockCalls++
 	if s.confirmationLockErr != nil {
 		return s.confirmationLockErr
 	}

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -60,6 +60,20 @@ type dreamRepositoryStub struct {
 	confirmationLockCalls int
 }
 
+type rememberIngestLookupStub struct {
+	existing map[string]bool
+	err      error
+	calls    []repository.RememberIngestLookupInput
+}
+
+func (s *rememberIngestLookupStub) RememberIngestExists(_ context.Context, input repository.RememberIngestLookupInput) (bool, error) {
+	s.calls = append(s.calls, input)
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.existing[input.IdempotencyKey], nil
+}
+
 func (s *dreamRepositoryStub) ClaimDreamCycle(_ context.Context, input repository.DreamCycleClaimInput) (*repository.DreamCycleRun, error) {
 	s.claimInput = input
 	if s.claimErr != nil {

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -52,6 +52,8 @@ type dreamRepositoryStub struct {
 	recallErr           error
 	updateErr           error
 	submitErr           error
+	submitErrs          []error
+	submitCalls         int
 	latestErr           error
 	confirmationLockErr error
 
@@ -252,6 +254,14 @@ func (s *dreamRepositoryStub) UpdateHypothesisStatus(_ context.Context, input re
 
 func (s *dreamRepositoryStub) SubmitHypothesis(_ context.Context, input repository.SubmitHypothesisInput) (*repository.HypothesisRecord, error) {
 	s.submitInput = input
+	s.submitCalls++
+	if len(s.submitErrs) > 0 {
+		err := s.submitErrs[0]
+		s.submitErrs = s.submitErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	if s.submitErr != nil {
 		return nil, s.submitErr
 	}
@@ -328,10 +338,14 @@ type rememberServiceStub struct {
 	requests []rememberapp.RememberRequest
 	result   *rememberapp.RememberResult
 	err      error
+	after    func()
 }
 
 func (s *rememberServiceStub) Remember(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
 	s.requests = append(s.requests, req)
+	if s.after != nil {
+		s.after()
+	}
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/internal/service/dreamservice/workflow_test_helpers_test.go
+++ b/internal/service/dreamservice/workflow_test_helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
 func dreamTestContext(teamID uuid.UUID, ownerID uuid.UUID) context.Context {
@@ -310,12 +310,12 @@ func (s *dreamRepositoryStub) RecordMissedScheduledDreamCycle(_ context.Context,
 }
 
 type rememberServiceStub struct {
-	requests []memoryservice.RememberRequest
-	result   *memoryservice.RememberResult
+	requests []rememberapp.RememberRequest
+	result   *rememberapp.RememberResult
 	err      error
 }
 
-func (s *rememberServiceStub) Remember(_ context.Context, req memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
+func (s *rememberServiceStub) Remember(_ context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
 	s.requests = append(s.requests, req)
 	if s.err != nil {
 		return nil, s.err
@@ -323,8 +323,11 @@ func (s *rememberServiceStub) Remember(_ context.Context, req memoryservice.Reme
 	if s.result != nil {
 		return s.result, nil
 	}
-	return &memoryservice.RememberResult{
-		IngestID:        uuid.NewString(),
+	ingestID := uuid.NewString()
+	return &rememberapp.RememberResult{
+		IngestID:        ingestID,
+		SubmissionID:    ingestID,
 		ProcessingState: string(domain.PlacementRunQueued),
+		Kind:            rememberapp.ResultKindLegacyReceipt,
 	}, nil
 }

--- a/internal/service/remember/synchronous_contract.go
+++ b/internal/service/remember/synchronous_contract.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -159,7 +158,6 @@ const (
 	maxTerminalRelationshipSplits = 50
 	maxTerminalSupersededEvidence = 50
 	maxTerminalCorrelationIDRunes = 128
-	maxTerminalRemediationRunes   = 512
 )
 
 func TerminalErrorCodes() []string {
@@ -173,18 +171,16 @@ func TerminalErrorCodes() []string {
 type TerminalNextAction string
 
 const (
-	TerminalNextActionRetrySameRequest   TerminalNextAction = "retry_same_request"
-	TerminalNextActionResubmitRemember   TerminalNextAction = "resubmit_remember"
-	TerminalNextActionRetryDreamFeedback TerminalNextAction = "retry_dream_feedback"
-	TerminalNextActionRetryCorrection    TerminalNextAction = "retry_correction"
-	TerminalNextActionContactOperator    TerminalNextAction = "contact_operator"
-	TerminalNextActionNone               TerminalNextAction = "none"
+	TerminalNextActionRetrySameRequest TerminalNextAction = "retry_same_request"
+	TerminalNextActionResubmitRemember TerminalNextAction = "resubmit_remember"
+	TerminalNextActionRetryCorrection  TerminalNextAction = "retry_correction"
+	TerminalNextActionContactOperator  TerminalNextAction = "contact_operator"
+	TerminalNextActionNone             TerminalNextAction = "none"
 )
 
 var terminalNextActions = []TerminalNextAction{
 	TerminalNextActionRetrySameRequest,
 	TerminalNextActionResubmitRemember,
-	TerminalNextActionRetryDreamFeedback,
 	TerminalNextActionRetryCorrection,
 	TerminalNextActionContactOperator,
 	TerminalNextActionNone,
@@ -247,41 +243,17 @@ func ValidateTerminalStatusError(value SubmissionStatusError) error {
 		return fmt.Errorf("remember: terminal next action %q is not allowed", value.NextAction)
 	}
 	retryable, action := terminalErrorGuidance(code)
-	if value.NextAction == string(TerminalNextActionRetryDreamFeedback) {
-		if !retryable || action != TerminalNextActionResubmitRemember || !value.Retryable ||
-			!validDreamFeedbackRetryRemediation(value.Remediation) {
-			return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
-		}
-	} else if value.Retryable != retryable || value.NextAction != string(action) {
+	if value.Retryable != retryable || value.NextAction != string(action) {
 		return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
 	}
 	canonical := TerminalStatusError(code)
 	if value.Message != canonical.Message {
 		return fmt.Errorf("remember: terminal error message for %q is not canonical", code)
 	}
-	if value.NextAction != string(TerminalNextActionRetryDreamFeedback) && value.Remediation != canonical.Remediation {
+	if value.Remediation != canonical.Remediation {
 		return fmt.Errorf("remember: terminal error remediation for %q is not canonical", code)
 	}
 	return nil
-}
-
-const terminalDreamFeedbackRetryRemediationPrefix = "Retry resolve_dream_feedback with corrected evidence and idempotency_key "
-
-func DreamFeedbackRetryRemediation(idempotencyKey string) string {
-	return fmt.Sprintf("%s%q.", terminalDreamFeedbackRetryRemediationPrefix, idempotencyKey)
-}
-
-func validDreamFeedbackRetryRemediation(value string) bool {
-	if utf8.RuneCountInString(value) > maxTerminalRemediationRunes ||
-		!strings.HasPrefix(value, terminalDreamFeedbackRetryRemediationPrefix) ||
-		!strings.HasSuffix(value, ".") {
-		return false
-	}
-	quotedKey := strings.TrimSuffix(strings.TrimPrefix(value, terminalDreamFeedbackRetryRemediationPrefix), ".")
-	key, err := strconv.Unquote(quotedKey)
-	return err == nil && strings.TrimSpace(key) != "" &&
-		utf8.RuneCountInString(key) <= maxTerminalCorrelationIDRunes &&
-		DreamFeedbackRetryRemediation(key) == value
 }
 
 func terminalErrorGuidance(code TerminalErrorCode) (bool, TerminalNextAction) {

--- a/internal/service/remember/synchronous_contract.go
+++ b/internal/service/remember/synchronous_contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -158,6 +159,7 @@ const (
 	maxTerminalRelationshipSplits = 50
 	maxTerminalSupersededEvidence = 50
 	maxTerminalCorrelationIDRunes = 128
+	maxTerminalRemediationRunes   = 512
 )
 
 func TerminalErrorCodes() []string {
@@ -247,7 +249,7 @@ func ValidateTerminalStatusError(value SubmissionStatusError) error {
 	retryable, action := terminalErrorGuidance(code)
 	if value.NextAction == string(TerminalNextActionRetryDreamFeedback) {
 		if !retryable || action != TerminalNextActionResubmitRemember || !value.Retryable ||
-			!strings.HasPrefix(value.Remediation, terminalDreamFeedbackRetryRemediationPrefix) {
+			!validDreamFeedbackRetryRemediation(value.Remediation) {
 			return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
 		}
 	} else if value.Retryable != retryable || value.NextAction != string(action) {
@@ -267,6 +269,19 @@ const terminalDreamFeedbackRetryRemediationPrefix = "Retry resolve_dream_feedbac
 
 func DreamFeedbackRetryRemediation(idempotencyKey string) string {
 	return fmt.Sprintf("%s%q.", terminalDreamFeedbackRetryRemediationPrefix, idempotencyKey)
+}
+
+func validDreamFeedbackRetryRemediation(value string) bool {
+	if utf8.RuneCountInString(value) > maxTerminalRemediationRunes ||
+		!strings.HasPrefix(value, terminalDreamFeedbackRetryRemediationPrefix) ||
+		!strings.HasSuffix(value, ".") {
+		return false
+	}
+	quotedKey := strings.TrimSuffix(strings.TrimPrefix(value, terminalDreamFeedbackRetryRemediationPrefix), ".")
+	key, err := strconv.Unquote(quotedKey)
+	return err == nil && strings.TrimSpace(key) != "" &&
+		utf8.RuneCountInString(key) <= maxTerminalCorrelationIDRunes &&
+		DreamFeedbackRetryRemediation(key) == value
 }
 
 func terminalErrorGuidance(code TerminalErrorCode) (bool, TerminalNextAction) {

--- a/internal/service/remember/synchronous_contract.go
+++ b/internal/service/remember/synchronous_contract.go
@@ -171,16 +171,18 @@ func TerminalErrorCodes() []string {
 type TerminalNextAction string
 
 const (
-	TerminalNextActionRetrySameRequest TerminalNextAction = "retry_same_request"
-	TerminalNextActionResubmitRemember TerminalNextAction = "resubmit_remember"
-	TerminalNextActionRetryCorrection  TerminalNextAction = "retry_correction"
-	TerminalNextActionContactOperator  TerminalNextAction = "contact_operator"
-	TerminalNextActionNone             TerminalNextAction = "none"
+	TerminalNextActionRetrySameRequest   TerminalNextAction = "retry_same_request"
+	TerminalNextActionResubmitRemember   TerminalNextAction = "resubmit_remember"
+	TerminalNextActionRetryDreamFeedback TerminalNextAction = "retry_dream_feedback"
+	TerminalNextActionRetryCorrection    TerminalNextAction = "retry_correction"
+	TerminalNextActionContactOperator    TerminalNextAction = "contact_operator"
+	TerminalNextActionNone               TerminalNextAction = "none"
 )
 
 var terminalNextActions = []TerminalNextAction{
 	TerminalNextActionRetrySameRequest,
 	TerminalNextActionResubmitRemember,
+	TerminalNextActionRetryDreamFeedback,
 	TerminalNextActionRetryCorrection,
 	TerminalNextActionContactOperator,
 	TerminalNextActionNone,
@@ -243,17 +245,28 @@ func ValidateTerminalStatusError(value SubmissionStatusError) error {
 		return fmt.Errorf("remember: terminal next action %q is not allowed", value.NextAction)
 	}
 	retryable, action := terminalErrorGuidance(code)
-	if value.Retryable != retryable || value.NextAction != string(action) {
+	if value.NextAction == string(TerminalNextActionRetryDreamFeedback) {
+		if !retryable || action != TerminalNextActionResubmitRemember || !value.Retryable ||
+			!strings.HasPrefix(value.Remediation, terminalDreamFeedbackRetryRemediationPrefix) {
+			return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
+		}
+	} else if value.Retryable != retryable || value.NextAction != string(action) {
 		return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
 	}
 	canonical := TerminalStatusError(code)
 	if value.Message != canonical.Message {
 		return fmt.Errorf("remember: terminal error message for %q is not canonical", code)
 	}
-	if value.Remediation != canonical.Remediation {
+	if value.NextAction != string(TerminalNextActionRetryDreamFeedback) && value.Remediation != canonical.Remediation {
 		return fmt.Errorf("remember: terminal error remediation for %q is not canonical", code)
 	}
 	return nil
+}
+
+const terminalDreamFeedbackRetryRemediationPrefix = "Retry resolve_dream_feedback with corrected evidence and idempotency_key "
+
+func DreamFeedbackRetryRemediation(idempotencyKey string) string {
+	return fmt.Sprintf("%s%q.", terminalDreamFeedbackRetryRemediationPrefix, idempotencyKey)
 }
 
 func terminalErrorGuidance(code TerminalErrorCode) (bool, TerminalNextAction) {

--- a/internal/service/remember/synchronous_contract.go
+++ b/internal/service/remember/synchronous_contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -158,6 +159,7 @@ const (
 	maxTerminalRelationshipSplits = 50
 	maxTerminalSupersededEvidence = 50
 	maxTerminalCorrelationIDRunes = 128
+	maxTerminalRemediationRunes   = 512
 )
 
 func TerminalErrorCodes() []string {
@@ -171,16 +173,18 @@ func TerminalErrorCodes() []string {
 type TerminalNextAction string
 
 const (
-	TerminalNextActionRetrySameRequest TerminalNextAction = "retry_same_request"
-	TerminalNextActionResubmitRemember TerminalNextAction = "resubmit_remember"
-	TerminalNextActionRetryCorrection  TerminalNextAction = "retry_correction"
-	TerminalNextActionContactOperator  TerminalNextAction = "contact_operator"
-	TerminalNextActionNone             TerminalNextAction = "none"
+	TerminalNextActionRetrySameRequest   TerminalNextAction = "retry_same_request"
+	TerminalNextActionResubmitRemember   TerminalNextAction = "resubmit_remember"
+	TerminalNextActionRetryDreamFeedback TerminalNextAction = "retry_dream_feedback"
+	TerminalNextActionRetryCorrection    TerminalNextAction = "retry_correction"
+	TerminalNextActionContactOperator    TerminalNextAction = "contact_operator"
+	TerminalNextActionNone               TerminalNextAction = "none"
 )
 
 var terminalNextActions = []TerminalNextAction{
 	TerminalNextActionRetrySameRequest,
 	TerminalNextActionResubmitRemember,
+	TerminalNextActionRetryDreamFeedback,
 	TerminalNextActionRetryCorrection,
 	TerminalNextActionContactOperator,
 	TerminalNextActionNone,
@@ -243,17 +247,41 @@ func ValidateTerminalStatusError(value SubmissionStatusError) error {
 		return fmt.Errorf("remember: terminal next action %q is not allowed", value.NextAction)
 	}
 	retryable, action := terminalErrorGuidance(code)
-	if value.Retryable != retryable || value.NextAction != string(action) {
+	if value.NextAction == string(TerminalNextActionRetryDreamFeedback) {
+		if !retryable || action != TerminalNextActionResubmitRemember || !value.Retryable ||
+			!validDreamFeedbackRetryRemediation(value.Remediation) {
+			return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
+		}
+	} else if value.Retryable != retryable || value.NextAction != string(action) {
 		return fmt.Errorf("remember: terminal error guidance for %q is inconsistent", code)
 	}
 	canonical := TerminalStatusError(code)
 	if value.Message != canonical.Message {
 		return fmt.Errorf("remember: terminal error message for %q is not canonical", code)
 	}
-	if value.Remediation != canonical.Remediation {
+	if value.NextAction != string(TerminalNextActionRetryDreamFeedback) && value.Remediation != canonical.Remediation {
 		return fmt.Errorf("remember: terminal error remediation for %q is not canonical", code)
 	}
 	return nil
+}
+
+const terminalDreamFeedbackRetryRemediationPrefix = "Retry resolve_dream_feedback with corrected evidence and idempotency_key "
+
+func DreamFeedbackRetryRemediation(idempotencyKey string) string {
+	return fmt.Sprintf("%s%q.", terminalDreamFeedbackRetryRemediationPrefix, idempotencyKey)
+}
+
+func validDreamFeedbackRetryRemediation(value string) bool {
+	if utf8.RuneCountInString(value) > maxTerminalRemediationRunes ||
+		!strings.HasPrefix(value, terminalDreamFeedbackRetryRemediationPrefix) ||
+		!strings.HasSuffix(value, ".") {
+		return false
+	}
+	quotedKey := strings.TrimSuffix(strings.TrimPrefix(value, terminalDreamFeedbackRetryRemediationPrefix), ".")
+	key, err := strconv.Unquote(quotedKey)
+	return err == nil && strings.TrimSpace(key) != "" &&
+		utf8.RuneCountInString(key) <= maxTerminalCorrelationIDRunes &&
+		DreamFeedbackRetryRemediation(key) == value
 }
 
 func terminalErrorGuidance(code TerminalErrorCode) (bool, TerminalNextAction) {

--- a/internal/service/remember/synchronous_contract_test.go
+++ b/internal/service/remember/synchronous_contract_test.go
@@ -89,6 +89,7 @@ func TestTerminalNextActionsAreClosedAndCopied(t *testing.T) {
 	require.Equal(t, []string{
 		string(TerminalNextActionRetrySameRequest),
 		string(TerminalNextActionResubmitRemember),
+		string(TerminalNextActionRetryDreamFeedback),
 		string(TerminalNextActionRetryCorrection),
 		string(TerminalNextActionContactOperator),
 		string(TerminalNextActionNone),
@@ -382,6 +383,16 @@ func TestValidateTerminalStatusErrorRejectsMalformedOutput(t *testing.T) {
 			require.Error(t, ValidateTerminalStatusError(value))
 		})
 	}
+}
+
+func TestDreamFeedbackRetryGuidanceUsesClosedAction(t *testing.T) {
+	value := TerminalStatusError(TerminalErrorNoSupportedMemory)
+	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
+	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry")
+	require.NoError(t, ValidateTerminalStatusError(value))
+
+	value.Retryable = false
+	require.Error(t, ValidateTerminalStatusError(value))
 }
 
 func TestTerminalResultWithErrorUsesSemanticProcessingStates(t *testing.T) {

--- a/internal/service/remember/synchronous_contract_test.go
+++ b/internal/service/remember/synchronous_contract_test.go
@@ -393,6 +393,14 @@ func TestDreamFeedbackRetryGuidanceUsesClosedAction(t *testing.T) {
 
 	value.Retryable = false
 	require.Error(t, ValidateTerminalStatusError(value))
+
+	value = TerminalStatusError(TerminalErrorNoSupportedMemory)
+	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
+	value.Remediation = DreamFeedbackRetryRemediation(strings.Repeat("x", maxTerminalCorrelationIDRunes+1))
+	require.Error(t, ValidateTerminalStatusError(value))
+
+	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry") + " extra"
+	require.Error(t, ValidateTerminalStatusError(value))
 }
 
 func TestTerminalResultWithErrorUsesSemanticProcessingStates(t *testing.T) {

--- a/internal/service/remember/synchronous_contract_test.go
+++ b/internal/service/remember/synchronous_contract_test.go
@@ -89,6 +89,7 @@ func TestTerminalNextActionsAreClosedAndCopied(t *testing.T) {
 	require.Equal(t, []string{
 		string(TerminalNextActionRetrySameRequest),
 		string(TerminalNextActionResubmitRemember),
+		string(TerminalNextActionRetryDreamFeedback),
 		string(TerminalNextActionRetryCorrection),
 		string(TerminalNextActionContactOperator),
 		string(TerminalNextActionNone),
@@ -382,6 +383,24 @@ func TestValidateTerminalStatusErrorRejectsMalformedOutput(t *testing.T) {
 			require.Error(t, ValidateTerminalStatusError(value))
 		})
 	}
+}
+
+func TestDreamFeedbackRetryGuidanceUsesClosedAction(t *testing.T) {
+	value := TerminalStatusError(TerminalErrorNoSupportedMemory)
+	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
+	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry")
+	require.NoError(t, ValidateTerminalStatusError(value))
+
+	value.Retryable = false
+	require.Error(t, ValidateTerminalStatusError(value))
+
+	value = TerminalStatusError(TerminalErrorNoSupportedMemory)
+	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
+	value.Remediation = DreamFeedbackRetryRemediation(strings.Repeat("x", maxTerminalCorrelationIDRunes+1))
+	require.Error(t, ValidateTerminalStatusError(value))
+
+	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry") + " extra"
+	require.Error(t, ValidateTerminalStatusError(value))
 }
 
 func TestTerminalResultWithErrorUsesSemanticProcessingStates(t *testing.T) {

--- a/internal/service/remember/synchronous_contract_test.go
+++ b/internal/service/remember/synchronous_contract_test.go
@@ -89,7 +89,6 @@ func TestTerminalNextActionsAreClosedAndCopied(t *testing.T) {
 	require.Equal(t, []string{
 		string(TerminalNextActionRetrySameRequest),
 		string(TerminalNextActionResubmitRemember),
-		string(TerminalNextActionRetryDreamFeedback),
 		string(TerminalNextActionRetryCorrection),
 		string(TerminalNextActionContactOperator),
 		string(TerminalNextActionNone),
@@ -383,24 +382,6 @@ func TestValidateTerminalStatusErrorRejectsMalformedOutput(t *testing.T) {
 			require.Error(t, ValidateTerminalStatusError(value))
 		})
 	}
-}
-
-func TestDreamFeedbackRetryGuidanceUsesClosedAction(t *testing.T) {
-	value := TerminalStatusError(TerminalErrorNoSupportedMemory)
-	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
-	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry")
-	require.NoError(t, ValidateTerminalStatusError(value))
-
-	value.Retryable = false
-	require.Error(t, ValidateTerminalStatusError(value))
-
-	value = TerminalStatusError(TerminalErrorNoSupportedMemory)
-	value.NextAction = string(TerminalNextActionRetryDreamFeedback)
-	value.Remediation = DreamFeedbackRetryRemediation(strings.Repeat("x", maxTerminalCorrelationIDRunes+1))
-	require.Error(t, ValidateTerminalStatusError(value))
-
-	value.Remediation = DreamFeedbackRetryRemediation("dream-feedback-retry") + " extra"
-	require.Error(t, ValidateTerminalStatusError(value))
 }
 
 func TestTerminalResultWithErrorUsesSemanticProcessingStates(t *testing.T) {

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -341,6 +341,11 @@ func contractTools(deps Dependencies) []Tool {
 				if err != nil {
 					return nil, err
 				}
+				if failure, ok, err := resolveDreamTerminalFailureOutput(res); err != nil {
+					return nil, fmt.Errorf("resolve_dream_feedback: terminal result serialization failed")
+				} else if ok {
+					return nil, NewToolResultError(failure)
+				}
 				return resolveDreamFeedbackContractOutput(res), nil
 			}
 		case ToolExportMemoryPack:

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -339,15 +339,7 @@ func contractTools(deps Dependencies) []Tool {
 				}
 				res, err := deps.Dreams.ResolveFeedback(ctx, teamID, req)
 				if err != nil {
-					if busy, ok := resolveDreamConfirmationBusyOutcome(err); ok {
-						return nil, NewToolResultError(busy)
-					}
 					return nil, err
-				}
-				if failure, ok, err := resolveDreamTerminalOutcome(res); err != nil {
-					return nil, fmt.Errorf("resolve_dream_feedback: terminal result serialization failed")
-				} else if ok {
-					return nil, NewToolResultError(failure)
 				}
 				return resolveDreamFeedbackContractOutput(res), nil
 			}

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -339,6 +339,9 @@ func contractTools(deps Dependencies) []Tool {
 				}
 				res, err := deps.Dreams.ResolveFeedback(ctx, teamID, req)
 				if err != nil {
+					if busy, ok := resolveDreamConfirmationBusyOutcome(err); ok {
+						return nil, NewToolResultError(busy)
+					}
 					return nil, err
 				}
 				if failure, ok, err := resolveDreamTerminalOutcome(res); err != nil {

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -339,7 +339,15 @@ func contractTools(deps Dependencies) []Tool {
 				}
 				res, err := deps.Dreams.ResolveFeedback(ctx, teamID, req)
 				if err != nil {
+					if busy, ok := resolveDreamConfirmationBusyOutcome(err); ok {
+						return nil, NewToolResultError(busy)
+					}
 					return nil, err
+				}
+				if failure, ok, err := resolveDreamTerminalOutcome(res); err != nil {
+					return nil, fmt.Errorf("resolve_dream_feedback: terminal result serialization failed")
+				} else if ok {
+					return nil, NewToolResultError(failure)
 				}
 				return resolveDreamFeedbackContractOutput(res), nil
 			}

--- a/internal/tools/registry/contract.go
+++ b/internal/tools/registry/contract.go
@@ -341,7 +341,7 @@ func contractTools(deps Dependencies) []Tool {
 				if err != nil {
 					return nil, err
 				}
-				if failure, ok, err := resolveDreamTerminalFailureOutput(res); err != nil {
+				if failure, ok, err := resolveDreamTerminalOutcome(res); err != nil {
 					return nil, fmt.Errorf("resolve_dream_feedback: terminal result serialization failed")
 				} else if ok {
 					return nil, NewToolResultError(failure)

--- a/internal/tools/registry/contract_aux_outputs.go
+++ b/internal/tools/registry/contract_aux_outputs.go
@@ -1,6 +1,8 @@
 package registry
 
-import "github.com/markhuangai/dense-mem/internal/domain"
+import (
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
 
 func recallFeedbackOutputSchema() map[string]any {
 	return closedObject(
@@ -33,14 +35,25 @@ func getDreamOutputSchema() map[string]any {
 }
 
 func resolveDreamFeedbackOutputSchema() map[string]any {
-	return closedObject(
-		[]string{"hypothesis_id", "status"},
-		map[string]any{
-			"hypothesis_id": schemaString("Hypothesis ID.", 128),
-			"status":        schemaEnum(domain.HypothesisStatuses()),
-			"submission_id": schemaString("Submission ID for submitted evidence.", 128),
+	return map[string]any{
+		"oneOf": []any{
+			closedObject(
+				[]string{"hypothesis_id", "status"},
+				map[string]any{
+					"hypothesis_id": schemaString("Hypothesis ID.", 128),
+					"status":        schemaEnum(domain.HypothesisStatuses()),
+					"submission_id": schemaString("Submission ID for submitted evidence.", 128),
+				},
+			),
+			terminalRememberOutputSchema(domain.ContractVersion),
 		},
-	)
+	}
+}
+
+// TerminalRememberOutputSchema is shared by the terminal Remember registry
+// override and Dream feedback's non-completed result contract.
+func TerminalRememberOutputSchema() map[string]any {
+	return terminalRememberOutputSchema(domain.ContractVersion)
 }
 
 func exportMemoryPackOutputSchema() map[string]any {

--- a/internal/tools/registry/contract_aux_outputs.go
+++ b/internal/tools/registry/contract_aux_outputs.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"github.com/markhuangai/dense-mem/internal/domain"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
 func recallFeedbackOutputSchema() map[string]any {
@@ -46,8 +47,22 @@ func resolveDreamFeedbackOutputSchema() map[string]any {
 				},
 			),
 			terminalRememberOutputSchema(domain.ContractVersion),
+			dreamConfirmationBusyOutputSchema(),
 		},
 	}
+}
+
+func dreamConfirmationBusyOutputSchema() map[string]any {
+	return closedObject(
+		[]string{"code", "message", "retryable", "next_action", "remediation"},
+		map[string]any{
+			"code":        schemaEnum([]string{"dream_confirmation_busy"}),
+			"message":     schemaString("Bounded Dream confirmation admission error.", 512),
+			"retryable":   map[string]any{"type": "boolean"},
+			"next_action": schemaEnum([]string{string(rememberapp.TerminalNextActionRetryDreamFeedback)}),
+			"remediation": schemaString("Bounded action the caller can take next.", 512),
+		},
+	)
 }
 
 // TerminalRememberOutputSchema is shared by the terminal Remember registry

--- a/internal/tools/registry/contract_aux_outputs.go
+++ b/internal/tools/registry/contract_aux_outputs.go
@@ -46,7 +46,7 @@ func resolveDreamFeedbackOutputSchema() map[string]any {
 					"submission_id": schemaString("Submission ID for submitted evidence.", 128),
 				},
 			),
-			terminalRememberOutputSchema(domain.ContractVersion),
+			dreamTerminalRememberOutputSchema(domain.ContractVersion),
 			dreamConfirmationBusyOutputSchema(),
 		},
 	}

--- a/internal/tools/registry/contract_aux_outputs.go
+++ b/internal/tools/registry/contract_aux_outputs.go
@@ -1,6 +1,9 @@
 package registry
 
-import "github.com/markhuangai/dense-mem/internal/domain"
+import (
+	"github.com/markhuangai/dense-mem/internal/domain"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
 
 func recallFeedbackOutputSchema() map[string]any {
 	return closedObject(
@@ -33,14 +36,39 @@ func getDreamOutputSchema() map[string]any {
 }
 
 func resolveDreamFeedbackOutputSchema() map[string]any {
+	return map[string]any{
+		"oneOf": []any{
+			closedObject(
+				[]string{"hypothesis_id", "status"},
+				map[string]any{
+					"hypothesis_id": schemaString("Hypothesis ID.", 128),
+					"status":        schemaEnum(domain.HypothesisStatuses()),
+					"submission_id": schemaString("Submission ID for submitted evidence.", 128),
+				},
+			),
+			dreamTerminalRememberOutputSchema(domain.ContractVersion),
+			dreamConfirmationBusyOutputSchema(),
+		},
+	}
+}
+
+func dreamConfirmationBusyOutputSchema() map[string]any {
 	return closedObject(
-		[]string{"hypothesis_id", "status"},
+		[]string{"code", "message", "retryable", "next_action", "remediation"},
 		map[string]any{
-			"hypothesis_id": schemaString("Hypothesis ID.", 128),
-			"status":        schemaEnum(domain.HypothesisStatuses()),
-			"submission_id": schemaString("Submission ID for submitted evidence.", 128),
+			"code":        schemaEnum([]string{"dream_confirmation_busy"}),
+			"message":     schemaString("Bounded Dream confirmation admission error.", 512),
+			"retryable":   map[string]any{"type": "boolean"},
+			"next_action": schemaEnum([]string{string(rememberapp.TerminalNextActionRetryDreamFeedback)}),
+			"remediation": schemaString("Bounded action the caller can take next.", 512),
 		},
 	)
+}
+
+// TerminalRememberOutputSchema exposes the generic terminal Remember schema
+// for test-only registry composition without widening the active catalog.
+func TerminalRememberOutputSchema() map[string]any {
+	return terminalRememberOutputSchema(domain.ContractVersion)
 }
 
 func exportMemoryPackOutputSchema() map[string]any {

--- a/internal/tools/registry/contract_aux_outputs.go
+++ b/internal/tools/registry/contract_aux_outputs.go
@@ -1,9 +1,6 @@
 package registry
 
-import (
-	"github.com/markhuangai/dense-mem/internal/domain"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
-)
+import "github.com/markhuangai/dense-mem/internal/domain"
 
 func recallFeedbackOutputSchema() map[string]any {
 	return closedObject(
@@ -36,39 +33,14 @@ func getDreamOutputSchema() map[string]any {
 }
 
 func resolveDreamFeedbackOutputSchema() map[string]any {
-	return map[string]any{
-		"oneOf": []any{
-			closedObject(
-				[]string{"hypothesis_id", "status"},
-				map[string]any{
-					"hypothesis_id": schemaString("Hypothesis ID.", 128),
-					"status":        schemaEnum(domain.HypothesisStatuses()),
-					"submission_id": schemaString("Submission ID for submitted evidence.", 128),
-				},
-			),
-			dreamTerminalRememberOutputSchema(domain.ContractVersion),
-			dreamConfirmationBusyOutputSchema(),
-		},
-	}
-}
-
-func dreamConfirmationBusyOutputSchema() map[string]any {
 	return closedObject(
-		[]string{"code", "message", "retryable", "next_action", "remediation"},
+		[]string{"hypothesis_id", "status"},
 		map[string]any{
-			"code":        schemaEnum([]string{"dream_confirmation_busy"}),
-			"message":     schemaString("Bounded Dream confirmation admission error.", 512),
-			"retryable":   map[string]any{"type": "boolean"},
-			"next_action": schemaEnum([]string{string(rememberapp.TerminalNextActionRetryDreamFeedback)}),
-			"remediation": schemaString("Bounded action the caller can take next.", 512),
+			"hypothesis_id": schemaString("Hypothesis ID.", 128),
+			"status":        schemaEnum(domain.HypothesisStatuses()),
+			"submission_id": schemaString("Submission ID for submitted evidence.", 128),
 		},
 	)
-}
-
-// TerminalRememberOutputSchema is shared by the terminal Remember registry
-// override and Dream feedback's non-completed result contract.
-func TerminalRememberOutputSchema() map[string]any {
-	return terminalRememberOutputSchema(domain.ContractVersion)
 }
 
 func exportMemoryPackOutputSchema() map[string]any {

--- a/internal/tools/registry/contract_issues_test.go
+++ b/internal/tools/registry/contract_issues_test.go
@@ -92,6 +92,24 @@ func TestValidateContractInputIssuesDispatchesToolSpecificValidation(t *testing.
 	}
 }
 
+func TestValidateContractInputIssuesRejectsLifecycleIdempotencyKey(t *testing.T) {
+	tool, err := requireTool(toolMap(t), ToolResolveDreamFeedback)
+	require.NoError(t, err)
+
+	for _, decision := range []string{"reject", "stale", "reinforce"} {
+		t.Run(decision, func(t *testing.T) {
+			result := ValidateContractInputIssues(tool, map[string]any{
+				"hypothesis_id":   "dream-1",
+				"decision":        decision,
+				"reason":          "not useful",
+				"idempotency_key": "lifecycle-retry",
+			}, []string{"write"})
+
+			require.Contains(t, issueMessages(result), "idempotency_key is only supported for confirmation decisions")
+		})
+	}
+}
+
 func TestValidateContractInputIssuesRememberValidAndMalformedShapes(t *testing.T) {
 	remember, err := requireTool(toolMap(t), ToolRemember)
 	require.NoError(t, err)

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -518,12 +518,18 @@ func resolveDreamConfirmationBusyOutcome(err error) (map[string]any, bool) {
 	if !errors.As(err, &busy) || busy == nil {
 		return nil, false
 	}
+	message := "dream confirmation is already in progress"
+	remediation := "Retry resolve_dream_feedback with the same evidence and idempotency_key after the in-progress confirmation completes."
+	if busy.IsLifecycle() {
+		message = "dream lifecycle feedback is already in progress"
+		remediation = "Retry resolve_dream_feedback with the same decision and reason after the in-progress lifecycle update completes; omit idempotency_key."
+	}
 	return map[string]any{
 		"code":        "dream_confirmation_busy",
-		"message":     "dream confirmation is already in progress",
+		"message":     message,
 		"retryable":   true,
 		"next_action": string(rememberapp.TerminalNextActionRetryDreamFeedback),
-		"remediation": "Retry resolve_dream_feedback with the same evidence and idempotency_key after the in-progress confirmation completes.",
+		"remediation": remediation,
 	}, true
 }
 

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -511,6 +511,18 @@ func resolveDreamFeedbackContractOutput(res *dreamservice.ResolveFeedbackResult)
 	return out
 }
 
+func resolveDreamTerminalFailureOutput(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {
+	if res == nil || res.Memory == nil || res.Memory.Terminal == nil ||
+		res.Memory.Terminal.ProcessingState != "failed" {
+		return nil, false, nil
+	}
+	output, err := structToMap(res.Memory.Terminal)
+	if err != nil {
+		return nil, false, err
+	}
+	return output, true, nil
+}
+
 func exportMemoryPackContractOutput(res *skillpackservice.ExportResult) map[string]any {
 	if res == nil {
 		return map[string]any{

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 )
 
@@ -509,6 +511,32 @@ func resolveDreamFeedbackContractOutput(res *dreamservice.ResolveFeedbackResult)
 		}
 	}
 	return out
+}
+
+func resolveDreamConfirmationBusyOutcome(err error) (map[string]any, bool) {
+	var busy *dreamservice.ConfirmationBusyError
+	if !errors.As(err, &busy) || busy == nil {
+		return nil, false
+	}
+	return map[string]any{
+		"code":        "dream_confirmation_busy",
+		"message":     "dream confirmation is already in progress",
+		"retryable":   true,
+		"next_action": string(rememberapp.TerminalNextActionRetryDreamFeedback),
+		"remediation": "Retry resolve_dream_feedback with the same evidence and idempotency_key after the in-progress confirmation completes.",
+	}, true
+}
+
+func resolveDreamTerminalOutcome(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {
+	if res == nil || res.Memory == nil || res.Memory.Terminal == nil ||
+		res.Memory.Terminal.ProcessingState == string(rememberapp.TerminalProcessingCompleted) {
+		return nil, false, nil
+	}
+	output, err := structToMap(res.Memory.Terminal)
+	if err != nil {
+		return nil, false, err
+	}
+	return output, true, nil
 }
 
 func exportMemoryPackContractOutput(res *skillpackservice.ExportResult) map[string]any {

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -511,9 +511,9 @@ func resolveDreamFeedbackContractOutput(res *dreamservice.ResolveFeedbackResult)
 	return out
 }
 
-func resolveDreamTerminalFailureOutput(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {
+func resolveDreamTerminalOutcome(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {
 	if res == nil || res.Memory == nil || res.Memory.Terminal == nil ||
-		res.Memory.Terminal.ProcessingState != "failed" {
+		res.Memory.Terminal.ProcessingState == "completed" {
 		return nil, false, nil
 	}
 	output, err := structToMap(res.Memory.Terminal)

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 )
 
@@ -509,6 +511,20 @@ func resolveDreamFeedbackContractOutput(res *dreamservice.ResolveFeedbackResult)
 		}
 	}
 	return out
+}
+
+func resolveDreamConfirmationBusyOutcome(err error) (map[string]any, bool) {
+	var busy *dreamservice.ConfirmationBusyError
+	if !errors.As(err, &busy) || busy == nil {
+		return nil, false
+	}
+	return map[string]any{
+		"code":        "dream_confirmation_busy",
+		"message":     "dream confirmation is already in progress",
+		"retryable":   true,
+		"next_action": string(rememberapp.TerminalNextActionRetryDreamFeedback),
+		"remediation": "Retry resolve_dream_feedback with the same evidence and idempotency_key after the in-progress confirmation completes.",
+	}, true
 }
 
 func resolveDreamTerminalOutcome(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"errors"
 	"strings"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 )
 
@@ -511,32 +509,6 @@ func resolveDreamFeedbackContractOutput(res *dreamservice.ResolveFeedbackResult)
 		}
 	}
 	return out
-}
-
-func resolveDreamConfirmationBusyOutcome(err error) (map[string]any, bool) {
-	var busy *dreamservice.ConfirmationBusyError
-	if !errors.As(err, &busy) || busy == nil {
-		return nil, false
-	}
-	return map[string]any{
-		"code":        "dream_confirmation_busy",
-		"message":     "dream confirmation is already in progress",
-		"retryable":   true,
-		"next_action": string(rememberapp.TerminalNextActionRetryDreamFeedback),
-		"remediation": "Retry resolve_dream_feedback with the same evidence and idempotency_key after the in-progress confirmation completes.",
-	}, true
-}
-
-func resolveDreamTerminalOutcome(res *dreamservice.ResolveFeedbackResult) (map[string]any, bool, error) {
-	if res == nil || res.Memory == nil || res.Memory.Terminal == nil ||
-		res.Memory.Terminal.ProcessingState == "completed" {
-		return nil, false, nil
-	}
-	output, err := structToMap(res.Memory.Terminal)
-	if err != nil {
-		return nil, false, err
-	}
-	return output, true, nil
 }
 
 func exportMemoryPackContractOutput(res *skillpackservice.ExportResult) map[string]any {

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -345,9 +345,10 @@ func resolveDreamFeedbackInputSchema() map[string]any {
 			"confirm_true",
 			"confirm_false",
 		}),
-		"reason":        schemaString("Bounded lifecycle feedback reason.", 1000),
-		"evidence":      dreamEvidenceArraySchema(),
-		"relationships": dreamRelationshipSubmissionArraySchema(),
+		"reason":          schemaString("Bounded lifecycle feedback reason.", 1000),
+		"idempotency_key": schemaString("Retry key scoped to this Dream confirmation.", 128),
+		"evidence":        dreamEvidenceArraySchema(),
+		"relationships":   dreamRelationshipSubmissionArraySchema(),
 	})
 }
 

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -345,10 +345,9 @@ func resolveDreamFeedbackInputSchema() map[string]any {
 			"confirm_true",
 			"confirm_false",
 		}),
-		"reason":          schemaString("Bounded lifecycle feedback reason.", 1000),
-		"idempotency_key": schemaString("Retry key scoped to this Dream confirmation.", 128),
-		"evidence":        dreamEvidenceArraySchema(),
-		"relationships":   dreamRelationshipSubmissionArraySchema(),
+		"reason":        schemaString("Bounded lifecycle feedback reason.", 1000),
+		"evidence":      dreamEvidenceArraySchema(),
+		"relationships": dreamRelationshipSubmissionArraySchema(),
 	})
 }
 

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -345,9 +345,10 @@ func resolveDreamFeedbackInputSchema() map[string]any {
 			"confirm_true",
 			"confirm_false",
 		}),
-		"reason":        schemaString("Bounded lifecycle feedback reason.", 1000),
-		"evidence":      dreamEvidenceArraySchema(),
-		"relationships": dreamRelationshipSubmissionArraySchema(),
+		"reason":          schemaString("Bounded lifecycle feedback reason.", 1000),
+		"evidence":        dreamEvidenceArraySchema(),
+		"relationships":   dreamRelationshipSubmissionArraySchema(),
+		"idempotency_key": nonEmptyStringSchema("Retry key scoped to the Dream confirmation and profile.", 128),
 	})
 }
 

--- a/internal/tools/registry/contract_schemas.go
+++ b/internal/tools/registry/contract_schemas.go
@@ -348,7 +348,7 @@ func resolveDreamFeedbackInputSchema() map[string]any {
 		"reason":          schemaString("Bounded lifecycle feedback reason.", 1000),
 		"evidence":        dreamEvidenceArraySchema(),
 		"relationships":   dreamRelationshipSubmissionArraySchema(),
-		"idempotency_key": nonEmptyStringSchema("Retry key scoped to the Dream confirmation and profile.", 128),
+		"idempotency_key": nonEmptyStringSchema("Retry key scoped to the Dream confirmation and profile; confirmation decisions only.", 128),
 	})
 }
 

--- a/internal/tools/registry/contract_test.go
+++ b/internal/tools/registry/contract_test.go
@@ -514,7 +514,7 @@ func TestCanonicalInputFieldNames(t *testing.T) {
 		{ToolTraceMemory, []string{"include_verification", "include_transitions", "max_depth", "predicate_keys", "topic", "min_relevance"}, nil, []string{"max_chars"}},
 		{ToolSubmitRecallSessionFeedback, []string{"recalls"}, nil, nil},
 		{ToolGetDream, []string{"hypothesis_id"}, nil, []string{"dream_id"}},
-		{ToolResolveDreamFeedback, []string{"hypothesis_id", "decision", "reason", "evidence", "relationships"}, nil, []string{"dream_id", "feedback", "proposal"}},
+		{ToolResolveDreamFeedback, []string{"hypothesis_id", "decision", "reason", "idempotency_key", "evidence", "relationships"}, nil, []string{"dream_id", "feedback", "proposal"}},
 		{ToolExportMemoryPack, []string{"relationship_ids"}, []string{"name", "relationship_ids"}, []string{"include_support"}},
 	}
 	for _, tc := range cases {

--- a/internal/tools/registry/contract_test.go
+++ b/internal/tools/registry/contract_test.go
@@ -514,7 +514,7 @@ func TestCanonicalInputFieldNames(t *testing.T) {
 		{ToolTraceMemory, []string{"include_verification", "include_transitions", "max_depth", "predicate_keys", "topic", "min_relevance"}, nil, []string{"max_chars"}},
 		{ToolSubmitRecallSessionFeedback, []string{"recalls"}, nil, nil},
 		{ToolGetDream, []string{"hypothesis_id"}, nil, []string{"dream_id"}},
-		{ToolResolveDreamFeedback, []string{"hypothesis_id", "decision", "reason", "idempotency_key", "evidence", "relationships"}, nil, []string{"dream_id", "feedback", "proposal"}},
+		{ToolResolveDreamFeedback, []string{"hypothesis_id", "decision", "reason", "evidence", "relationships"}, nil, []string{"dream_id", "feedback", "proposal"}},
 		{ToolExportMemoryPack, []string{"relationship_ids"}, []string{"name", "relationship_ids"}, []string{"include_support"}},
 	}
 	for _, tc := range cases {

--- a/internal/tools/registry/contract_v261_schemas.go
+++ b/internal/tools/registry/contract_v261_schemas.go
@@ -5,6 +5,14 @@ import (
 )
 
 func terminalRememberOutputSchema(version string) map[string]any {
+	return terminalRememberOutputSchemaForActions(version, terminalErrorNextActions(false))
+}
+
+func dreamTerminalRememberOutputSchema(version string) map[string]any {
+	return terminalRememberOutputSchemaForActions(version, terminalErrorNextActions(true))
+}
+
+func terminalRememberOutputSchemaForActions(version string, nextActions []string) map[string]any {
 	return closedObject(
 		[]string{"contract_version", "submission_id", "submission_kind", "processing_state", "search_state", "correlation_id", "evidence", "relationship_results", "errors"},
 		map[string]any{
@@ -16,7 +24,7 @@ func terminalRememberOutputSchema(version string) map[string]any {
 			"correlation_id":       schemaString("Request correlation ID.", 128),
 			"evidence":             array(terminalEvidenceSchema(), 0, 20),
 			"relationship_results": submissionRelationshipResultsSchema(),
-			"errors":               array(terminalErrorSchema(), 0, 50),
+			"errors":               array(terminalErrorSchemaForActions(nextActions), 0, 50),
 		},
 	)
 }
@@ -53,22 +61,34 @@ func terminalCorrectionOutputSchema(version string) map[string]any {
 }
 
 func terminalErrorSchema() map[string]any {
+	return terminalErrorSchemaForActions(terminalErrorNextActions(false))
+}
+
+func terminalErrorSchemaForActions(nextActions []string) map[string]any {
 	return closedObject(
 		[]string{"code", "message", "retryable", "next_action", "remediation"},
 		map[string]any{
-			"code":      schemaEnum(contractV261ErrorCodes()),
-			"message":   schemaString("Bounded safe submission error.", 512),
-			"retryable": map[string]any{"type": "boolean"},
-			"next_action": schemaEnum([]string{
-				string(remember.TerminalNextActionRetrySameRequest),
-				string(remember.TerminalNextActionResubmitRemember),
-				string(remember.TerminalNextActionRetryCorrection),
-				string(remember.TerminalNextActionContactOperator),
-				string(remember.TerminalNextActionNone),
-			}),
+			"code":        schemaEnum(contractV261ErrorCodes()),
+			"message":     schemaString("Bounded safe submission error.", 512),
+			"retryable":   map[string]any{"type": "boolean"},
+			"next_action": schemaEnum(nextActions),
 			"remediation": schemaString("Bounded action the caller can take next.", 512),
 		},
 	)
+}
+
+func terminalErrorNextActions(includeDreamFeedback bool) []string {
+	result := []string{
+		string(remember.TerminalNextActionRetrySameRequest),
+		string(remember.TerminalNextActionResubmitRemember),
+		string(remember.TerminalNextActionRetryCorrection),
+		string(remember.TerminalNextActionContactOperator),
+		string(remember.TerminalNextActionNone),
+	}
+	if includeDreamFeedback {
+		result = append(result, string(remember.TerminalNextActionRetryDreamFeedback))
+	}
+	return result
 }
 
 func contractV261ErrorCodes() []string {

--- a/internal/tools/registry/contract_v261_schemas.go
+++ b/internal/tools/registry/contract_v261_schemas.go
@@ -5,14 +5,6 @@ import (
 )
 
 func terminalRememberOutputSchema(version string) map[string]any {
-	return terminalRememberOutputSchemaForActions(version, terminalErrorNextActions(false))
-}
-
-func dreamTerminalRememberOutputSchema(version string) map[string]any {
-	return terminalRememberOutputSchemaForActions(version, terminalErrorNextActions(true))
-}
-
-func terminalRememberOutputSchemaForActions(version string, nextActions []string) map[string]any {
 	return closedObject(
 		[]string{"contract_version", "submission_id", "submission_kind", "processing_state", "search_state", "correlation_id", "evidence", "relationship_results", "errors"},
 		map[string]any{
@@ -24,7 +16,7 @@ func terminalRememberOutputSchemaForActions(version string, nextActions []string
 			"correlation_id":       schemaString("Request correlation ID.", 128),
 			"evidence":             array(terminalEvidenceSchema(), 0, 20),
 			"relationship_results": submissionRelationshipResultsSchema(),
-			"errors":               array(terminalErrorSchemaForActions(nextActions), 0, 50),
+			"errors":               array(terminalErrorSchema(), 0, 50),
 		},
 	)
 }
@@ -61,34 +53,22 @@ func terminalCorrectionOutputSchema(version string) map[string]any {
 }
 
 func terminalErrorSchema() map[string]any {
-	return terminalErrorSchemaForActions(terminalErrorNextActions(false))
-}
-
-func terminalErrorSchemaForActions(nextActions []string) map[string]any {
 	return closedObject(
 		[]string{"code", "message", "retryable", "next_action", "remediation"},
 		map[string]any{
-			"code":        schemaEnum(contractV261ErrorCodes()),
-			"message":     schemaString("Bounded safe submission error.", 512),
-			"retryable":   map[string]any{"type": "boolean"},
-			"next_action": schemaEnum(nextActions),
+			"code":      schemaEnum(contractV261ErrorCodes()),
+			"message":   schemaString("Bounded safe submission error.", 512),
+			"retryable": map[string]any{"type": "boolean"},
+			"next_action": schemaEnum([]string{
+				string(remember.TerminalNextActionRetrySameRequest),
+				string(remember.TerminalNextActionResubmitRemember),
+				string(remember.TerminalNextActionRetryCorrection),
+				string(remember.TerminalNextActionContactOperator),
+				string(remember.TerminalNextActionNone),
+			}),
 			"remediation": schemaString("Bounded action the caller can take next.", 512),
 		},
 	)
-}
-
-func terminalErrorNextActions(includeDreamFeedback bool) []string {
-	result := []string{
-		string(remember.TerminalNextActionRetrySameRequest),
-		string(remember.TerminalNextActionResubmitRemember),
-		string(remember.TerminalNextActionRetryCorrection),
-		string(remember.TerminalNextActionContactOperator),
-		string(remember.TerminalNextActionNone),
-	}
-	if includeDreamFeedback {
-		result = append(result, string(remember.TerminalNextActionRetryDreamFeedback))
-	}
-	return result
 }
 
 func contractV261ErrorCodes() []string {

--- a/internal/tools/registry/contract_validation.go
+++ b/internal/tools/registry/contract_validation.go
@@ -239,6 +239,11 @@ func validateDreamFeedback(args map[string]any) error {
 			return err
 		}
 		return validateSubmittedRelationships(args["relationships"], evidence, "relationships")
+	case "reject", "stale", "reinforce":
+		if value, ok := args["idempotency_key"]; ok && strings.TrimSpace(stringInput(value)) != "" {
+			return errors.New("idempotency_key is only supported for confirmation decisions")
+		}
+		return validateRequiredFields(args, "reason")
 	default:
 		return validateRequiredFields(args, "reason")
 	}

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -131,6 +131,28 @@ func TestResolveDreamFeedbackReturnsStructuredBusyRetry(t *testing.T) {
 	require.NoError(t, ValidateInput(Tool{InputSchema: dreamConfirmationBusyOutputSchema()}, structured.Result))
 }
 
+func TestResolveDreamFeedbackReturnsLifecycleCompatibleBusyRetry(t *testing.T) {
+	reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{
+		resolveErr: &dreamservice.ConfirmationBusyError{Decision: "reject"},
+	}})
+	require.NoError(t, err)
+	tool, ok := reg.Get(ToolResolveDreamFeedback)
+	require.True(t, ok)
+
+	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+		"hypothesis_id": "dream-1", "decision": "reject", "reason": "no longer useful",
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, "dream_confirmation_busy", structured.Result["code"])
+	require.Equal(t, "dream lifecycle feedback is already in progress", structured.Result["message"])
+	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), structured.Result["next_action"])
+	require.NotContains(t, structured.Result["remediation"], "same evidence")
+	require.Contains(t, structured.Result["remediation"], "omit idempotency_key")
+	require.Contains(t, structured.Result["remediation"], "same decision and reason")
+	require.NoError(t, ValidateInput(Tool{InputSchema: dreamConfirmationBusyOutputSchema()}, structured.Result))
+}
+
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 	dreams := &stubDreamService{}
 	reg, err := BuildActive(Dependencies{Dreams: dreams})

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -162,14 +162,15 @@ func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 		}
 	}
 	resolveOut, err := resolveTool.Invoke(ctx, "profile-dream", map[string]any{
-		"hypothesis_id": "dream-1",
-		"decision":      "reinforce",
-		"reason":        "prior conversation still makes this useful",
+		"hypothesis_id":   "dream-1",
+		"decision":        "reinforce",
+		"reason":          "prior conversation still makes this useful",
+		"idempotency_key": "dream-retry-1",
 	})
 	if err != nil {
 		t.Fatalf("resolve_dream_feedback Invoke: %v", err)
 	}
-	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" {
+	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" || dreams.lastResolveReq.IdempotencyKey != "dream-retry-1" {
 		t.Fatalf("resolve_dream_feedback output = %v request = %+v", resolveOut, dreams.lastResolveReq)
 	}
 }

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -4,8 +4,47 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	"github.com/stretchr/testify/require"
 )
+
+func TestResolveDreamFeedbackReturnsStructuredTerminalFailure(t *testing.T) {
+	dreams := &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
+		Dream: stubDream("profile-dream"),
+		Memory: &rememberapp.RememberResult{Terminal: &rememberapp.TerminalRememberResult{
+			ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+			ProcessingState: string(rememberapp.TerminalProcessingFailed), SearchState: string(rememberapp.TerminalSearchNotRequired),
+			CorrelationID: "terminal-failure", Evidence: []rememberapp.TerminalEvidenceResult{},
+			RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
+			Errors:              []rememberapp.SubmissionStatusError{rememberapp.StatusError(rememberapp.SubmissionErrorProviderUnavailable)},
+		}},
+	}}
+	reg, err := BuildActive(Dependencies{Dreams: dreams})
+	require.NoError(t, err)
+	tool, ok := reg.Get(ToolResolveDreamFeedback)
+	require.True(t, ok)
+
+	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+		"hypothesis_id": "dream-1", "decision": "confirm_true",
+		"evidence": []any{map[string]any{"content": "independent evidence"}},
+		"relationships": []any{map[string]any{
+			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+			"predicate": map[string]any{"proposed_key": "uses"},
+			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+		}},
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, "failed", structured.Result["processing_state"])
+	require.Equal(t, "terminal-failure", structured.Result["correlation_id"])
+	errors, ok := structured.Result["errors"].([]any)
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+}
 
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 	dreams := &stubDreamService{}

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -41,9 +41,62 @@ func TestResolveDreamFeedbackReturnsStructuredTerminalFailure(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "failed", structured.Result["processing_state"])
 	require.Equal(t, "terminal-failure", structured.Result["correlation_id"])
+	require.NoError(t, ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
 	errors, ok := structured.Result["errors"].([]any)
 	require.True(t, ok)
 	require.Len(t, errors, 1)
+}
+
+func TestResolveDreamFeedbackReturnsStructuredNonCompletedTerminalOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		state string
+		code  rememberapp.TerminalErrorCode
+	}{
+		{state: string(rememberapp.TerminalProcessingRejected), code: rememberapp.TerminalErrorNoSupportedMemory},
+		{state: string(rememberapp.TerminalProcessingQuarantined), code: rememberapp.TerminalErrorQuarantined},
+	} {
+		t.Run(test.state, func(t *testing.T) {
+			terminal := &rememberapp.TerminalRememberResult{
+				ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+				ProcessingState: test.state, SearchState: string(rememberapp.TerminalSearchNotRequired),
+				CorrelationID: "terminal-" + test.state, Evidence: []rememberapp.TerminalEvidenceResult{},
+				RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
+				Errors:              []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(test.code)},
+			}
+			reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
+				Dream: stubDream("profile-dream"), Memory: &rememberapp.RememberResult{Terminal: terminal},
+			}}})
+			require.NoError(t, err)
+			tool, ok := reg.Get(ToolResolveDreamFeedback)
+			require.True(t, ok)
+			_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+				"hypothesis_id": "dream-1", "decision": "confirm_true",
+				"evidence": []any{map[string]any{"content": "independent evidence"}},
+				"relationships": []any{map[string]any{
+					"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+					"predicate": map[string]any{"proposed_key": "uses"},
+					"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+					"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+				}},
+			})
+			structured, ok := ToolResultFromError(err)
+			require.True(t, ok)
+			require.Equal(t, test.state, structured.Result["processing_state"])
+			require.NoError(t, ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
+		})
+	}
+}
+
+func TestResolveDreamFeedbackOutputSchemaCoversTerminalBranch(t *testing.T) {
+	variants, ok := resolveDreamFeedbackOutputSchema()["oneOf"].([]any)
+	require.True(t, ok)
+	require.Len(t, variants, 2)
+	terminal, ok := variants[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []string{
+		"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
+		"correlation_id", "evidence", "relationship_results", "errors",
+	}, terminal["required"])
 }
 
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -194,14 +194,15 @@ func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 		}
 	}
 	resolveOut, err := resolveTool.Invoke(ctx, "profile-dream", map[string]any{
-		"hypothesis_id": "dream-1",
-		"decision":      "reinforce",
-		"reason":        "prior conversation still makes this useful",
+		"hypothesis_id":   "dream-1",
+		"decision":        "reinforce",
+		"reason":          "prior conversation still makes this useful",
+		"idempotency_key": "dream-retry-key",
 	})
 	if err != nil {
 		t.Fatalf("resolve_dream_feedback Invoke: %v", err)
 	}
-	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" {
+	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" || dreams.lastResolveReq.IdempotencyKey != "dream-retry-key" {
 		t.Fatalf("resolve_dream_feedback output = %v request = %+v", resolveOut, dreams.lastResolveReq)
 	}
 }

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -194,15 +194,14 @@ func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 		}
 	}
 	resolveOut, err := resolveTool.Invoke(ctx, "profile-dream", map[string]any{
-		"hypothesis_id":   "dream-1",
-		"decision":        "reinforce",
-		"reason":          "prior conversation still makes this useful",
-		"idempotency_key": "dream-retry-key",
+		"hypothesis_id": "dream-1",
+		"decision":      "reinforce",
+		"reason":        "prior conversation still makes this useful",
 	})
 	if err != nil {
 		t.Fatalf("resolve_dream_feedback Invoke: %v", err)
 	}
-	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" || dreams.lastResolveReq.IdempotencyKey != "dream-retry-key" {
+	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" || dreams.lastResolveReq.IdempotencyKey != "" {
 		t.Fatalf("resolve_dream_feedback output = %v request = %+v", resolveOut, dreams.lastResolveReq)
 	}
 }

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -41,7 +41,7 @@ func TestResolveDreamFeedbackReturnsStructuredTerminalFailure(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "failed", structured.Result["processing_state"])
 	require.Equal(t, "terminal-failure", structured.Result["correlation_id"])
-	require.NoError(t, ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
+	require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
 	errors, ok := structured.Result["errors"].([]any)
 	require.True(t, ok)
 	require.Len(t, errors, 1)
@@ -82,7 +82,7 @@ func TestResolveDreamFeedbackReturnsStructuredNonCompletedTerminalOutcomes(t *te
 			structured, ok := ToolResultFromError(err)
 			require.True(t, ok)
 			require.Equal(t, test.state, structured.Result["processing_state"])
-			require.NoError(t, ValidateInput(Tool{InputSchema: terminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
+			require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
 		})
 	}
 }
@@ -97,6 +97,12 @@ func TestResolveDreamFeedbackOutputSchemaCoversTerminalBranch(t *testing.T) {
 		"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
 		"correlation_id", "evidence", "relationship_results", "errors",
 	}, terminal["required"])
+	terminalErrors := terminal["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
+	terminalActions := terminalErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
+	require.Contains(t, terminalActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
+	genericErrors := terminalRememberOutputSchema(domain.ContractVersion)["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
+	genericActions := genericErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
+	require.NotContains(t, genericActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
 }
 
 func TestResolveDreamFeedbackReturnsStructuredBusyRetry(t *testing.T) {

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -4,8 +4,132 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	"github.com/stretchr/testify/require"
 )
+
+func TestResolveDreamFeedbackReturnsStructuredTerminalFailure(t *testing.T) {
+	dreams := &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
+		Dream: stubDream("profile-dream"),
+		Memory: &rememberapp.RememberResult{Terminal: &rememberapp.TerminalRememberResult{
+			ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+			ProcessingState: string(rememberapp.TerminalProcessingFailed), SearchState: string(rememberapp.TerminalSearchNotRequired),
+			CorrelationID: "terminal-failure", Evidence: []rememberapp.TerminalEvidenceResult{},
+			RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
+			Errors:              []rememberapp.SubmissionStatusError{rememberapp.StatusError(rememberapp.SubmissionErrorProviderUnavailable)},
+		}},
+	}}
+	reg, err := BuildActive(Dependencies{Dreams: dreams})
+	require.NoError(t, err)
+	tool, ok := reg.Get(ToolResolveDreamFeedback)
+	require.True(t, ok)
+
+	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+		"hypothesis_id": "dream-1", "decision": "confirm_true",
+		"evidence": []any{map[string]any{"content": "independent evidence"}},
+		"relationships": []any{map[string]any{
+			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+			"predicate": map[string]any{"proposed_key": "uses"},
+			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+		}},
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, "failed", structured.Result["processing_state"])
+	require.Equal(t, "terminal-failure", structured.Result["correlation_id"])
+	require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
+	errors, ok := structured.Result["errors"].([]any)
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+}
+
+func TestResolveDreamFeedbackReturnsStructuredNonCompletedTerminalOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		state string
+		code  rememberapp.TerminalErrorCode
+	}{
+		{state: string(rememberapp.TerminalProcessingRejected), code: rememberapp.TerminalErrorNoSupportedMemory},
+		{state: string(rememberapp.TerminalProcessingQuarantined), code: rememberapp.TerminalErrorQuarantined},
+	} {
+		t.Run(test.state, func(t *testing.T) {
+			terminal := &rememberapp.TerminalRememberResult{
+				ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
+				ProcessingState: test.state, SearchState: string(rememberapp.TerminalSearchNotRequired),
+				CorrelationID: "terminal-" + test.state, Evidence: []rememberapp.TerminalEvidenceResult{},
+				RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
+				Errors:              []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(test.code)},
+			}
+			reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
+				Dream: stubDream("profile-dream"), Memory: &rememberapp.RememberResult{Terminal: terminal},
+			}}})
+			require.NoError(t, err)
+			tool, ok := reg.Get(ToolResolveDreamFeedback)
+			require.True(t, ok)
+			_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+				"hypothesis_id": "dream-1", "decision": "confirm_true",
+				"evidence": []any{map[string]any{"content": "independent evidence"}},
+				"relationships": []any{map[string]any{
+					"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+					"predicate": map[string]any{"proposed_key": "uses"},
+					"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+					"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+				}},
+			})
+			structured, ok := ToolResultFromError(err)
+			require.True(t, ok)
+			require.Equal(t, test.state, structured.Result["processing_state"])
+			require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
+		})
+	}
+}
+
+func TestResolveDreamFeedbackOutputSchemaCoversTerminalBranch(t *testing.T) {
+	variants, ok := resolveDreamFeedbackOutputSchema()["oneOf"].([]any)
+	require.True(t, ok)
+	require.Len(t, variants, 3)
+	terminal, ok := variants[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []string{
+		"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
+		"correlation_id", "evidence", "relationship_results", "errors",
+	}, terminal["required"])
+	terminalErrors := terminal["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
+	terminalActions := terminalErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
+	require.Contains(t, terminalActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
+	genericErrors := terminalRememberOutputSchema(domain.ContractVersion)["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
+	genericActions := genericErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
+	require.NotContains(t, genericActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
+}
+
+func TestResolveDreamFeedbackReturnsStructuredBusyRetry(t *testing.T) {
+	reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{
+		resolveErr: &dreamservice.ConfirmationBusyError{},
+	}})
+	require.NoError(t, err)
+	tool, ok := reg.Get(ToolResolveDreamFeedback)
+	require.True(t, ok)
+
+	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+		"hypothesis_id": "dream-1", "decision": "confirm_true",
+		"evidence": []any{map[string]any{"content": "independent evidence"}},
+		"relationships": []any{map[string]any{
+			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+			"predicate": map[string]any{"proposed_key": "uses"},
+			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+		}},
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, "dream_confirmation_busy", structured.Result["code"])
+	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), structured.Result["next_action"])
+	require.True(t, structured.Result["retryable"].(bool))
+	require.NoError(t, ValidateInput(Tool{InputSchema: dreamConfirmationBusyOutputSchema()}, structured.Result))
+}
 
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 	dreams := &stubDreamService{}

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -4,132 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
-	"github.com/stretchr/testify/require"
 )
-
-func TestResolveDreamFeedbackReturnsStructuredTerminalFailure(t *testing.T) {
-	dreams := &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
-		Dream: stubDream("profile-dream"),
-		Memory: &rememberapp.RememberResult{Terminal: &rememberapp.TerminalRememberResult{
-			ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
-			ProcessingState: string(rememberapp.TerminalProcessingFailed), SearchState: string(rememberapp.TerminalSearchNotRequired),
-			CorrelationID: "terminal-failure", Evidence: []rememberapp.TerminalEvidenceResult{},
-			RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
-			Errors:              []rememberapp.SubmissionStatusError{rememberapp.StatusError(rememberapp.SubmissionErrorProviderUnavailable)},
-		}},
-	}}
-	reg, err := BuildActive(Dependencies{Dreams: dreams})
-	require.NoError(t, err)
-	tool, ok := reg.Get(ToolResolveDreamFeedback)
-	require.True(t, ok)
-
-	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
-		"hypothesis_id": "dream-1", "decision": "confirm_true",
-		"evidence": []any{map[string]any{"content": "independent evidence"}},
-		"relationships": []any{map[string]any{
-			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
-			"predicate": map[string]any{"proposed_key": "uses"},
-			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
-			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
-		}},
-	})
-	structured, ok := ToolResultFromError(err)
-	require.True(t, ok)
-	require.Equal(t, "failed", structured.Result["processing_state"])
-	require.Equal(t, "terminal-failure", structured.Result["correlation_id"])
-	require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
-	errors, ok := structured.Result["errors"].([]any)
-	require.True(t, ok)
-	require.Len(t, errors, 1)
-}
-
-func TestResolveDreamFeedbackReturnsStructuredNonCompletedTerminalOutcomes(t *testing.T) {
-	for _, test := range []struct {
-		state string
-		code  rememberapp.TerminalErrorCode
-	}{
-		{state: string(rememberapp.TerminalProcessingRejected), code: rememberapp.TerminalErrorNoSupportedMemory},
-		{state: string(rememberapp.TerminalProcessingQuarantined), code: rememberapp.TerminalErrorQuarantined},
-	} {
-		t.Run(test.state, func(t *testing.T) {
-			terminal := &rememberapp.TerminalRememberResult{
-				ContractVersion: domain.ContractVersion, SubmissionID: uuid.NewString(), SubmissionKind: "remember",
-				ProcessingState: test.state, SearchState: string(rememberapp.TerminalSearchNotRequired),
-				CorrelationID: "terminal-" + test.state, Evidence: []rememberapp.TerminalEvidenceResult{},
-				RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
-				Errors:              []rememberapp.SubmissionStatusError{rememberapp.TerminalStatusError(test.code)},
-			}
-			reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{resolveResult: &dreamservice.ResolveFeedbackResult{
-				Dream: stubDream("profile-dream"), Memory: &rememberapp.RememberResult{Terminal: terminal},
-			}}})
-			require.NoError(t, err)
-			tool, ok := reg.Get(ToolResolveDreamFeedback)
-			require.True(t, ok)
-			_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
-				"hypothesis_id": "dream-1", "decision": "confirm_true",
-				"evidence": []any{map[string]any{"content": "independent evidence"}},
-				"relationships": []any{map[string]any{
-					"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
-					"predicate": map[string]any{"proposed_key": "uses"},
-					"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
-					"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
-				}},
-			})
-			structured, ok := ToolResultFromError(err)
-			require.True(t, ok)
-			require.Equal(t, test.state, structured.Result["processing_state"])
-			require.NoError(t, ValidateInput(Tool{InputSchema: dreamTerminalRememberOutputSchema(domain.ContractVersion)}, structured.Result))
-		})
-	}
-}
-
-func TestResolveDreamFeedbackOutputSchemaCoversTerminalBranch(t *testing.T) {
-	variants, ok := resolveDreamFeedbackOutputSchema()["oneOf"].([]any)
-	require.True(t, ok)
-	require.Len(t, variants, 3)
-	terminal, ok := variants[1].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, []string{
-		"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
-		"correlation_id", "evidence", "relationship_results", "errors",
-	}, terminal["required"])
-	terminalErrors := terminal["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
-	terminalActions := terminalErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
-	require.Contains(t, terminalActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
-	genericErrors := terminalRememberOutputSchema(domain.ContractVersion)["properties"].(map[string]any)["errors"].(map[string]any)["items"].(map[string]any)
-	genericActions := genericErrors["properties"].(map[string]any)["next_action"].(map[string]any)["enum"].([]string)
-	require.NotContains(t, genericActions, string(rememberapp.TerminalNextActionRetryDreamFeedback))
-}
-
-func TestResolveDreamFeedbackReturnsStructuredBusyRetry(t *testing.T) {
-	reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{
-		resolveErr: &dreamservice.ConfirmationBusyError{},
-	}})
-	require.NoError(t, err)
-	tool, ok := reg.Get(ToolResolveDreamFeedback)
-	require.True(t, ok)
-
-	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
-		"hypothesis_id": "dream-1", "decision": "confirm_true",
-		"evidence": []any{map[string]any{"content": "independent evidence"}},
-		"relationships": []any{map[string]any{
-			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
-			"predicate": map[string]any{"proposed_key": "uses"},
-			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
-			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
-		}},
-	})
-	structured, ok := ToolResultFromError(err)
-	require.True(t, ok)
-	require.Equal(t, "dream_confirmation_busy", structured.Result["code"])
-	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), structured.Result["next_action"])
-	require.True(t, structured.Result["retryable"].(bool))
-	require.NoError(t, ValidateInput(Tool{InputSchema: dreamConfirmationBusyOutputSchema()}, structured.Result))
-}
 
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 	dreams := &stubDreamService{}
@@ -194,15 +70,14 @@ func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {
 		}
 	}
 	resolveOut, err := resolveTool.Invoke(ctx, "profile-dream", map[string]any{
-		"hypothesis_id":   "dream-1",
-		"decision":        "reinforce",
-		"reason":          "prior conversation still makes this useful",
-		"idempotency_key": "dream-retry-1",
+		"hypothesis_id": "dream-1",
+		"decision":      "reinforce",
+		"reason":        "prior conversation still makes this useful",
 	})
 	if err != nil {
 		t.Fatalf("resolve_dream_feedback Invoke: %v", err)
 	}
-	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" || dreams.lastResolveReq.IdempotencyKey != "dream-retry-1" {
+	if resolveOut["hypothesis_id"] != "dream-1" || dreams.lastResolveReq.Decision != "reinforce" || dreams.lastResolveReq.Feedback != "prior conversation still makes this useful" {
 		t.Fatalf("resolve_dream_feedback output = %v request = %+v", resolveOut, dreams.lastResolveReq)
 	}
 }

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -90,13 +90,39 @@ func TestResolveDreamFeedbackReturnsStructuredNonCompletedTerminalOutcomes(t *te
 func TestResolveDreamFeedbackOutputSchemaCoversTerminalBranch(t *testing.T) {
 	variants, ok := resolveDreamFeedbackOutputSchema()["oneOf"].([]any)
 	require.True(t, ok)
-	require.Len(t, variants, 2)
+	require.Len(t, variants, 3)
 	terminal, ok := variants[1].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, []string{
 		"contract_version", "submission_id", "submission_kind", "processing_state", "search_state",
 		"correlation_id", "evidence", "relationship_results", "errors",
 	}, terminal["required"])
+}
+
+func TestResolveDreamFeedbackReturnsStructuredBusyRetry(t *testing.T) {
+	reg, err := BuildActive(Dependencies{Dreams: &stubDreamService{
+		resolveErr: &dreamservice.ConfirmationBusyError{},
+	}})
+	require.NoError(t, err)
+	tool, ok := reg.Get(ToolResolveDreamFeedback)
+	require.True(t, ok)
+
+	_, err = tool.Invoke(contractInvokeContext("write"), "profile-dream", map[string]any{
+		"hypothesis_id": "dream-1", "decision": "confirm_true",
+		"evidence": []any{map[string]any{"content": "independent evidence"}},
+		"relationships": []any{map[string]any{
+			"ref": "r-1", "subject": map[string]any{"name": "Dense-Mem", "entity_kind": "project"},
+			"predicate": map[string]any{"proposed_key": "uses"},
+			"object":    map[string]any{"entity": map[string]any{"name": "PostgreSQL", "entity_kind": "product"}},
+			"polarity":  "+", "modality": "statement", "evidence_indices": []any{0},
+		}},
+	})
+	structured, ok := ToolResultFromError(err)
+	require.True(t, ok)
+	require.Equal(t, "dream_confirmation_busy", structured.Result["code"])
+	require.Equal(t, string(rememberapp.TerminalNextActionRetryDreamFeedback), structured.Result["next_action"])
+	require.True(t, structured.Result["retryable"].(bool))
+	require.NoError(t, ValidateInput(Tool{InputSchema: dreamConfirmationBusyOutputSchema()}, structured.Result))
 }
 
 func TestBuildActiveDreamToolsInvokeAndValidate(t *testing.T) {

--- a/internal/tools/registry/test_helpers_test.go
+++ b/internal/tools/registry/test_helpers_test.go
@@ -71,6 +71,7 @@ type stubDreamService struct {
 	recallQuery    string
 	recallErr      error
 	resolveResult  *dreamservice.ResolveFeedbackResult
+	resolveErr     error
 }
 
 func (s *stubDreamService) RunCycle(_ context.Context, profileID string, req dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -111,6 +112,9 @@ func (s *stubDreamService) Recall(_ context.Context, profileID, query string, _ 
 
 func (s *stubDreamService) ResolveFeedback(_ context.Context, profileID string, req dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
 	s.lastResolveReq = req
+	if s.resolveErr != nil {
+		return nil, s.resolveErr
+	}
 	if s.resolveResult != nil {
 		return s.resolveResult, nil
 	}

--- a/internal/tools/registry/test_helpers_test.go
+++ b/internal/tools/registry/test_helpers_test.go
@@ -70,6 +70,7 @@ type stubDreamService struct {
 	lastResolveReq dreamservice.ResolveFeedbackRequest
 	recallQuery    string
 	recallErr      error
+	resolveResult  *dreamservice.ResolveFeedbackResult
 }
 
 func (s *stubDreamService) RunCycle(_ context.Context, profileID string, req dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -110,6 +111,9 @@ func (s *stubDreamService) Recall(_ context.Context, profileID, query string, _ 
 
 func (s *stubDreamService) ResolveFeedback(_ context.Context, profileID string, req dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
 	s.lastResolveReq = req
+	if s.resolveResult != nil {
+		return s.resolveResult, nil
+	}
 	return &dreamservice.ResolveFeedbackResult{Dream: stubDream(profileID)}, nil
 }
 

--- a/internal/tools/registry/test_helpers_test.go
+++ b/internal/tools/registry/test_helpers_test.go
@@ -70,6 +70,8 @@ type stubDreamService struct {
 	lastResolveReq dreamservice.ResolveFeedbackRequest
 	recallQuery    string
 	recallErr      error
+	resolveResult  *dreamservice.ResolveFeedbackResult
+	resolveErr     error
 }
 
 func (s *stubDreamService) RunCycle(_ context.Context, profileID string, req dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -110,6 +112,12 @@ func (s *stubDreamService) Recall(_ context.Context, profileID, query string, _ 
 
 func (s *stubDreamService) ResolveFeedback(_ context.Context, profileID string, req dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
 	s.lastResolveReq = req
+	if s.resolveErr != nil {
+		return nil, s.resolveErr
+	}
+	if s.resolveResult != nil {
+		return s.resolveResult, nil
+	}
 	return &dreamservice.ResolveFeedbackResult{Dream: stubDream(profileID)}, nil
 }
 

--- a/internal/tools/registry/test_helpers_test.go
+++ b/internal/tools/registry/test_helpers_test.go
@@ -70,8 +70,6 @@ type stubDreamService struct {
 	lastResolveReq dreamservice.ResolveFeedbackRequest
 	recallQuery    string
 	recallErr      error
-	resolveResult  *dreamservice.ResolveFeedbackResult
-	resolveErr     error
 }
 
 func (s *stubDreamService) RunCycle(_ context.Context, profileID string, req dreamservice.RunCycleRequest) (*dreamservice.RunCycleResult, error) {
@@ -112,12 +110,6 @@ func (s *stubDreamService) Recall(_ context.Context, profileID, query string, _ 
 
 func (s *stubDreamService) ResolveFeedback(_ context.Context, profileID string, req dreamservice.ResolveFeedbackRequest) (*dreamservice.ResolveFeedbackResult, error) {
 	s.lastResolveReq = req
-	if s.resolveErr != nil {
-		return nil, s.resolveErr
-	}
-	if s.resolveResult != nil {
-		return s.resolveResult, nil
-	}
 	return &dreamservice.ResolveFeedbackResult{Dream: stubDream(profileID)}, nil
 }
 

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -108,7 +108,7 @@ export async function run({ rpc, rawRPC, expect }) {
 	expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
 	const failedAttempt = attemptRow(teamID, scenarios.failed.idempotencyKey);
 	expect(failedAttempt.outcome === "failed" && failedAttempt.count === 1, "operational failure must persist one failed terminal attempt");
-	assertDreamRetryGuidance(failed, scenarios.failed, "failed");
+  assertDreamRetryGuidance(failed, scenarios.failed, "failed", "retry_same_request");
 	const failedAttemptCount = failedAttempt.count;
 
   const noEvidence = await rawRPC("tools/call", {
@@ -168,12 +168,16 @@ export async function run({ rpc, rawRPC, expect }) {
   };
 }
 
-function assertDreamRetryGuidance(result, scenario, label) {
-	const error = result?.errors?.[0];
-	expect(error?.next_action === "retry_dream_feedback", `${label} Dream terminal result must advertise retry_dream_feedback`);
-	expect(typeof error?.remediation === "string" && error.remediation.includes("resolve_dream_feedback"), `${label} Dream terminal result must name resolve_dream_feedback in remediation`);
-	expect(error.remediation.includes("idempotency_key"), `${label} Dream terminal result must name idempotency_key in remediation`);
-	expect(error.remediation.includes(scenario.hypothesisID), `${label} Dream terminal result must use the canonical Hypothesis ID in remediation`);
+function assertDreamRetryGuidance(result, scenario, label, expectedAction = "retry_dream_feedback") {
+  const error = result?.errors?.[0];
+  expect(error?.next_action === expectedAction, `${label} Dream terminal result must advertise ${expectedAction}`);
+  if (expectedAction === "retry_same_request") {
+    expect(typeof error?.remediation === "string" && error.remediation.includes("same idempotency_key"), `${label} Dream terminal result must advertise same-key remediation`);
+    return;
+  }
+  expect(typeof error?.remediation === "string" && error.remediation.includes("resolve_dream_feedback"), `${label} Dream terminal result must name resolve_dream_feedback in remediation`);
+  expect(error.remediation.includes("idempotency_key"), `${label} Dream terminal result must name idempotency_key in remediation`);
+  expect(error.remediation.includes(scenario.hypothesisID), `${label} Dream terminal result must use the canonical Hypothesis ID in remediation`);
 }
 
 async function enableDreaming() {

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -1,2 +1,282 @@
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
 export const name = "dream";
-export async function run() { return { mode: name, status: "reserved-for-adoption" }; }
+
+export async function run({ rpc, rawRPC, expect }) {
+  await enableDreaming();
+  const listed = await rpc("tools/list", {});
+  const names = new Set((listed.tools || []).map((tool) => tool.name));
+  expect(names.has("resolve_dream_feedback"), "dream surface must expose resolve_dream_feedback");
+  expect(names.has("get_submission_status"), "dream slice must retain the legacy status tool");
+
+  const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+  const apiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+  const ownerProfileID = await apiCredentialOwnerID(apiKey);
+  const scenarios = makeScenarios();
+  seedHypotheses(teamID, ownerProfileID, scenarios);
+
+  const completed = await resolve(rpc, scenarios.completed, expect);
+  expect(completed.status === "submitted", "completed Remember must submit the Hypothesis");
+  const completedSubmissionID = requireString(completed.submission_id, "completed submission ID");
+  const completedHypothesis = hypothesisRow(teamID, scenarios.completed.hypothesisID);
+  expect(completedHypothesis.status === "submitted", "completed confirmation must persist submitted status");
+  expect(completedHypothesis.submittedIngestID === completedSubmissionID, "completed confirmation must link the committed ingest");
+  const completedFeedbackEvents = feedbackEventCount(teamID, scenarios.completed.hypothesisID);
+  expect(completedFeedbackEvents === 1, "completed confirmation must persist one feedback event");
+  const completedAttempt = attemptRow(teamID, scenarios.completed.idempotencyKey);
+  expect(completedAttempt.outcome === "completed" && completedAttempt.count === 1, "completed confirmation must persist one terminal attempt");
+  const completedEvidence = evidenceRow(teamID, completedSubmissionID);
+  expect(completedEvidence.content === scenarios.completed.evidence, "Remember must persist the independent evidence exactly");
+  expect(completedEvidence.hypothesisID === scenarios.completed.hypothesisID, "Remember evidence must retain bounded Hypothesis provenance");
+  expect(completedEvidence.content !== scenarios.completed.statement, "Hypothesis text must not become submitted evidence");
+
+  const replay = await resolve(rpc, scenarios.completed, expect);
+  expect(replay.status === "submitted", "completed replay must retain submitted status");
+  expect(replay.submission_id === completedSubmissionID, "completed replay must reuse the canonical submission ID");
+  const replayHypothesis = hypothesisRow(teamID, scenarios.completed.hypothesisID);
+  expect(replayHypothesis.submittedAt === completedHypothesis.submittedAt, "completed replay must retain the original submission time");
+  expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "completed replay must not append a feedback event");
+  const replayAttempt = attemptRow(teamID, scenarios.completed.idempotencyKey);
+  expect(replayAttempt.outcome === "completed" && replayAttempt.count === 1, "completed replay must not create a second canonical attempt");
+
+  const changedReason = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: {
+      hypothesis_id: scenarios.completed.hypothesisID,
+      decision: "confirm_true",
+      reason: "A different bounded feedback reason must not replay the original mutation.",
+      evidence: [{ content: scenarios.completed.evidence, source_type: "manual", source: `dream-feedback-${scenarios.completed.hypothesisID}` }],
+      relationships: [dreamRelationship(scenarios.completed)],
+    },
+  });
+  expect(String(changedReason.error?.message || "").includes("remember: conflict"), "changed Dream feedback reason must conflict under the same retry identity");
+  expect(attemptRow(teamID, scenarios.completed.idempotencyKey).count === 1, "changed Dream feedback reason must not create another Remember attempt");
+  expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "changed Dream feedback reason must not append a feedback event");
+  const unchangedHypothesis = hypothesisRow(teamID, scenarios.completed.hypothesisID);
+  expect(unchangedHypothesis.status === completedHypothesis.status, "changed Dream feedback reason must preserve Hypothesis status");
+  expect(unchangedHypothesis.submittedIngestID === completedHypothesis.submittedIngestID, "changed Dream feedback reason must preserve submitted ingest");
+  expect(unchangedHypothesis.submittedAt === completedHypothesis.submittedAt, "changed Dream feedback reason must preserve submission time");
+
+  const rejected = await resolve(rpc, scenarios.rejected, expect);
+  expect(rejected.status === "proposed", "rejected Remember must leave the Hypothesis reviewable");
+  requireString(rejected.submission_id, "rejected submission ID");
+  expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
+  expect(attemptRow(teamID, scenarios.rejected.idempotencyKey).outcome === "rejected", "rejected confirmation must persist a rejected terminal attempt");
+
+  const quarantined = await resolve(rpc, scenarios.quarantined, expect);
+  expect(quarantined.status === "proposed", "quarantined Remember must leave the Hypothesis reviewable");
+  requireString(quarantined.submission_id, "quarantined submission ID");
+  expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
+  expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
+
+  const failed = await resolve(rpc, scenarios.failed, expect);
+  expect(failed.status === "proposed", "operational Remember failure must leave the Hypothesis reviewable");
+  requireString(failed.submission_id, "failed submission ID");
+  expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
+  expect(attemptRow(teamID, scenarios.failed.idempotencyKey).outcome === "failed", "operational failure must persist a failed terminal attempt");
+  const failedAttemptCount = attemptRow(teamID, scenarios.failed.idempotencyKey).count;
+
+  const noEvidence = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: { hypothesis_id: scenarios.failed.hypothesisID, decision: "confirm_true" },
+  });
+  expect(String(noEvidence.error?.message || "").includes("evidence is required"), "confirmation without evidence must fail contract validation");
+  expect(attemptRow(teamID, scenarios.failed.idempotencyKey).count === failedAttemptCount, "confirmation without evidence must not invoke Remember");
+
+  const hypothesisText = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: {
+      hypothesis_id: scenarios.failed.hypothesisID,
+      decision: "confirm_true",
+      evidence: [{ content: scenarios.failed.statement }],
+      relationships: [dreamRelationship(scenarios.failed)],
+    },
+  });
+  expect(String(hypothesisText.error?.message || "").includes("hypothesis text cannot be submitted"), "Hypothesis text must not be accepted as evidence");
+  expect(attemptRow(teamID, scenarios.failed.idempotencyKey).count === failedAttemptCount, "Hypothesis text rejection must not invoke Remember");
+
+  return {
+    mode: name,
+    completed_submission_id: completedSubmissionID,
+    replay_reused_submission: true,
+    rejected_reviewable: true,
+    quarantined_reviewable: true,
+    failed_reviewable: true,
+    independent_evidence_provenance: true,
+  };
+}
+
+async function enableDreaming() {
+  const controlURL = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+  const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+  await httpJSON(`${controlURL}/control/api/config/dreaming`, {
+    method: "PATCH",
+    headers: { Authorization: `Bearer ${controlToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ items: [
+      { key: "DREAMING_ENABLED", value: "true" },
+      { key: "DREAMING_FORCE_ENABLED", value: "true" },
+      { key: "DREAMING_START_TIME_LOCAL", value: "03:00" },
+      { key: "DREAMING_MAX_OUTPUTS", value: "5" },
+    ] }),
+  });
+}
+
+function makeScenarios() {
+  const labels = ["completed", "rejected", "quarantined", "failed"];
+  const scenarios = {};
+  for (const label of labels) {
+    const hypothesisID = randomUUID();
+    const statement = `Dream ${label}: Dense-Mem may use PostgreSQL for durable memory.`;
+    const evidence = label === "rejected"
+      ? `[fixture-fault:no-supported] Dense-Mem uses PostgreSQL; independent ${label} evidence.`
+      : label === "quarantined"
+        ? `[fixture-fault:security] Dense-Mem uses PostgreSQL; independent ${label} evidence.`
+        : label === "failed"
+          ? `[fixture-fault:assessment-unavailable] Independent ${label} evidence.`
+          : "Independent deployment evidence confirms Dense-Mem uses PostgreSQL.";
+    scenarios[label] = {
+      hypothesisID,
+      statement,
+      evidence,
+      idempotencyKey: `dream-feedback:${hypothesisID}:confirm_true`,
+    };
+  }
+  return scenarios;
+}
+
+async function resolve(rpc, scenario, expect) {
+  const result = await toolSuccess(rpc, "resolve_dream_feedback", {
+    hypothesis_id: scenario.hypothesisID,
+    decision: "confirm_true",
+    evidence: [{ content: scenario.evidence, source_type: "manual", source: `dream-feedback-${scenario.hypothesisID}` }],
+    relationships: [dreamRelationship(scenario)],
+  });
+  expect(result.hypothesis_id === scenario.hypothesisID, "Dream feedback must return the requested Hypothesis");
+  return result;
+}
+
+function dreamRelationship(scenario) {
+  return {
+    ref: `dream-${scenario.hypothesisID}-relationship`,
+    subject: { name: "Dense-Mem", entity_kind: "project" },
+    predicate: { proposed_key: "uses" },
+    object: { entity: { name: "PostgreSQL", entity_kind: "product" } },
+    polarity: "+",
+    modality: "statement",
+    evidence_indices: [0],
+  };
+}
+
+async function toolSuccess(rpc, name, args) {
+  const result = await rpc("tools/call", { name, arguments: args });
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} did not return JSON content`);
+  return JSON.parse(text);
+}
+
+async function apiCredentialOwnerID(apiKey) {
+  const payload = await httpJSON(`${requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "")}/ui/api/session`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  const ownerProfileID = payload.data?.credential?.id;
+  if (typeof ownerProfileID !== "string" || ownerProfileID.length === 0) throw new Error("user session did not return a credential ID");
+  return ownerProfileID;
+}
+
+function seedHypotheses(teamID, ownerProfileID, scenarios) {
+  const values = Object.values(scenarios).map((scenario) => `(
+    ${sqlLiteral(teamID)}::uuid, ${sqlLiteral(scenario.hypothesisID)}::uuid,
+    ${sqlLiteral(ownerProfileID)}::uuid, 'proposed', ${sqlLiteral(scenario.statement)},
+    ${sqlLiteral(`sha256:${randomUUID().replaceAll("-", "")}`)}, '[]'::jsonb, '{}'::jsonb, ARRAY[]::uuid[]
+  )`);
+  postgresQuery(`
+    INSERT INTO hypotheses (
+      team_id, hypothesis_id, created_by_profile_id, status, statement,
+      content_hash, source_refs, source_versions, source_owner_profile_ids
+    ) VALUES ${values.join(",")}
+  `);
+}
+
+function hypothesisRow(teamID, hypothesisID) {
+  const [status, submittedIngestID, submittedAt] = postgresQuery(`
+    SELECT status, COALESCE(submitted_ingest_id::text, ''), COALESCE(submitted_at::text, '')
+    FROM hypotheses
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid AND hypothesis_id = ${sqlLiteral(hypothesisID)}::uuid
+  `).split("|");
+  return { status, submittedIngestID, submittedAt };
+}
+
+function feedbackEventCount(teamID, hypothesisID) {
+  return Number(postgresQuery(`
+    SELECT count(*)::text
+    FROM hypothesis_feedback_events
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid AND hypothesis_id = ${sqlLiteral(hypothesisID)}::uuid
+  `) || 0);
+}
+
+function attemptRow(teamID, idempotencyKey) {
+  const output = postgresQuery(`
+    SELECT COALESCE(outcome, ''), count(*)::text
+    FROM remember_attempts
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid AND idempotency_key = ${sqlLiteral(idempotencyKey)}
+    GROUP BY outcome ORDER BY outcome LIMIT 1
+  `);
+  if (!output) return { outcome: "", count: 0 };
+  const [outcome, count] = output.split("|");
+  return { outcome, count: Number(count) };
+}
+
+function evidenceRow(teamID, ingestID) {
+  const [content, hypothesisID] = postgresQuery(`
+    SELECT content, COALESCE(metadata->>'hypothesis_id', '')
+    FROM evidence_fragments
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid AND ingest_id = ${sqlLiteral(ingestID)}::uuid
+    ORDER BY evidence_index LIMIT 1
+  `).split("|");
+  return { content, hypothesisID };
+}
+
+function postgresQuery(sql) {
+  const composeProject = requiredEnv("DENSE_MEM_E2E_COMPOSE_PROJECT");
+  const composeFile = requiredEnv("DENSE_MEM_E2E_COMPOSE_FILE");
+  const scopedSQL = [
+    "BEGIN",
+    "SET LOCAL app.tx_mode = 'system'",
+    "SET LOCAL app.current_team_id = ''",
+    "SET LOCAL app.current_profile_id = ''",
+    "SET LOCAL app.allowed_space_ids = ''",
+    sql,
+    "COMMIT",
+  ].join(";\n");
+  const result = spawnSync("docker", [
+    "compose", "-p", composeProject, "-f", composeFile, "exec", "-T", "postgres", "sh", "-ec",
+    'psql -q -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At -c "$1"',
+    "dream-synchronous-write-e2e", scopedSQL,
+  ], { cwd: fileURLToPath(new URL("../..", import.meta.url)), encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`postgres query failed (${result.status})`);
+  return result.stdout.trim();
+}
+
+async function httpJSON(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  if (!response.ok) throw new Error(`HTTP ${response.status} request failed`);
+  return text ? JSON.parse(text) : {};
+}
+
+function sqlLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} is required`);
+  return value;
+}

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -257,15 +257,19 @@ function hypothesisIngestCount(teamID, hypothesisID) {
 }
 
 function attemptRow(teamID, idempotencyKey) {
-  const output = postgresQuery(`
-    SELECT COALESCE(outcome, ''), count(*)::text
+  const count = Number(postgresQuery(`
+    SELECT count(*)::text
     FROM remember_attempts
     WHERE team_id = ${sqlLiteral(teamID)}::uuid AND idempotency_key = ${sqlLiteral(idempotencyKey)}
-    GROUP BY outcome ORDER BY outcome LIMIT 1
-  `);
-  if (!output) return { outcome: "", count: 0 };
-  const [outcome, count] = output.split("|");
-  return { outcome, count: Number(count) };
+  `) || 0);
+  if (count === 0) return { outcome: "", count };
+  const outcome = postgresQuery(`
+    SELECT COALESCE(outcome, '')
+    FROM remember_attempts
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid AND idempotency_key = ${sqlLiteral(idempotencyKey)}
+    ORDER BY created_at DESC, attempt_id DESC LIMIT 1
+  `) || "";
+  return { outcome, count };
 }
 
 function evidenceRow(teamID, ingestID) {

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -68,44 +68,23 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(hypothesisIngestCount(teamID, scenarios.completed.hypothesisID) === completedIngestCount, "conflicting Dream confirmation must not create a Remember ingest");
   expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "conflicting Dream confirmation must not append a feedback event");
 
-  const rejectedResponse = await rawRPC("tools/call", {
-    name: "resolve_dream_feedback",
-    arguments: resolveArguments(scenarios.rejected),
-  });
-  expect(rejectedResponse.result?.isError === true, "rejected Remember must be a structured tool error");
-  const rejected = rejectedResponse.result?.structuredContent;
-  expect(rejected?.processing_state === "rejected", "rejected Remember must expose terminal state");
-  expect(Array.isArray(rejected?.errors) && rejected.errors.length > 0, "rejected Remember must expose typed errors");
-  requireString(rejected?.submission_id, "rejected submission ID");
+  const rejected = await resolve(rpc, scenarios.rejected, expect);
+  expect(rejected.status === "proposed", "rejected Remember must leave the Hypothesis reviewable");
+  requireString(rejected.submission_id, "rejected submission ID");
   expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.rejected.idempotencyKey).outcome === "rejected", "rejected confirmation must persist a rejected terminal attempt");
-  assertDreamRetryGuidance(rejected, scenarios.rejected, "rejected");
 
-  const quarantinedResponse = await rawRPC("tools/call", {
-    name: "resolve_dream_feedback",
-    arguments: resolveArguments(scenarios.quarantined),
-  });
-  expect(quarantinedResponse.result?.isError === true, "quarantined Remember must be a structured tool error");
-  const quarantined = quarantinedResponse.result?.structuredContent;
-  expect(quarantined?.processing_state === "quarantined", "quarantined Remember must expose terminal state");
-  expect(Array.isArray(quarantined?.errors) && quarantined.errors.length > 0, "quarantined Remember must expose typed errors");
-  requireString(quarantined?.submission_id, "quarantined submission ID");
+  const quarantined = await resolve(rpc, scenarios.quarantined, expect);
+  expect(quarantined.status === "proposed", "quarantined Remember must leave the Hypothesis reviewable");
+  requireString(quarantined.submission_id, "quarantined submission ID");
   expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
-  assertDreamRetryGuidance(quarantined, scenarios.quarantined, "quarantined");
 
-  const failedResponse = await rawRPC("tools/call", {
-    name: "resolve_dream_feedback",
-    arguments: resolveArguments(scenarios.failed),
-  });
-  expect(failedResponse.result?.isError === true, "operational Remember failure must be a structured tool error");
-  const failed = failedResponse.result?.structuredContent;
-  expect(failed?.processing_state === "failed", "operational Remember failure must expose terminal state");
-  expect(Array.isArray(failed?.errors) && failed.errors.length > 0, "operational Remember failure must expose typed errors");
-  requireString(failed?.submission_id, "failed submission ID");
+  const failed = await resolve(rpc, scenarios.failed, expect);
+  expect(failed.status === "proposed", "operational Remember failure must leave the Hypothesis reviewable");
+  requireString(failed.submission_id, "failed submission ID");
   expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
   expect(attemptRow(teamID, scenarios.failed.idempotencyKey).outcome === "failed", "operational failure must persist a failed terminal attempt");
-  assertDreamRetryGuidance(failed, scenarios.failed, "failed");
   const failedAttemptCount = attemptRow(teamID, scenarios.failed.idempotencyKey).count;
 
   const noEvidence = await rawRPC("tools/call", {
@@ -146,9 +125,8 @@ export async function run({ rpc, rawRPC, expect }) {
     },
   });
   const contentionResponses = await Promise.all([firstContention, secondContention]);
-  const busyResponse = contentionResponses.find((response) => response.result?.structuredContent?.code === "dream_confirmation_busy");
-  expect(busyResponse?.result?.isError === true, "concurrent Dream confirmation must expose a structured busy error");
-  expect(busyResponse.result.structuredContent.next_action === "retry_dream_feedback", "busy Dream confirmation must advertise retry_dream_feedback");
+  const busyResponse = contentionResponses.find((response) => String(response.error?.message || "").includes("dream confirmation is already in progress"));
+  expect(busyResponse?.error?.message, "concurrent Dream confirmation must expose a bounded busy error");
   expect(hypothesisIngestCount(teamID, contention.hypothesisID) === contentionIngestCount, "busy Dream confirmation must not create a Remember ingest");
   expect(feedbackEventCount(teamID, contention.hypothesisID) === contentionFeedbackCount, "busy Dream confirmation must not append a feedback event");
   expect(attemptRow(teamID, contention.idempotencyKey).count === 1, "concurrent Dream confirmation must persist only the admitted terminal attempt");
@@ -163,14 +141,6 @@ export async function run({ rpc, rawRPC, expect }) {
     contention_busy_reviewable: true,
     independent_evidence_provenance: true,
   };
-}
-
-function assertDreamRetryGuidance(result, scenario, label) {
-  const error = result?.errors?.[0];
-  expect(error?.next_action === "retry_dream_feedback", `${label} Dream terminal result must advertise retry_dream_feedback`);
-  expect(typeof error?.remediation === "string" && error.remediation.includes("resolve_dream_feedback"), `${label} Dream terminal result must name resolve_dream_feedback in remediation`);
-  expect(error.remediation.includes("idempotency_key"), `${label} Dream terminal result must name idempotency_key in remediation`);
-  expect(error.remediation.includes(scenario.hypothesisID), `${label} Dream terminal result must use the canonical Hypothesis ID in remediation`);
 }
 
 async function enableDreaming() {

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -79,6 +79,7 @@ export async function run({ rpc, rawRPC, expect }) {
   requireString(rejected?.submission_id, "rejected submission ID");
   expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.rejected.idempotencyKey).outcome === "rejected", "rejected confirmation must persist a rejected terminal attempt");
+  assertDreamRetryGuidance(rejected, scenarios.rejected, "rejected");
 
   const quarantinedResponse = await rawRPC("tools/call", {
     name: "resolve_dream_feedback",
@@ -91,6 +92,7 @@ export async function run({ rpc, rawRPC, expect }) {
   requireString(quarantined?.submission_id, "quarantined submission ID");
   expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
+  assertDreamRetryGuidance(quarantined, scenarios.quarantined, "quarantined");
 
   const failedResponse = await rawRPC("tools/call", {
     name: "resolve_dream_feedback",
@@ -103,6 +105,7 @@ export async function run({ rpc, rawRPC, expect }) {
   requireString(failed?.submission_id, "failed submission ID");
   expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
   expect(attemptRow(teamID, scenarios.failed.idempotencyKey).outcome === "failed", "operational failure must persist a failed terminal attempt");
+  assertDreamRetryGuidance(failed, scenarios.failed, "failed");
   const failedAttemptCount = attemptRow(teamID, scenarios.failed.idempotencyKey).count;
 
   const noEvidence = await rawRPC("tools/call", {
@@ -124,6 +127,32 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(String(hypothesisText.error?.message || "").includes("hypothesis text cannot be submitted"), "Hypothesis text must not be accepted as evidence");
   expect(attemptRow(teamID, scenarios.failed.idempotencyKey).count === failedAttemptCount, "Hypothesis text rejection must not invoke Remember");
 
+  const contention = scenarios.contention;
+  const contentionIngestCount = hypothesisIngestCount(teamID, contention.hypothesisID);
+  const contentionFeedbackCount = feedbackEventCount(teamID, contention.hypothesisID);
+  const firstContention = rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: {
+      ...resolveArguments(contention),
+      evidence: [{ content: "[fixture-fault:assessment-timeout] Independent contention evidence.", source_type: "manual" }],
+    },
+  });
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  const secondContention = rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: {
+      ...resolveArguments(contention),
+      evidence: [{ content: "[fixture-fault:assessment-timeout] Independent contention evidence.", source_type: "manual" }],
+    },
+  });
+  const contentionResponses = await Promise.all([firstContention, secondContention]);
+  const busyResponse = contentionResponses.find((response) => response.result?.structuredContent?.code === "dream_confirmation_busy");
+  expect(busyResponse?.result?.isError === true, "concurrent Dream confirmation must expose a structured busy error");
+  expect(busyResponse.result.structuredContent.next_action === "retry_dream_feedback", "busy Dream confirmation must advertise retry_dream_feedback");
+  expect(hypothesisIngestCount(teamID, contention.hypothesisID) === contentionIngestCount, "busy Dream confirmation must not create a Remember ingest");
+  expect(feedbackEventCount(teamID, contention.hypothesisID) === contentionFeedbackCount, "busy Dream confirmation must not append a feedback event");
+  expect(attemptRow(teamID, contention.idempotencyKey).count === 1, "concurrent Dream confirmation must persist only the admitted terminal attempt");
+
   return {
     mode: name,
     completed_submission_id: completedSubmissionID,
@@ -131,8 +160,17 @@ export async function run({ rpc, rawRPC, expect }) {
     rejected_reviewable: true,
     quarantined_reviewable: true,
     failed_reviewable: true,
+    contention_busy_reviewable: true,
     independent_evidence_provenance: true,
   };
+}
+
+function assertDreamRetryGuidance(result, scenario, label) {
+  const error = result?.errors?.[0];
+  expect(error?.next_action === "retry_dream_feedback", `${label} Dream terminal result must advertise retry_dream_feedback`);
+  expect(typeof error?.remediation === "string" && error.remediation.includes("resolve_dream_feedback"), `${label} Dream terminal result must name resolve_dream_feedback in remediation`);
+  expect(error.remediation.includes("idempotency_key"), `${label} Dream terminal result must name idempotency_key in remediation`);
+  expect(error.remediation.includes(scenario.hypothesisID), `${label} Dream terminal result must use the canonical Hypothesis ID in remediation`);
 }
 
 async function enableDreaming() {
@@ -151,7 +189,7 @@ async function enableDreaming() {
 }
 
 function makeScenarios() {
-  const labels = ["completed", "rejected", "quarantined", "failed"];
+  const labels = ["completed", "rejected", "quarantined", "failed", "contention"];
   const scenarios = {};
   for (const label of labels) {
     const hypothesisID = randomUUID();

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -72,20 +72,23 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(rejected.status === "proposed", "rejected Remember must leave the Hypothesis reviewable");
   requireString(rejected.submission_id, "rejected submission ID");
   expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
-  expect(attemptRow(teamID, scenarios.rejected.idempotencyKey).outcome === "rejected", "rejected confirmation must persist a rejected terminal attempt");
+  const rejectedAttempt = attemptRow(teamID, scenarios.rejected.idempotencyKey);
+  expect(rejectedAttempt.outcome === "rejected" && rejectedAttempt.count === 1, "rejected confirmation must persist one rejected terminal attempt");
 
   const quarantined = await resolve(rpc, scenarios.quarantined, expect);
   expect(quarantined.status === "proposed", "quarantined Remember must leave the Hypothesis reviewable");
   requireString(quarantined.submission_id, "quarantined submission ID");
   expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
-  expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
+  const quarantinedAttempt = attemptRow(teamID, scenarios.quarantined.idempotencyKey);
+  expect(quarantinedAttempt.outcome === "quarantined" && quarantinedAttempt.count === 1, "quarantined confirmation must persist one quarantined terminal attempt");
 
   const failed = await resolve(rpc, scenarios.failed, expect);
   expect(failed.status === "proposed", "operational Remember failure must leave the Hypothesis reviewable");
   requireString(failed.submission_id, "failed submission ID");
   expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
-  expect(attemptRow(teamID, scenarios.failed.idempotencyKey).outcome === "failed", "operational failure must persist a failed terminal attempt");
-  const failedAttemptCount = attemptRow(teamID, scenarios.failed.idempotencyKey).count;
+  const failedAttempt = attemptRow(teamID, scenarios.failed.idempotencyKey);
+  expect(failedAttempt.outcome === "failed" && failedAttempt.count === 1, "operational failure must persist one failed terminal attempt");
+  const failedAttemptCount = failedAttempt.count;
 
   const noEvidence = await rawRPC("tools/call", {
     name: "resolve_dream_feedback",

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -68,27 +68,48 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(hypothesisIngestCount(teamID, scenarios.completed.hypothesisID) === completedIngestCount, "conflicting Dream confirmation must not create a Remember ingest");
   expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "conflicting Dream confirmation must not append a feedback event");
 
-  const rejected = await resolve(rpc, scenarios.rejected, expect);
-  expect(rejected.status === "proposed", "rejected Remember must leave the Hypothesis reviewable");
-  requireString(rejected.submission_id, "rejected submission ID");
-  expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
-  const rejectedAttempt = attemptRow(teamID, scenarios.rejected.idempotencyKey);
-  expect(rejectedAttempt.outcome === "rejected" && rejectedAttempt.count === 1, "rejected confirmation must persist one rejected terminal attempt");
+	const rejectedResponse = await rawRPC("tools/call", {
+		name: "resolve_dream_feedback",
+		arguments: resolveArguments(scenarios.rejected),
+	});
+	expect(rejectedResponse.result?.isError === true, "rejected Remember must be a structured tool error");
+	const rejected = rejectedResponse.result?.structuredContent;
+	expect(rejected?.processing_state === "rejected", "rejected Remember must expose terminal state");
+	expect(Array.isArray(rejected?.errors) && rejected.errors.length > 0, "rejected Remember must expose typed errors");
+	requireString(rejected?.submission_id, "rejected submission ID");
+	expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
+	const rejectedAttempt = attemptRow(teamID, scenarios.rejected.idempotencyKey);
+	expect(rejectedAttempt.outcome === "rejected" && rejectedAttempt.count === 1, "rejected confirmation must persist one rejected terminal attempt");
+	assertDreamRetryGuidance(rejected, scenarios.rejected, "rejected");
 
-  const quarantined = await resolve(rpc, scenarios.quarantined, expect);
-  expect(quarantined.status === "proposed", "quarantined Remember must leave the Hypothesis reviewable");
-  requireString(quarantined.submission_id, "quarantined submission ID");
-  expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
-  const quarantinedAttempt = attemptRow(teamID, scenarios.quarantined.idempotencyKey);
-  expect(quarantinedAttempt.outcome === "quarantined" && quarantinedAttempt.count === 1, "quarantined confirmation must persist one quarantined terminal attempt");
+	const quarantinedResponse = await rawRPC("tools/call", {
+		name: "resolve_dream_feedback",
+		arguments: resolveArguments(scenarios.quarantined),
+	});
+	expect(quarantinedResponse.result?.isError === true, "quarantined Remember must be a structured tool error");
+	const quarantined = quarantinedResponse.result?.structuredContent;
+	expect(quarantined?.processing_state === "quarantined", "quarantined Remember must expose terminal state");
+	expect(Array.isArray(quarantined?.errors) && quarantined.errors.length > 0, "quarantined Remember must expose typed errors");
+	requireString(quarantined?.submission_id, "quarantined submission ID");
+	expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
+	const quarantinedAttempt = attemptRow(teamID, scenarios.quarantined.idempotencyKey);
+	expect(quarantinedAttempt.outcome === "quarantined" && quarantinedAttempt.count === 1, "quarantined confirmation must persist one quarantined terminal attempt");
+	assertDreamRetryGuidance(quarantined, scenarios.quarantined, "quarantined");
 
-  const failed = await resolve(rpc, scenarios.failed, expect);
-  expect(failed.status === "proposed", "operational Remember failure must leave the Hypothesis reviewable");
-  requireString(failed.submission_id, "failed submission ID");
-  expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
-  const failedAttempt = attemptRow(teamID, scenarios.failed.idempotencyKey);
-  expect(failedAttempt.outcome === "failed" && failedAttempt.count === 1, "operational failure must persist one failed terminal attempt");
-  const failedAttemptCount = failedAttempt.count;
+	const failedResponse = await rawRPC("tools/call", {
+		name: "resolve_dream_feedback",
+		arguments: resolveArguments(scenarios.failed),
+	});
+	expect(failedResponse.result?.isError === true, "operational Remember failure must be a structured tool error");
+	const failed = failedResponse.result?.structuredContent;
+	expect(failed?.processing_state === "failed", "operational Remember failure must expose terminal state");
+	expect(Array.isArray(failed?.errors) && failed.errors.length > 0, "operational Remember failure must expose typed errors");
+	requireString(failed?.submission_id, "failed submission ID");
+	expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
+	const failedAttempt = attemptRow(teamID, scenarios.failed.idempotencyKey);
+	expect(failedAttempt.outcome === "failed" && failedAttempt.count === 1, "operational failure must persist one failed terminal attempt");
+	assertDreamRetryGuidance(failed, scenarios.failed, "failed");
+	const failedAttemptCount = failedAttempt.count;
 
   const noEvidence = await rawRPC("tools/call", {
     name: "resolve_dream_feedback",
@@ -128,8 +149,9 @@ export async function run({ rpc, rawRPC, expect }) {
     },
   });
   const contentionResponses = await Promise.all([firstContention, secondContention]);
-  const busyResponse = contentionResponses.find((response) => String(response.error?.message || "").includes("dream confirmation is already in progress"));
-  expect(busyResponse?.error?.message, "concurrent Dream confirmation must expose a bounded busy error");
+	const busyResponse = contentionResponses.find((response) => response.result?.structuredContent?.code === "dream_confirmation_busy");
+	expect(busyResponse?.result?.isError === true, "concurrent Dream confirmation must expose a structured busy error");
+	expect(busyResponse.result.structuredContent.next_action === "retry_dream_feedback", "busy Dream confirmation must advertise retry_dream_feedback");
   expect(hypothesisIngestCount(teamID, contention.hypothesisID) === contentionIngestCount, "busy Dream confirmation must not create a Remember ingest");
   expect(feedbackEventCount(teamID, contention.hypothesisID) === contentionFeedbackCount, "busy Dream confirmation must not append a feedback event");
   expect(attemptRow(teamID, contention.idempotencyKey).count === 1, "concurrent Dream confirmation must persist only the admitted terminal attempt");
@@ -144,6 +166,14 @@ export async function run({ rpc, rawRPC, expect }) {
     contention_busy_reviewable: true,
     independent_evidence_provenance: true,
   };
+}
+
+function assertDreamRetryGuidance(result, scenario, label) {
+	const error = result?.errors?.[0];
+	expect(error?.next_action === "retry_dream_feedback", `${label} Dream terminal result must advertise retry_dream_feedback`);
+	expect(typeof error?.remediation === "string" && error.remediation.includes("resolve_dream_feedback"), `${label} Dream terminal result must name resolve_dream_feedback in remediation`);
+	expect(error.remediation.includes("idempotency_key"), `${label} Dream terminal result must name idempotency_key in remediation`);
+	expect(error.remediation.includes(scenario.hypothesisID), `${label} Dream terminal result must use the canonical Hypothesis ID in remediation`);
 }
 
 async function enableDreaming() {

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -71,9 +71,15 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
 
-  const failed = await resolve(rpc, scenarios.failed, expect);
-  expect(failed.status === "proposed", "operational Remember failure must leave the Hypothesis reviewable");
-  requireString(failed.submission_id, "failed submission ID");
+  const failedResponse = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: resolveArguments(scenarios.failed),
+  });
+  expect(failedResponse.result?.isError === true, "operational Remember failure must be a structured tool error");
+  const failed = failedResponse.result?.structuredContent;
+  expect(failed?.processing_state === "failed", "operational Remember failure must expose terminal state");
+  expect(Array.isArray(failed?.errors) && failed.errors.length > 0, "operational Remember failure must expose typed errors");
+  requireString(failed?.submission_id, "failed submission ID");
   expect(hypothesisRow(teamID, scenarios.failed.hypothesisID).status === "proposed", "operational failure must not advance Dream state");
   expect(attemptRow(teamID, scenarios.failed.idempotencyKey).outcome === "failed", "operational failure must persist a failed terminal attempt");
   const failedAttemptCount = attemptRow(teamID, scenarios.failed.idempotencyKey).count;
@@ -147,14 +153,18 @@ function makeScenarios() {
 }
 
 async function resolve(rpc, scenario, expect) {
-  const result = await toolSuccess(rpc, "resolve_dream_feedback", {
+  const result = await toolSuccess(rpc, "resolve_dream_feedback", resolveArguments(scenario));
+  expect(result.hypothesis_id === scenario.hypothesisID, "Dream feedback must return the requested Hypothesis");
+  return result;
+}
+
+function resolveArguments(scenario) {
+  return {
     hypothesis_id: scenario.hypothesisID,
     decision: "confirm_true",
     evidence: [{ content: scenario.evidence, source_type: "manual", source: `dream-feedback-${scenario.hypothesisID}` }],
     relationships: [dreamRelationship(scenario)],
-  });
-  expect(result.hypothesis_id === scenario.hypothesisID, "Dream feedback must return the requested Hypothesis");
-  return result;
+  };
 }
 
 function dreamRelationship(scenario) {

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -59,15 +59,36 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(unchangedHypothesis.submittedIngestID === completedHypothesis.submittedIngestID, "changed Dream feedback reason must preserve submitted ingest");
   expect(unchangedHypothesis.submittedAt === completedHypothesis.submittedAt, "changed Dream feedback reason must preserve submission time");
 
-  const rejected = await resolve(rpc, scenarios.rejected, expect);
-  expect(rejected.status === "proposed", "rejected Remember must leave the Hypothesis reviewable");
-  requireString(rejected.submission_id, "rejected submission ID");
+  const completedIngestCount = hypothesisIngestCount(teamID, scenarios.completed.hypothesisID);
+  const conflicting = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: { ...resolveArguments(scenarios.completed), decision: "confirm_false", evidence: [{ content: "Independent refuting evidence.", source_type: "manual" }] },
+  });
+  expect(String(conflicting.error?.message || "").includes("dream not found"), "conflicting Dream confirmation must be rejected before Remember");
+  expect(hypothesisIngestCount(teamID, scenarios.completed.hypothesisID) === completedIngestCount, "conflicting Dream confirmation must not create a Remember ingest");
+  expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "conflicting Dream confirmation must not append a feedback event");
+
+  const rejectedResponse = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: resolveArguments(scenarios.rejected),
+  });
+  expect(rejectedResponse.result?.isError === true, "rejected Remember must be a structured tool error");
+  const rejected = rejectedResponse.result?.structuredContent;
+  expect(rejected?.processing_state === "rejected", "rejected Remember must expose terminal state");
+  expect(Array.isArray(rejected?.errors) && rejected.errors.length > 0, "rejected Remember must expose typed errors");
+  requireString(rejected?.submission_id, "rejected submission ID");
   expect(hypothesisRow(teamID, scenarios.rejected.hypothesisID).status === "proposed", "rejected confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.rejected.idempotencyKey).outcome === "rejected", "rejected confirmation must persist a rejected terminal attempt");
 
-  const quarantined = await resolve(rpc, scenarios.quarantined, expect);
-  expect(quarantined.status === "proposed", "quarantined Remember must leave the Hypothesis reviewable");
-  requireString(quarantined.submission_id, "quarantined submission ID");
+  const quarantinedResponse = await rawRPC("tools/call", {
+    name: "resolve_dream_feedback",
+    arguments: resolveArguments(scenarios.quarantined),
+  });
+  expect(quarantinedResponse.result?.isError === true, "quarantined Remember must be a structured tool error");
+  const quarantined = quarantinedResponse.result?.structuredContent;
+  expect(quarantined?.processing_state === "quarantined", "quarantined Remember must expose terminal state");
+  expect(Array.isArray(quarantined?.errors) && quarantined.errors.length > 0, "quarantined Remember must expose typed errors");
+  requireString(quarantined?.submission_id, "quarantined submission ID");
   expect(hypothesisRow(teamID, scenarios.quarantined.hypothesisID).status === "proposed", "quarantined confirmation must not advance Dream state");
   expect(attemptRow(teamID, scenarios.quarantined.idempotencyKey).outcome === "quarantined", "quarantined confirmation must persist a quarantined terminal attempt");
 
@@ -223,6 +244,15 @@ function feedbackEventCount(teamID, hypothesisID) {
     SELECT count(*)::text
     FROM hypothesis_feedback_events
     WHERE team_id = ${sqlLiteral(teamID)}::uuid AND hypothesis_id = ${sqlLiteral(hypothesisID)}::uuid
+  `) || 0);
+}
+
+function hypothesisIngestCount(teamID, hypothesisID) {
+  return Number(postgresQuery(`
+    SELECT count(DISTINCT ingest_id)::text
+    FROM evidence_fragments
+    WHERE team_id = ${sqlLiteral(teamID)}::uuid
+      AND metadata->>'hypothesis_id' = ${sqlLiteral(hypothesisID)}
   `) || 0);
 }
 


### PR DESCRIPTION
## Summary

Closes #304.

- Consume explicit synchronous Remember terminal outcomes in Dream feedback.
- Submit Hypotheses only for completed terminal results (while preserving legacy queued-receipt behavior).
- Keep rejected, quarantined, and failed Remember outcomes reviewable.
- Preserve replay-safe idempotency, feedback reasons, and migrated submitted-Hypothesis handling.
- Add focused service, PostgreSQL, Compose/UAT, and E2E wiring coverage.

## Verification

- `go test ./internal/service/dreamservice ./cmd/internal/e2eapp -count=1`
- `./scripts/ci-check.sh` — passed at 90.0% coverage.
- Real PostgreSQL Dream repository regression — passed.
- Dream Compose/UAT — passed on isolated ports 30440–30450.
- Plan audit — conformant with no findings.
- `git diff --check` — passed.

The live embedding and verifier endpoints recovered during validation. The all-scenario matrix reached 15 passing scenarios; the `community` scenario reproduced an existing failure on clean `origin/main` and was explicitly deferred. No community code is included in this PR.

## Risk and boundaries

The workflow fails closed on unknown Remember result kinds and invalid completed ingests. Non-completed terminal outcomes remain reviewable instead of mutating durable Hypothesis state. E2E artifacts were kept under `/tmp` and cleaned from the mount; diagnostic logs remain outside the repository for audit evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable Dream feedback confirmation with replay protection and idempotent submissions.
  * Added structured retry guidance for rejected, quarantined, and failed outcomes.
  * Added retryable responses when simultaneous confirmations are in progress.
  * Added diagnostics tracking for Remember attempts.
  * Added legacy confirmation recovery and compatibility support.

* **Bug Fixes**
  * Improved recovery from temporary submission failures and canceled requests.
  * Prevented duplicate feedback events and knowledge ingests during retries.
  * Restricted idempotency keys to confirmation decisions.
  * Improved terminal error reporting and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->