### PR TITLE
ci: parallelize checks and trim preview artifacts

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,6 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  go-unit:
-    name: Go unit tests
+  ci:
+    name: CI
     uses: ./.github/workflows/ci-shared.yml

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  go-unit:
-    name: Go unit tests
+  ci:
+    name: CI
     uses: ./.github/workflows/ci-shared.yml
     with:
       migration-base-ref: ${{ github.event.before }}

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -16,8 +16,67 @@ env:
   COVERAGE_THRESHOLD: "90.0"
 
 jobs:
-  go-unit:
-    name: Go unit tests
+  npm-audit:
+    name: NPM vulnerability audits
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Run npm vulnerability audits
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit_with_retry() {
+            local prefix="$1"
+            local attempt=1
+            local max_attempts=4
+            local output status sleep_seconds
+
+            while (( attempt <= max_attempts )); do
+              set +e
+              output="$(npm audit --prefix "${prefix}" --audit-level=high \
+                --fetch-retries=4 \
+                --fetch-retry-factor=2 \
+                --fetch-retry-mintimeout=1000 \
+                --fetch-retry-maxtimeout=30000 \
+                --fetch-timeout=30000 2>&1)"
+              status=$?
+              set -e
+              printf '%s\n' "${output}"
+              if (( status == 0 )); then
+                return 0
+              fi
+              if ! grep -Eq 'npm (warn|error) (audit )?5[0-9]{2}\b|npm error code (E5[0-9]{2}|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ECONNREFUSED)' <<<"${output}"; then
+                return "${status}"
+              fi
+              if (( attempt == max_attempts )); then
+                printf 'npm audit failed after %d attempts for %s\n' "${max_attempts}" "${prefix}" >&2
+                return "${status}"
+              fi
+              sleep_seconds=$((2 ** (attempt - 1)))
+              printf 'Transient npm audit failure for %s; retrying in %ss (attempt %d/%d).\n' \
+                "${prefix}" "${sleep_seconds}" "${attempt}" "${max_attempts}" >&2
+              sleep "${sleep_seconds}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          audit_with_retry .lint
+          audit_with_retry web
+          audit_with_retry packages/mcp-proxy
+
+  postgres-migrations:
+    name: PostgreSQL migration integration
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +87,25 @@ jobs:
 
       - name: Validate PostgreSQL migration history
         run: scripts/check-postgres-migrations.sh "${{ inputs.migration-base-ref }}"
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26.6"
+          cache: false
+
+      - name: Run PostgreSQL migration integration suite
+        run: go test -tags=integration ./internal/storage/postgres -count=1
+
+  quality:
+    name: Quality and unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -46,14 +124,6 @@ jobs:
 
       - name: Install MCP proxy dependencies
         run: npm ci --prefix packages/mcp-proxy
-
-      - name: Run npm vulnerability audits
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm audit --prefix .lint --audit-level=high
-          npm audit --prefix web --audit-level=high
-          npm audit --prefix packages/mcp-proxy --audit-level=high
 
       - name: Run repository lint
         run: npm run --prefix .lint lint:lines
@@ -99,9 +169,6 @@ jobs:
 
       - name: Run Go vulnerability scan
         run: scripts/go-vulnerability-scan.sh
-
-      - name: Run PostgreSQL migration integration suite
-        run: go test -tags=integration ./internal/storage/postgres -count=1
 
       - name: Run unit coverage gate
         shell: bash

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -56,7 +56,7 @@ jobs:
               if (( status == 0 )); then
                 return 0
               fi
-              if ! grep -Eq 'npm (warn|error) (audit )?5[0-9]{2}\b|npm error code (E5[0-9]{2}|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ECONNREFUSED)' <<<"${output}"; then
+              if ! grep -Eq 'npm (warn|error) (audit )?5[0-9]{2}\b|npm (warn|error) audit network timeout\b|npm error code (E5[0-9]{2}|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ECONNREFUSED)' <<<"${output}"; then
                 return "${status}"
               fi
               if (( attempt == max_attempts )); then

--- a/.github/workflows/pr-test-image.yml
+++ b/.github/workflows/pr-test-image.yml
@@ -180,13 +180,6 @@ jobs:
                   target_url: targetUrl,
                 });
               }
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: resolved.pullNumber,
-                body: `Test image attempt failed for \`${resolved.headSha}\`: ` +
-                  `the branch does not contain current \`main\` (${mainSha}).\n\n${targetUrl}`,
-              });
               core.setOutput("should_build", "false");
               return;
             }
@@ -424,6 +417,7 @@ jobs:
     needs: [resolve, build, publish]
     if: always() && needs.resolve.outputs.should_build == 'true'
     permissions:
+      actions: write
       contents: read
       pull-requests: write
       statuses: write
@@ -458,17 +452,60 @@ jobs:
               target_url: targetUrl,
             });
 
-            const image = `ghcr.io/${context.repo.owner.toLowerCase()}/` +
-              `${context.repo.repo.toLowerCase()}:test-${pullNumber}`;
-            const body = succeeded
-              ? `Published test image \`${process.env.PUBLISHED_IMAGE || image}\` for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`
-              : `Test image attempt failed for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullNumber,
-              body,
-            });
+            if (succeeded) {
+              const image = `ghcr.io/${context.repo.owner.toLowerCase()}/` +
+                `${context.repo.repo.toLowerCase()}:test-${pullNumber}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                body: `Published test image \`${process.env.PUBLISHED_IMAGE || image}\` for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`,
+              });
+            }
+
+      - name: Delete OCI handoff artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          EXPECTED_HEAD: ${{ needs.resolve.outputs.head_sha }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          script: |
+            const artifactName = `preview-oci-${process.env.EXPECTED_HEAD}-${process.env.RUN_ATTEMPT}`;
+            try {
+              if (!/^[0-9a-f]{40}$/.test(process.env.EXPECTED_HEAD) ||
+                  !/^[1-9][0-9]*$/.test(process.env.RUN_ATTEMPT)) {
+                core.warning(`Skipping OCI handoff cleanup for invalid artifact identity: ${artifactName}`);
+                return;
+              }
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.runId,
+                  per_page: 100,
+                },
+              );
+              const matches = artifacts.filter(({ name }) => name === artifactName);
+              if (matches.length === 0) {
+                core.info(`OCI handoff artifact ${artifactName} was not present.`);
+                return;
+              }
+              if (matches.length !== 1) {
+                core.warning(`Skipping OCI handoff cleanup: found ${matches.length} artifacts named ${artifactName}.`);
+                return;
+              }
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matches[0].id,
+              });
+              core.info(`Deleted OCI handoff artifact ${artifactName}.`);
+            } catch (error) {
+              core.warning(`OCI handoff artifact cleanup failed: ${error.message}`);
+            }
 
   production-e2e:
     name: Run production-image E2E
@@ -492,7 +529,6 @@ jobs:
     if: always() && needs.resolve.outputs.should_build == 'true'
     permissions:
       contents: read
-      pull-requests: write
       statuses: write
     runs-on: ubuntu-latest
 
@@ -503,7 +539,6 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           E2E_RESULT: ${{ needs.production-e2e.result }}
           EXPECTED_HEAD: ${{ needs.resolve.outputs.head_sha }}
-          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           PUBLISH_RESULT: ${{ needs.publish.result }}
         with:
           script: |
@@ -523,16 +558,6 @@ jobs:
                 : "Production-image E2E, image build, or cleanup failed.",
               target_url: targetUrl,
             });
-            if (imagePublished) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: Number(process.env.PR_NUMBER),
-                body: succeeded
-                  ? `Production image E2E passed for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`
-                  : `Production image E2E failed for \`${process.env.EXPECTED_HEAD}\`.\n\n${targetUrl}`,
-              });
-            }
 
   resolve-failure:
     name: Report controller failure
@@ -545,7 +570,6 @@ jobs:
       }}
     permissions:
       contents: read
-      pull-requests: write
       statuses: write
     runs-on: ubuntu-latest
 
@@ -554,7 +578,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const pullNumber = context.payload.pull_request.number;
             const eventHead = context.payload.pull_request.head.sha;
             const targetUrl = `${context.serverUrl}/${context.repo.owner}/` +
               `${context.repo.repo}/actions/runs/${context.runId}`;
@@ -572,9 +595,3 @@ jobs:
                 target_url: targetUrl,
               });
             }
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullNumber,
-              body: `Test image request validation failed for \`${eventHead}\`.\n\n${targetUrl}`,
-            });

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ user-dist/
 .env
 .env.local
 .env.*.local
-# Local Docker Compose configuration
-docker-compose.yml
+# Local Docker Compose overrides
 docker-compose.override.yml
 
 # IDE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,5 +218,10 @@ npm test --prefix web
 - Mocks may isolate outbound provider transport failures or pure query
   construction. Tests must still exercise the real validation and domain policy
   around those boundaries.
+- For production E2E-covered changes, run only the registered local scenarios
+  that exercise the changed behavior (for example, `scripts/e2e.sh <scenario>`);
+  the full scenario matrix is a GitHub pipeline gate, not a routine local gate.
+- The final-head production-image E2E status must pass before merge. A skipped,
+  pending, or absent full-matrix status is incomplete evidence, not a pass.
 - Keep changes small, preserve unrelated worktree edits, and surface failures
   before retrying or changing scope.

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -214,6 +214,7 @@ test("shared CI partitions slow gates into independent hosted jobs", async () =>
   assert.match(audit, /local max_attempts=4/);
   assert.match(audit, /while \(\( attempt <= max_attempts \)\)/);
   assert.match(audit, /npm \(warn\|error\) \(audit \)\?5\[0-9\]\{2\}/);
+  assert.match(audit, /npm \(warn\|error\) audit network timeout/);
   assert.match(audit, /E5\[0-9\]\{2\}\|ECONNRESET\|ETIMEDOUT\|EAI_AGAIN\|ENETUNREACH\|ECONNREFUSED/);
   assert.match(audit, /status=\$\?/);
   const transientGuard = audit.indexOf("if ! grep -Eq");

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -177,6 +177,91 @@ test("low-trust preview builds do not export an Actions cache", async () => {
   assert.doesNotMatch(workflow, /^\s+cache-to:/m);
 });
 
+test("shared CI partitions slow gates into independent hosted jobs", async () => {
+  const [shared, pullRequest, push] = await Promise.all([
+    readFile(new URL("../../.github/workflows/ci-shared.yml", import.meta.url), "utf8"),
+    readFile(new URL("../../.github/workflows/ci-pr.yml", import.meta.url), "utf8"),
+    readFile(new URL("../../.github/workflows/ci-push.yml", import.meta.url), "utf8"),
+  ]);
+  const jobIds = [...shared.matchAll(/^  ([a-z0-9-]+):$/gm)].map(([, id]) => id);
+  assert.deepEqual(jobIds, ["npm-audit", "postgres-migrations", "quality"]);
+  const audit = workflowJob(shared, "npm-audit");
+  const migrations = workflowJob(shared, "postgres-migrations");
+  const quality = workflowJob(shared, "quality");
+  assert.match(shared, /^  COVERAGE_THRESHOLD: "90\.0"$/m);
+  assert.equal((shared.match(/COVERAGE_THRESHOLD: "90\.0"/g) || []).length, 1);
+
+  for (const [name, job] of [
+    ["npm-audit", audit],
+    ["postgres-migrations", migrations],
+    ["quality", quality],
+  ]) {
+    assert.match(job, /^    runs-on: ubuntu-latest$/m, `${name} must use a hosted runner`);
+    assert.doesNotMatch(job, /^    needs:/m, `${name} must not depend on another CI job`);
+  }
+  assert.match(audit, /Run npm vulnerability audits/);
+  assert.doesNotMatch(audit, /npm ci/);
+  for (const option of [
+    "--fetch-retries=4",
+    "--fetch-retry-factor=2",
+    "--fetch-retry-mintimeout=1000",
+    "--fetch-retry-maxtimeout=30000",
+    "--fetch-timeout=30000",
+  ]) {
+    assert.equal((audit.match(new RegExp(option, "g")) || []).length, 1, `${option} must be shared by every audit retry`);
+  }
+  assert.match(audit, /audit_with_retry\(\)/);
+  assert.match(audit, /local max_attempts=4/);
+  assert.match(audit, /while \(\( attempt <= max_attempts \)\)/);
+  assert.match(audit, /npm \(warn\|error\) \(audit \)\?5\[0-9\]\{2\}/);
+  assert.match(audit, /E5\[0-9\]\{2\}\|ECONNRESET\|ETIMEDOUT\|EAI_AGAIN\|ENETUNREACH\|ECONNREFUSED/);
+  assert.match(audit, /status=\$\?/);
+  const transientGuard = audit.indexOf("if ! grep -Eq");
+  const nonTransientReturn = audit.indexOf('return "${status}"', transientGuard);
+  const retryBackoff = audit.indexOf("sleep_seconds=$(", transientGuard);
+  assert.ok(transientGuard !== -1 && nonTransientReturn > transientGuard && nonTransientReturn < retryBackoff);
+  for (const prefix of [".lint", "web", "packages/mcp-proxy"]) {
+    assert.match(audit, new RegExp(`audit_with_retry ${prefix.replace("/", "\\/")}`), `${prefix} audit must be invoked`);
+  }
+  assert.equal((audit.match(/^\s+audit_with_retry (?:\.lint|web|packages\/mcp-proxy)$/gm) || []).length, 3);
+
+  for (const step of [
+    "Install lint dependencies",
+    "Install MCP proxy dependencies",
+    "Run repository lint",
+    "Run architecture conformance",
+    "Run MCP proxy tests",
+    "Run scheduled-dreaming timing test",
+    "Run image release policy tests",
+    "Run prerelease version tests",
+    "Run Go vulnerability scan policy tests",
+    "Run AI PR review policy tests",
+    "Run evaluation monitor shell test",
+    "Run Go tests",
+    "Run pinned Go static analysis",
+    "Run Go vulnerability scan",
+    "Run unit coverage gate",
+  ]) {
+    assert.equal((quality.match(new RegExp(`^      - name: ${step.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "gm")) || []).length, 1, `${step} must run exactly once`);
+  }
+  assert.match(migrations, /Validate PostgreSQL migration history/);
+  assert.match(migrations, /go test -tags=integration \.\/internal\/storage\/postgres -count=1/);
+  assert.doesNotMatch(migrations, /Run Go tests|Run unit coverage gate/);
+  assert.match(quality, /Run Go tests/);
+  assert.match(quality, /Run unit coverage gate/);
+  assert.doesNotMatch(quality, /Run npm vulnerability audits|Run PostgreSQL migration integration suite|Validate PostgreSQL migration history/);
+  assert.match(shared, /^  workflow_call:\n    inputs:\n      migration-base-ref:\n        description:/m);
+  assert.match(shared, /^        required: false$/m);
+  assert.match(shared, /^        type: string$/m);
+  assert.match(shared, /^        default: origin\/main$/m);
+  assert.match(migrations, /scripts\/check-postgres-migrations\.sh "\$\{\{ inputs\.migration-base-ref \}\}"/);
+  assert.match(pullRequest, /^name: CI Pull Request$/m);
+  assert.match(push, /^name: CI Push$/m);
+  assert.match(pullRequest, /  ci:\n    name: CI\n    uses: \.\/\.github\/workflows\/ci-shared\.yml/);
+  assert.match(push, /  ci:\n    name: CI\n    uses: \.\/\.github\/workflows\/ci-shared\.yml/);
+  assert.match(push, /migration-base-ref: \$\{\{ github\.event\.before \}\}/);
+});
+
 test("non-E2E image and release jobs use GitHub-hosted runners", async () => {
   const [preview, prereleaseImage, demoImage, prerelease, release, startPrerelease] =
     await Promise.all([
@@ -243,19 +328,76 @@ test("PR preview workflow gates owner/admin and one-shot approval before digest 
   }
 });
 
-test("PR preview reporting does not claim skipped production E2E failed", async () => {
+test("preview reporting comments only on successful publication and reports E2E by status", async () => {
   const workflow = await readFile(
     new URL("../../.github/workflows/pr-test-image.yml", import.meta.url),
     "utf8",
   );
+  const report = workflowJob(workflow, "report");
   const reportE2E = workflowJob(workflow, "report-e2e");
+  const resolveFailure = workflowJob(workflow, "resolve-failure");
   const statusCall = reportE2E.indexOf("github.rest.repos.createCommitStatus");
-  const publishedImageGuard = reportE2E.indexOf("if (imagePublished)");
-  const commentCall = reportE2E.indexOf("github.rest.issues.createComment");
+  const statusGuard = reportE2E.indexOf("if (imagePublished)");
 
   assert.match(reportE2E, /const imagePublished = process\.env\.BUILD_RESULT === "success"/);
-  assert.ok(statusCall !== -1 && statusCall < publishedImageGuard);
-  assert.ok(publishedImageGuard < commentCall);
+  assert.ok(statusCall !== -1);
+  assert.equal(statusGuard, -1);
+  assert.equal((report.match(/github\.rest\.repos\.createCommitStatus/g) || []).length, 1);
+  assert.match(report, /const succeeded = process\.env\.BUILD_RESULT === "success" &&\s+process\.env\.PUBLISH_RESULT === "success"/);
+  assert.match(report, /state: succeeded \? "success" : "failure"/);
+  assert.match(report, /context: process\.env\.POLICY_STATUS_CONTEXT/);
+  assert.equal((reportE2E.match(/github\.rest\.repos\.createCommitStatus/g) || []).length, 1);
+  assert.match(reportE2E, /const succeeded = imagePublished && process\.env\.E2E_RESULT === "success"/);
+  assert.match(reportE2E, /state: succeeded \? "success" : "failure"/);
+  assert.match(reportE2E, /context: process\.env\.E2E_STATUS_CONTEXT/);
+  assert.equal((resolveFailure.match(/github\.rest\.repos\.createCommitStatus/g) || []).length, 1);
+  assert.match(resolveFailure, /state: "failure"/);
+  assert.match(resolveFailure, /for \(const contextName of \[/);
+  assert.doesNotMatch(reportE2E, /github\.rest\.issues\.createComment/);
+  assert.doesNotMatch(resolveFailure, /github\.rest\.issues\.createComment/);
+  assert.equal((workflow.match(/github\.rest\.issues\.createComment/g) || []).length, 1);
+  const successStart = report.indexOf("if (succeeded) {");
+  const successEnd = report.indexOf("\n            }\n", successStart);
+  assert.ok(successStart !== -1 && successEnd > successStart);
+  const successBlock = report.slice(successStart, successEnd);
+  assert.match(successBlock, /github\.rest\.issues\.createComment/);
+  assert.doesNotMatch(report.slice(0, successStart), /github\.rest\.issues\.createComment/);
+  assert.doesNotMatch(report.slice(successEnd), /github\.rest\.issues\.createComment/);
+  assert.doesNotMatch(report, /Test image attempt failed/);
+});
+
+test("preview OCI cleanup is fenced to the current run and nonblocking", async () => {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/pr-test-image.yml", import.meta.url),
+    "utf8",
+  );
+  const report = workflowJob(workflow, "report");
+
+  assert.match(report, /^      actions: write$/m);
+  assert.match(report, /- name: Delete OCI handoff artifact[\s\S]*if: always\(\)[\s\S]*continue-on-error: true/);
+  assert.match(report, /^    needs: \[resolve, build, publish\]$/m);
+  assert.doesNotMatch(report, /production-e2e/);
+  assert.match(report, /preview-oci-\$\{process\.env\.EXPECTED_HEAD\}-\$\{process\.env\.RUN_ATTEMPT\}/);
+  assert.match(report, /listWorkflowRunArtifacts/);
+  assert.match(report, /run_id: context\.runId/);
+  assert.match(report, /matches = artifacts\.filter\(\(\{ name \}\) => name === artifactName\)/);
+  const ambiguityGuard = report.indexOf("if (matches.length !== 1)");
+  const ambiguityEnd = report.indexOf("\n              }\n", ambiguityGuard);
+  const deleteCall = report.indexOf("github.rest.actions.deleteArtifact");
+  assert.ok(ambiguityGuard !== -1 && ambiguityEnd > ambiguityGuard && ambiguityEnd < deleteCall);
+  assert.equal((report.match(/github\.rest\.actions\.deleteArtifact/g) || []).length, 1);
+  const runIdLookup = report.indexOf("run_id: context.runId");
+  const exactNameFilter = report.indexOf("matches = artifacts.filter");
+  assert.ok(runIdLookup !== -1 && exactNameFilter > runIdLookup && deleteCall > exactNameFilter);
+  const ambiguityBlock = report.slice(ambiguityGuard, ambiguityEnd);
+  assert.match(ambiguityBlock, /core\.warning/);
+  assert.match(ambiguityBlock, /return;/);
+  assert.doesNotMatch(ambiguityBlock, /deleteArtifact/);
+  assert.match(report, /Skipping OCI handoff cleanup: found \$\{matches\.length\} artifacts named \$\{artifactName\}\./);
+  assert.match(report, /deleteArtifact/);
+  assert.match(report, /artifact_id: matches\[0\]\.id/);
+  assert.match(report, /OCI handoff artifact cleanup failed/);
+  assert.match(workflow, /retention-days: 1/);
 });
 
 test("OCI promotion avoids jq 1.6 reserved variable names", async () => {


### PR DESCRIPTION
## Summary

- Split the shared CI workflow into independent Ubuntu-hosted npm audit, PostgreSQL migration integration, and quality/unit/coverage jobs.
- Added bounded outer npm audit retries for transient registry 5xx and network failures, with a 30-second request timeout.
- Removed preview validation/failure and production-E2E comments; retain only the successful preview-image publication comment while preserving commit statuses and job results.
- Delete the exact current-run OCI handoff artifact after publication, with one-day retention as fallback.
- Document targeted local E2E usage and remove the obsolete ignored root docker-compose.yml.
- Expanded image-release policy coverage for partitioning, retry classification, status reporting, comment policy, and artifact fencing.

## Verification

- `./scripts/ci-check.sh` passed, including the 90.0% coverage gate.
- `go test -tags=integration ./internal/storage/postgres -count=1` passed.
- `npm test --prefix packages/mcp-proxy` passed (16/16).
- `node --test tests/uat/image_release_policy.test.mjs` passed (30/30).
- `node --test tests/uat/go_vulnerability_scan_policy.test.mjs` passed (6/6).
- All three npm audits passed at `--audit-level=high`; the MCP audit reported only moderate advisories and exited successfully.
- Scoped actionlint and diff checks passed.
- `scripts/go-vulnerability-scan.sh` found no reachable vulnerabilities.

## Plan audit

```
verdict: conformant
auditor: gpt-5.6-terra (max)
base_sha: e3c462f0257617d9c943fec7299dbe5999cd9594
findings: []
```

## Risk and boundaries

The OCI artifact remains the byte handoff required between the untrusted PR build and trusted publisher; a hash-only artifact cannot reconstruct the image. Cleanup is best-effort and one-day retention bounds failures or cancellations. CI caller check names change from the old Go-unit label to the three explicit CI job names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - CI now separates dependency auditing, PostgreSQL migration checks, and quality validation into independent hosted jobs.
  - Dependency audits retry transient registry or network failures.
  - Pull request preview reporting comments only after successful publication, while E2E results are reported through status checks.
  - Preview artifacts are cleaned up safely without blocking the workflow when cleanup issues occur.

- **Documentation**
  - Clarified local E2E testing guidance and final production-image E2E requirements.

- **Developer Experience**
  - Local Docker Compose configuration can now be tracked directly, while override files remain ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->