### PR TITLE
fix(search): reconcile missing evidence search documents

### DIFF
--- a/internal/repository/search_convergence.go
+++ b/internal/repository/search_convergence.go
@@ -323,7 +323,6 @@ func addMissingCanonicalSearchStats(
 			  ON ingest.team_id = fragment.team_id
 			 AND ingest.ingest_id = fragment.ingest_id
 			 AND ingest.owner_profile_id = fragment.owner_profile_id
-			 AND ingest.status = 'completed'
 			LEFT JOIN evidence_sources AS source
 			  ON source.team_id = fragment.team_id
 			 AND source.source_id = fragment.source_id

--- a/internal/repository/search_reconciliation_documents.go
+++ b/internal/repository/search_reconciliation_documents.go
@@ -25,11 +25,14 @@ func canonicalSearchDocument(ctx context.Context, tx *gorm.DB, document SearchDo
 		err := tx.WithContext(ctx).Raw(`
 			SELECT fragment.content, fragment.space_id::text, COALESCE(fragment.space_generation, 0)
 			FROM evidence_fragments AS fragment
+			JOIN teams AS team
+			  ON team.id = fragment.team_id
+			 AND team.status = 'active'
+			 AND team.deleted_at IS NULL
 			JOIN knowledge_ingests AS ingest
 			  ON ingest.team_id = fragment.team_id
 			 AND ingest.ingest_id = fragment.ingest_id
 			 AND ingest.owner_profile_id = fragment.owner_profile_id
-			 AND ingest.status = 'completed'
 			LEFT JOIN evidence_sources AS source
 			  ON source.team_id = fragment.team_id
 			 AND source.source_id = fragment.source_id
@@ -141,7 +144,6 @@ func selectMissingCanonicalSearchDocuments(
 		  ON ingest.team_id = fragment.team_id
 		 AND ingest.ingest_id = fragment.ingest_id
 		 AND ingest.owner_profile_id = fragment.owner_profile_id
-		 AND ingest.status = 'completed'
 		LEFT JOIN evidence_sources AS source
 		  ON source.team_id = fragment.team_id
 		 AND source.source_id = fragment.source_id

--- a/internal/repository/search_reconciliation_integration_test.go
+++ b/internal/repository/search_reconciliation_integration_test.go
@@ -105,7 +105,7 @@ func TestSearchReconciliationSelectionAndHashFence(t *testing.T) {
 	}))
 }
 
-func TestSearchReconciliationExcludesRejectedEvidence(t *testing.T) {
+func TestSearchReconciliationProjectsSafeHistoricalRejectedEvidence(t *testing.T) {
 	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -126,15 +126,75 @@ func TestSearchReconciliationExcludesRejectedEvidence(t *testing.T) {
 		EmbeddingContractID: contractID, EmbeddingDimensions: 2, Limit: 256,
 	})
 	require.NoError(t, err)
-	require.Empty(t, selected)
+	require.Len(t, selected, 1)
+	require.Equal(t, rejected.Evidence[0].FragmentID, selected[0].SourceID)
+	require.Empty(t, selected[0].SearchDocumentID)
 
 	convergence, err := repo.GetSearchConvergence(ctx, SearchConvergenceInput{
 		EmbeddingContractID: contractID, EmbeddingDimensions: 2,
 	})
 	require.NoError(t, err)
-	require.Zero(t, convergence.ExpectedDocuments)
-	require.Zero(t, convergence.DriftedDocuments)
+	require.EqualValues(t, 1, convergence.ExpectedDocuments)
+	require.EqualValues(t, 1, convergence.DriftedDocuments)
 	require.Zero(t, convergence.CurrentDocuments)
+	require.Contains(t, convergence.DriftClasses, SearchDocumentDriftCount{Class: "canonical_document_missing", Count: 1})
+
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE teams
+			SET status = 'deleted', deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+			WHERE id = ?::uuid
+		`, teamID).Error
+	}))
+	selectedEmbedding := SearchDocumentEmbedding{
+		TeamID: selected[0].TeamID, SearchDocumentID: selected[0].SearchDocumentID,
+		OwnerProfileID: selected[0].OwnerProfileID, SourceKind: selected[0].SourceKind,
+		SourceID: selected[0].SourceID, DocumentText: selected[0].DocumentText,
+		DocumentHash: selected[0].DocumentHash, StoredDocumentHash: selected[0].StoredDocumentHash,
+		SourceVersion: selected[0].SourceVersion, ProjectionFormat: selected[0].ProjectionFormat,
+		ProjectionGenerationID: selected[0].ProjectionGenerationID, DocumentVersion: selected[0].DocumentVersion,
+		EmbeddingContractID: selected[0].EmbeddingContractID, EmbeddingDimensions: selected[0].EmbeddingDimensions,
+		Embedding: []float32{0.6, 0.8}, SpaceID: selected[0].SpaceID, SpaceGeneration: selected[0].SpaceGeneration,
+	}
+	deletedTeamApply, err := repo.CompleteSearchReconciliationDocuments(ctx, ApplySearchReconciliationInput{
+		EmbeddingContractID: contractID, EmbeddingDimensions: 2,
+		Documents: []SearchDocumentEmbedding{selectedEmbedding},
+	})
+	require.NoError(t, err)
+	require.Zero(t, deletedTeamApply.UpdatedCount)
+	require.EqualValues(t, 1, deletedTeamApply.SkippedCount)
+	var deletedTeamDocumentCount int64
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Raw(`
+			SELECT count(*)
+			FROM search_documents
+			WHERE team_id = ?::uuid AND source_kind = 'evidence' AND source_id = ?::uuid
+		`, teamID, selected[0].SourceID).Scan(&deletedTeamDocumentCount).Error
+	}))
+	require.Zero(t, deletedTeamDocumentCount)
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE teams
+			SET status = 'active', deleted_at = NULL, updated_at = clock_timestamp()
+			WHERE id = ?::uuid
+		`, teamID).Error
+	}))
+
+	apply, err := repo.CompleteSearchReconciliationDocuments(ctx, ApplySearchReconciliationInput{
+		EmbeddingContractID: contractID, EmbeddingDimensions: 2,
+		Documents: []SearchDocumentEmbedding{selectedEmbedding},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, apply.UpdatedCount)
+	require.Zero(t, apply.RemainingDriftedCount)
+
+	convergence, err = repo.GetSearchConvergence(ctx, SearchConvergenceInput{
+		EmbeddingContractID: contractID, EmbeddingDimensions: 2,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, convergence.ExpectedDocuments)
+	require.EqualValues(t, 1, convergence.CurrentDocuments)
+	require.Zero(t, convergence.DriftedDocuments)
 }
 
 func TestSearchReconciliationSelectionAdvancesDurableCursorPastHealthyDocuments(t *testing.T) {

--- a/internal/storage/postgres/synchronous_remember_cutover_migration_integration_test.go
+++ b/internal/storage/postgres/synchronous_remember_cutover_migration_integration_test.go
@@ -17,6 +17,31 @@ import (
 
 const synchronousRememberCutoverMigrationVersion int64 = 20260831010001
 
+func requireLegacyV261RememberResult(t *testing.T, result remember.TerminalRememberResult, submissionID, processingState, searchState string,
+	evidenceCount, relationshipCount int, errorCode string) {
+	t.Helper()
+	require.Equal(t, "dense-mem.v2.6.1", result.ContractVersion)
+	require.Equal(t, submissionID, result.SubmissionID)
+	require.Equal(t, "remember", result.SubmissionKind)
+	require.Equal(t, processingState, result.ProcessingState)
+	require.Equal(t, searchState, result.SearchState)
+	require.Equal(t, submissionID, result.CorrelationID)
+	require.NotNil(t, result.Evidence)
+	require.Len(t, result.Evidence, evidenceCount)
+	require.NotNil(t, result.RelationshipResults)
+	require.Len(t, result.RelationshipResults, relationshipCount)
+	require.NotNil(t, result.Errors)
+	if errorCode == "" {
+		require.Empty(t, result.Errors)
+		return
+	}
+	require.Len(t, result.Errors, 1)
+	require.Equal(t, errorCode, result.Errors[0].Code)
+	require.True(t, result.Errors[0].Retryable)
+	require.Equal(t, "resubmit_remember", result.Errors[0].NextAction)
+	require.Equal(t, "Submit the complete batch again with remember and a new idempotency_key after correcting the input.", result.Errors[0].Remediation)
+}
+
 func TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement(t *testing.T) {
 	ctx := context.Background()
 	db, cleanup := openMigrationSQLDB(t, ctx)
@@ -251,8 +276,20 @@ func TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement(t *t
 	`, teamID, ingestID).Scan(&migratedCompletedJSON))
 	var migratedCompleted remember.TerminalRememberResult
 	require.NoError(t, json.Unmarshal(migratedCompletedJSON, &migratedCompleted))
-	migratedCompleted.Kind = remember.ResultKindTerminal
-	require.NoError(t, remember.ValidateTerminalRememberResult(&migratedCompleted, 1, []string{"legacy-ref"}))
+	requireLegacyV261RememberResult(t, migratedCompleted, ingestID.String(), "completed", "current", 1, 1, "")
+	require.Equal(t, 0, migratedCompleted.Evidence[0].EvidenceIndex)
+	require.NotNil(t, migratedCompleted.Evidence[0].SupersededEvidenceIDs)
+	require.Empty(t, migratedCompleted.Evidence[0].SupersededEvidenceIDs)
+	require.Equal(t, "current", migratedCompleted.Evidence[0].SearchState)
+	require.Empty(t, migratedCompleted.Evidence[0].Reason)
+	require.Equal(t, "legacy-ref", migratedCompleted.RelationshipResults[0].RelationshipRef)
+	require.Equal(t, "stored", migratedCompleted.RelationshipResults[0].Disposition)
+	require.Empty(t, migratedCompleted.RelationshipResults[0].Reason)
+	require.Len(t, migratedCompleted.RelationshipResults[0].Splits, 1)
+	require.Equal(t, 0, migratedCompleted.RelationshipResults[0].Splits[0].SplitIndex)
+	require.Equal(t, relationshipID.String(), migratedCompleted.RelationshipResults[0].Splits[0].RelationshipID)
+	require.Equal(t, 1, migratedCompleted.RelationshipResults[0].Splits[0].RelationshipVersion)
+	require.Equal(t, "active", migratedCompleted.RelationshipResults[0].Splits[0].Status)
 
 	var rejectedDisposition, rejectedReason, rejectedErrorCode string
 	require.NoError(t, db.QueryRowContext(ctx, `
@@ -273,8 +310,13 @@ func TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement(t *t
 	`, teamID, rejectedIngestID).Scan(&migratedRejectedJSON))
 	var migratedRejected remember.TerminalRememberResult
 	require.NoError(t, json.Unmarshal(migratedRejectedJSON, &migratedRejected))
-	migratedRejected.Kind = remember.ResultKindTerminal
-	require.NoError(t, remember.ValidateTerminalRememberResult(&migratedRejected, 1, nil))
+	requireLegacyV261RememberResult(t, migratedRejected, rejectedIngestID.String(), "rejected", "not_required", 1, 0, "no_supported_memory")
+	require.Equal(t, 0, migratedRejected.Evidence[0].EvidenceIndex)
+	require.Empty(t, migratedRejected.Evidence[0].EvidenceID)
+	require.NotNil(t, migratedRejected.Evidence[0].SupersededEvidenceIDs)
+	require.Empty(t, migratedRejected.Evidence[0].SupersededEvidenceIDs)
+	require.Equal(t, "not_required", migratedRejected.Evidence[0].SearchState)
+	require.Equal(t, "no supported memory could be stored from this submission", migratedRejected.Errors[0].Message)
 
 	var expiredErrorCode string
 	require.NoError(t, db.QueryRowContext(ctx, `
@@ -291,8 +333,10 @@ func TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement(t *t
 	`, teamID, expiredIngestID).Scan(&migratedQuarantinedJSON))
 	var migratedQuarantined remember.TerminalRememberResult
 	require.NoError(t, json.Unmarshal(migratedQuarantinedJSON, &migratedQuarantined))
-	migratedQuarantined.Kind = remember.ResultKindTerminal
-	require.NoError(t, remember.ValidateTerminalRememberResult(&migratedQuarantined, 0, nil))
+	requireLegacyV261RememberResult(
+		t, migratedQuarantined, expiredIngestID.String(), "quarantined", "not_required", 0, 0, "submission_quarantined",
+	)
+	require.Equal(t, "the submission was quarantined by security policy", migratedQuarantined.Errors[0].Message)
 
 	var eventCount, itemEvents, outcomeEvents int
 	require.NoError(t, db.QueryRowContext(ctx, `

--- a/tests/uat/conflict_mcp_e2e.mjs
+++ b/tests/uat/conflict_mcp_e2e.mjs
@@ -242,7 +242,7 @@ async function provenanceAndIsolationScenario() {
     authority: "primary",
     conflictContext: { conflict_id: fixture.conflictID, expected_version: observedVersion },
   });
-  assert(stale.processing_state === "rejected" && stale.errors?.[0]?.code === "stale_input", `stale conflict submission did not fail exact preflight: ${JSON.stringify(stale)}`);
+  assert(stale.processing_state === "failed" && stale.errors?.[0]?.code === "stale_input", `stale conflict submission did not fail exact preflight: ${JSON.stringify(stale)}`);
   const semanticAfterStale = conflictSemanticSnapshot(fixture.teamID, fixture.conflictID);
   assert(stableJSON(semanticAfterStale) === stableJSON(semanticBeforeStale), `stale conflict submission changed semantic state: before=${JSON.stringify(semanticBeforeStale)} after=${JSON.stringify(semanticAfterStale)}`);
 
@@ -426,7 +426,7 @@ async function submitRelationshipExpectValidationError(apiKey, input) {
     }
   }
   assert(
-    response.error || (response.result?.isError === true && terminal?.processing_state === "rejected"),
+    response.error || (response.result?.isError === true && terminal?.processing_state === "failed"),
     `stale remember unexpectedly staged: ${JSON.stringify(response)}`,
   );
   const staged = Number(postgresQuery(`

--- a/tests/uat/conflict_openai_stub.mjs
+++ b/tests/uat/conflict_openai_stub.mjs
@@ -161,15 +161,20 @@ function semanticAssessmentResponse(input, repairTurn) {
     });
   }
   const securitySignalEvidenceIDs = new Set(securitySignals.map((signal) => signal.evidence_id));
-  const securityResults = (input.evidence ?? []).map((evidence) => ({
-    evidence_id: evidence.evidence_id,
-    decision: securitySignalEvidenceIDs.has(evidence.evidence_id) ? "quarantine" : "pass",
-  }));
+  const securityResults = (input.evidence ?? []).map((evidence) => {
+    const signals = securitySignals
+      .filter((signal) => signal.evidence_id === evidence.evidence_id)
+      .map(({ kind, start_ref, end_ref }) => ({ kind, start_ref, end_ref }));
+    return {
+      evidence_id: evidence.evidence_id,
+      decision: securitySignalEvidenceIDs.has(evidence.evidence_id) ? "reject" : "pass",
+      signals,
+    };
+  });
 
   return {
     request_id: input.request_id,
-    security_signals: securitySignals,
-    security_results: securityResults,
+    evidence_security_results: securityResults,
     entity_results: entityResults,
     relationship_results: relationshipResults,
   };

--- a/tests/uat/security_intake_mcp_e2e.mjs
+++ b/tests/uat/security_intake_mcp_e2e.mjs
@@ -90,25 +90,33 @@ for (const testCase of rejectedCases) {
   assertSafeAuditRecord(audit, testCase, teamID);
 }
 
-let verifierAfterRejects = verifierBeforeRejects;
-for (const testCase of rejectedCases) {
-  verifierAfterRejects = await waitForExactlyOneVerifierRequest(verifierAfterRejects, teamID);
-}
+const verifierAfterRejects = await assertVerifierStable(verifierBeforeRejects, teamID);
 let verifierAfterAccepted = verifierAfterRejects;
 const acceptedResults = [];
 for (const testCase of acceptedCases) {
+  const correlationID = `${runID}:${testCase.name}`;
   const input = relationshipRememberInput(
     testCase.payload,
     `${runID}:${testCase.name}`,
     `security-intake:${runID}:${testCase.name}`,
     testCase.clientComment,
   );
-  const accepted = await mcpSuccess(apiKey, "remember", input, `${runID}:${testCase.name}`);
+  const accepted = await mcpSuccess(apiKey, "remember", input, correlationID);
   const submissionID = stringValue(accepted.submission_id);
   if (!submissionID) {
     throw new Error(`${testCase.name} remember did not return a submission_id`);
   }
-  assertAcceptedIngest(submissionID, input.evidence[0].content);
+  if (accepted.processing_state === "failed") {
+    if (!testCase.allowProviderQuarantine || accepted.errors?.[0]?.code !== "submission_policy_rejected" || accepted.search_state !== "not_required") {
+      throw new Error(`${testCase.name} provider rejection returned an unexpected terminal result: ${JSON.stringify(accepted)}`);
+    }
+    assertNoCorrelatedIngest(correlationID);
+  } else {
+    if (accepted.processing_state !== "completed") {
+      throw new Error(`${testCase.name} remember returned an unexpected processing state: ${JSON.stringify(accepted)}`);
+    }
+    assertAcceptedIngest(submissionID, input.evidence[0].content);
+  }
   verifierAfterAccepted = await waitForExactlyOneVerifierRequest(verifierAfterAccepted, teamID);
   assertTerminalRelationshipDisposition(accepted, testCase.name);
   acceptedResults.push({

--- a/tests/uat/synchronous_write/cases/dream.mjs
+++ b/tests/uat/synchronous_write/cases/dream.mjs
@@ -51,7 +51,12 @@ export async function run({ rpc, rawRPC, expect }) {
       relationships: [dreamRelationship(scenarios.completed)],
     },
   });
-  expect(String(changedReason.error?.message || "").includes("remember: conflict"), "changed Dream feedback reason must conflict under the same retry identity");
+  expect(
+    changedReason.result?.isError === true &&
+      changedReason.result?.structuredContent?.processing_state === "failed" &&
+      changedReason.result?.structuredContent?.errors?.[0]?.code === "idempotency_conflict",
+    `changed Dream feedback reason must conflict under the same retry identity: ${JSON.stringify(changedReason)}`,
+  );
   expect(attemptRow(teamID, scenarios.completed.idempotencyKey).count === 1, "changed Dream feedback reason must not create another Remember attempt");
   expect(feedbackEventCount(teamID, scenarios.completed.hypothesisID) === completedFeedbackEvents, "changed Dream feedback reason must not append a feedback event");
   const unchangedHypothesis = hypothesisRow(teamID, scenarios.completed.hypothesisID);


### PR DESCRIPTION
## Summary

Closes #319.

Canonical search reconciliation now considers safe historical evidence independently of the ingest terminal status, so evidence accepted before a rejected ingest remains eligible for a missing search-document projection. Completion revalidates active, non-deleted teams before writing. The regression suite and v2.6.2 UAT assertions now match the current terminal and verifier contracts, including the third security-intake correction.

## Scope

- Remove the `completed` ingest-status predicate from all three canonical evidence/convergence queries while retaining referential, lifecycle, source, space, deletion, and active-team fences.
- Add a real PostgreSQL regression covering rejected historical evidence, missing-document drift, inactive-team completion fencing, restoration, and convergence.
- Correct approved migration-history and UAT fixture/assertion contracts for v2.6.2.

## Risk and mitigation

A broad eligibility query could project unsafe or deleted evidence; canonical hydration and completion retain the existing evidence safety/lifecycle/source/space/deletion checks, and completion additionally requires an active, non-deleted team. The PostgreSQL regression verifies the deleted-team fence and zero drift after a valid repair.

## Audit receipt

- Base SHA: `64769a73c99c9525d65c93fac198fd211060126d`
- Auditor: independent `gpt-5.6-terra`, max reasoning effort
- Result: `conformant`
- Findings: none
- Audited branch state: eight approved paths only; no staged or non-ignored untracked files; ignored artifacts untouched.
- A follow-up independent scan after the third UAT assertion correction also returned `conformant` with no findings.

## Validation

- Focused repository and service tests passed.
- Historical rejected-evidence PostgreSQL regression passed.
- Complete tagged PostgreSQL storage suite passed.
- `./scripts/ci-check.sh` passed at 90.0% coverage.
- Standalone `security_intake` UAT passed: deterministic rejects made zero verifier requests, accepted cases made exactly two, safe evidence remained exact/current, and quoted provider rejection returned the bounded terminal contract.
- Sequential `DENSE_MEM_E2E_SCENARIO=all DENSE_MEM_E2E_PARALLELISM=1 bash scripts/e2e-compose.sh` passed all 21 Compose scenarios, including `synchronous_write`, `conflict`, `security_intake`, and `full`.

## Post-audit changes

No source paths changed after the conformant audit; the final commit contains the same eight approved paths.
