### PR TITLE
refactor: separate shared construction and read ownership

### DIFF
--- a/cmd/internal/serverapp/dream_composition.go
+++ b/cmd/internal/serverapp/dream_composition.go
@@ -1,0 +1,62 @@
+package serverapp
+
+import (
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/assessor"
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/dreamgeneration"
+	"github.com/markhuangai/dense-mem/internal/modelprovider"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+type dreamApplicationDependencies struct {
+	Remember           rememberapp.Service
+	Store              repository.DreamRepository
+	ScheduledStore     repository.ScheduledDreamRepository
+	AppConfig          dreamservice.AppConfig
+	Teams              dreamservice.TeamService
+	GeneratorTransport modelprovider.StructuredTransport
+	EvidenceStore      repository.EvidenceDiscoveryRepository
+	Model              string
+	Limits             assessor.SemanticAssessmentLimits
+	Metrics            observability.DiscoverabilityMetrics
+	ProviderCycleLease time.Duration
+}
+
+func dreamProviderCycleLease(cfg config.Config) time.Duration {
+	return time.Duration(cfg.GetAIVerifierTimeoutSeconds())*time.Second*
+		time.Duration(dreamgeneration.DreamGenerationMaxProviderTurns) + time.Minute
+}
+
+func buildDreamApplication(deps dreamApplicationDependencies) dreamservice.Service {
+	return dreamservice.New(dreamservice.Dependencies{
+		Remember:           deps.Remember,
+		Store:              deps.Store,
+		ScheduledStore:     deps.ScheduledStore,
+		AppConfig:          deps.AppConfig,
+		Teams:              deps.Teams,
+		Generator:          dreamservice.NewProviderGenerator(dreamgeneration.NewProvider(deps.GeneratorTransport, deps.Model, deps.Limits)),
+		EvidenceStore:      deps.EvidenceStore,
+		EvidenceGenerator:  dreamservice.NewEvidenceProviderGenerator(deps.GeneratorTransport, deps.Model, deps.Limits),
+		Metrics:            deps.Metrics,
+		ProviderCycleLease: deps.ProviderCycleLease,
+	})
+}
+
+type controlDreamApplicationDependencies struct {
+	Store     repository.DreamControlRepository
+	AppConfig dreamservice.AppConfig
+	Teams     dreamservice.TeamConfigService
+}
+
+func buildControlDreamApplication(deps controlDreamApplicationDependencies) dreamservice.ControlService {
+	return dreamservice.NewControl(dreamservice.ControlDependencies{
+		Store:     deps.Store,
+		AppConfig: deps.AppConfig,
+		Teams:     deps.Teams,
+	})
+}

--- a/cmd/internal/serverapp/graph_composition.go
+++ b/cmd/internal/serverapp/graph_composition.go
@@ -1,0 +1,7 @@
+package serverapp
+
+import "github.com/markhuangai/dense-mem/internal/service/graphview"
+
+func buildGraphApplication(store graphview.SemanticStore) graphview.Service {
+	return graphview.NewSemantic(store)
+}

--- a/cmd/internal/serverapp/remember_composition.go
+++ b/cmd/internal/serverapp/remember_composition.go
@@ -1,0 +1,39 @@
+package serverapp
+
+import (
+	"github.com/markhuangai/dense-mem/internal/assessor"
+	"github.com/markhuangai/dense-mem/internal/embedding"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+type rememberApplicationDependencies struct {
+	Ledger   *repository.LedgerRepositoryImpl
+	Catalog  memoryservice.SubmissionAssessmentCatalog
+	Assessor assessor.Provider
+	Embedder embedding.EmbeddingProviderInterface
+	Limits   assessor.SemanticAssessmentLimits
+	Metrics  observability.DiscoverabilityMetrics
+	Logger   observability.LogProvider
+	Audit    securityRejectionAuditAppender
+}
+
+func buildRememberApplication(deps rememberApplicationDependencies) rememberapp.Service {
+	processor := newRememberSynchronousProcessor(
+		deps.Ledger,
+		deps.Catalog,
+		deps.Assessor,
+		deps.Embedder,
+		deps.Limits,
+		deps.Metrics,
+		deps.Logger,
+	)
+	return rememberapp.NewService(rememberapp.Dependencies{
+		Synchronous: processor,
+		Auditor:     newRememberSecurityRejectionAuditAdapter(deps.Audit),
+		Metrics:     deps.Metrics,
+		Logger:      deps.Logger,
+	})
+}

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/markhuangai/dense-mem/internal/conflictassessment"
 	"github.com/markhuangai/dense-mem/internal/crypto"
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/dreamgeneration"
 	"github.com/markhuangai/dense-mem/internal/embedding"
 	"github.com/markhuangai/dense-mem/internal/http"
 	"github.com/markhuangai/dense-mem/internal/http/handler"
@@ -35,12 +34,9 @@ import (
 	"github.com/markhuangai/dense-mem/internal/service/communityservice"
 	"github.com/markhuangai/dense-mem/internal/service/conflictqueue"
 	"github.com/markhuangai/dense-mem/internal/service/conflictreview"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
 	"github.com/markhuangai/dense-mem/internal/service/evidenceconflict"
-	"github.com/markhuangai/dense-mem/internal/service/graphview"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
 	"github.com/markhuangai/dense-mem/internal/sse"
 	"github.com/markhuangai/dense-mem/internal/storage/postgres"
@@ -231,21 +227,11 @@ func RunActiveServer(
 	if err != nil {
 		log.Fatalf("failed to build conflict review runner: %v", err)
 	}
-	rememberAuditor := newRememberSecurityRejectionAuditAdapter(auditService)
-	rememberProcessor := newRememberSynchronousProcessor(
-		ledgerRepo,
-		semanticRepo,
-		assessorProvider,
-		openaiProvider,
-		assessmentLimits,
-		discoverabilityMetrics,
-		logger,
-	)
-	rememberCore := rememberapp.NewService(rememberapp.Dependencies{
-		Synchronous: rememberProcessor, Auditor: rememberAuditor,
-		Metrics: discoverabilityMetrics, Logger: logger,
+	rememberSvc := buildRememberApplication(rememberApplicationDependencies{
+		Ledger: ledgerRepo, Catalog: semanticRepo, Assessor: assessorProvider,
+		Embedder: openaiProvider, Limits: assessmentLimits,
+		Metrics: discoverabilityMetrics, Logger: logger, Audit: auditService,
 	})
-	rememberSvc := rememberCore
 	recallSvc := memoryservice.NewRecallService(memoryservice.RecallDependencies{
 		Search:          searchRepo,
 		Provider:        retryEmbedder,
@@ -266,27 +252,20 @@ func RunActiveServer(
 		CorrectionExecutor:         newSemanticwriteEmbeddingExecutor(openaiProvider),
 		CorrectionEmbeddingTimeout: time.Duration(cfg.GetAIEmbeddingTimeoutSeconds()) * time.Second,
 	})
-	contextSvc := contextservice.NewSemantic(semanticRepo)
-	dreamSvc := dreamservice.New(dreamservice.Dependencies{
-		Remember:          rememberSvc,
-		Store:             semanticRepo,
-		ScheduledStore:    semanticRepo,
-		AppConfig:         appConfigService,
-		Teams:             teamService,
-		Generator:         dreamservice.NewProviderGenerator(dreamgeneration.NewProvider(assessorProvider, cfg.GetAIVerifierModel(), assessmentLimits)),
-		EvidenceStore:     semanticRepo,
-		EvidenceGenerator: dreamservice.NewEvidenceProviderGenerator(assessorProvider, cfg.GetAIVerifierModel(), assessmentLimits),
-		Metrics:           discoverabilityMetrics,
-		ProviderCycleLease: time.Duration(cfg.GetAIVerifierTimeoutSeconds())*
-			time.Second*time.Duration(dreamgeneration.DreamGenerationMaxProviderTurns) + time.Minute,
+	contextSvc := buildContextApplication(semanticRepo)
+	dreamSvc := buildDreamApplication(dreamApplicationDependencies{
+		Remember: rememberSvc, Store: semanticRepo, ScheduledStore: semanticRepo,
+		AppConfig: appConfigService, Teams: teamService,
+		GeneratorTransport: assessorProvider, EvidenceStore: semanticRepo,
+		Model: cfg.GetAIVerifierModel(), Limits: assessmentLimits,
+		Metrics:            discoverabilityMetrics,
+		ProviderCycleLease: dreamProviderCycleLease(cfg),
 	})
 	configureTelemetryFeatures(telemetryPrometheusService, appConfigService, dreamSvc)
-	controlDreamSvc := dreamservice.NewControl(dreamservice.ControlDependencies{
-		Store:     semanticRepo,
-		AppConfig: appConfigService,
-		Teams:     teamService,
+	controlDreamSvc := buildControlDreamApplication(controlDreamApplicationDependencies{
+		Store: semanticRepo, AppConfig: appConfigService, Teams: teamService,
 	})
-	graphViewSvc := graphview.NewSemantic(semanticRepo)
+	graphViewSvc := buildGraphApplication(semanticRepo)
 	memoryPackSvc := skillpackservice.NewMemoryPackService(skillpackservice.MemoryPackDependencies{
 		Semantic: semanticRepo,
 	})

--- a/cmd/internal/serverapp/trace_composition.go
+++ b/cmd/internal/serverapp/trace_composition.go
@@ -1,0 +1,7 @@
+package serverapp
+
+import "github.com/markhuangai/dense-mem/internal/service/contextservice"
+
+func buildContextApplication(store contextservice.SemanticTraceStore) contextservice.Service {
+	return contextservice.NewSemantic(store)
+}

--- a/internal/repository/semantic_graph_repository.go
+++ b/internal/repository/semantic_graph_repository.go
@@ -3,44 +3,129 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
 
-func loadTraceGraphContext(
+const (
+	defaultSemanticGraphLimit = 80
+	defaultSemanticGraphDepth = 2
+	maxSemanticGraphDepth     = 5
+)
+
+func (r *SemanticRepositoryImpl) SemanticGraph(
 	ctx context.Context,
-	tx *gorm.DB,
-	relationship *RelationshipTraceRecord,
-	input TraceRelationshipInput,
-) ([]SemanticGraphNode, []SemanticGraphEdge, error) {
-	if relationship == nil || input.MaxEdges <= 0 || input.MaxDepth <= 0 {
-		return nil, nil, nil
+	input SemanticGraphQuery,
+) (*SemanticGraphSnapshot, error) {
+	input = normalizeSemanticGraphQuery(input)
+	if err := validateSemanticGraphQuery(input); err != nil {
+		return nil, err
 	}
-	rows, err := loadSemanticLocalGraphRows(ctx, tx, SemanticGraphQuery{
-		TeamID:       input.TeamID,
-		Scope:        "local",
-		Query:        strings.ToLower(input.Topic),
-		Types:        []string{"entity", "value"},
-		AnchorType:   "entity",
-		AnchorID:     relationship.SubjectEntityID,
-		Depth:        input.MaxDepth,
-		Limit:        input.MaxEdges,
-		MinRelevance: optionalRelevanceValue(input.MinRelevance),
-		spaceID:      relationship.SpaceID,
+	var rows []semanticGraphEdgeRow
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		var err error
+		if input.Scope == "local" {
+			rows, err = loadSemanticLocalGraphRows(ctx, tx, input)
+		} else {
+			rows, err = loadSemanticOverviewGraphRows(ctx, tx, input)
+		}
+		return err
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, fmt.Errorf("semantic graph: %w", err)
 	}
-	snapshot := semanticGraphSnapshot(SemanticGraphQuery{
-		TeamID: input.TeamID,
-		Scope:  "local",
-		Depth:  input.MaxDepth,
-		Limit:  input.MaxEdges,
-	}, rows)
-	return snapshot.Nodes, snapshot.Edges, nil
+	return semanticGraphSnapshot(input, rows), nil
+}
+
+func (r *SemanticRepositoryImpl) SemanticGraphNodeDetail(
+	ctx context.Context,
+	input SemanticGraphNodeDetailInput,
+) (*SemanticGraphNode, error) {
+	input = normalizeSemanticGraphNodeDetailInput(input)
+	if err := validateSemanticGraphNodeDetailInput(input); err != nil {
+		return nil, err
+	}
+	var node *SemanticGraphNode
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		var err error
+		switch input.NodeType {
+		case "entity":
+			node, err = loadSemanticEntityGraphNode(ctx, tx, input.TeamID, input.NodeID)
+		case "value":
+			node, err = loadSemanticValueGraphNode(ctx, tx, input.TeamID, input.NodeID)
+		default:
+			return sql.ErrNoRows
+		}
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph node: %w", err)
+	}
+	return node, nil
+}
+
+type semanticGraphEdgeRow struct {
+	source SemanticGraphNode
+	target SemanticGraphNode
+	edge   SemanticGraphEdge
+}
+
+func normalizeSemanticGraphQuery(input SemanticGraphQuery) SemanticGraphQuery {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.spaceID = strings.TrimSpace(input.spaceID)
+	input.Scope = strings.ToLower(strings.TrimSpace(input.Scope))
+	if input.Scope == "" || input.Scope != "local" {
+		input.Scope = "overview"
+	}
+	input.Query = strings.ToLower(strings.TrimSpace(input.Query))
+	input.AnchorType = normalizeSemanticGraphNodeType(input.AnchorType)
+	input.AnchorID = strings.TrimSpace(input.AnchorID)
+	input.Types = normalizeSemanticGraphTypes(input.Types)
+	input.Depth = clampInt(input.Depth, defaultSemanticGraphDepth, maxSemanticGraphDepth)
+	input.Limit = defaultPositiveInt(input.Limit, defaultSemanticGraphLimit)
+	input.MinRelevance = normalizeRelevance(input.MinRelevance)
+	return input
+}
+
+func validateSemanticGraphQuery(input SemanticGraphQuery) error {
+	if _, err := uuid.Parse(input.TeamID); err != nil {
+		return fmt.Errorf("team_id is required: %w", err)
+	}
+	if input.Scope == "local" {
+		if input.AnchorType == "" {
+			return errors.New("anchor_type is required for local graph")
+		}
+		if _, err := uuid.Parse(input.AnchorID); err != nil {
+			return fmt.Errorf("anchor_id is required for local graph: %w", err)
+		}
+	}
+	return nil
+}
+
+func normalizeSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) SemanticGraphNodeDetailInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.NodeType = normalizeSemanticGraphNodeType(input.NodeType)
+	input.NodeID = strings.TrimSpace(input.NodeID)
+	return input
+}
+
+func validateSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) error {
+	if _, err := uuid.Parse(input.TeamID); err != nil {
+		return fmt.Errorf("team_id is required: %w", err)
+	}
+	if input.NodeType == "" {
+		return errors.New("node_type must be entity or value")
+	}
+	if _, err := uuid.Parse(input.NodeID); err != nil {
+		return fmt.Errorf("node_id is required: %w", err)
+	}
+	return nil
 }
 
 func loadSemanticOverviewGraphRows(
@@ -258,13 +343,6 @@ func semanticGraphQueryArgs(input SemanticGraphQuery, limit int, extraArgs ...an
 	return args
 }
 
-func optionalRelevanceValue(value *float64) float64 {
-	if value == nil {
-		return 0
-	}
-	return normalizeRelevance(*value)
-}
-
 func scanSemanticGraphRows(rows *sql.Rows, types []string) ([]semanticGraphEdgeRow, error) {
 	typeSet := semanticGraphTypeSet(types)
 	if !typeSet["entity"] {
@@ -451,26 +529,6 @@ func semanticGraphSnapshot(input SemanticGraphQuery, rows []semanticGraphEdgeRow
 		}
 	}
 	return snapshot
-}
-
-func normalizeTracePredicateKeys(values []string) []string {
-	out := make([]string, 0, len(values))
-	seen := map[string]struct{}{}
-	for _, raw := range values {
-		value := strings.TrimSpace(raw)
-		if value == "" {
-			continue
-		}
-		if _, exists := seen[value]; exists {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-		if len(out) == 30 {
-			break
-		}
-	}
-	return out
 }
 
 func normalizeSemanticGraphTypes(values []string) []string {

--- a/internal/repository/semantic_read_helpers.go
+++ b/internal/repository/semantic_read_helpers.go
@@ -1,0 +1,85 @@
+package repository
+
+import (
+	"database/sql"
+	"encoding/json"
+	"math"
+	"strings"
+	"time"
+)
+
+// These helpers are shared by repository read adapters. They contain only
+// bounded decoding and normalization, not capability policy.
+func jSONMap(raw string) map[string]any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" || raw == "[]" {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err == nil {
+		return out
+	}
+	return map[string]any{"raw": raw}
+}
+
+func jSON(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal([]byte(raw), &out); err == nil {
+		return out
+	}
+	return map[string]any{"raw": raw}
+}
+
+func boolDefault(value *bool, defaultValue bool) bool {
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}
+
+func timePtr(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	t := value.Time.UTC()
+	return &t
+}
+
+func clampInt(value, defaultValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func defaultPositiveInt(value, defaultValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	return value
+}
+
+func normalizeOptionalRelevance(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	normalized := normalizeRelevance(*value)
+	return &normalized
+}
+
+func normalizeRelevance(value float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value <= 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}

--- a/internal/repository/semantic_trace_repository.go
+++ b/internal/repository/semantic_trace_repository.go
@@ -3,12 +3,9 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -24,9 +21,6 @@ const (
 	maxTraceEvents            = 500
 	defaultTraceFragmentRunes = 2000
 	maxTraceFragmentRunes     = 8000
-	defaultSemanticGraphLimit = 80
-	defaultSemanticGraphDepth = 2
-	maxSemanticGraphDepth     = 5
 )
 
 var ErrTraceRelationshipNotFound = errors.New("trace relationship not found")
@@ -153,63 +147,6 @@ func (r *SemanticRepositoryImpl) TraceRelationship(
 	return result, nil
 }
 
-func (r *SemanticRepositoryImpl) SemanticGraph(
-	ctx context.Context,
-	input SemanticGraphQuery,
-) (*SemanticGraphSnapshot, error) {
-	input = normalizeSemanticGraphQuery(input)
-	if err := validateSemanticGraphQuery(input); err != nil {
-		return nil, err
-	}
-	var rows []semanticGraphEdgeRow
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		var err error
-		if input.Scope == "local" {
-			rows, err = loadSemanticLocalGraphRows(ctx, tx, input)
-		} else {
-			rows, err = loadSemanticOverviewGraphRows(ctx, tx, input)
-		}
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("semantic graph: %w", err)
-	}
-	return semanticGraphSnapshot(input, rows), nil
-}
-
-func (r *SemanticRepositoryImpl) SemanticGraphNodeDetail(
-	ctx context.Context,
-	input SemanticGraphNodeDetailInput,
-) (*SemanticGraphNode, error) {
-	input = normalizeSemanticGraphNodeDetailInput(input)
-	if err := validateSemanticGraphNodeDetailInput(input); err != nil {
-		return nil, err
-	}
-	var node *SemanticGraphNode
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		var err error
-		switch input.NodeType {
-		case "entity":
-			node, err = loadSemanticEntityGraphNode(ctx, tx, input.TeamID, input.NodeID)
-		case "value":
-			node, err = loadSemanticValueGraphNode(ctx, tx, input.TeamID, input.NodeID)
-		default:
-			return sql.ErrNoRows
-		}
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("semantic graph node: %w", err)
-	}
-	return node, nil
-}
-
-type semanticGraphEdgeRow struct {
-	source SemanticGraphNode
-	target SemanticGraphNode
-	edge   SemanticGraphEdge
-}
-
 func normalizeTraceRelationshipInput(input TraceRelationshipInput) TraceRelationshipInput {
 	input.TeamID = strings.TrimSpace(input.TeamID)
 	input.RelationshipID = strings.TrimSpace(input.RelationshipID)
@@ -233,56 +170,37 @@ func validateTraceRelationshipInput(input TraceRelationshipInput) error {
 	return nil
 }
 
-func normalizeSemanticGraphQuery(input SemanticGraphQuery) SemanticGraphQuery {
-	input.TeamID = strings.TrimSpace(input.TeamID)
-	input.spaceID = strings.TrimSpace(input.spaceID)
-	input.Scope = strings.ToLower(strings.TrimSpace(input.Scope))
-	if input.Scope == "" || input.Scope != "local" {
-		input.Scope = "overview"
+func loadTraceGraphContext(
+	ctx context.Context,
+	tx *gorm.DB,
+	relationship *RelationshipTraceRecord,
+	input TraceRelationshipInput,
+) ([]SemanticGraphNode, []SemanticGraphEdge, error) {
+	if relationship == nil || input.MaxEdges <= 0 || input.MaxDepth <= 0 {
+		return nil, nil, nil
 	}
-	input.Query = strings.ToLower(strings.TrimSpace(input.Query))
-	input.AnchorType = normalizeSemanticGraphNodeType(input.AnchorType)
-	input.AnchorID = strings.TrimSpace(input.AnchorID)
-	input.Types = normalizeSemanticGraphTypes(input.Types)
-	input.Depth = clampInt(input.Depth, defaultSemanticGraphDepth, maxSemanticGraphDepth)
-	input.Limit = defaultPositiveInt(input.Limit, defaultSemanticGraphLimit)
-	input.MinRelevance = normalizeRelevance(input.MinRelevance)
-	return input
-}
-
-func validateSemanticGraphQuery(input SemanticGraphQuery) error {
-	if _, err := uuid.Parse(input.TeamID); err != nil {
-		return fmt.Errorf("team_id is required: %w", err)
+	rows, err := loadSemanticLocalGraphRows(ctx, tx, SemanticGraphQuery{
+		TeamID:       input.TeamID,
+		Scope:        "local",
+		Query:        strings.ToLower(input.Topic),
+		Types:        []string{"entity", "value"},
+		AnchorType:   "entity",
+		AnchorID:     relationship.SubjectEntityID,
+		Depth:        input.MaxDepth,
+		Limit:        input.MaxEdges,
+		MinRelevance: optionalRelevanceValue(input.MinRelevance),
+		spaceID:      relationship.SpaceID,
+	})
+	if err != nil {
+		return nil, nil, err
 	}
-	if input.Scope == "local" {
-		if input.AnchorType == "" {
-			return errors.New("anchor_type is required for local graph")
-		}
-		if _, err := uuid.Parse(input.AnchorID); err != nil {
-			return fmt.Errorf("anchor_id is required for local graph: %w", err)
-		}
-	}
-	return nil
-}
-
-func normalizeSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) SemanticGraphNodeDetailInput {
-	input.TeamID = strings.TrimSpace(input.TeamID)
-	input.NodeType = normalizeSemanticGraphNodeType(input.NodeType)
-	input.NodeID = strings.TrimSpace(input.NodeID)
-	return input
-}
-
-func validateSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) error {
-	if _, err := uuid.Parse(input.TeamID); err != nil {
-		return fmt.Errorf("team_id is required: %w", err)
-	}
-	if input.NodeType == "" {
-		return errors.New("node_type must be entity or value")
-	}
-	if _, err := uuid.Parse(input.NodeID); err != nil {
-		return fmt.Errorf("node_id is required: %w", err)
-	}
-	return nil
+	snapshot := semanticGraphSnapshot(SemanticGraphQuery{
+		TeamID: input.TeamID,
+		Scope:  "local",
+		Depth:  input.MaxDepth,
+		Limit:  input.MaxEdges,
+	}, rows)
+	return snapshot.Nodes, snapshot.Edges, nil
 }
 
 func loadTraceRelationship(
@@ -908,76 +826,29 @@ func traceVisitedEntityIDs(relationship *RelationshipTraceRecord, nodes []Semant
 	return out
 }
 
-func jSONMap(raw string) map[string]any {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "{}" || raw == "[]" {
-		return nil
+func normalizeTracePredicateKeys(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+		if len(out) == 30 {
+			break
+		}
 	}
-	var out map[string]any
-	if err := json.Unmarshal([]byte(raw), &out); err == nil {
-		return out
-	}
-	return map[string]any{"raw": raw}
+	return out
 }
 
-func jSON(raw string) any {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil
-	}
-	var out any
-	if err := json.Unmarshal([]byte(raw), &out); err == nil {
-		return out
-	}
-	return map[string]any{"raw": raw}
-}
-
-func boolDefault(value *bool, defaultValue bool) bool {
+func optionalRelevanceValue(value *float64) float64 {
 	if value == nil {
-		return defaultValue
-	}
-	return *value
-}
-
-func timePtr(value sql.NullTime) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	t := value.Time.UTC()
-	return &t
-}
-
-func clampInt(value, defaultValue, maxValue int) int {
-	if value <= 0 {
-		return defaultValue
-	}
-	if value > maxValue {
-		return maxValue
-	}
-	return value
-}
-
-func defaultPositiveInt(value, defaultValue int) int {
-	if value <= 0 {
-		return defaultValue
-	}
-	return value
-}
-
-func normalizeOptionalRelevance(value *float64) *float64 {
-	if value == nil {
-		return nil
-	}
-	normalized := normalizeRelevance(*value)
-	return &normalized
-}
-
-func normalizeRelevance(value float64) float64 {
-	if math.IsNaN(value) || math.IsInf(value, 0) || value <= 0 {
 		return 0
 	}
-	if value > 1 {
-		return 1
-	}
-	return value
+	return normalizeRelevance(*value)
 }


### PR DESCRIPTION
## Summary

- Split Remember and Dream composition wiring into capability-owned files.
- Isolate trace repository responsibilities from graph reads while preserving existing SQL, transaction scope, and public contracts.
- Move shared decoding and normalization helpers to a single repository helper owner.

Closes #348

## Ownership map

- `cmd/internal/serverapp/remember_composition.go`: Remember composition owner.
- `cmd/internal/serverapp/dream_composition.go`: Dream and control-Dream composition owner.
- `cmd/internal/serverapp/trace_composition.go`: trace application composition owner.
- `cmd/internal/serverapp/graph_composition.go`: graph application composition owner.
- `internal/repository/semantic_trace_repository.go`: trace read implementation owner.
- `internal/repository/semantic_graph_repository.go`: graph read implementation owner.
- `internal/repository/semantic_read_helpers.go`: shared bounded decoding/normalization helper owner.
- `cmd/internal/serverapp/server.go`: named central wiring editor; ordering and worker lifecycle are unchanged.

## Verification

- Focused server/repository/service tests.
- `go test $(scripts/go-packages.sh) -count=1`
- `node scripts/check-architecture.mjs`
- `./scripts/ci-check.sh` (90.0% coverage)
- `./scripts/e2e.sh full` (40 Playwright tests passed)

No schema, configuration, provider, SQL, or durable-state behavior changes.
