### PR TITLE
fix: normalize assessor conversation input limit diagnostics

### DIFF
--- a/internal/assessor/assessor_budget.go
+++ b/internal/assessor/assessor_budget.go
@@ -274,6 +274,7 @@ func allocateSemanticAssessmentOptionalContext(
 }
 
 func semanticAssessmentConversationInputLimit(limits SemanticAssessmentLimits) int {
+	limits = normalizeSemanticAssessmentLimits(limits)
 	repairTurns := SemanticAssessmentMaxProviderTurns - 1
 	headroom := repairTurns * (limits.MaxOutputTokens + semanticAssessmentRepairSafetyTokens)
 	if headroom >= limits.MaxInputTokens {

--- a/internal/assessor/assessor_budget_test.go
+++ b/internal/assessor/assessor_budget_test.go
@@ -258,6 +258,17 @@ func TestSemanticAssessmentBudgetFailureStageUsesRepairAwareInputLimit(t *testin
 	require.Equal(t, "assessment_input", SemanticAssessmentBudgetFailureStage(request, "input_tokens", limits))
 }
 
+func TestSemanticAssessmentConversationInputLimitNormalizesDefaults(t *testing.T) {
+	defaults := DefaultSemanticAssessmentLimits()
+	expected := semanticAssessmentConversationInputLimit(defaults)
+
+	require.Equal(t, expected, SemanticAssessmentConversationInputLimit(SemanticAssessmentLimits{}))
+
+	partial := defaults
+	partial.MaxOutputTokens = 0
+	require.Equal(t, expected, SemanticAssessmentConversationInputLimit(partial))
+}
+
 func TestValidateSemanticAssessmentLimitsRequiresUsableInputBudget(t *testing.T) {
 	require.NoError(t, ValidateSemanticAssessmentLimits(DefaultSemanticAssessmentLimits()))
 	limits := DefaultSemanticAssessmentLimits()


### PR DESCRIPTION
## Problem

The exported assessor budget diagnostic could report a different effective conversation input limit than `PrepareSemanticAssessmentRequest` when a caller supplied zero-valued limits. Preparation applies configured defaults, while the diagnostic helper calculated repair headroom from the raw values.

## Change

Normalize limits inside the shared conversation input limit calculation and add a regression test covering zero and partially specified limits. This keeps actionable budget measurements aligned with the admission path.

## Validation

- `go test ./internal/... -count=1`
- pre-push checks passed, including architecture checks, static analysis, full internal package tests, and the 90% coverage gate
- evaluation was intentionally skipped

Follow-up to CodeRabbit finding: https://github.com/markhuangai/dense-mem/pull/356#discussion_r3944630398
