### PR TITLE
refactor: complete Wave 5 shared readiness (#389)

### DIFF
--- a/architecture/capability-contracts.md
+++ b/architecture/capability-contracts.md
@@ -57,3 +57,34 @@ Recall execution keeps prepared search contracts, embeddings, degradation
 state, and derived memory-space scope in private service/adapter wrappers.
 The public request and storage ports cannot carry derived scope or provider
 state.
+
+## Wave 5 shared-readiness ownership
+
+Issue #389 freezes the writable partition for the eight Wave 5 adopters. The
+capability fragments are the authoritative source-to-owner map; the central
+manifest, shared contracts, role rules, assemblers, and mixed fixtures remain
+read-only infrastructure for adopters.
+
+The following files intentionally remain shared-read-only because they contain
+cross-capability contracts or mixed acceptance setup:
+
+- `internal/repository/semantic_types.go` and `internal/repository/semantic_read_helpers.go`
+- `internal/repository/semantic_trace_graph_integration.e2e`
+- `internal/repository/remember_primitives_integration.e2e`
+- `cmd/internal/serverapp/application_composition.go` and `cmd/internal/serverapp/server.go`
+- `cmd/e2e/main.go` and `scripts/e2e-host-controller.sh`, except for the bounded
+  precheck project-name helper owned by #389
+
+Database-case registrations use the same partition: `knowledge` (#362),
+`trace` (#363), `privacy` (#364), `dream` (#365), `graph` (#366),
+`community` (#367), `audit` (#368), and `settings` (#369). The empty settings
+fragment is intentional; its owner is reserved before that capability adds
+database-backed cases. Existing `http`, `migration`, `postgres`,
+`repository`, `server`, and `service` fragments retain cases outside this
+Wave 5 partition.
+
+The retained `internal/repository/remember_artifact_hold.go` symbol is a
+single-hop compatibility forwarder. Its authoritative writer is
+`internal/storage/postgres/remember_artifact_hold.go:SetRememberFailureArtifactHoldStateTx`.
+The three current consumers and the zero-supported-consumer removal condition
+are recorded in the `postgres-storage-adapter` fragment for cleanup by #382.

--- a/architecture/manifest.mjs
+++ b/architecture/manifest.mjs
@@ -94,10 +94,10 @@ const requiredSourceOwnership = Object.freeze([
   ["cmd/demo-server/main.go", "demo-composition", 381],
   ["cmd/internal/serverapp/access_composition.go", "access-application", 370],
   ["cmd/internal/serverapp/access_adapters.go", "access-application", 370],
-  ["cmd/internal/serverapp/private_memory.go", "application-services", 364],
-  ["cmd/internal/serverapp/audit_composition.go", "application-services", 368],
-  ["cmd/internal/serverapp/configuration_composition.go", "application-services", 369],
-  ["cmd/internal/serverapp/security_composition.go", "application-services", 369],
+  ["cmd/internal/serverapp/private_memory.go", "privacy-application", 364],
+  ["cmd/internal/serverapp/audit_composition.go", "audit-application", 368],
+  ["cmd/internal/serverapp/configuration_composition.go", "settings-application", 369],
+  ["cmd/internal/serverapp/security_composition.go", "settings-application", 369],
   ["cmd/internal/serverapp/operation_log_composition.go", "application-services", 371],
   ["cmd/internal/serverapp/usage_metrics_composition.go", "application-services", 371],
   ["cmd/internal/serverapp/telemetry_composition.go", "application-services", 371],
@@ -114,7 +114,7 @@ const requiredSourceOwnership = Object.freeze([
   ["cmd/internal/serverapp/remember_failure_logging.go", "remember-application", 372],
   ["cmd/internal/serverapp/remember_failure_artifact.go", "remember-application", 372],
   ["cmd/internal/serverapp/remember_embedding_helpers.go", "remember-application", 372],
-  ["cmd/internal/serverapp/security_rejection_audit.go", "remember-application", 372],
+  ["cmd/internal/serverapp/security_rejection_audit.go", "audit-application", 368],
   ["cmd/internal/serverapp/remember_composition.go", "remember-application", 372],
   ["internal/tools/registry/remember_bindings.go", "remember-application", 372],
   ["cmd/internal/serverapp/dream_composition.go", "dream-application", 365],
@@ -501,6 +501,20 @@ function validateFragmentShape(fragment, relativePath, root, diagnostics) {
       }
       if (!isIssueNumber(bridge.removal_issue)) {
         diagnostics.push(diagnostic("invalid-fragment", `${relativePath} compatibility bridge ${bridge.source_path} needs a positive removal issue`));
+      }
+      if (bridge.implementation_owner !== undefined) {
+        if (!bridge.implementation_owner || typeof bridge.implementation_owner !== "object"
+          || !isSafeSourcePath(root, bridge.implementation_owner.path)
+          || typeof bridge.implementation_owner.symbol !== "string"
+          || bridge.implementation_owner.symbol.length === 0
+          || hasWildcard(bridge.implementation_owner.symbol)
+          || !sourceDefinesGoSymbol(root, bridge.implementation_owner)) {
+          diagnostics.push(diagnostic("invalid-fragment", `${relativePath} compatibility bridge ${bridge.source_path} has an invalid implementation owner`));
+        }
+      }
+      if (bridge.removal_condition !== undefined
+        && (typeof bridge.removal_condition !== "string" || bridge.removal_condition.trim().length === 0)) {
+        diagnostics.push(diagnostic("invalid-fragment", `${relativePath} compatibility bridge ${bridge.source_path} needs a removal condition`));
       }
     }
   }

--- a/architecture/modules/application-services.json
+++ b/architecture/modules/application-services.json
@@ -2,14 +2,10 @@
   "schema_version": 1,
   "capability": "application-services",
   "source_ownership": [
-    {"path": "cmd/internal/serverapp/audit_composition.go", "issue": 368},
-    {"path": "cmd/internal/serverapp/configuration_composition.go", "issue": 369},
-    {"path": "cmd/internal/serverapp/security_composition.go", "issue": 369},
     {"path": "cmd/internal/serverapp/operation_log_composition.go", "issue": 371},
     {"path": "cmd/internal/serverapp/usage_metrics_composition.go", "issue": 371},
     {"path": "cmd/internal/serverapp/telemetry_composition.go", "issue": 371},
-    {"path": "cmd/internal/serverapp/telemetry_features.go", "issue": 371},
-    {"path": "cmd/internal/serverapp/private_memory.go", "issue": 364}
+    {"path": "cmd/internal/serverapp/telemetry_features.go", "issue": 371}
   ],
   "completed_issues": [],
   "go": {
@@ -30,12 +26,6 @@
       "target": "github.com/markhuangai/dense-mem/internal/repository",
       "removal_issue": 382,
       "reason": "The broad application service still consumes the legacy repository adapter until final architecture certification."
-    },
-    {
-      "source": "github.com/markhuangai/dense-mem/internal/service",
-      "target": "github.com/markhuangai/dense-mem/internal/storage/postgres",
-      "removal_issue": 368,
-      "reason": "The operations audit service still uses PostgreSQL directly until operations ownership is isolated."
     }
   ],
   "workers": [
@@ -44,22 +34,6 @@
       "function": "Start",
       "kind": "goroutine",
       "ordinal": 1,
-      "role": "worker",
-      "lifecycle_issue": 381
-    },
-    {
-      "path": "internal/service/private_memory_service.go",
-      "function": "Start",
-      "kind": "goroutine",
-      "ordinal": 1,
-      "role": "worker",
-      "lifecycle_issue": 381
-    },
-    {
-      "path": "internal/service/private_memory_service.go",
-      "function": "Start",
-      "kind": "goroutine",
-      "ordinal": 2,
       "role": "worker",
       "lifecycle_issue": 381
     },

--- a/architecture/modules/audit-application.json
+++ b/architecture/modules/audit-application.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "capability": "audit-application",
+  "source_ownership": [
+    {"path": "cmd/internal/serverapp/audit_composition.go", "issue": 368},
+    {"path": "cmd/internal/serverapp/security_rejection_audit.go", "issue": 368},
+    {"path": "cmd/internal/serverapp/security_rejection_audit_test.go", "issue": 368},
+    {"path": "internal/service/audit_service.e2e", "issue": 368},
+    {"path": "internal/service/audit_service.go", "issue": 368},
+    {"path": "internal/service/audit_service_unit_test.go", "issue": 368}
+  ],
+  "completed_issues": [],
+  "go": {"units": []},
+  "browser": {"units": []},
+  "exceptions": [
+    {
+      "source_path": "internal/service/audit_service.go",
+      "source": "github.com/markhuangai/dense-mem/internal/service",
+      "target": "github.com/markhuangai/dense-mem/internal/storage/postgres",
+      "removal_issue": 368,
+      "reason": "The operations audit service still uses PostgreSQL directly until operations ownership is isolated."
+    }
+  ],
+  "workers": []
+}

--- a/architecture/modules/community-application.json
+++ b/architecture/modules/community-application.json
@@ -2,7 +2,23 @@
   "schema_version": 1,
   "capability": "community-application",
   "source_ownership": [
-    {"path": "cmd/internal/serverapp/community_composition.go", "issue": 367}
+    {"path": "cmd/internal/serverapp/community_composition.go", "issue": 367},
+    {"path": "internal/community/detector.go", "issue": 367},
+    {"path": "internal/community/detector_test.go", "issue": 367},
+    {"path": "internal/repository/community_discovery_repository.go", "issue": 367},
+    {"path": "internal/repository/community_recall_coverage_repository.go", "issue": 367},
+    {"path": "internal/repository/community_recall_repository.go", "issue": 367},
+    {"path": "internal/repository/community_repository.go", "issue": 367},
+    {"path": "internal/repository/community_repository_helpers.go", "issue": 367},
+    {"path": "internal/repository/community_repository_integration.e2e", "issue": 367},
+    {"path": "internal/repository/community_repository_read_helpers.go", "issue": 367},
+    {"path": "internal/repository/community_repository_write_helpers.go", "issue": 367},
+    {"path": "internal/repository/community_summary_repository.go", "issue": 367},
+    {"path": "internal/service/communityservice/scheduler.go", "issue": 367},
+    {"path": "internal/service/communityservice/scheduler_test.go", "issue": 367},
+    {"path": "internal/service/communityservice/service.go", "issue": 367},
+    {"path": "internal/service/communityservice/service_test.go", "issue": 367},
+    {"path": "internal/service/communityservice/types.go", "issue": 367}
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/context-application.json
+++ b/architecture/modules/context-application.json
@@ -3,7 +3,16 @@
   "capability": "context-application",
   "source_ownership": [
     {"path": "cmd/internal/serverapp/trace_composition.go", "issue": 363},
-    {"path": "internal/tools/registry/trace_bindings.go", "issue": 363}
+    {"path": "internal/tools/registry/trace_bindings.go", "issue": 363},
+    {"path": "internal/repository/evidence_duplicate_trace_integration.e2e", "issue": 363},
+    {"path": "internal/repository/evidence_lifecycle_trace_repository.go", "issue": 363},
+    {"path": "internal/repository/semantic_read_search_repository.go", "issue": 363},
+    {"path": "internal/repository/semantic_read_repository_test.go", "issue": 363},
+    {"path": "internal/repository/semantic_trace_occurrence.go", "issue": 363},
+    {"path": "internal/repository/semantic_trace_repository.go", "issue": 363},
+    {"path": "internal/service/contextservice/context.go", "issue": 363},
+    {"path": "internal/service/contextservice/semantic_trace.go", "issue": 363},
+    {"path": "internal/service/contextservice/semantic_trace_test.go", "issue": 363}
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/dream-application.json
+++ b/architecture/modules/dream-application.json
@@ -2,8 +2,270 @@
   "schema_version": 1,
   "capability": "dream-application",
   "source_ownership": [
-    {"path": "cmd/internal/serverapp/dream_composition.go", "issue": 365},
-    {"path": "internal/tools/registry/dream_bindings.go", "issue": 365}
+    {
+      "path": "cmd/internal/serverapp/dream_composition.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/contract.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/contract_edge_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/contract_schema_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/contract_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/evidence_contract.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/evidence_contract_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/provider.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/dreamgeneration/provider_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_confirmation_lock.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_confirmation_lock_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_control_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_cycle_recovery_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_cycle_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_derivation_read_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_derivation_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_derivation_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_duplicate_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_errors.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_input_validation.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_target_lock.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_target_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_evidence_target_repository_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_generation_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_lock_admission_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_path_evaluation_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository_integration.e2e",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository_scan.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository_sql.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository_validation.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_repository_validation_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_target_repository.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/repository/dream_types.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/config.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/config_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/control.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/control_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/evidence_paths.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/evidence_paths_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/generator.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/generator_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/list.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/provider_generator.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/provider_generator_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/scheduler.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/scheduler_evidence_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/scheduler_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/service.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/types.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_confirmation.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_evidence.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_evidence_regression_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_evidence_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_generation_helpers.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_inactive_team_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_read_errors_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_schedule.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_schedule_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_terminal_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_test_helpers_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/service/dreamservice/workflow_test_stubs_test.go",
+      "issue": 365
+    },
+    {
+      "path": "internal/tools/registry/dream_bindings.go",
+      "issue": 365
+    }
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/graph-application.json
+++ b/architecture/modules/graph-application.json
@@ -2,7 +2,11 @@
   "schema_version": 1,
   "capability": "graph-application",
   "source_ownership": [
-    {"path": "cmd/internal/serverapp/graph_composition.go", "issue": 366}
+    {"path": "cmd/internal/serverapp/graph_composition.go", "issue": 366},
+    {"path": "internal/repository/semantic_graph_repository.go", "issue": 366},
+    {"path": "internal/repository/semantic_graph_repository_test.go", "issue": 366},
+    {"path": "internal/service/graphview/graphview.go", "issue": 366},
+    {"path": "internal/service/graphview/graphview_test.go", "issue": 366}
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/postgres-adapter.json
+++ b/architecture/modules/postgres-adapter.json
@@ -1,6 +1,10 @@
 {
   "schema_version": 1,
   "capability": "postgres-adapter",
+  "source_ownership": [
+    {"path": "internal/storage/postgres/remember_artifact_hold.go", "issue": 389},
+    {"path": "internal/storage/postgres/remember_artifact_hold_test.go", "issue": 389}
+  ],
   "completed_issues": [],
   "go": {
     "units": [

--- a/architecture/modules/postgres-storage-adapter.json
+++ b/architecture/modules/postgres-storage-adapter.json
@@ -1,6 +1,24 @@
 {
   "schema_version": 1,
   "capability": "postgres-storage-adapter",
+  "source_ownership": [
+    {"path": "internal/repository/remember_artifact_hold.go", "issue": 389},
+    {"path": "internal/repository/remember_artifact_hold_rollback_integration.e2e", "issue": 389}
+  ],
+  "compatibility_bridges": [
+    {
+      "source_path": "internal/repository/remember_artifact_hold.go",
+      "fields": ["setRememberFailureArtifactHoldStateTx"],
+      "consumers": [
+        {"path": "internal/repository/remember_artifact_hold.go", "symbol": "LedgerRepositoryImpl.synchronizeRememberFailureArtifactHold"},
+        {"path": "internal/repository/private_memory_repository_operations.go", "symbol": "PrivateMemoryRepositoryImpl.PlaceLegalHold"},
+        {"path": "internal/repository/private_memory_repository_operations.go", "symbol": "PrivateMemoryRepositoryImpl.ReleaseLegalHold"}
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {"path": "internal/storage/postgres/remember_artifact_hold.go", "symbol": "SetRememberFailureArtifactHoldStateTx"},
+      "removal_condition": "Remove the forwarder when every supported production, evaluation, demo, transport, and test caller uses the PostgreSQL owner or its migrated capability."
+    }
+  ],
   "completed_issues": [],
   "go": {
     "units": [

--- a/architecture/modules/privacy-application.json
+++ b/architecture/modules/privacy-application.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "capability": "privacy-application",
+  "source_ownership": [
+    {"path": "cmd/internal/serverapp/private_memory.go", "issue": 364},
+    {"path": "internal/repository/credential_deletion_audit.go", "issue": 364},
+    {"path": "internal/repository/credential_private_memory_delete.go", "issue": 364},
+    {"path": "internal/repository/private_memory_audit_integration.e2e", "issue": 364},
+    {"path": "internal/repository/private_memory_conflict_fixture_test.go", "issue": 364},
+    {"path": "internal/repository/private_memory_credential_retirement_integration.e2e", "issue": 364},
+    {"path": "internal/repository/private_memory_idempotency.go", "issue": 364},
+    {"path": "internal/repository/private_memory_remember_assessment_integration.e2e", "issue": 364},
+    {"path": "internal/repository/private_memory_repository.go", "issue": 364},
+    {"path": "internal/repository/private_memory_repository_errors_test.go", "issue": 364},
+    {"path": "internal/repository/private_memory_repository_integration.e2e", "issue": 364},
+    {"path": "internal/repository/private_memory_repository_operations.go", "issue": 364},
+    {"path": "internal/repository/private_memory_semantic_lineage_integration.e2e", "issue": 364},
+    {"path": "internal/service/private_memory_service.go", "issue": 364},
+    {"path": "internal/service/private_memory_service_test.go", "issue": 364}
+  ],
+  "completed_issues": [],
+  "go": {"units": []},
+  "browser": {"units": []},
+  "exceptions": [],
+  "workers": [
+    {"path": "internal/service/private_memory_service.go", "function": "Start", "kind": "goroutine", "ordinal": 1, "role": "worker", "lifecycle_issue": 381},
+    {"path": "internal/service/private_memory_service.go", "function": "Start", "kind": "goroutine", "ordinal": 2, "role": "worker", "lifecycle_issue": 381}
+  ]
+}

--- a/architecture/modules/remember-application.json
+++ b/architecture/modules/remember-application.json
@@ -9,7 +9,21 @@
     {"path": "cmd/internal/serverapp/remember_failure_logging.go", "issue": 372},
     {"path": "cmd/internal/serverapp/remember_failure_artifact.go", "issue": 372},
     {"path": "cmd/internal/serverapp/remember_embedding_helpers.go", "issue": 372},
-    {"path": "cmd/internal/serverapp/security_rejection_audit.go", "issue": 372}
+    {"path": "internal/service/remember/deadlines.go", "issue": 372},
+    {"path": "internal/service/remember/evidence_conversion.go", "issue": 372},
+    {"path": "internal/service/remember/ports.go", "issue": 372},
+    {"path": "internal/service/remember/request_hash.go", "issue": 372},
+    {"path": "internal/service/remember/security_audit.go", "issue": 372},
+    {"path": "internal/service/remember/security_scan.go", "issue": 372},
+    {"path": "internal/service/remember/security_scan_helpers.go", "issue": 372},
+    {"path": "internal/service/remember/security_scan_test.go", "issue": 372},
+    {"path": "internal/service/remember/service.go", "issue": 372},
+    {"path": "internal/service/remember/service_helpers_test.go", "issue": 372},
+    {"path": "internal/service/remember/service_synchronous_test.go", "issue": 372},
+    {"path": "internal/service/remember/status_errors.go", "issue": 372},
+    {"path": "internal/service/remember/status_errors_test.go", "issue": 372},
+    {"path": "internal/service/remember/synchronous_contract.go", "issue": 372},
+    {"path": "internal/service/remember/synchronous_contract_test.go", "issue": 372}
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/semantic-write-application.json
+++ b/architecture/modules/semantic-write-application.json
@@ -2,8 +2,210 @@
   "schema_version": 1,
   "capability": "semantic-write-application",
   "source_ownership": [
-    {"path": "cmd/internal/serverapp/semanticwrite_composition.go", "issue": 362},
-    {"path": "cmd/internal/serverapp/semanticwrite_embedding_adapter.go", "issue": 362}
+    {
+      "path": "cmd/internal/serverapp/semanticwrite_composition.go",
+      "issue": 362
+    },
+    {
+      "path": "cmd/internal/serverapp/semanticwrite_embedding_adapter.go",
+      "issue": 362
+    },
+    {
+      "path": "cmd/internal/serverapp/semanticwrite_embedding_adapter_test.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/conflict_derived_evidence_task_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/conflict_overdue_resolution_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/conflict_placement_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/conflict_resolution_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/evidence_lifecycle_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/evidence_lifecycle_repository_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/evidence_lifecycle_validation_test.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/placement_commit_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/placement_commit_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/placement_commit_search.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/placement_commit_types.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_embedding_plan.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_inline_embedding.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_canonical_projection_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_fence_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_lock_order_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_correction_occurrence_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/relationship_identity_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_commit.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_commit_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_commit_helpers_test.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_embedding_plan.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_result.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_result_test.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/remember_transaction.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_lifecycle_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_observation_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_repository_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_review_catalog_repository_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_review_regression.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_space_generation_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_space_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_support_helpers.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/semantic_support_helpers_test.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_commit_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_inline_embedding.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_known_evidence_fence.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_known_evidence_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_catalog_repository_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_known_evidence_repository_integration.e2e",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_assessment_types.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/repository/submission_relationship_result_repository.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/service/semanticwrite/executor.go",
+      "issue": 362
+    },
+    {
+      "path": "internal/service/semanticwrite/executor_test.go",
+      "issue": 362
+    }
   ],
   "completed_issues": [],
   "go": {

--- a/architecture/modules/settings-application.json
+++ b/architecture/modules/settings-application.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "capability": "settings-application",
+  "source_ownership": [
+    {"path": "cmd/internal/serverapp/configuration_composition.go", "issue": 369},
+    {"path": "cmd/internal/serverapp/security_composition.go", "issue": 369},
+    {"path": "internal/repository/app_config_repository.go", "issue": 369},
+    {"path": "internal/repository/security_repository.go", "issue": 369},
+    {"path": "internal/repository/security_repository_test.go", "issue": 369},
+    {"path": "internal/service/app_config_mcp.go", "issue": 369},
+    {"path": "internal/service/app_config_payload.go", "issue": 369},
+    {"path": "internal/service/app_config_recall_feedback.go", "issue": 369},
+    {"path": "internal/service/app_config_retention.go", "issue": 369},
+    {"path": "internal/service/app_config_service.go", "issue": 369},
+    {"path": "internal/service/app_config_service_audit_test.go", "issue": 369},
+    {"path": "internal/service/app_config_service_test.go", "issue": 369},
+    {"path": "internal/service/app_config_telemetry_pricing.go", "issue": 369},
+    {"path": "internal/service/security_service.go", "issue": 369},
+    {"path": "internal/service/security_service_test.go", "issue": 369}
+  ],
+  "completed_issues": [],
+  "go": {"units": []},
+  "browser": {"units": []},
+  "exceptions": [],
+  "workers": []
+}

--- a/architecture/ownership.v1.json
+++ b/architecture/ownership.v1.json
@@ -76,6 +76,7 @@
   },
   "fragments": [
     "architecture/modules/access-application.json",
+    "architecture/modules/audit-application.json",
     "architecture/modules/application-services.json",
     "architecture/modules/architecture.json",
     "architecture/modules/classification-policy.json",
@@ -112,6 +113,7 @@
     "architecture/modules/postgres-graph-read.json",
     "architecture/modules/postgres-lock-admission.json",
     "architecture/modules/postgres-storage-adapter.json",
+    "architecture/modules/privacy-application.json",
     "architecture/modules/process-coordination-adapter.json",
     "architecture/modules/prompt-policy.json",
     "architecture/modules/recall-quality-policy.json",
@@ -125,6 +127,7 @@
     "architecture/modules/semantic-write-application.json",
     "architecture/modules/semanticwrite-contract.json",
     "architecture/modules/server-composition.json",
+    "architecture/modules/settings-application.json",
     "architecture/modules/shared-domain.json",
     "architecture/modules/skill-pack-application.json",
     "architecture/modules/sse-transport.json",

--- a/cmd/e2e/main_test.go
+++ b/cmd/e2e/main_test.go
@@ -188,8 +188,11 @@ func TestWave5DatabaseCaseFragmentsPreserveBaselineInventory(t *testing.T) {
 		}
 		seen[item.ID] = true
 		capabilities[item.Capability]++
+		if item.ID == "repository/TestRememberFailureArtifactHoldTransactionRollback" && item.Capability != "privacy" {
+			t.Fatalf("rollback case belongs to capability %s, want privacy", item.Capability)
+		}
 		if item.ID != "repository/TestRememberFailureArtifactHoldTransactionRollback" {
-			baseline = append(baseline, strings.Join([]string{item.ID, item.Package, item.Run, item.Phase, item.Scenario, item.Source}, "\t"))
+			baseline = append(baseline, strings.Join([]string{item.ID, item.Package, item.Run, item.Phase, item.Scenario, item.Source, item.Capability}, "\t"))
 		}
 	}
 	if len(all) != 379 {
@@ -197,12 +200,13 @@ func TestWave5DatabaseCaseFragmentsPreserveBaselineInventory(t *testing.T) {
 	}
 	sort.Strings(baseline)
 	baselineHash := sha256.Sum256([]byte(strings.Join(baseline, "\n") + "\n"))
-	if got := fmt.Sprintf("%x", baselineHash); got != "28ba4bd3b8657832532db447ef5f3de1eee74e8f86002014c9b84fa805ab4d17" {
+	if got := fmt.Sprintf("%x", baselineHash); got != "3b9df32a4596522d6a2bfacfc4028c4acc76527c0d32a3669280e300e78a31c0" {
 		t.Fatalf("baseline database case inventory changed: %s", got)
 	}
 	for capability, want := range map[string]int{
-		"audit": 8, "community": 1, "dream": 33, "graph": 2,
-		"knowledge": 51, "privacy": 20, "trace": 3,
+		"audit": 8, "community": 1, "dream": 33, "graph": 2, "http": 1,
+		"knowledge": 51, "migration": 2, "postgres": 110, "privacy": 20,
+		"repository": 138, "server": 2, "service": 8, "settings": 0, "trace": 3,
 	} {
 		if capabilities[capability] != want {
 			t.Fatalf("capability %s contains %d cases, want %d", capability, capabilities[capability], want)

--- a/cmd/e2e/main_test.go
+++ b/cmd/e2e/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -146,5 +149,63 @@ func TestLoadCasesReconcilesRegistryDeclarations(t *testing.T) {
 	}
 	if _, err := loadCases(root, "precheck", "repository", "", ""); err == nil || !strings.Contains(err.Error(), "has no declaration") {
 		t.Fatalf("loadCases() error = %v, want missing declaration failure", err)
+	}
+}
+
+func TestWave5DatabaseCaseFragmentsPreserveBaselineInventory(t *testing.T) {
+	root, err := repositoryRoot("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "scripts", "e2e-db-cases"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := make([]databaseCase, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		contents, err := os.ReadFile(filepath.Join(root, "scripts", "e2e-db-cases", entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fragment caseFragment
+		if err := json.Unmarshal(contents, &fragment); err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range fragment.Cases {
+			item.Capability = fragment.Capability
+			all = append(all, item)
+		}
+	}
+	seen := make(map[string]bool, len(all))
+	capabilities := make(map[string]int)
+	baseline := make([]string, 0, len(all)-1)
+	for _, item := range all {
+		if seen[item.ID] {
+			t.Fatalf("duplicate database case %s", item.ID)
+		}
+		seen[item.ID] = true
+		capabilities[item.Capability]++
+		if item.ID != "repository/TestRememberFailureArtifactHoldTransactionRollback" {
+			baseline = append(baseline, strings.Join([]string{item.ID, item.Package, item.Run, item.Phase, item.Scenario, item.Source}, "\t"))
+		}
+	}
+	if len(all) != 379 {
+		t.Fatalf("database case inventory contains %d cases, want 379", len(all))
+	}
+	sort.Strings(baseline)
+	baselineHash := sha256.Sum256([]byte(strings.Join(baseline, "\n") + "\n"))
+	if got := fmt.Sprintf("%x", baselineHash); got != "28ba4bd3b8657832532db447ef5f3de1eee74e8f86002014c9b84fa805ab4d17" {
+		t.Fatalf("baseline database case inventory changed: %s", got)
+	}
+	for capability, want := range map[string]int{
+		"audit": 8, "community": 1, "dream": 33, "graph": 2,
+		"knowledge": 51, "privacy": 20, "trace": 3,
+	} {
+		if capabilities[capability] != want {
+			t.Fatalf("capability %s contains %d cases, want %d", capability, capabilities[capability], want)
+		}
 	}
 }

--- a/internal/repository/remember_artifact_hold.go
+++ b/internal/repository/remember_artifact_hold.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
 )
 
 func (r *LedgerRepositoryImpl) synchronizeRememberFailureArtifactHold(ctx context.Context, rawSpaceID string) error {
@@ -42,29 +44,5 @@ func (r *LedgerRepositoryImpl) synchronizeRememberFailureArtifactHold(ctx contex
 }
 
 func setRememberFailureArtifactHoldStateTx(ctx context.Context, tx *gorm.DB, spaceID uuid.UUID, retained bool) error {
-	if spaceID == uuid.Nil {
-		return nil
-	}
-	if err := tx.WithContext(ctx).Exec(
-		"SELECT set_config('app.remember_failure_artifact_retention_space_id', ?, true), set_config('app.remember_failure_artifact_retention_value', ?, true)",
-		spaceID.String(), fmt.Sprint(retained),
-	).Error; err != nil {
-		return err
-	}
-	result := tx.WithContext(ctx).Exec(`
-		UPDATE remember_failure_artifacts AS artifact
-		SET retained_by_legal_hold = ?
-		FROM remember_attempts AS attempt
-		WHERE attempt.team_id = artifact.team_id
-		  AND attempt.attempt_id = artifact.attempt_id
-		  AND attempt.owner_profile_id = artifact.owner_profile_id
-		  AND attempt.space_id = ?::uuid
-		  AND artifact.retained_by_legal_hold IS DISTINCT FROM ?
-	`, retained, spaceID, retained)
-	if result.Error != nil {
-		return result.Error
-	}
-	return tx.WithContext(ctx).Exec(
-		"SELECT set_config('app.remember_failure_artifact_retention_space_id', '', true), set_config('app.remember_failure_artifact_retention_value', '', true)",
-	).Error
+	return storagepostgres.SetRememberFailureArtifactHoldStateTx(ctx, tx, spaceID, retained)
 }

--- a/internal/repository/remember_artifact_hold_rollback_integration.e2e
+++ b/internal/repository/remember_artifact_hold_rollback_integration.e2e
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/domain"
+)
+
+func TestRememberFailureArtifactHoldTransactionRollback(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	teamID := createLedgerTeam(t, adminDB, rls, "remember-primitives-hold-rollback")
+	identityID := createLedgerSSOIdentity(t, adminDB, rls, uuid.MustParse(teamID))
+	credentialRepo := NewCredentialRepository(appDB, rls)
+	credential := createOwnedCredential(t, credentialRepo, uuid.MustParse(teamID), identityID, "remember-primitives-hold-rollback", domain.CredentialBindingCredentialPrivate)
+	ownerID := credential.ID.String()
+	repo := NewLedgerRepository(appDB, rls)
+	privateRepo := NewPrivateMemoryRepository(appDB, rls)
+	require.NoError(t, privateRepo.Prepare(ctx))
+
+	attemptID, artifactID := uuid.NewString(), uuid.NewString()
+	require.NoError(t, repo.RecordRememberFailure(ctx, RememberFailureRecordInput{
+		Attempt: RememberAttemptRecordInput{
+			TeamID: teamID, OwnerProfileID: ownerID, AttemptID: attemptID,
+			SpaceID: credential.MemorySpaceID.String(), SpaceGeneration: credential.MemorySpaceGeneration,
+			IdempotencyKey: "remember-primitives-hold-rollback", RequestHash: "remember-primitives-hold-rollback-hash",
+			ContractVersion: domain.ContractVersion, SubmissionKind: "remember", Outcome: "failed",
+			FailedPhase: "preflight", ErrorCode: "provider_unavailable", PublicResult: map[string]any{},
+		},
+		Artifacts: []RememberFailureArtifactInput{{
+			ArtifactID: artifactID, ArtifactKind: "failure", ContentType: "application/json",
+			Content: []byte(`{"rollback":true}`), CapturedAt: time.Now().UTC(), ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		}},
+	}))
+	_, created, err := privateRepo.PlaceLegalHold(ctx, credential.MemorySpaceID, "remember-primitives-hold-rollback")
+	require.NoError(t, err)
+	require.True(t, created)
+
+	err = rls.WithSystemTx(ctx, appDB, func(tx *gorm.DB) error {
+		result := tx.Exec(`UPDATE private_memory_legal_holds SET released_at = clock_timestamp() WHERE space_id = ?::uuid AND released_at IS NULL`, credential.MemorySpaceID)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return errors.New("expected one legal hold to release")
+		}
+		require.NoError(t, setRememberFailureArtifactHoldStateTx(ctx, tx, credential.MemorySpaceID, false))
+		return errors.New("force artifact-hold rollback")
+	})
+	require.ErrorContains(t, err, "force artifact-hold rollback")
+
+	var retained bool
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Raw(`SELECT retained_by_legal_hold FROM remember_failure_artifacts WHERE team_id = ?::uuid AND artifact_id = ?::uuid`, teamID, artifactID).Row().Scan(&retained)
+	}))
+	require.True(t, retained, "rolled-back writer must leave the legal-hold state unchanged")
+}

--- a/internal/service/access/credential_activity_test.go
+++ b/internal/service/access/credential_activity_test.go
@@ -98,6 +98,31 @@ func TestCredentialActivityWriterUsesExplicitBatchPort(t *testing.T) {
 	require.True(t, batch.updates[0].At.Equal(at))
 }
 
+func TestCredentialActivityWriterFlushesThroughSinglePort(t *testing.T) {
+	repo := &activitySingleRepo{}
+	writer := NewCredentialActivityWriter(repo)
+
+	writer.RecordLastUsed(uuid.New(), time.Now().UTC())
+	require.NoError(t, writer.flush(context.Background()))
+	require.Equal(t, 1, repo.updates)
+}
+
+func TestCredentialActivityWriterRunsCanceledContextDeterministically(t *testing.T) {
+	repo := &activityBatchRepo{}
+	writer := NewCredentialActivityWriter(repo)
+	id := uuid.New()
+	writer.RecordLastUsed(id, time.Now().UTC())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	writer.run(ctx)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	require.Len(t, repo.updates, 1)
+	require.Equal(t, id, repo.updates[0].ID)
+}
+
 func TestCredentialActivityWriterFlushesOnContextCancellation(t *testing.T) {
 	repo := &activityBatchRepo{}
 	writer := NewCredentialActivityWriter(repo)

--- a/internal/storage/postgres/remember_artifact_hold.go
+++ b/internal/storage/postgres/remember_artifact_hold.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// SetRememberFailureArtifactHoldStateTx updates failure-artifact retention in
+// the caller's transaction after the caller has established the hold state.
+func SetRememberFailureArtifactHoldStateTx(ctx context.Context, tx *gorm.DB, spaceID uuid.UUID, retained bool) error {
+	if spaceID == uuid.Nil {
+		return nil
+	}
+	if err := tx.WithContext(ctx).Exec(
+		"SELECT set_config('app.remember_failure_artifact_retention_space_id', ?, true), set_config('app.remember_failure_artifact_retention_value', ?, true)",
+		spaceID.String(), fmt.Sprint(retained),
+	).Error; err != nil {
+		return err
+	}
+	result := tx.WithContext(ctx).Exec(`
+		UPDATE remember_failure_artifacts AS artifact
+		SET retained_by_legal_hold = ?
+		FROM remember_attempts AS attempt
+		WHERE attempt.team_id = artifact.team_id
+		  AND attempt.attempt_id = artifact.attempt_id
+		  AND attempt.owner_profile_id = artifact.owner_profile_id
+		  AND attempt.space_id = ?::uuid
+		  AND artifact.retained_by_legal_hold IS DISTINCT FROM ?
+	`, retained, spaceID, retained)
+	if result.Error != nil {
+		return result.Error
+	}
+	return tx.WithContext(ctx).Exec(
+		"SELECT set_config('app.remember_failure_artifact_retention_space_id', '', true), set_config('app.remember_failure_artifact_retention_value', '', true)",
+	).Error
+}

--- a/internal/storage/postgres/remember_artifact_hold_test.go
+++ b/internal/storage/postgres/remember_artifact_hold_test.go
@@ -15,7 +15,10 @@ import (
 func TestSetRememberFailureArtifactHoldStateTxUsesCallerTransaction(t *testing.T) {
 	sqlDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer sqlDB.Close()
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, sqlDB.Close())
+	})
 	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
 	require.NoError(t, err)
 
@@ -36,7 +39,10 @@ func TestSetRememberFailureArtifactHoldStateTxUsesCallerTransaction(t *testing.T
 func TestSetRememberFailureArtifactHoldStateTxSkipsNilSpace(t *testing.T) {
 	sqlDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer sqlDB.Close()
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, sqlDB.Close())
+	})
 	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
 	require.NoError(t, err)
 

--- a/internal/storage/postgres/remember_artifact_hold_test.go
+++ b/internal/storage/postgres/remember_artifact_hold_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestSetRememberFailureArtifactHoldStateTxUsesCallerTransaction(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+
+	spaceID := uuid.New()
+	mock.ExpectExec(regexp.QuoteMeta("SELECT set_config('app.remember_failure_artifact_retention_space_id', $1, true), set_config('app.remember_failure_artifact_retention_value', $2, true)")).
+		WithArgs(spaceID.String(), "true").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE remember_failure_artifacts AS artifact")).
+		WithArgs(true, spaceID, true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("SELECT set_config('app.remember_failure_artifact_retention_space_id', '', true), set_config('app.remember_failure_artifact_retention_value', '', true)")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, SetRememberFailureArtifactHoldStateTx(context.Background(), db, spaceID, true))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSetRememberFailureArtifactHoldStateTxSkipsNilSpace(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, SetRememberFailureArtifactHoldStateTx(context.Background(), db, uuid.Nil, true))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/scripts/e2e-db-cases/audit.json
+++ b/scripts/e2e-db-cases/audit.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "capability": "audit",
+  "cases": [
+    {
+      "id": "service/TestAuditLogAppendOnlyTriggerBlocksDelete",
+      "package": "./internal/service",
+      "run": "^TestAuditLogAppendOnlyTriggerBlocksDelete$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditLogAppendOnlyTriggerBlocksUpdate",
+      "package": "./internal/service",
+      "run": "^TestAuditLogAppendOnlyTriggerBlocksUpdate$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceAppend",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceAppend$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceAppendStoresNullClientIPWhenMissing",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceAppendStoresNullClientIPWhenMissing$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceAppendUsesContextClientIPWhenEntryBlank",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceAppendUsesContextClientIPWhenEntryBlank$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceHelperMethods",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceHelperMethods$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceListHidesSealedPrivateSpaceRows",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceListHidesSealedPrivateSpaceRows$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceRedactsSecrets",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceRedactsSecrets$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/community.json
+++ b/scripts/e2e-db-cases/community.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "capability": "community",
+  "cases": [
+    {
+      "id": "repository/TestCommunityRepositorySnapshotLifecycleAndRecallExpansion",
+      "package": "./internal/repository",
+      "run": "^TestCommunityRepositorySnapshotLifecycleAndRecallExpansion$",
+      "phase": "precheck",
+      "source": "internal/repository/community_repository_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/dream.json
+++ b/scripts/e2e-db-cases/dream.json
@@ -1,0 +1,237 @@
+{
+  "version": 1,
+  "capability": "dream",
+  "cases": [
+    {
+      "id": "postgres/TestHypothesisTeamPredicateMigrationRollsBackBeforeTeamOnlyHypothesesExist",
+      "package": "./internal/storage/postgres",
+      "run": "^TestHypothesisTeamPredicateMigrationRollsBackBeforeTeamOnlyHypothesesExist$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/hypothesis_team_predicate_migration_integration.e2e"
+    },
+    {
+      "id": "postgres/TestHypothesisTeamPredicateMigrationScopesForeignKeyByTeam",
+      "package": "./internal/storage/postgres",
+      "run": "^TestHypothesisTeamPredicateMigrationScopesForeignKeyByTeam$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/hypothesis_team_predicate_migration_integration.e2e"
+    },
+    {
+      "id": "repository/TestAdvisoryLockAdmissionsSharePoolBudgetAcrossEvidenceAndConfirmation",
+      "package": "./internal/repository",
+      "run": "^TestAdvisoryLockAdmissionsSharePoolBudgetAcrossEvidenceAndConfirmation$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_lock_admission_integration.e2e"
+    },
+    {
+      "id": "repository/TestDreamListSortValidation",
+      "package": "./internal/repository",
+      "run": "^TestDreamListSortValidation$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment",
+      "package": "./internal/repository",
+      "run": "^TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestDreamRepositoryPersistsTeamScopedPredicateHypothesis",
+      "package": "./internal/repository",
+      "run": "^TestDreamRepositoryPersistsTeamScopedPredicateHypothesis$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryContextsPrioritizeSameSourceAndExcludePrivateSpaces",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryContextsPrioritizeSameSourceAndExcludePrivateSpaces$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryEvaluationPersistsDerivationsAndReadsThemBack",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryEvaluationPersistsDerivationsAndReadsThemBack$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryEvaluationRejectsMixedDuplicateResponseAtomically",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryEvaluationRejectsMixedDuplicateResponseAtomically$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_duplicate_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryMarkerFailureDoesNotReclaimStartedDispatch",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryMarkerFailureDoesNotReclaimStartedDispatch$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryNodesRankEvidenceMentionsBeforeTheGlobalBound",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryNodesRankEvidenceMentionsBeforeTheGlobalBound$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryPredicatesRankTargetRelevantDefinitionsBeforeTheGlobalBound",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryPredicatesRankTargetRelevantDefinitionsBeforeTheGlobalBound$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryRecoveryClaimsOnlyItsLane",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryRecoveryClaimsOnlyItsLane$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryRecoveryExhaustionReportsPersistedTotals",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryRecoveryExhaustionReportsPersistedTotals$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_cycle_recovery_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryRecoveryReportsDistinctTargetCount",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryRecoveryReportsDistinctTargetCount$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryTargetEligibilityFiltersAliasesQuarantineLifecycleStaleAndDeletionOnly",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryTargetEligibilityFiltersAliasesQuarantineLifecycleStaleAndDeletionOnly$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryTargetLockCapsConcurrentProviderPasses",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryTargetLockCapsConcurrentProviderPasses$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryTargetOrderingUsesAttemptFallback",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryTargetOrderingUsesAttemptFallback$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryTargetPassCapStopsAfterTwoRecordedEvaluations",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryTargetPassCapStopsAfterTwoRecordedEvaluations$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryTargetsAreBoundAndTeamScoped",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryTargetsAreBoundAndTeamScoped$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestEvidenceDiscoveryValidatedAttemptConsumesPassAfterPersistenceFailure",
+      "package": "./internal/repository",
+      "run": "^TestEvidenceDiscoveryValidatedAttemptConsumesPassAfterPersistenceFailure$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockAdmitsOneCallback",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockAdmitsOneCallback$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockAllowsNestedRepositoryUseWithinPoolBudget",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockAllowsNestedRepositoryUseWithinPoolBudget$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockClassifiesInvalidHypothesisID",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockClassifiesInvalidHypothesisID$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockDiscardsFailedCleanupConnection",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockDiscardsFailedCleanupConnection$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockReleasesAfterContextCancellation",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockReleasesAfterContextCancellation$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestHypothesisConfirmationLockUsesCanonicalAlias",
+      "package": "./internal/repository",
+      "run": "^TestHypothesisConfirmationLockUsesCanonicalAlias$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
+    },
+    {
+      "id": "repository/TestScheduledDreamRecoveryFencesExpiredLease",
+      "package": "./internal/repository",
+      "run": "^TestScheduledDreamRecoveryFencesExpiredLease$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestScheduledDreamsAreTeamOwnedAndFeedbackIsActorAudited",
+      "package": "./internal/repository",
+      "run": "^TestScheduledDreamsAreTeamOwnedAndFeedbackIsActorAudited$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestStaleDreamSourceErrorMapsMissingRelationship",
+      "package": "./internal/repository",
+      "run": "^TestStaleDreamSourceErrorMapsMissingRelationship$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestUpdateHypothesisStatusValidationBindsDecisionToStatus",
+      "package": "./internal/repository",
+      "run": "^TestUpdateHypothesisStatusValidationBindsDecisionToStatus$",
+      "phase": "precheck",
+      "source": "internal/repository/dream_repository_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/graph.json
+++ b/scripts/e2e-db-cases/graph.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "capability": "graph",
+  "cases": [
+    {
+      "id": "repository/TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive",
+      "package": "./internal/repository",
+      "run": "^TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_trace_graph_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticGraphReadsEntityValueEdgesAndNodeDetail",
+      "package": "./internal/repository",
+      "run": "^TestSemanticGraphReadsEntityValueEdgesAndNodeDetail$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_trace_graph_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/knowledge.json
+++ b/scripts/e2e-db-cases/knowledge.json
@@ -1,0 +1,363 @@
+{
+  "version": 1,
+  "capability": "knowledge",
+  "cases": [
+    {
+      "id": "postgres/TestOverdueConflictResolutionMigrationAvoidsLegacySystemProfileNameCollision",
+      "package": "./internal/storage/postgres",
+      "run": "^TestOverdueConflictResolutionMigrationAvoidsLegacySystemProfileNameCollision$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/overdue_conflict_resolution_migration_integration.e2e"
+    },
+    {
+      "id": "postgres/TestRememberNormalizerMigrationFailsLegacyWorkAndPreservesIndependentWorkflows",
+      "package": "./internal/storage/postgres",
+      "run": "^TestRememberNormalizerMigrationFailsLegacyWorkAndPreservesIndependentWorkflows$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/submission_assessment_migration_integration.e2e"
+    },
+    {
+      "id": "postgres/TestSemanticLedgerMigrationGuardedRollbackRejectsCanonicalAuthority",
+      "package": "./internal/storage/postgres",
+      "run": "^TestSemanticLedgerMigrationGuardedRollbackRejectsCanonicalAuthority$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/client.e2e"
+    },
+    {
+      "id": "postgres/TestSemanticLedgerMigrationRejectsLegacyDerivedAuthority",
+      "package": "./internal/storage/postgres",
+      "run": "^TestSemanticLedgerMigrationRejectsLegacyDerivedAuthority$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/client.e2e"
+    },
+    {
+      "id": "postgres/TestSemanticLedgerMigrationUpgradesPopulated1703",
+      "package": "./internal/storage/postgres",
+      "run": "^TestSemanticLedgerMigrationUpgradesPopulated1703$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/client.e2e"
+    },
+    {
+      "id": "postgres/TestSubmissionAssessmentMigrationReconcilesLegacyRuns",
+      "package": "./internal/storage/postgres",
+      "run": "^TestSubmissionAssessmentMigrationReconcilesLegacyRuns$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/submission_assessment_migration_integration.e2e"
+    },
+    {
+      "id": "repository/TestActiveSpaceGenerationHelperHonorsLifecycleAndExecutionPrivilege",
+      "package": "./internal/repository",
+      "run": "^TestActiveSpaceGenerationHelperHonorsLifecycleAndExecutionPrivilege$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_space_generation_integration.e2e"
+    },
+    {
+      "id": "repository/TestCorrectRelationshipValidationRejectsInvalidConfirmation",
+      "package": "./internal/repository",
+      "run": "^TestCorrectRelationshipValidationRejectsInvalidConfirmation$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestInsertRelationshipTransitionReturnsExistingIDForIdempotentReplay",
+      "package": "./internal/repository",
+      "run": "^TestInsertRelationshipTransitionReturnsExistingIDForIdempotentReplay$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestLedgerDirectEvidenceSupersessionRejectsCrossSpaceReplacement",
+      "package": "./internal/repository",
+      "run": "^TestLedgerDirectEvidenceSupersessionRejectsCrossSpaceReplacement$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestLedgerDirectEvidenceSupersessionRejectsSameTeamCrossOwnerReplacement",
+      "package": "./internal/repository",
+      "run": "^TestLedgerDirectEvidenceSupersessionRejectsSameTeamCrossOwnerReplacement$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestLedgerDirectEvidenceSupersessionRetiresTargetWhenReplacementIsQuarantined",
+      "package": "./internal/repository",
+      "run": "^TestLedgerDirectEvidenceSupersessionRetiresTargetWhenReplacementIsQuarantined$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestLedgerEvidenceLifecyclePersistsTargetSpaceAndRejectsMixedSpaces",
+      "package": "./internal/repository",
+      "run": "^TestLedgerEvidenceLifecyclePersistsTargetSpaceAndRejectsMixedSpaces$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestLedgerRetractEvidenceRevokesOnlyItsSupportAndReplaysAtomically",
+      "package": "./internal/repository",
+      "run": "^TestLedgerRetractEvidenceRevokesOnlyItsSupportAndReplaysAtomically$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestNormalizeCorrectRelationshipInputCanonicalizesWithoutMutatingCaller",
+      "package": "./internal/repository",
+      "run": "^TestNormalizeCorrectRelationshipInputCanonicalizesWithoutMutatingCaller$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionEqualHashUsesOneEmbeddingForBothDocumentStates",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionEqualHashUsesOneEmbeddingForBothDocumentStates$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionLocksCrossScopePairCanonically",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionLocksCrossScopePairCanonically$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_lock_order_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionPlannerKeepsStoredResolvedSelection",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionPlannerKeepsStoredResolvedSelection$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionPlannerUsesCanonicalNameForUniqueSubmitMatch",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionPlannerUsesCanonicalNameForUniqueSubmitMatch$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_canonical_projection_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionPreservesOccurrenceSupport",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionPreservesOccurrenceSupport$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_occurrence_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionRejectsInvalidEmbeddingAtomically",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionRejectsInvalidEmbeddingAtomically$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionRejectsSearchContractRotationAfterPlan",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionRejectsSearchContractRotationAfterPlan$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionRejectsStaleVersionAfterPlan",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionRejectsStaleVersionAfterPlan$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_fence_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionRejectsSupportRevisionChangeAfterPlan",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionRejectsSupportRevisionChangeAfterPlan$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_fence_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp",
+      "package": "./internal/repository",
+      "run": "^TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticAppendOnlyHistoryAndRetraction",
+      "package": "./internal/repository",
+      "run": "^TestSemanticAppendOnlyHistoryAndRetraction$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticApplyRelationshipDecisionValidationAllowsStructuralRememberAcceptance",
+      "package": "./internal/repository",
+      "run": "^TestSemanticApplyRelationshipDecisionValidationAllowsStructuralRememberAcceptance$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRejectsLegacySupportAuthority",
+      "package": "./internal/repository",
+      "run": "^TestSemanticApplyRelationshipDecisionValidationRejectsLegacySupportAuthority$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRejectsMalformedSupportForAnyVerdict",
+      "package": "./internal/repository",
+      "run": "^TestSemanticApplyRelationshipDecisionValidationRejectsMalformedSupportForAnyVerdict$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRequiresEntailedSupport",
+      "package": "./internal/repository",
+      "run": "^TestSemanticApplyRelationshipDecisionValidationRequiresEntailedSupport$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticAssessmentEntityMatchesUseOnlyCanonicalAndAliasNames",
+      "package": "./internal/repository",
+      "run": "^TestSemanticAssessmentEntityMatchesUseOnlyCanonicalAndAliasNames$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticCatalogsOmitSealedGenerationEntities",
+      "package": "./internal/repository",
+      "run": "^TestSemanticCatalogsOmitSealedGenerationEntities$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticCreateHypothesisBootstrapsRefsAndDefaultsProposed",
+      "package": "./internal/repository",
+      "run": "^TestSemanticCreateHypothesisBootstrapsRefsAndDefaultsProposed$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticDelayedOlderOneVersionDoesNotSupersedeNewerManyRows",
+      "package": "./internal/repository",
+      "run": "^TestSemanticDelayedOlderOneVersionDoesNotSupersedeNewerManyRows$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_regression.e2e"
+    },
+    {
+      "id": "repository/TestSemanticEntitiesAllowHomonymsAndTypedValuesDeduplicate",
+      "package": "./internal/repository",
+      "run": "^TestSemanticEntitiesAllowHomonymsAndTypedValuesDeduplicate$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticGroupKeyExcludesMutableValidTo",
+      "package": "./internal/repository",
+      "run": "^TestSemanticGroupKeyExcludesMutableValidTo$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_identity_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticOneCardinalitySupersedesPriorActiveRelationship",
+      "package": "./internal/repository",
+      "run": "^TestSemanticOneCardinalitySupersedesPriorActiveRelationship$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticOneCardinalityUpgradeSupersedesLegacyManyRows",
+      "package": "./internal/repository",
+      "run": "^TestSemanticOneCardinalityUpgradeSupersedesLegacyManyRows$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_regression.e2e"
+    },
+    {
+      "id": "repository/TestSemanticRelationshipLifecycleAndRLS",
+      "package": "./internal/repository",
+      "run": "^TestSemanticRelationshipLifecycleAndRLS$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticRepositoryFailsClosedWithoutDependencies",
+      "package": "./internal/repository",
+      "run": "^TestSemanticRepositoryFailsClosedWithoutDependencies$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticReviewCatalogListsTeamCandidatesAndPredicateAliases",
+      "package": "./internal/repository",
+      "run": "^TestSemanticReviewCatalogListsTeamCandidatesAndPredicateAliases$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticSupportDecisionsRecomputeEffectiveState",
+      "package": "./internal/repository",
+      "run": "^TestSemanticSupportDecisionsRecomputeEffectiveState$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_lifecycle_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticSupportMustMatchSuppliedIngest",
+      "package": "./internal/repository",
+      "run": "^TestSemanticSupportMustMatchSuppliedIngest$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_review_regression.e2e"
+    },
+    {
+      "id": "repository/TestSemanticSupportSourceRevisionMustMatchSource",
+      "package": "./internal/repository",
+      "run": "^TestSemanticSupportSourceRevisionMustMatchSource$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticValidToDisagreementFailsAtomicallyWithoutMutatingCanonicalRelationship",
+      "package": "./internal/repository",
+      "run": "^TestSemanticValidToDisagreementFailsAtomicallyWithoutMutatingCanonicalRelationship$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_identity_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticValueUpsertConcurrentDuplicateReturnsCanonical",
+      "package": "./internal/repository",
+      "run": "^TestSemanticValueUpsertConcurrentDuplicateReturnsCanonical$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSourceRevisionAdvanceRevokesAdoptedSupportAndRecomputesRelationships",
+      "package": "./internal/repository",
+      "run": "^TestSourceRevisionAdvanceRevokesAdoptedSupportAndRecomputesRelationships$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_lifecycle_integration.e2e"
+    },
+    {
+      "id": "repository/TestSubmissionAssessmentCatalogIsTeamScopedAndUsesBoundedPredicateResolution",
+      "package": "./internal/repository",
+      "run": "^TestSubmissionAssessmentCatalogIsTeamScopedAndUsesBoundedPredicateResolution$",
+      "phase": "precheck",
+      "source": "internal/repository/submission_assessment_catalog_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestSubmissionAssessmentKnownEvidenceCatalogEnforcesVisibilityAndEligibility",
+      "package": "./internal/repository",
+      "run": "^TestSubmissionAssessmentKnownEvidenceCatalogEnforcesVisibilityAndEligibility$",
+      "phase": "precheck",
+      "source": "internal/repository/submission_assessment_known_evidence_repository_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/postgres.json
+++ b/scripts/e2e-db-cases/postgres.json
@@ -129,20 +129,6 @@
       "source": "internal/storage/postgres/hourly_evidence_dreams_migration_integration.e2e"
     },
     {
-      "id": "postgres/TestHypothesisTeamPredicateMigrationRollsBackBeforeTeamOnlyHypothesesExist",
-      "package": "./internal/storage/postgres",
-      "run": "^TestHypothesisTeamPredicateMigrationRollsBackBeforeTeamOnlyHypothesesExist$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/hypothesis_team_predicate_migration_integration.e2e"
-    },
-    {
-      "id": "postgres/TestHypothesisTeamPredicateMigrationScopesForeignKeyByTeam",
-      "package": "./internal/storage/postgres",
-      "run": "^TestHypothesisTeamPredicateMigrationScopesForeignKeyByTeam$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/hypothesis_team_predicate_migration_integration.e2e"
-    },
-    {
       "id": "postgres/TestIdentityBridgeBackfillsStableIDsAndLegacyGovernance",
       "package": "./internal/storage/postgres",
       "run": "^TestIdentityBridgeBackfillsStableIDsAndLegacyGovernance$",
@@ -401,13 +387,6 @@
       "source": "internal/storage/postgres/organization_directory_identity_migration.e2e"
     },
     {
-      "id": "postgres/TestOverdueConflictResolutionMigrationAvoidsLegacySystemProfileNameCollision",
-      "package": "./internal/storage/postgres",
-      "run": "^TestOverdueConflictResolutionMigrationAvoidsLegacySystemProfileNameCollision$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/overdue_conflict_resolution_migration_integration.e2e"
-    },
-    {
       "id": "postgres/TestPostCutoverCleanupMigrationBlocksLegacyAPIKeyWithoutCanonicalTeamProfile",
       "package": "./internal/storage/postgres",
       "run": "^TestPostCutoverCleanupMigrationBlocksLegacyAPIKeyWithoutCanonicalTeamProfile$",
@@ -450,13 +429,6 @@
       "source": "internal/storage/postgres/client.e2e"
     },
     {
-      "id": "postgres/TestPrivateMemoryAuditBackfillAssociatesMatchingCredentialRows",
-      "package": "./internal/storage/postgres",
-      "run": "^TestPrivateMemoryAuditBackfillAssociatesMatchingCredentialRows$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/private_memory_audit_migration.e2e"
-    },
-    {
       "id": "postgres/TestReadOnlyRepeatableReadTransactionOptions",
       "package": "./internal/storage/postgres",
       "run": "^TestReadOnlyRepeatableReadTransactionOptions$",
@@ -483,13 +455,6 @@
       "run": "^TestRelationshipTelemetryMigrationRecoversInvalidIndexesAndRollsBack$",
       "phase": "precheck",
       "source": "internal/storage/postgres/relationship_telemetry_migration.e2e"
-    },
-    {
-      "id": "postgres/TestRememberNormalizerMigrationFailsLegacyWorkAndPreservesIndependentWorkflows",
-      "package": "./internal/storage/postgres",
-      "run": "^TestRememberNormalizerMigrationFailsLegacyWorkAndPreservesIndependentWorkflows$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/submission_assessment_migration_integration.e2e"
     },
     {
       "id": "postgres/TestRememberReliabilityMigrationDownRejectsQueuedV26RememberIngest",
@@ -679,34 +644,6 @@
       "run": "^TestSearchStorageMigrationAllowsIndexGenerationLifecycleOnly$",
       "phase": "precheck",
       "source": "internal/storage/postgres/client.e2e"
-    },
-    {
-      "id": "postgres/TestSemanticLedgerMigrationGuardedRollbackRejectsCanonicalAuthority",
-      "package": "./internal/storage/postgres",
-      "run": "^TestSemanticLedgerMigrationGuardedRollbackRejectsCanonicalAuthority$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/client.e2e"
-    },
-    {
-      "id": "postgres/TestSemanticLedgerMigrationRejectsLegacyDerivedAuthority",
-      "package": "./internal/storage/postgres",
-      "run": "^TestSemanticLedgerMigrationRejectsLegacyDerivedAuthority$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/client.e2e"
-    },
-    {
-      "id": "postgres/TestSemanticLedgerMigrationUpgradesPopulated1703",
-      "package": "./internal/storage/postgres",
-      "run": "^TestSemanticLedgerMigrationUpgradesPopulated1703$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/client.e2e"
-    },
-    {
-      "id": "postgres/TestSubmissionAssessmentMigrationReconcilesLegacyRuns",
-      "package": "./internal/storage/postgres",
-      "run": "^TestSubmissionAssessmentMigrationReconcilesLegacyRuns$",
-      "phase": "precheck",
-      "source": "internal/storage/postgres/submission_assessment_migration_integration.e2e"
     },
     {
       "id": "postgres/TestSubmissionDiagnosticsIndexesAreValid",

--- a/scripts/e2e-db-cases/privacy.json
+++ b/scripts/e2e-db-cases/privacy.json
@@ -1,0 +1,146 @@
+{
+  "version": 1,
+  "capability": "privacy",
+  "cases": [
+    {
+      "id": "repository/TestRememberFailureArtifactHoldTransactionRollback",
+      "package": "./internal/repository",
+      "run": "^TestRememberFailureArtifactHoldTransactionRollback$",
+      "phase": "precheck",
+      "source": "internal/repository/remember_artifact_hold_rollback_integration.e2e"
+    },
+    {
+      "id": "postgres/TestPrivateMemoryAuditBackfillAssociatesMatchingCredentialRows",
+      "package": "./internal/storage/postgres",
+      "run": "^TestPrivateMemoryAuditBackfillAssociatesMatchingCredentialRows$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/private_memory_audit_migration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryCorrectionStatusHidesSealedGeneration",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryCorrectionStatusHidesSealedGeneration$",
+      "phase": "precheck",
+      "source": "internal/repository/relationship_correction_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryCredentialErasureIsHeldIdempotentAndExact",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryCredentialErasureIsHeldIdempotentAndExact$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryCredentialRetirementUpgradesActiveErasure",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryCredentialRetirementUpgradesActiveErasure$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_credential_retirement_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryErasureCleansPrivateSemanticDecisionLineage",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryErasureCleansPrivateSemanticDecisionLineage$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_semantic_lineage_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryErasureCleansSynchronousAssessmentAfterAttemptOrder",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryErasureCleansSynchronousAssessmentAfterAttemptOrder$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_remember_assessment_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryErasureRemovesInboundCrossSpaceReferences",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryErasureRemovesInboundCrossSpaceReferences$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryExpiredLeaseIsReclaimedWithNewFence",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryExpiredLeaseIsReclaimedWithNewFence$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryFailureRetriesAreBackedOffAndBounded",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryFailureRetriesAreBackedOffAndBounded$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryGenerationTriggerAllowsAuthenticatedSharedWrites",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryGenerationTriggerAllowsAuthenticatedSharedWrites$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryIdempotencyConcurrentReplay",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryIdempotencyConcurrentReplay$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryManifestMatchesCatalog",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryManifestMatchesCatalog$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryManifestMismatchBlocksPrepare",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryManifestMismatchBlocksPrepare$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryMissingRetiredCredentialLosesClaim",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryMissingRetiredCredentialLosesClaim$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemoryRetentionSelectsExpiredSpacesAndExcludesLegalHolds",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemoryRetentionSelectsExpiredSpacesAndExcludesLegalHolds$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemorySSOCredentialDeletePreservesSharedActorMembership",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemorySSOCredentialDeletePreservesSharedActorMembership$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemorySSOCredentialDeleteRetiresOnlyCredentialPrivateSpace",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemorySSOCredentialDeleteRetiresOnlyCredentialPrivateSpace$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_repository_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemorySSOCredentialRevocationAuditFailureRollsBackDisable",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemorySSOCredentialRevocationAuditFailureRollsBackDisable$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_audit_integration.e2e"
+    },
+    {
+      "id": "repository/TestPrivateMemorySSOCredentialRevocationAuditStoresProfileAndCredentialActors",
+      "package": "./internal/repository",
+      "run": "^TestPrivateMemorySSOCredentialRevocationAuditStoresProfileAndCredentialActors$",
+      "phase": "precheck",
+      "source": "internal/repository/private_memory_audit_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-db-cases/repository.json
+++ b/scripts/e2e-db-cases/repository.json
@@ -3,13 +3,6 @@
   "capability": "repository",
   "cases": [
     {
-      "id": "repository/TestActiveSpaceGenerationHelperHonorsLifecycleAndExecutionPrivilege",
-      "package": "./internal/repository",
-      "run": "^TestActiveSpaceGenerationHelperHonorsLifecycleAndExecutionPrivilege$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_space_generation_integration.e2e"
-    },
-    {
       "id": "repository/TestActiveTeamMutationGuardsAllowConcurrentTransactions",
       "package": "./internal/repository",
       "run": "^TestActiveTeamMutationGuardsAllowConcurrentTransactions$",
@@ -22,13 +15,6 @@
       "run": "^TestActiveTeamMutationGuardSerializesWithTeamDelete$",
       "phase": "precheck",
       "source": "internal/repository/team_soft_delete_integration.e2e"
-    },
-    {
-      "id": "repository/TestAdvisoryLockAdmissionsSharePoolBudgetAcrossEvidenceAndConfirmation",
-      "package": "./internal/repository",
-      "run": "^TestAdvisoryLockAdmissionsSharePoolBudgetAcrossEvidenceAndConfirmation$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_lock_admission_integration.e2e"
     },
     {
       "id": "repository/TestAuthorityRepositoryBlocksFreshAuthorityWhenApplicationDataExists",
@@ -87,13 +73,6 @@
       "source": "internal/repository/conflict_review_private_space_integration.e2e"
     },
     {
-      "id": "repository/TestCommunityRepositorySnapshotLifecycleAndRecallExpansion",
-      "package": "./internal/repository",
-      "run": "^TestCommunityRepositorySnapshotLifecycleAndRecallExpansion$",
-      "phase": "precheck",
-      "source": "internal/repository/community_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestComposeRememberPrimitives",
       "package": "./internal/repository",
       "run": "^TestComposeRememberPrimitives$",
@@ -121,13 +100,6 @@
       "run": "^TestConflictSnapshotScopeSerializesPlacementReviewAndWrite$",
       "phase": "precheck",
       "source": "internal/repository/conflict_review_synchronous_integration.e2e"
-    },
-    {
-      "id": "repository/TestCorrectRelationshipValidationRejectsInvalidConfirmation",
-      "package": "./internal/repository",
-      "run": "^TestCorrectRelationshipValidationRejectsInvalidConfirmation$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
     },
     {
       "id": "repository/TestDeleteForTeamRetiresPromotedSSOCredentialPrivateSpace",
@@ -177,27 +149,6 @@
       "run": "^TestDirectoryReconcileFenceAndDisableRetireOnlyDirectoryGrants$",
       "phase": "precheck",
       "source": "internal/repository/directory_identity_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestDreamListSortValidation",
-      "package": "./internal/repository",
-      "run": "^TestDreamListSortValidation$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment",
-      "package": "./internal/repository",
-      "run": "^TestDreamRepositoryPersistsEvidenceGroundedHypothesisAndPathAssessment$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestDreamRepositoryPersistsTeamScopedPredicateHypothesis",
-      "package": "./internal/repository",
-      "run": "^TestDreamRepositoryPersistsTeamScopedPredicateHypothesis$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
     },
     {
       "id": "repository/TestEvidenceConflictAllowsExplicitKnownCitationWithoutCandidateAssociation",
@@ -284,174 +235,6 @@
       "source": "internal/repository/evidence_conflict_integration.e2e"
     },
     {
-      "id": "repository/TestEvidenceDiscoveryContextsPrioritizeSameSourceAndExcludePrivateSpaces",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryContextsPrioritizeSameSourceAndExcludePrivateSpaces$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryEvaluationPersistsDerivationsAndReadsThemBack",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryEvaluationPersistsDerivationsAndReadsThemBack$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryEvaluationRejectsMixedDuplicateResponseAtomically",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryEvaluationRejectsMixedDuplicateResponseAtomically$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_duplicate_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryMarkerFailureDoesNotReclaimStartedDispatch",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryMarkerFailureDoesNotReclaimStartedDispatch$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryNodesRankEvidenceMentionsBeforeTheGlobalBound",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryNodesRankEvidenceMentionsBeforeTheGlobalBound$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryPredicatesRankTargetRelevantDefinitionsBeforeTheGlobalBound",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryPredicatesRankTargetRelevantDefinitionsBeforeTheGlobalBound$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryRecoveryClaimsOnlyItsLane",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryRecoveryClaimsOnlyItsLane$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryRecoveryExhaustionReportsPersistedTotals",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryRecoveryExhaustionReportsPersistedTotals$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_cycle_recovery_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryRecoveryReportsDistinctTargetCount",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryRecoveryReportsDistinctTargetCount$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryTargetEligibilityFiltersAliasesQuarantineLifecycleStaleAndDeletionOnly",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryTargetEligibilityFiltersAliasesQuarantineLifecycleStaleAndDeletionOnly$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryTargetLockCapsConcurrentProviderPasses",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryTargetLockCapsConcurrentProviderPasses$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryTargetOrderingUsesAttemptFallback",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryTargetOrderingUsesAttemptFallback$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryTargetPassCapStopsAfterTwoRecordedEvaluations",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryTargetPassCapStopsAfterTwoRecordedEvaluations$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryTargetsAreBoundAndTeamScoped",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryTargetsAreBoundAndTeamScoped$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestEvidenceDiscoveryValidatedAttemptConsumesPassAfterPersistenceFailure",
-      "package": "./internal/repository",
-      "run": "^TestEvidenceDiscoveryValidatedAttemptConsumesPassAfterPersistenceFailure$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_evidence_target_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockAdmitsOneCallback",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockAdmitsOneCallback$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockAllowsNestedRepositoryUseWithinPoolBudget",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockAllowsNestedRepositoryUseWithinPoolBudget$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockBoundsDifferentHypothesesWithinPoolBudget$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockClassifiesInvalidHypothesisID",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockClassifiesInvalidHypothesisID$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockDiscardsFailedCleanupConnection",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockDiscardsFailedCleanupConnection$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockRejectsPoolWithoutApplicationCapacity$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockReleasesAfterContextCancellation",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockReleasesAfterContextCancellation$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestHypothesisConfirmationLockUsesCanonicalAlias",
-      "package": "./internal/repository",
-      "run": "^TestHypothesisConfirmationLockUsesCanonicalAlias$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_confirmation_lock_integration.e2e"
-    },
-    {
-      "id": "repository/TestInsertRelationshipTransitionReturnsExistingIDForIdempotentReplay",
-      "package": "./internal/repository",
-      "run": "^TestInsertRelationshipTransitionReturnsExistingIDForIdempotentReplay$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestKnownEvidenceFenceAllowsVisibleCrossOwnerEvidenceUnderRLS",
       "package": "./internal/repository",
       "run": "^TestKnownEvidenceFenceAllowsVisibleCrossOwnerEvidenceUnderRLS$",
@@ -529,41 +312,6 @@
       "source": "internal/repository/ledger_source_revision_supersedes_integration.e2e"
     },
     {
-      "id": "repository/TestLedgerDirectEvidenceSupersessionRejectsCrossSpaceReplacement",
-      "package": "./internal/repository",
-      "run": "^TestLedgerDirectEvidenceSupersessionRejectsCrossSpaceReplacement$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestLedgerDirectEvidenceSupersessionRejectsSameTeamCrossOwnerReplacement",
-      "package": "./internal/repository",
-      "run": "^TestLedgerDirectEvidenceSupersessionRejectsSameTeamCrossOwnerReplacement$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestLedgerDirectEvidenceSupersessionRetiresTargetWhenReplacementIsQuarantined",
-      "package": "./internal/repository",
-      "run": "^TestLedgerDirectEvidenceSupersessionRetiresTargetWhenReplacementIsQuarantined$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestLedgerEvidenceLifecyclePersistsTargetSpaceAndRejectsMixedSpaces",
-      "package": "./internal/repository",
-      "run": "^TestLedgerEvidenceLifecyclePersistsTargetSpaceAndRejectsMixedSpaces$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestLedgerRetractEvidenceRevokesOnlyItsSupportAndReplaysAtomically",
-      "package": "./internal/repository",
-      "run": "^TestLedgerRetractEvidenceRevokesOnlyItsSupportAndReplaysAtomically$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestLedgerSourceRevisionCompareAndSet",
       "package": "./internal/repository",
       "run": "^TestLedgerSourceRevisionCompareAndSet$",
@@ -578,13 +326,6 @@
       "source": "internal/repository/ledger_repository_integration.e2e"
     },
     {
-      "id": "repository/TestNormalizeCorrectRelationshipInputCanonicalizesWithoutMutatingCaller",
-      "package": "./internal/repository",
-      "run": "^TestNormalizeCorrectRelationshipInputCanonicalizesWithoutMutatingCaller$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestOverdueConflictResolutionRetainsEvidenceUsedByAnotherOwner",
       "package": "./internal/repository",
       "run": "^TestOverdueConflictResolutionRetainsEvidenceUsedByAnotherOwner$",
@@ -597,132 +338,6 @@
       "run": "^TestOverdueConflictResolutionRetainsEvidenceUsedByLosingOwner$",
       "phase": "precheck",
       "source": "internal/repository/conflict_review_synchronous_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryCorrectionStatusHidesSealedGeneration",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryCorrectionStatusHidesSealedGeneration$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryCredentialErasureIsHeldIdempotentAndExact",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryCredentialErasureIsHeldIdempotentAndExact$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryCredentialRetirementUpgradesActiveErasure",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryCredentialRetirementUpgradesActiveErasure$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_credential_retirement_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryErasureCleansPrivateSemanticDecisionLineage",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryErasureCleansPrivateSemanticDecisionLineage$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_semantic_lineage_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryErasureCleansSynchronousAssessmentAfterAttemptOrder",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryErasureCleansSynchronousAssessmentAfterAttemptOrder$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_remember_assessment_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryErasureRemovesInboundCrossSpaceReferences",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryErasureRemovesInboundCrossSpaceReferences$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryExpiredLeaseIsReclaimedWithNewFence",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryExpiredLeaseIsReclaimedWithNewFence$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryFailureRetriesAreBackedOffAndBounded",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryFailureRetriesAreBackedOffAndBounded$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryGenerationTriggerAllowsAuthenticatedSharedWrites",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryGenerationTriggerAllowsAuthenticatedSharedWrites$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryIdempotencyConcurrentReplay",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryIdempotencyConcurrentReplay$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryManifestMatchesCatalog",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryManifestMatchesCatalog$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryManifestMismatchBlocksPrepare",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryManifestMismatchBlocksPrepare$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryMissingRetiredCredentialLosesClaim",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryMissingRetiredCredentialLosesClaim$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemoryRetentionSelectsExpiredSpacesAndExcludesLegalHolds",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemoryRetentionSelectsExpiredSpacesAndExcludesLegalHolds$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemorySSOCredentialDeletePreservesSharedActorMembership",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemorySSOCredentialDeletePreservesSharedActorMembership$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemorySSOCredentialDeleteRetiresOnlyCredentialPrivateSpace",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemorySSOCredentialDeleteRetiresOnlyCredentialPrivateSpace$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemorySSOCredentialRevocationAuditFailureRollsBackDisable",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemorySSOCredentialRevocationAuditFailureRollsBackDisable$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_audit_integration.e2e"
-    },
-    {
-      "id": "repository/TestPrivateMemorySSOCredentialRevocationAuditStoresProfileAndCredentialActors",
-      "package": "./internal/repository",
-      "run": "^TestPrivateMemorySSOCredentialRevocationAuditStoresProfileAndCredentialActors$",
-      "phase": "precheck",
-      "source": "internal/repository/private_memory_audit_integration.e2e"
     },
     {
       "id": "repository/TestReadTelemetryLifecycleIsolatesSystemTeamAndProfileScopes",
@@ -933,90 +548,6 @@
       "run": "^TestReferenceDefinitionGuardRequiresSystemOrMigrationMode$",
       "phase": "precheck",
       "source": "internal/repository/ledger_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionAmbiguityRequiresOneOwnerConfirmation$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionEqualHashUsesOneEmbeddingForBothDocumentStates",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionEqualHashUsesOneEmbeddingForBothDocumentStates$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionLocksCrossScopePairCanonically",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionLocksCrossScopePairCanonically$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_lock_order_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionPlannerKeepsStoredResolvedSelection",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionPlannerKeepsStoredResolvedSelection$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionPlannerUsesCanonicalNameForUniqueSubmitMatch",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionPlannerUsesCanonicalNameForUniqueSubmitMatch$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_canonical_projection_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionPreservesOccurrenceSupport",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionPreservesOccurrenceSupport$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_occurrence_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionRejectsInvalidEmbeddingAtomically",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionRejectsInvalidEmbeddingAtomically$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionRejectsSearchContractRotationAfterPlan",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionRejectsSearchContractRotationAfterPlan$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionRejectsStaleVersionAfterPlan",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionRejectsStaleVersionAfterPlan$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_fence_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionRejectsSupportRevisionChangeAfterPlan",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionRejectsSupportRevisionChangeAfterPlan$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_fence_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp",
-      "package": "./internal/repository",
-      "run": "^TestRelationshipCorrectionReusesActiveCollisionAndRejectsNoOp$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_correction_repository_integration.e2e"
     },
     {
       "id": "repository/TestRememberAttemptDiagnosticsIncludesReplayedHistoryAndArtifacts",
@@ -1250,20 +781,6 @@
       "source": "internal/repository/ledger_source_revision_supersedes_integration.e2e"
     },
     {
-      "id": "repository/TestScheduledDreamRecoveryFencesExpiredLease",
-      "package": "./internal/repository",
-      "run": "^TestScheduledDreamRecoveryFencesExpiredLease$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestScheduledDreamsAreTeamOwnedAndFeedbackIsActorAudited",
-      "package": "./internal/repository",
-      "run": "^TestScheduledDreamsAreTeamOwnedAndFeedbackIsActorAudited$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestSearchConvergenceHydratesRelationshipDocumentsAfterClosingDocumentRows",
       "package": "./internal/repository",
       "run": "^TestSearchConvergenceHydratesRelationshipDocumentsAfterClosingDocumentRows$",
@@ -1355,188 +872,6 @@
       "source": "internal/repository/search_reconciliation_integration.e2e"
     },
     {
-      "id": "repository/TestSemanticAppendOnlyHistoryAndRetraction",
-      "package": "./internal/repository",
-      "run": "^TestSemanticAppendOnlyHistoryAndRetraction$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticApplyRelationshipDecisionValidationAllowsStructuralRememberAcceptance",
-      "package": "./internal/repository",
-      "run": "^TestSemanticApplyRelationshipDecisionValidationAllowsStructuralRememberAcceptance$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRejectsLegacySupportAuthority",
-      "package": "./internal/repository",
-      "run": "^TestSemanticApplyRelationshipDecisionValidationRejectsLegacySupportAuthority$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRejectsMalformedSupportForAnyVerdict",
-      "package": "./internal/repository",
-      "run": "^TestSemanticApplyRelationshipDecisionValidationRejectsMalformedSupportForAnyVerdict$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticApplyRelationshipDecisionValidationRequiresEntailedSupport",
-      "package": "./internal/repository",
-      "run": "^TestSemanticApplyRelationshipDecisionValidationRequiresEntailedSupport$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticAssessmentEntityMatchesUseOnlyCanonicalAndAliasNames",
-      "package": "./internal/repository",
-      "run": "^TestSemanticAssessmentEntityMatchesUseOnlyCanonicalAndAliasNames$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticCatalogsOmitSealedGenerationEntities",
-      "package": "./internal/repository",
-      "run": "^TestSemanticCatalogsOmitSealedGenerationEntities$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticCreateHypothesisBootstrapsRefsAndDefaultsProposed",
-      "package": "./internal/repository",
-      "run": "^TestSemanticCreateHypothesisBootstrapsRefsAndDefaultsProposed$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticDelayedOlderOneVersionDoesNotSupersedeNewerManyRows",
-      "package": "./internal/repository",
-      "run": "^TestSemanticDelayedOlderOneVersionDoesNotSupersedeNewerManyRows$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_regression.e2e"
-    },
-    {
-      "id": "repository/TestSemanticEntitiesAllowHomonymsAndTypedValuesDeduplicate",
-      "package": "./internal/repository",
-      "run": "^TestSemanticEntitiesAllowHomonymsAndTypedValuesDeduplicate$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive",
-      "package": "./internal/repository",
-      "run": "^TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_trace_graph_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticGraphReadsEntityValueEdgesAndNodeDetail",
-      "package": "./internal/repository",
-      "run": "^TestSemanticGraphReadsEntityValueEdgesAndNodeDetail$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_trace_graph_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticGroupKeyExcludesMutableValidTo",
-      "package": "./internal/repository",
-      "run": "^TestSemanticGroupKeyExcludesMutableValidTo$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_identity_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticOneCardinalitySupersedesPriorActiveRelationship",
-      "package": "./internal/repository",
-      "run": "^TestSemanticOneCardinalitySupersedesPriorActiveRelationship$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticOneCardinalityUpgradeSupersedesLegacyManyRows",
-      "package": "./internal/repository",
-      "run": "^TestSemanticOneCardinalityUpgradeSupersedesLegacyManyRows$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_regression.e2e"
-    },
-    {
-      "id": "repository/TestSemanticRelationshipLifecycleAndRLS",
-      "package": "./internal/repository",
-      "run": "^TestSemanticRelationshipLifecycleAndRLS$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticRepositoryFailsClosedWithoutDependencies",
-      "package": "./internal/repository",
-      "run": "^TestSemanticRepositoryFailsClosedWithoutDependencies$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticReviewCatalogListsTeamCandidatesAndPredicateAliases",
-      "package": "./internal/repository",
-      "run": "^TestSemanticReviewCatalogListsTeamCandidatesAndPredicateAliases$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_catalog_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticSupportDecisionsRecomputeEffectiveState",
-      "package": "./internal/repository",
-      "run": "^TestSemanticSupportDecisionsRecomputeEffectiveState$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_lifecycle_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticSupportMustMatchSuppliedIngest",
-      "package": "./internal/repository",
-      "run": "^TestSemanticSupportMustMatchSuppliedIngest$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_review_regression.e2e"
-    },
-    {
-      "id": "repository/TestSemanticSupportSourceRevisionMustMatchSource",
-      "package": "./internal/repository",
-      "run": "^TestSemanticSupportSourceRevisionMustMatchSource$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams",
-      "package": "./internal/repository",
-      "run": "^TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_trace_graph_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticTraceRelationshipHydratesLineageAndBoundedGraph",
-      "package": "./internal/repository",
-      "run": "^TestSemanticTraceRelationshipHydratesLineageAndBoundedGraph$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_trace_graph_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticValidToDisagreementFailsAtomicallyWithoutMutatingCanonicalRelationship",
-      "package": "./internal/repository",
-      "run": "^TestSemanticValidToDisagreementFailsAtomicallyWithoutMutatingCanonicalRelationship$",
-      "phase": "precheck",
-      "source": "internal/repository/relationship_identity_integration.e2e"
-    },
-    {
-      "id": "repository/TestSemanticValueUpsertConcurrentDuplicateReturnsCanonical",
-      "package": "./internal/repository",
-      "run": "^TestSemanticValueUpsertConcurrentDuplicateReturnsCanonical$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSourceRevisionAdvanceRevokesAdoptedSupportAndRecomputesRelationships",
-      "package": "./internal/repository",
-      "run": "^TestSourceRevisionAdvanceRevokesAdoptedSupportAndRecomputesRelationships$",
-      "phase": "precheck",
-      "source": "internal/repository/semantic_lifecycle_integration.e2e"
-    },
-    {
       "id": "repository/TestSSOListMappingsExcludesRetiredMappings",
       "package": "./internal/repository",
       "run": "^TestSSOListMappingsExcludesRetiredMappings$",
@@ -1586,27 +921,6 @@
       "source": "internal/repository/team_soft_delete_integration.e2e"
     },
     {
-      "id": "repository/TestStaleDreamSourceErrorMapsMissingRelationship",
-      "package": "./internal/repository",
-      "run": "^TestStaleDreamSourceErrorMapsMissingRelationship$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSubmissionAssessmentCatalogIsTeamScopedAndUsesBoundedPredicateResolution",
-      "package": "./internal/repository",
-      "run": "^TestSubmissionAssessmentCatalogIsTeamScopedAndUsesBoundedPredicateResolution$",
-      "phase": "precheck",
-      "source": "internal/repository/submission_assessment_catalog_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestSubmissionAssessmentKnownEvidenceCatalogEnforcesVisibilityAndEligibility",
-      "package": "./internal/repository",
-      "run": "^TestSubmissionAssessmentKnownEvidenceCatalogEnforcesVisibilityAndEligibility$",
-      "phase": "precheck",
-      "source": "internal/repository/submission_assessment_known_evidence_repository_integration.e2e"
-    },
-    {
       "id": "repository/TestTeamHardDeletePreservesAuditRowWhenMemorySpaceIsRemoved",
       "package": "./internal/repository",
       "run": "^TestTeamHardDeletePreservesAuditRowWhenMemorySpaceIsRemoved$",
@@ -1640,20 +954,6 @@
       "run": "^TestTeamSoftDeletePreservesSemanticLedgerAndRejectsFutureWork$",
       "phase": "precheck",
       "source": "internal/repository/team_soft_delete_integration.e2e"
-    },
-    {
-      "id": "repository/TestTraceRelationshipMarksLifecycleEventLimitAsTruncated",
-      "package": "./internal/repository",
-      "run": "^TestTraceRelationshipMarksLifecycleEventLimitAsTruncated$",
-      "phase": "precheck",
-      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
-    },
-    {
-      "id": "repository/TestUpdateHypothesisStatusValidationBindsDecisionToStatus",
-      "package": "./internal/repository",
-      "run": "^TestUpdateHypothesisStatusValidationBindsDecisionToStatus$",
-      "phase": "precheck",
-      "source": "internal/repository/dream_repository_integration.e2e"
     },
     {
       "id": "repository/TestUsageMetricsSnapshotLabelsSSOOwnershipAlias",

--- a/scripts/e2e-db-cases/service.json
+++ b/scripts/e2e-db-cases/service.json
@@ -3,62 +3,6 @@
   "capability": "service",
   "cases": [
     {
-      "id": "service/TestAuditLogAppendOnlyTriggerBlocksDelete",
-      "package": "./internal/service",
-      "run": "^TestAuditLogAppendOnlyTriggerBlocksDelete$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditLogAppendOnlyTriggerBlocksUpdate",
-      "package": "./internal/service",
-      "run": "^TestAuditLogAppendOnlyTriggerBlocksUpdate$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceAppend",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceAppend$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceAppendStoresNullClientIPWhenMissing",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceAppendStoresNullClientIPWhenMissing$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceAppendUsesContextClientIPWhenEntryBlank",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceAppendUsesContextClientIPWhenEntryBlank$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceHelperMethods",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceHelperMethods$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceListHidesSealedPrivateSpaceRows",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceListHidesSealedPrivateSpaceRows$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
-      "id": "service/TestAuditServiceRedactsSecrets",
-      "package": "./internal/service",
-      "run": "^TestAuditServiceRedactsSecrets$",
-      "phase": "precheck",
-      "source": "internal/service/audit_service.e2e"
-    },
-    {
       "id": "service/TestComposeSynchronousEvidenceOnlyAssessorBatch",
       "package": "./internal/service/memoryservice",
       "run": "^TestComposeSynchronousEvidenceOnlyAssessorBatch$",

--- a/scripts/e2e-db-cases/settings.json
+++ b/scripts/e2e-db-cases/settings.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "capability": "settings",
+  "cases": []
+}

--- a/scripts/e2e-db-cases/trace.json
+++ b/scripts/e2e-db-cases/trace.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "capability": "trace",
+  "cases": [
+    {
+      "id": "repository/TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams",
+      "package": "./internal/repository",
+      "run": "^TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_trace_graph_integration.e2e"
+    },
+    {
+      "id": "repository/TestSemanticTraceRelationshipHydratesLineageAndBoundedGraph",
+      "package": "./internal/repository",
+      "run": "^TestSemanticTraceRelationshipHydratesLineageAndBoundedGraph$",
+      "phase": "precheck",
+      "source": "internal/repository/semantic_trace_graph_integration.e2e"
+    },
+    {
+      "id": "repository/TestTraceRelationshipMarksLifecycleEventLimitAsTruncated",
+      "package": "./internal/repository",
+      "run": "^TestTraceRelationshipMarksLifecycleEventLimitAsTruncated$",
+      "phase": "precheck",
+      "source": "internal/repository/evidence_lifecycle_repository_integration.e2e"
+    }
+  ]
+}

--- a/scripts/e2e-host-controller.sh
+++ b/scripts/e2e-host-controller.sh
@@ -59,7 +59,12 @@ validate_project() {
 
 managed_project_name() {
   local run_id="$1" attempt="$2" phase="$3" scenario="$4"
-  local project="densemem-ci-${run_id}-${attempt}-${phase}-${scenario//_/-}"
+  local project="densemem-ci-${run_id}-${attempt}-${phase}"
+  if [[ -n "$scenario" ]]; then
+    local scenario_suffix="${scenario//_/-}"
+    scenario_suffix="${scenario_suffix//,/-}"
+    project+="-${scenario_suffix}"
+  fi
   if (( ${#project} > 63 )); then
     local suffix
     suffix="$(node -e 'process.stdout.write(require("node:crypto").createHash("sha256").update(process.argv[1]).digest("hex").slice(0,8))' "$project")"
@@ -369,11 +374,8 @@ precheck_capability() {
 
   local docker_socket
   docker_socket="$(docker_socket_path)"
-  local project="densemem-ci-${run_id}-${attempt}-precheck"
-  if [[ -n "$capabilities" ]]; then
-    project+="-${capabilities//,/-}"
-  fi
-  validate_project "$project"
+  local project
+  project="$(managed_project_name "$run_id" "$attempt" precheck "$capabilities")"
   local precheck_network="$project"
   cleanup_precheck_resources() {
     remove_network_containers "$precheck_network"

--- a/scripts/e2e-host-controller.sh
+++ b/scripts/e2e-host-controller.sh
@@ -63,7 +63,9 @@ managed_project_name() {
   if [[ -n "$scenario" ]]; then
     local scenario_suffix="${scenario//_/-}"
     scenario_suffix="${scenario_suffix//,/-}"
-    project+="-${scenario_suffix}"
+    local scenario_digest
+    scenario_digest="$(node -e 'process.stdout.write(require("node:crypto").createHash("sha256").update(process.argv[1]).digest("hex").slice(0,8))' "$scenario")"
+    project+="-${scenario_suffix}-${scenario_digest}"
   fi
   if (( ${#project} > 63 )); then
     local suffix

--- a/tests/uat/architecture_conformance.test.mjs
+++ b/tests/uat/architecture_conformance.test.mjs
@@ -81,6 +81,12 @@ function copyManifestFixture() {
         fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
         fs.copyFileSync(sourcePath, destinationPath);
       }
+      if (bridge.implementation_owner) {
+        const sourcePath = path.join(root, bridge.implementation_owner.path);
+        const destinationPath = path.join(fixtureRoot, bridge.implementation_owner.path);
+        fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+        fs.copyFileSync(sourcePath, destinationPath);
+      }
     }
   }
   return { fixtureRoot, rootManifest };
@@ -88,7 +94,7 @@ function copyManifestFixture() {
 
 test("loads the complete independently owned architecture inventory", () => {
   assert.equal(productionManifest.load_diagnostics.length, 0);
-  assert.equal(productionManifest.fragments.length, 58);
+  assert.equal(productionManifest.fragments.length, 61);
   assert.equal(productionManifest.go.units.length, 64);
   assert.equal(productionManifest.browser.units.length, 40);
   assert.equal(productionManifest.exceptions.length, 25);
@@ -335,6 +341,22 @@ test("rejects bridge consumers whose symbols are absent from the declared file",
     fs.writeFileSync(fragmentPath, JSON.stringify(fragment, null, 2));
     const loaded = loadManifest(fixtureCopy.fixtureRoot);
     assert.ok(loaded.load_diagnostics.some((item) => item.includes("consumer internal/tools/registry/capability_bindings.go does not define Dependencies.missing")));
+  } finally {
+    fs.rmSync(fixtureCopy.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("validates compatibility bridge implementation ownership and removal conditions", () => {
+  const fixtureCopy = copyManifestFixture();
+  try {
+    const fragmentPath = path.join(fixtureCopy.fixtureRoot, "architecture/modules/postgres-storage-adapter.json");
+    const fragment = JSON.parse(fs.readFileSync(fragmentPath, "utf8"));
+    fragment.compatibility_bridges[0].implementation_owner.path = "internal/storage/postgres/missing.go";
+    fragment.compatibility_bridges[0].removal_condition = "";
+    fs.writeFileSync(fragmentPath, JSON.stringify(fragment, null, 2));
+    const loaded = loadManifest(fixtureCopy.fixtureRoot);
+    assert.ok(loaded.load_diagnostics.some((item) => item.includes("invalid implementation owner")));
+    assert.ok(loaded.load_diagnostics.some((item) => item.includes("needs a removal condition")));
   } finally {
     fs.rmSync(fixtureCopy.fixtureRoot, { recursive: true, force: true });
   }

--- a/tests/uat/e2e_host_controller.test.mjs
+++ b/tests/uat/e2e_host_controller.test.mjs
@@ -184,6 +184,31 @@ partition_precheck_capabilities "${sourceRoot}"
   }
 });
 
+test("capability-specific precheck project names stay bounded and distinct", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "dense-mem-precheck-project-name-"));
+  try {
+    const validateStart = controller.indexOf("\nvalidate_project()") + 1;
+    const validateEnd = controller.indexOf("\nvalidate_phase()", validateStart);
+    const managedStart = controller.indexOf("\nmanaged_project_name()") + 1;
+    const managedEnd = controller.indexOf("\nvalidate_phase()", managedStart);
+    const script = `#!/usr/bin/env bash
+set -euo pipefail
+${controller.slice(validateStart, validateEnd)}
+${controller.slice(managedStart, managedEnd)}
+first="$(managed_project_name 1234567890 1 precheck audit,graph,migration,repository,trace)"
+second="$(managed_project_name 1234567890 1 precheck community,http,postgres,server)"
+[[ "\${first}" != "\${second}" ]]
+(( \${#first} <= 63 ))
+(( \${#second} <= 63 ))
+`;
+    const scriptPath = join(fixture, "project-name-test.sh");
+    await executable(scriptPath, script);
+    await assert.doesNotReject(run("bash", [scriptPath]));
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("local adapter builds the working tree and delegates to the shared controller", () => {
   assert.match(local, /docker build --target production/);
   assert.match(local, /DENSE_MEM_CI_LOCAL=1/);

--- a/tests/uat/e2e_host_controller.test.mjs
+++ b/tests/uat/e2e_host_controller.test.mjs
@@ -197,9 +197,14 @@ ${controller.slice(validateStart, validateEnd)}
 ${controller.slice(managedStart, managedEnd)}
 first="$(managed_project_name 1234567890 1 precheck audit,graph,migration,repository,trace)"
 second="$(managed_project_name 1234567890 1 precheck community,http,postgres,server)"
+collision_first="$(managed_project_name 1234567890 1 precheck a,b)"
+collision_second="$(managed_project_name 1234567890 1 precheck a-b)"
 [[ "\${first}" != "\${second}" ]]
+[[ "\${collision_first}" != "\${collision_second}" ]]
 (( \${#first} <= 63 ))
 (( \${#second} <= 63 ))
+(( \${#collision_first} <= 63 ))
+(( \${#collision_second} <= 63 ))
 `;
     const scriptPath = join(fixture, "project-name-test.sh");
     await executable(scriptPath, script);


### PR DESCRIPTION
## Problem

Wave 5 capability cutovers still share a repository-owned artifact-hold SQL writer, broad architecture ownership fragments, and capability-agnostic database-case registries. That prevents the eight adopters from merging independently and leaves the legacy forwarder without an explicit removal contract.

## Change

- Move the artifact-hold SQL implementation into `internal/storage/postgres` and keep the repository symbol as a single-hop compatibility forwarder.
- Add PostgreSQL/sqlmock coverage and a real PostgreSQL rollback regression for the supplied transaction.
- Add independent ownership fragments for audit, privacy, and settings, reconcile Wave 5 source ownership, and record the #382 compatibility owner/removal condition.
- Partition database cases by capability while preserving the 378-case baseline; the combined inventory is 379 with the new rollback regression.
- Keep precheck project names bounded and distinct and add architecture, registry, and controller regressions.

No public route, MCP contract, schema, migration, provider behavior, or worker behavior changes.

## Verification

- `go test ./internal/storage/postgres/... -count=1`
- `go test ./internal/repository/... -count=1`
- `go -C cmd/e2e test ./... -count=1`
- `node --test tests/uat/architecture_conformance.test.mjs tests/uat/e2e_host_controller.test.mjs`
- `./scripts/ci-check.sh` (passed; coverage 90.0%)
- Disposable PostgreSQL hold cases, `synchronous_write_primitives`, and `private_memory_erasure` E2E scenarios passed.

Closes #389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture ownership records for audit, privacy, settings, community, context, dream, graph, semantic-write, and related capabilities.
  - Documented compatibility ownership and removal conditions for legal-hold handling.

- **Bug Fixes**
  - Improved legal-hold updates for failed artifacts, including transaction rollback behavior.
  - Standardized precheck project names and ensured they remain distinct and within platform limits.

- **Tests**
  - Added extensive end-to-end database coverage across multiple capabilities.
  - Added validation for database case inventories and compatibility configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->