### PR TITLE
fix: classify missing trace relationships

### DIFF
--- a/internal/repository/semantic_read_repository.go
+++ b/internal/repository/semantic_read_repository.go
@@ -29,6 +29,8 @@ const (
 	maxSemanticGraphDepth     = 5
 )
 
+var ErrTraceRelationshipNotFound = errors.New("trace relationship not found")
+
 func (r *SemanticRepositoryImpl) TraceRelationship(
 	ctx context.Context,
 	input TraceRelationshipInput,
@@ -40,6 +42,9 @@ func (r *SemanticRepositoryImpl) TraceRelationship(
 	result := &RelationshipTraceResult{}
 	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
 		relationship, err := loadTraceRelationship(ctx, tx, input.TeamID, input.RelationshipID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrTraceRelationshipNotFound
+		}
 		if err != nil {
 			return err
 		}
@@ -357,6 +362,9 @@ func loadTraceRelationship(
 	}
 	defer rows.Close()
 	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 		return nil, sql.ErrNoRows
 	}
 	var record RelationshipTraceRecord

--- a/internal/repository/semantic_read_repository_test.go
+++ b/internal/repository/semantic_read_repository_test.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestLoadTraceRelationshipPropagatesIteratorError(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+
+	iteratorErr := errors.New("trace relationship iterator failed")
+	mock.ExpectQuery(`SELECT r\.team_id`).
+		WithArgs("team-id", "relationship-id").
+		WillReturnRows(sqlmock.NewRows([]string{"relationship_id"}).AddRow("ignored").RowError(0, iteratorErr))
+
+	_, err = loadTraceRelationship(context.Background(), db, "team-id", "relationship-id")
+	require.ErrorIs(t, err, iteratorErr)
+	require.NotErrorIs(t, err, sql.ErrNoRows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/repository/semantic_trace_graph_integration_test.go
+++ b/internal/repository/semantic_trace_graph_integration_test.go
@@ -245,11 +245,15 @@ func TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams(t *testin
 	_, err = semanticRepo.TraceRelationship(ctxB, TraceRelationshipInput{
 		TeamID: teamA, RelationshipID: rootRelationshipID.String(),
 	})
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTraceRelationshipNotFound)
 	_, err = semanticRepo.TraceRelationship(ctxC, TraceRelationshipInput{
 		TeamID: teamC, RelationshipID: rootRelationshipID.String(),
 	})
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTraceRelationshipNotFound)
+	_, err = semanticRepo.TraceRelationship(ctxA, TraceRelationshipInput{
+		TeamID: teamA, RelationshipID: uuid.NewString(),
+	})
+	require.ErrorIs(t, err, ErrTraceRelationshipNotFound)
 
 	graphA, err := semanticRepo.SemanticGraph(ctxA, SemanticGraphQuery{TeamID: teamA, Limit: 10})
 	require.NoError(t, err)
@@ -296,7 +300,7 @@ func TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams(t *testin
 	_, err = semanticRepo.TraceRelationship(ctxA, TraceRelationshipInput{
 		TeamID: teamA, RelationshipID: rootRelationshipID.String(),
 	})
-	require.ErrorIs(t, err, sql.ErrNoRows)
+	require.ErrorIs(t, err, ErrTraceRelationshipNotFound)
 	sealedGraph, err := semanticRepo.SemanticGraph(ctxA, SemanticGraphQuery{TeamID: teamA, Limit: 10})
 	require.NoError(t, err)
 	assert.Empty(t, sealedGraph.Edges)

--- a/internal/service/contextservice/semantic_trace.go
+++ b/internal/service/contextservice/semantic_trace.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	ErrTraceAuthContext            = errors.New("trace: authenticated actor context is required")
+	ErrTraceRelationshipNotFound   = errors.New("not_found: relationship not found")
 	ErrTraceRepositoryTeamMismatch = errors.New("trace: repository returned a mismatched team")
 )
 
@@ -78,6 +79,9 @@ func (s *semanticTraceService) Trace(ctx context.Context, _ string, req TraceReq
 		MinRelevance:           req.MinRelevance,
 	})
 	if err != nil {
+		if errors.Is(err, repository.ErrTraceRelationshipNotFound) {
+			return nil, ErrTraceRelationshipNotFound
+		}
 		return nil, fmt.Errorf("trace: %w", err)
 	}
 	if err := validateTraceConflictTeams(trace, actor.TeamID.String()); err != nil {

--- a/internal/service/contextservice/semantic_trace_test.go
+++ b/internal/service/contextservice/semantic_trace_test.go
@@ -2,6 +2,7 @@ package contextservice
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,11 +15,42 @@ import (
 type semanticTraceStoreStub struct {
 	result *repository.RelationshipTraceResult
 	input  repository.TraceRelationshipInput
+	err    error
 }
 
 func (s *semanticTraceStoreStub) TraceRelationship(_ context.Context, input repository.TraceRelationshipInput) (*repository.RelationshipTraceResult, error) {
 	s.input = input
-	return s.result, nil
+	return s.result, s.err
+}
+
+func TestSemanticTraceMapsMissingRelationship(t *testing.T) {
+	teamID := uuid.New()
+	store := &semanticTraceStoreStub{err: repository.ErrTraceRelationshipNotFound}
+	service := NewSemantic(store)
+	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{
+		TeamID:  teamID,
+		OwnerID: uuid.New(),
+	})
+
+	_, err := service.Trace(ctx, "", TraceRequest{RelationshipID: uuid.NewString()})
+	require.ErrorIs(t, err, ErrTraceRelationshipNotFound)
+	require.Equal(t, "not_found: relationship not found", err.Error())
+}
+
+func TestSemanticTracePreservesRepositoryFailures(t *testing.T) {
+	teamID := uuid.New()
+	databaseErr := errors.New("database unavailable")
+	store := &semanticTraceStoreStub{err: databaseErr}
+	service := NewSemantic(store)
+	ctx := requestctx.WithActor(context.Background(), requestctx.Actor{
+		TeamID:  teamID,
+		OwnerID: uuid.New(),
+	})
+
+	_, err := service.Trace(ctx, "", TraceRequest{RelationshipID: uuid.NewString()})
+	require.ErrorIs(t, err, databaseErr)
+	require.NotErrorIs(t, err, ErrTraceRelationshipNotFound)
+	require.Equal(t, "trace: database unavailable", err.Error())
 }
 
 func TestSemanticTraceRejectsMismatchedConflictTeam(t *testing.T) {

--- a/internal/service/skillpackservice/memory_pack.go
+++ b/internal/service/skillpackservice/memory_pack.go
@@ -2,6 +2,7 @@ package skillpackservice
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -61,6 +62,9 @@ func (s *memoryPackService) Export(ctx context.Context, req ExportRequest) (*Exp
 			MaxFragmentContentRunes: 8000,
 		})
 		if err != nil {
+			if errors.Is(err, repository.ErrTraceRelationshipNotFound) {
+				return nil, sql.ErrNoRows
+			}
 			return nil, err
 		}
 		if trace.Relationship == nil {

--- a/internal/service/skillpackservice/memory_pack_export_test.go
+++ b/internal/service/skillpackservice/memory_pack_export_test.go
@@ -109,6 +109,7 @@ func TestMemoryPackExportRejectsMissingInputsAndUnavailableRelationships(t *test
 		{name: "name required", svc: base, ctx: ctx, req: ExportRequest{RelationshipIDs: []string{"rel-1"}}, want: "name is required"},
 		{name: "relationship ids required", svc: base, ctx: ctx, req: ExportRequest{Name: "pack"}, want: "relationship_ids is required"},
 		{name: "trace failure", svc: NewMemoryPackService(MemoryPackDependencies{Semantic: &exportSemanticStub{err: errors.New("trace failed")}}), ctx: ctx, req: ExportRequest{Name: "pack", RelationshipIDs: []string{"rel-1"}}, want: "trace failed"},
+		{name: "trace relationship not found", svc: NewMemoryPackService(MemoryPackDependencies{Semantic: &exportSemanticStub{err: repository.ErrTraceRelationshipNotFound}}), ctx: ctx, req: ExportRequest{Name: "pack", RelationshipIDs: []string{"rel-1"}}, want: "sql: no rows in result set"},
 		{name: "relationship missing", svc: NewMemoryPackService(MemoryPackDependencies{Semantic: &exportSemanticStub{result: &repository.RelationshipTraceResult{}}}), ctx: ctx, req: ExportRequest{Name: "pack", RelationshipIDs: []string{"rel-1"}}, want: "not found"},
 		{name: "relationship inactive", svc: NewMemoryPackService(MemoryPackDependencies{Semantic: &exportSemanticStub{record: &repository.RelationshipTraceRecord{RelationshipID: "rel-1", Status: string(domain.RelationshipStatusSuperseded)}}}), ctx: ctx, req: ExportRequest{Name: "pack", RelationshipIDs: []string{"rel-1"}}, want: "not active"},
 	}

--- a/tests/uat/synchronous_write/cases/contract.mjs
+++ b/tests/uat/synchronous_write/cases/contract.mjs
@@ -7,7 +7,7 @@ import {
 
 export const name = "contract";
 
-export async function run({ rpc, rawRPC, expect }) {
+export async function run({ rpc, expect }) {
   await enableTargetFeatureGates();
   validatedUserURL();
   const listed = await rpc("tools/list", {});
@@ -23,7 +23,9 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(!Object.hasOwn(rememberProperties, "status_tool") && !Object.hasOwn(rememberProperties, "check_after_seconds"), "v2.6.1 Remember schema must not expose polling fields");
 
   const runID = `synchronous-write-contract-${randomUUID()}`;
-  const sourceRaw = await rawRPC("tools/call", { name: "remember", arguments: rememberArguments(runID, "none") });
+  const teamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
+  const sourceCredential = await createControlCredential(teamID, `${runID}-shared-source`, "shared_only");
+  const sourceRaw = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", { name: "remember", arguments: rememberArguments(runID, "none") });
   const source = successfulToolResult(sourceRaw, expect);
   assertTerminalRememberResult(source);
   expect(source.contract_version === "dense-mem.v2.6.1", "terminal Remember must return v2.6.1");
@@ -31,10 +33,10 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(source.relationship_results?.[0]?.splits?.[0]?.relationship_id, "terminal Remember must return a relationship split");
   assertTextStructuredParity(sourceRaw, expect);
 
-  const removed = await rawRPC("tools/call", { name: "get_submission_status", arguments: { submission_id: source.submission_id } });
+  const removed = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", { name: "get_submission_status", arguments: { submission_id: source.submission_id } });
   expect(removed.error?.code === -32601 && !removed.result, "removed get_submission_status must return bounded method-not-found");
 
-  const rejectedRaw = await rawRPC("tools/call", { name: "remember", arguments: rememberArguments(`${runID}-rejected`, "no-supported") });
+  const rejectedRaw = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", { name: "remember", arguments: rememberArguments(`${runID}-rejected`, "no-supported") });
   const rejected = structuredToolResult(rejectedRaw, expect);
   assertTerminalRememberResult(rejected);
   expect(rejected.contract_version === "dense-mem.v2.6.1" && rejected.processing_state === "rejected", "terminal rejection must preserve target state");
@@ -42,12 +44,15 @@ export async function run({ rpc, rawRPC, expect }) {
   assertTextStructuredParity(rejectedRaw, expect);
 
   const split = source.relationship_results[0].splits[0];
-  const trace = await toolSuccess(rpc, "trace_memory", { relationship_id: split.relationship_id });
+  const traceRaw = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", { name: "trace_memory", arguments: { relationship_id: split.relationship_id } });
+  const trace = successfulToolResult(traceRaw, expect);
   const support = trace.evidence_supports?.[0];
   expect(support?.evidence_id && Number.isInteger(support.span_start) && Number.isInteger(support.span_end), "trace must expose correction support spans");
+  const unknownTrace = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", { name: "trace_memory", arguments: { relationship_id: randomUUID() } });
+  expect(unknownTrace.error?.code === -32000 && unknownTrace.error?.message === "not_found: relationship not found" && !unknownTrace.result, `unknown trace target must be a bounded not-found error: ${JSON.stringify(unknownTrace)}`);
   const ownership = await assertOwnershipIsolation({ runID, source, split, trace, support, expect });
 
-  const correctionRaw = await rawRPC("tools/call", {
+  const correctionRaw = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", {
     name: "correct_relationship",
     arguments: {
       action: "submit",
@@ -65,7 +70,7 @@ export async function run({ rpc, rawRPC, expect }) {
   expect(!Object.hasOwn(correction, "status_tool") && !Object.hasOwn(correction, "check_after_seconds"), "direct correction must not return polling metadata");
   assertTextStructuredParity(correctionRaw, expect);
 
-  const staleRaw = await rawRPC("tools/call", {
+  const staleRaw = await rawRPCWithKey(sourceCredential.apiKey, "tools/call", {
     name: "correct_relationship",
     arguments: {
       action: "submit",
@@ -213,6 +218,17 @@ async function assertOwnershipIsolation({ runID, source, split, trace, support, 
 
   const sameTeamRaw = await rawRPCWithKey(sameTeamCredential.apiKey, "tools/call", { name: "correct_relationship", arguments: correction });
   const crossTeamRaw = await rawRPCWithKey(crossTeamCredential.apiKey, "tools/call", { name: "correct_relationship", arguments: correction });
+  const sameTeamTraceRaw = await rawRPCWithKey(sameTeamCredential.apiKey, "tools/call", {
+    name: "trace_memory",
+    arguments: { relationship_id: split.relationship_id },
+  });
+  const sameTeamTrace = successfulToolResult(sameTeamTraceRaw, expect);
+  expect(sameTeamTrace.relationship?.relationship_id === split.relationship_id, "same-team actors must trace shared Relationships");
+  const crossTeamTraceRaw = await rawRPCWithKey(crossTeamCredential.apiKey, "tools/call", {
+    name: "trace_memory",
+    arguments: { relationship_id: split.relationship_id },
+  });
+  expect(crossTeamTraceRaw.error?.code === -32000 && crossTeamTraceRaw.error?.message === "not_found: relationship not found" && !crossTeamTraceRaw.result, `cross-team trace target must be indistinguishable from unknown: ${JSON.stringify(crossTeamTraceRaw)}`);
   const sameTeamDenied = assertOwnershipDenied(sameTeamRaw, source, split.relationship_id, expect, "same-team non-owner");
   const crossTeamDenied = assertOwnershipDenied(crossTeamRaw, source, split.relationship_id, expect, "cross-team actor");
 
@@ -230,12 +246,14 @@ async function assertOwnershipIsolation({ runID, source, split, trace, support, 
   };
 }
 
-async function createControlCredential(teamID, name) {
-  const payload = await controlPayload(`/teams/${teamID}/credentials`, {
+async function createControlCredential(teamID, name, memoryBinding) {
+  const request = {
     name,
     scopes: ["read", "write"],
     rate_limit: 300,
-  });
+  };
+  if (memoryBinding) request.memory_binding = memoryBinding;
+  const payload = await controlPayload(`/teams/${teamID}/credentials`, request);
   return { apiKey: requiredString(payload.data?.api_key, "credential api key") };
 }
 
@@ -313,13 +331,6 @@ function assertTextStructuredParity(raw, expect) {
   const text = raw.result?.content?.[0]?.text;
   const parsed = JSON.parse(text);
   expect(stableJSON(parsed) === stableJSON(raw.result?.structuredContent), "MCP text and structuredContent must be equivalent");
-}
-
-async function toolSuccess(rpc, name, argumentsValue) {
-  const raw = await rpc("tools/call", { name, arguments: argumentsValue });
-  const text = raw?.content?.[0]?.text;
-  if (typeof text !== "string") throw new Error(`MCP ${name} did not return JSON content`);
-  return JSON.parse(text);
 }
 
 function stableJSON(value) {


### PR DESCRIPTION
Closes #288

## Summary

Classify an unknown or RLS-hidden root Relationship during `trace_memory` as the bounded `not_found: relationship not found` error.

## Changes

- Translate only the initial root `sql.ErrNoRows` into a repository sentinel.
- Map that sentinel in contextservice to the exact public message.
- Preserve iterator, loader, transaction, and database failures.
- Preserve `export_memory_pack`'s existing generic failure behavior.
- Add PostgreSQL, service, sqlmock, and MCP UAT coverage for unknown, private, sealed, shared, and cross-team targets.

## Verification

- `$plan-audit`: `conformant`, Terra/max, base `20d6f6adde188b6800ba02f4a2c0eafd4c6e2f4a`, no findings.
- `go test ./internal/service/contextservice -count=1`: passed.
- Focused PostgreSQL trace tests with Testcontainers: passed.
- Iterator and memory-pack boundary tests: passed.
- `node --test tests/uat/synchronous_write/runner.test.mjs`: passed.
- Synchronous-write contract Compose UAT: passed.
- `go test ./internal/service/... -count=1`: passed.
- `go test ./internal/repository/... -count=1`: passed.
- `./scripts/ci-check.sh`: passed; coverage 90.1%.
- Full Compose matrix was attempted. The unfiltered run reproduced the existing Dream changed-reason assertion blocker; a filtered run passed the changed synchronous-write contract and then hit the unrelated mcp_oauth bearer-persistence blocker. Individual identity-cleanup verification passed. No #288 paths are involved in either failure.

No migration, public success-schema, retrieval, ranking, embedding, or deterministic evaluation changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Relationship lookups now return a consistent not-found error when relationships are missing or inaccessible.
  - Database and repository errors are preserved accurately instead of being misreported as missing data.
  - Memory pack exports now report missing relationships with the standard “no rows” error.

- **Tests**
  - Added coverage for missing relationships, database failures, and ownership isolation across teams and private spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->