### PR TITLE
refactor: move graph capability into native module (#366)

### DIFF
--- a/.github/scripts/image-release-policy.cjs
+++ b/.github/scripts/image-release-policy.cjs
@@ -267,7 +267,7 @@ function isTooManyFilesPullError(error) {
   return /too many files changed/i.test(message);
 }
 
-function graphQLPullRequest(pull) {
+function graphQLPullRequest(pull, labels = pull?.labels?.nodes || []) {
   if (!pull) {
     throw new Error("Could not resolve the current pull request.");
   }
@@ -275,7 +275,7 @@ function graphQLPullRequest(pull) {
     number: pull.number,
     state: String(pull.state || "").toLowerCase(),
     base: { ref: pull.baseRefName || "" },
-    labels: (pull.labels?.nodes || []).map(({ name }) => name),
+    labels: labels.map(({ name }) => name),
     user: { login: pull.author?.login || "" },
     head: {
       sha: pull.headRefOid || "",
@@ -296,23 +296,45 @@ async function loadPullRequest({ github, owner, repo, pullNumber }) {
     if (!isTooManyFilesPullError(error)) throw error;
   }
 
-  const data = await github.graphql(
-    `query PullRequest($owner: String!, $repo: String!, $number: Int!) {
-      repository(owner: $owner, name: $repo) {
-        pullRequest(number: $number) {
-          number
-          state
-          baseRefName
-          headRefOid
-          author { login }
-          headRepository { nameWithOwner }
-          labels(first: 100) { nodes { name } }
+  const labels = [];
+  const seenCursors = new Set();
+  let cursor = null;
+  let pull;
+  for (;;) {
+    const data = await github.graphql(
+      `query PullRequest($owner: String!, $repo: String!, $number: Int!, $labelCursor: String) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            number
+            state
+            baseRefName
+            headRefOid
+            author { login }
+            headRepository { nameWithOwner }
+            labels(first: 100, after: $labelCursor) {
+              nodes { name }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
         }
-      }
-    }`,
-    { owner, repo, number: pullNumber },
-  );
-  return graphQLPullRequest(data.repository?.pullRequest);
+      }`,
+      { owner, repo, number: pullNumber, labelCursor: cursor },
+    );
+    pull = data.repository?.pullRequest;
+    if (!pull) {
+      throw new Error("Could not resolve the current pull request.");
+    }
+    const labelPage = pull.labels;
+    labels.push(...(labelPage?.nodes || []));
+    if (!labelPage?.pageInfo?.hasNextPage) break;
+    const nextCursor = labelPage.pageInfo.endCursor;
+    if (typeof nextCursor !== "string" || nextCursor === "" || seenCursors.has(nextCursor)) {
+      throw new Error("Could not paginate pull request labels.");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return graphQLPullRequest(pull, labels);
 }
 
 async function resolvePreviewAttempt({

--- a/.github/scripts/image-release-policy.cjs
+++ b/.github/scripts/image-release-policy.cjs
@@ -261,6 +261,60 @@ function resolvePullRequestEvent(payload, actorPermission) {
   };
 }
 
+function isTooManyFilesPullError(error) {
+  if (error?.status !== 422) return false;
+  const message = `${error.message || ""} ${error.response?.data?.message || ""}`;
+  return /too many files changed/i.test(message);
+}
+
+function graphQLPullRequest(pull) {
+  if (!pull) {
+    throw new Error("Could not resolve the current pull request.");
+  }
+  return {
+    number: pull.number,
+    state: String(pull.state || "").toLowerCase(),
+    base: { ref: pull.baseRefName || "" },
+    labels: (pull.labels?.nodes || []).map(({ name }) => name),
+    user: { login: pull.author?.login || "" },
+    head: {
+      sha: pull.headRefOid || "",
+      repo: pull.headRepository ? { full_name: pull.headRepository.nameWithOwner || "" } : null,
+    },
+  };
+}
+
+async function loadPullRequest({ github, owner, repo, pullNumber }) {
+  try {
+    const { data: pull } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    return pull;
+  } catch (error) {
+    if (!isTooManyFilesPullError(error)) throw error;
+  }
+
+  const data = await github.graphql(
+    `query PullRequest($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          number
+          state
+          baseRefName
+          headRefOid
+          author { login }
+          headRepository { nameWithOwner }
+          labels(first: 100) { nodes { name } }
+        }
+      }
+    }`,
+    { owner, repo, number: pullNumber },
+  );
+  return graphQLPullRequest(data.repository?.pullRequest);
+}
+
 async function resolvePreviewAttempt({
   github,
   context,
@@ -268,10 +322,11 @@ async function resolvePreviewAttempt({
   authorPermission,
 }) {
   const event = resolvePullRequestEvent(context.payload, actorPermission);
-  const { data: pull } = await github.rest.pulls.get({
+  const pull = await loadPullRequest({
+    github,
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: event.pullNumber,
+    pullNumber: event.pullNumber,
   });
 
   if (pull.state !== "open" || pull.base.ref !== "main") {
@@ -312,10 +367,11 @@ async function resolveRcPreview({ github, context, mainCommit }) {
     return { eligible: false, reason: selected.reason };
   }
 
-  const { data: pull } = await github.rest.pulls.get({
+  const pull = await loadPullRequest({
+    github,
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: selected.pull.number,
+    pullNumber: selected.pull.number,
   });
   const statuses = await github.paginate(
     github.rest.repos.listCommitStatusesForRef,

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -169,7 +169,7 @@ jobs:
           packages="$(
             go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./internal/... |
               sed '/^$/d' |
-              grep -Ev '/(evalharness|repository|knowledge/postgres|dream/postgres|trace/postgres)$|/storage/(postgres|redis)$'
+              grep -Ev '/(evalharness|repository|knowledge/postgres|dream/postgres|trace/postgres|graph/postgres)$|/storage/(postgres|redis)$'
           )"
 
           printf '%s\n' "${packages}"

--- a/.lint/package.json
+++ b/.lint/package.json
@@ -10,5 +10,8 @@
     "typescript": "7.0.2",
     "textlint": "^15.8.0",
     "textlint-rule-max-number-of-lines": "^1.0.3"
+  },
+  "overrides": {
+    "js-yaml": "4.3.2"
   }
 }

--- a/architecture/modules/graph-application.json
+++ b/architecture/modules/graph-application.json
@@ -3,14 +3,30 @@
   "capability": "graph-application",
   "source_ownership": [
     {"path": "cmd/internal/serverapp/graph_composition.go", "issue": 366},
+    {"path": "internal/graph/graph.go", "issue": 366},
+    {"path": "internal/graph/graph_test.go", "issue": 366},
+    {"path": "internal/graph/postgres/graph_repository.go", "issue": 366},
+    {"path": "internal/graph/postgres/graph_repository_test.go", "issue": 366},
+    {"path": "internal/graph/postgres/graph_repository_sqlmock_test.go", "issue": 366},
     {"path": "internal/repository/semantic_graph_repository.go", "issue": 366},
     {"path": "internal/repository/semantic_graph_repository_test.go", "issue": 366},
     {"path": "internal/service/graphview/graphview.go", "issue": 366},
-    {"path": "internal/service/graphview/graphview_test.go", "issue": 366}
+    {"path": "web/tests-compose/compose-portal.spec.ts", "issue": 366},
+    {"path": "web/tests-compose/graph-views.ts", "issue": 366}
   ],
   "completed_issues": [],
   "go": {
     "units": [
+      {
+        "id": "github.com/markhuangai/dense-mem/internal/graph",
+        "role": "application_api",
+        "visibility": "public"
+      },
+      {
+        "id": "github.com/markhuangai/dense-mem/internal/graph/postgres",
+        "role": "postgres_adapter",
+        "visibility": "private"
+      },
       {
         "id": "github.com/markhuangai/dense-mem/internal/service/graphview",
         "role": "application_api",
@@ -21,13 +37,37 @@
   "browser": {
     "units": []
   },
-  "exceptions": [
+  "compatibility_bridges": [
     {
-      "source": "github.com/markhuangai/dense-mem/internal/service/graphview",
-      "target": "github.com/markhuangai/dense-mem/internal/repository",
-      "removal_issue": 366,
-      "reason": "Graph application code still consumes the legacy repository until graph view ownership is isolated."
+      "source_path": "internal/repository/semantic_graph_repository.go",
+      "fields": ["SemanticRepositoryImpl.SemanticGraph", "SemanticRepositoryImpl.SemanticGraphNodeDetail", "SemanticRepositoryImpl.GraphStore", "loadSemanticLocalGraphRows", "semanticGraphSnapshot"],
+      "consumers": [
+        {"path": "cmd/internal/serverapp/graph_composition.go", "symbol": "buildGraphApplication"},
+        {"path": "internal/repository/semantic_trace_graph_integration.e2e", "symbol": "TestSemanticTraceAndGraphIsolatePrivateSpacesWithinAndAcrossTeams"},
+        {"path": "internal/repository/semantic_trace_graph_integration.e2e", "symbol": "TestSemanticGraphReadsEntityValueEdgesAndNodeDetail"},
+        {"path": "internal/repository/semantic_trace_graph_integration.e2e", "symbol": "TestSemanticGraphLocalDepthDefaultsToTwoAndCapsAtFive"},
+        {"path": "internal/repository/semantic_trace_repository.go", "symbol": "loadTraceGraphSnapshot"},
+        {"path": "internal/repository/relationship_correction_repository_integration.e2e", "symbol": "TestRelationshipCorrectionReplacesOwnedRelationshipAndPreservesSupport"}
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {"path": "internal/graph/postgres/graph_repository.go", "symbol": "Store.SemanticGraph"},
+      "removal_condition": "Remove repository graph forwarding methods after all named production, evaluation, demo, transport and fixture consumers use internal/graph contracts or the graph PostgreSQL adapter directly."
+    },
+    {
+      "source_path": "internal/service/graphview/graphview.go",
+      "fields": ["Service", "Query", "Snapshot", "Node", "Edge", "NewSemantic"],
+      "consumers": [
+        {"path": "internal/http/user_portal.go", "symbol": "userPortalHandler.graphSnapshot"},
+        {"path": "internal/http/user_portal.go", "symbol": "userPortalHandler.graphNodeDetail"},
+        {"path": "internal/http/user_portal_test.go", "symbol": "userPortalGraphSvc.Graph"},
+        {"path": "internal/http/user_portal_test.go", "symbol": "userPortalGraphSvc.NodeDetail"},
+        {"path": "cmd/internal/serverapp/application_composition.go", "symbol": "buildApplicationBundle"}
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {"path": "internal/graph/graph.go", "symbol": "New"},
+      "removal_condition": "Remove the graphview aliases after all named transport, composition and retained fixture consumers import internal/graph directly."
     }
   ],
+  "exceptions": [],
   "workers": []
 }

--- a/architecture/modules/postgres-storage-adapter.json
+++ b/architecture/modules/postgres-storage-adapter.json
@@ -641,6 +641,12 @@
       "target": "github.com/markhuangai/dense-mem/internal/settings/postgres",
       "removal_issue": 382,
       "reason": "The settings repository constructors remain bounded single-hop compatibility facades recorded in the settings capability manifest until final compatibility-facade cleanup."
+    },
+    {
+      "source": "github.com/markhuangai/dense-mem/internal/repository",
+      "target": "github.com/markhuangai/dense-mem/internal/graph/postgres",
+      "removal_issue": 382,
+      "reason": "Graph repository methods remain bounded single-hop compatibility facades while graph consumers migrate to the native PostgreSQL adapter; #382 removes the exception after the named consumers migrate."
     }
   ],
   "workers": [

--- a/cmd/internal/migrationapp/migration_integration.e2e
+++ b/cmd/internal/migrationapp/migration_integration.e2e
@@ -120,6 +120,9 @@ func openMigrationIntegrationDB(t *testing.T) *gorm.DB {
 	}
 	container, err := tcpostgres.Run(ctx, "pgvector/pgvector:0.8.2-pg18-trixie", containerOptions...)
 	if err != nil {
+		if os.Getenv("DENSE_MEM_REQUIRE_POSTGRES_TESTS") == "1" {
+			t.Fatalf("Postgres is required for this test run: %v", err)
+		}
 		t.Skipf("Postgres not available: %v", err)
 	}
 	t.Cleanup(func() {

--- a/cmd/internal/migrationapp/migration_integration.e2e
+++ b/cmd/internal/migrationapp/migration_integration.e2e
@@ -23,7 +23,12 @@ import (
 
 var migrationWorkingDirectoryMu sync.Mutex
 
-const migrationTestSafetyTimeout = 30 * time.Second
+const (
+	migrationTestSetupTimeout     = 30 * time.Second
+	migrationTestOperationTimeout = 5 * time.Minute
+	migrationTestSafetyTimeout    = 30 * time.Second
+	migrationTestLockProbeTimeout = time.Second
+)
 
 func TestRunUpTimeoutRollsBackBlockedMigrationAndReleasesLock(t *testing.T) {
 	db := openMigrationIntegrationDB(t)
@@ -48,7 +53,7 @@ func TestRunUpTimeoutRollsBackBlockedMigrationAndReleasesLock(t *testing.T) {
 	require.NoError(t, err)
 
 	err = runBlockedMigrationUntilDeadline(t, sqlDB, func(parent context.Context) error {
-		return RunUp(parent, db, migrationTestSafetyTimeout, newRecordingLogger())
+		return RunUp(parent, db, migrationTestOperationTimeout, newRecordingLogger())
 	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "migration error = %v, want context deadline exceeded", err)
@@ -56,7 +61,7 @@ func TestRunUpTimeoutRollsBackBlockedMigrationAndReleasesLock(t *testing.T) {
 
 	require.NoError(t, blockerTx.Rollback())
 	require.NoError(t, blockerConn.Close())
-	require.NoError(t, RunUp(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
+	require.NoError(t, RunUp(context.Background(), db, migrationTestSetupTimeout, newRecordingLogger()))
 	require.True(t, migrationTimeoutProbeExists(t, sqlDB), "retry must acquire the migration lock and apply the migration")
 }
 
@@ -68,7 +73,7 @@ func TestRunDownTimeoutRollsBackBlockedMigration(t *testing.T) {
 	useBlockedMigrationDirectory(t)
 	_, err = sqlDB.Exec(`CREATE TABLE migration_timeout_blocker (id integer PRIMARY KEY)`)
 	require.NoError(t, err)
-	require.NoError(t, RunUp(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
+	require.NoError(t, RunUp(context.Background(), db, migrationTestSetupTimeout, newRecordingLogger()))
 	require.True(t, migrationTimeoutProbeExists(t, sqlDB), "setup must apply the probe migration")
 
 	blockerConn, err := sqlDB.Conn(context.Background())
@@ -85,7 +90,7 @@ func TestRunDownTimeoutRollsBackBlockedMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	err = runBlockedMigrationUntilDeadline(t, sqlDB, func(parent context.Context) error {
-		return RunDown(parent, db, migrationTestSafetyTimeout, newRecordingLogger())
+		return RunDown(parent, db, migrationTestOperationTimeout, newRecordingLogger())
 	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "migration error = %v, want context deadline exceeded", err)
@@ -93,7 +98,7 @@ func TestRunDownTimeoutRollsBackBlockedMigration(t *testing.T) {
 
 	require.NoError(t, blockerTx.Rollback())
 	require.NoError(t, blockerConn.Close())
-	require.NoError(t, RunDown(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
+	require.NoError(t, RunDown(context.Background(), db, migrationTestSetupTimeout, newRecordingLogger()))
 	require.False(t, migrationTimeoutProbeExists(t, sqlDB), "retry must complete the rollback")
 }
 
@@ -210,7 +215,7 @@ func waitForBlockedMigrationLock(t *testing.T, db *sql.DB) {
 	t.Helper()
 	deadline := time.Now().Add(migrationTestSafetyTimeout)
 	for {
-		probeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		probeCtx, cancel := context.WithTimeout(context.Background(), migrationTestLockProbeTimeout)
 		var waiting bool
 		err := db.QueryRowContext(probeCtx, `
 			SELECT EXISTS (
@@ -223,8 +228,10 @@ func waitForBlockedMigrationLock(t *testing.T, db *sql.DB) {
 			)
 		`).Scan(&waiting)
 		cancel()
-		require.NoError(t, err)
-		if waiting {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			require.NoError(t, err)
+		}
+		if err == nil && waiting {
 			return
 		}
 		if time.Now().After(deadline) {

--- a/cmd/internal/migrationapp/migration_integration.e2e
+++ b/cmd/internal/migrationapp/migration_integration.e2e
@@ -23,6 +23,8 @@ import (
 
 var migrationWorkingDirectoryMu sync.Mutex
 
+const migrationTestSafetyTimeout = 30 * time.Second
+
 func TestRunUpTimeoutRollsBackBlockedMigrationAndReleasesLock(t *testing.T) {
 	db := openMigrationIntegrationDB(t)
 	sqlDB, err := db.DB()
@@ -45,16 +47,16 @@ func TestRunUpTimeoutRollsBackBlockedMigrationAndReleasesLock(t *testing.T) {
 	_, err = blockerTx.Exec(`LOCK TABLE migration_timeout_blocker IN ACCESS SHARE MODE`)
 	require.NoError(t, err)
 
-	startedAt := time.Now()
-	err = RunUp(context.Background(), db, 2*time.Second, newRecordingLogger())
+	err = runBlockedMigrationUntilDeadline(t, sqlDB, func(parent context.Context) error {
+		return RunUp(parent, db, migrationTestSafetyTimeout, newRecordingLogger())
+	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "migration error = %v, want context deadline exceeded", err)
-	require.GreaterOrEqual(t, time.Since(startedAt), time.Second)
 	require.False(t, migrationTimeoutProbeExists(t, sqlDB), "timed-out migration must roll back its probe table")
 
 	require.NoError(t, blockerTx.Rollback())
 	require.NoError(t, blockerConn.Close())
-	require.NoError(t, RunUp(context.Background(), db, 5*time.Second, newRecordingLogger()))
+	require.NoError(t, RunUp(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
 	require.True(t, migrationTimeoutProbeExists(t, sqlDB), "retry must acquire the migration lock and apply the migration")
 }
 
@@ -66,7 +68,7 @@ func TestRunDownTimeoutRollsBackBlockedMigration(t *testing.T) {
 	useBlockedMigrationDirectory(t)
 	_, err = sqlDB.Exec(`CREATE TABLE migration_timeout_blocker (id integer PRIMARY KEY)`)
 	require.NoError(t, err)
-	require.NoError(t, RunUp(context.Background(), db, 5*time.Second, newRecordingLogger()))
+	require.NoError(t, RunUp(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
 	require.True(t, migrationTimeoutProbeExists(t, sqlDB), "setup must apply the probe migration")
 
 	blockerConn, err := sqlDB.Conn(context.Background())
@@ -82,16 +84,16 @@ func TestRunDownTimeoutRollsBackBlockedMigration(t *testing.T) {
 	_, err = blockerTx.Exec(`LOCK TABLE migration_timeout_blocker IN ACCESS SHARE MODE`)
 	require.NoError(t, err)
 
-	startedAt := time.Now()
-	err = RunDown(context.Background(), db, 2*time.Second, newRecordingLogger())
+	err = runBlockedMigrationUntilDeadline(t, sqlDB, func(parent context.Context) error {
+		return RunDown(parent, db, migrationTestSafetyTimeout, newRecordingLogger())
+	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "migration error = %v, want context deadline exceeded", err)
-	require.GreaterOrEqual(t, time.Since(startedAt), time.Second)
 	require.True(t, migrationTimeoutProbeExists(t, sqlDB), "timed-out rollback must restore its probe table")
 
 	require.NoError(t, blockerTx.Rollback())
 	require.NoError(t, blockerConn.Close())
-	require.NoError(t, RunDown(context.Background(), db, 5*time.Second, newRecordingLogger()))
+	require.NoError(t, RunDown(context.Background(), db, migrationTestSafetyTimeout, newRecordingLogger()))
 	require.False(t, migrationTimeoutProbeExists(t, sqlDB), "retry must complete the rollback")
 }
 
@@ -180,4 +182,90 @@ func migrationTimeoutProbeExists(t *testing.T, db *sql.DB) bool {
 	var exists bool
 	require.NoError(t, db.QueryRow(`SELECT to_regclass('public.migration_timeout_probe') IS NOT NULL`).Scan(&exists))
 	return exists
+}
+
+func runBlockedMigrationUntilDeadline(t *testing.T, db *sql.DB, run func(context.Context) error) error {
+	t.Helper()
+	parent := newControlledDeadlineContext()
+	t.Cleanup(parent.expire)
+
+	result := make(chan error, 1)
+	go func() {
+		result <- run(parent)
+	}()
+
+	waitForBlockedMigrationLock(t, db)
+	parent.expire()
+
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(migrationTestSafetyTimeout):
+		t.Fatal("migration did not stop after the test deadline expired")
+		return nil
+	}
+}
+
+func waitForBlockedMigrationLock(t *testing.T, db *sql.DB) {
+	t.Helper()
+	deadline := time.Now().Add(migrationTestSafetyTimeout)
+	for {
+		probeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		var waiting bool
+		err := db.QueryRowContext(probeCtx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks AS lock
+				JOIN pg_class AS relation ON relation.oid = lock.relation
+				WHERE relation.relname = 'migration_timeout_blocker'
+					AND lock.mode = 'AccessExclusiveLock'
+					AND NOT lock.granted
+			)
+		`).Scan(&waiting)
+		cancel()
+		require.NoError(t, err)
+		if waiting {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("migration did not reach the blocked exclusive lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type controlledDeadlineContext struct {
+	context.Context
+	done chan struct{}
+	once sync.Once
+}
+
+func newControlledDeadlineContext() *controlledDeadlineContext {
+	return &controlledDeadlineContext{
+		Context: context.Background(),
+		done:    make(chan struct{}),
+	}
+}
+
+func (ctx *controlledDeadlineContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (ctx *controlledDeadlineContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *controlledDeadlineContext) Err() error {
+	select {
+	case <-ctx.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+func (ctx *controlledDeadlineContext) expire() {
+	ctx.once.Do(func() {
+		close(ctx.done)
+	})
 }

--- a/cmd/internal/serverapp/graph_composition.go
+++ b/cmd/internal/serverapp/graph_composition.go
@@ -1,7 +1,17 @@
 package serverapp
 
-import "github.com/markhuangai/dense-mem/internal/service/graphview"
+import (
+	graphapp "github.com/markhuangai/dense-mem/internal/graph"
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+)
 
-func buildGraphApplication(store graphview.SemanticStore) graphview.Service {
-	return graphview.NewSemantic(store)
+type graphStoreSource interface {
+	GraphStore() graphcontract.Store
+}
+
+func buildGraphApplication(source graphStoreSource) graphapp.Service {
+	if source == nil {
+		return graphapp.New(nil)
+	}
+	return graphapp.New(source.GraphStore())
 }

--- a/internal/dream/postgres/dream_cycle_repository.go
+++ b/internal/dream/postgres/dream_cycle_repository.go
@@ -39,9 +39,7 @@ func (r *Store) claimDreamCycle(ctx context.Context, input DreamCycleClaimInput,
 			    NULLIF(?, '')::uuid, ?, ?, ?, ?, 'running', ?::uuid, ?, 1,
 			    ?::jsonb
 			)
-			ON CONFLICT (team_id, lane, window_key)
-			WHERE canonical_run_id IS NULL
-			DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING ` + dreamCycleRunSelectColumns
 		rows, err := tx.WithContext(ctx).Raw(query, input.TeamID, input.TeamID, input.TeamID, input.InitiatedByProfileID,
 			input.RunDate, input.WindowKey, input.Lane, input.ScheduledFor, input.LeaseToken,
@@ -272,9 +270,7 @@ func (r *Store) RecordMissedScheduledDreamCycle(ctx context.Context, input Dream
 			    ?::uuid, dense_mem_team_shared_space(?::uuid), dense_mem_team_shared_generation(?::uuid), ?, ?, ?, ?, 'missed', ?::jsonb, now(),
 			    'scheduler was not running during the configured window'
 			)
-			ON CONFLICT (team_id, lane, window_key)
-			WHERE canonical_run_id IS NULL
-			DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING ` + dreamCycleRunSelectColumns
 		rows, err := tx.WithContext(ctx).Raw(query, input.TeamID, input.TeamID, input.TeamID, input.RunDate,
 			input.WindowKey, input.Lane, input.ScheduledFor, string(snapshot)).Rows()

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,0 +1,292 @@
+package graph
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+)
+
+const (
+	ScopeOverview = "overview"
+	ScopeLocal    = "local"
+
+	DefaultLimit = 80
+	DefaultDepth = 2
+	MaxDepth     = 5
+
+	maxNodeBodyRunes = 420
+)
+
+var (
+	ErrMissingAnchor     = errors.New("graph local view requires anchor_type and anchor_id")
+	ErrInvalidAnchorType = errors.New("unsupported graph anchor_type")
+	ErrMissingNode       = errors.New("graph node detail requires type and id")
+	ErrInvalidNodeType   = errors.New("unsupported graph node type")
+	ErrNodeNotFound      = errors.New("graph node not found")
+)
+
+type Store = graphcontract.Store
+
+type Service interface {
+	Graph(ctx context.Context, profileID string, query Query) (*Snapshot, error)
+	NodeDetail(ctx context.Context, profileID string, nodeType string, nodeID string) (*Node, error)
+}
+
+type Query struct {
+	Scope      string
+	Query      string
+	Types      []string
+	AnchorType string
+	AnchorID   string
+	Depth      int
+	Limit      int
+}
+
+type Snapshot struct {
+	Scope     string  `json:"scope"`
+	Query     string  `json:"query,omitempty"`
+	Anchor    *Anchor `json:"anchor,omitempty"`
+	Depth     int     `json:"depth"`
+	Limit     int     `json:"limit"`
+	Truncated bool    `json:"truncated"`
+	Nodes     []Node  `json:"nodes"`
+	Edges     []Edge  `json:"edges"`
+}
+
+type Anchor struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+}
+
+type Node struct {
+	Key         string     `json:"key"`
+	ID          string     `json:"id"`
+	Type        string     `json:"type"`
+	Title       string     `json:"title"`
+	Body        string     `json:"body,omitempty"`
+	Status      string     `json:"status,omitempty"`
+	CommunityID string     `json:"community_id,omitempty"`
+	Source      string     `json:"source,omitempty"`
+	Score       float64    `json:"score,omitempty"`
+	RecordedAt  *time.Time `json:"recorded_at,omitempty"`
+}
+
+type Edge struct {
+	ID           string `json:"id"`
+	Source       string `json:"source"`
+	Target       string `json:"target"`
+	Relationship string `json:"relationship"`
+	Directed     bool   `json:"directed"`
+}
+
+type semanticService struct {
+	store Store
+}
+
+var _ Service = (*semanticService)(nil)
+
+func New(store Store) Service {
+	return &semanticService{store: store}
+}
+
+type normalizedSemanticQuery struct {
+	scope      string
+	search     string
+	types      []string
+	anchorType string
+	anchorID   string
+	depth      int
+	limit      int
+}
+
+func (s *semanticService) Graph(ctx context.Context, teamID string, query Query) (*Snapshot, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("graph view semantic store is not configured")
+	}
+	normalized, err := normalizeSemanticQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := s.store.SemanticGraph(ctx, graphcontract.Query{
+		TeamID:     strings.TrimSpace(teamID),
+		Scope:      normalized.scope,
+		Query:      normalized.search,
+		Types:      normalized.types,
+		AnchorType: normalized.anchorType,
+		AnchorID:   normalized.anchorID,
+		Depth:      normalized.depth,
+		Limit:      normalized.limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph view: %w", err)
+	}
+	return snapshotFromSemantic(snapshot), nil
+}
+
+func (s *semanticService) NodeDetail(ctx context.Context, teamID string, nodeType string, nodeID string) (*Node, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("graph view semantic store is not configured")
+	}
+	normalizedType := normalizeSemanticGraphType(nodeType)
+	normalizedID := strings.TrimSpace(nodeID)
+	if normalizedType == "" && strings.TrimSpace(nodeType) != "" {
+		return nil, ErrInvalidNodeType
+	}
+	if normalizedType == "" || normalizedID == "" {
+		return nil, ErrMissingNode
+	}
+	node, err := s.store.SemanticGraphNodeDetail(ctx, graphcontract.NodeDetailInput{
+		TeamID:   strings.TrimSpace(teamID),
+		NodeType: normalizedType,
+		NodeID:   normalizedID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNodeNotFound
+		}
+		return nil, fmt.Errorf("semantic graph node detail: %w", err)
+	}
+	if node == nil {
+		return nil, ErrNodeNotFound
+	}
+	return nodeFromSemantic(*node), nil
+}
+
+func normalizeSemanticQuery(query Query) (normalizedSemanticQuery, error) {
+	scope := strings.ToLower(strings.TrimSpace(query.Scope))
+	if scope == "" || scope != ScopeLocal {
+		scope = ScopeOverview
+	}
+	normalized := normalizedSemanticQuery{
+		scope:  scope,
+		search: strings.ToLower(strings.TrimSpace(query.Query)),
+		types:  normalizeSemanticGraphTypes(query.Types),
+		limit:  defaultPositive(query.Limit, DefaultLimit),
+		depth:  clamp(query.Depth, DefaultDepth, MaxDepth),
+	}
+	if normalized.scope == ScopeLocal {
+		normalized.anchorType = normalizeSemanticGraphType(query.AnchorType)
+		normalized.anchorID = strings.TrimSpace(query.AnchorID)
+		if normalized.anchorType == "" && strings.TrimSpace(query.AnchorType) != "" {
+			return normalizedSemanticQuery{}, ErrInvalidAnchorType
+		}
+		if normalized.anchorType == "" || normalized.anchorID == "" {
+			return normalizedSemanticQuery{}, ErrMissingAnchor
+		}
+	}
+	return normalized, nil
+}
+
+func normalizeSemanticGraphTypes(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		normalized := normalizeSemanticGraphType(raw)
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	if len(out) == 0 {
+		return []string{"entity", "value"}
+	}
+	return out
+}
+
+func normalizeSemanticGraphType(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "entity", "entities":
+		return "entity"
+	case "value", "values":
+		return "value"
+	default:
+		return ""
+	}
+}
+
+func clamp(value, defaultValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func defaultPositive(value, defaultValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	return value
+}
+
+func snapshotFromSemantic(snapshot *graphcontract.Snapshot) *Snapshot {
+	if snapshot == nil {
+		return &Snapshot{Nodes: []Node{}, Edges: []Edge{}}
+	}
+	out := &Snapshot{
+		Scope:     snapshot.Scope,
+		Query:     snapshot.Query,
+		Depth:     snapshot.Depth,
+		Limit:     snapshot.Limit,
+		Truncated: snapshot.Truncated,
+		Nodes:     make([]Node, 0, len(snapshot.Nodes)),
+		Edges:     make([]Edge, 0, len(snapshot.Edges)),
+	}
+	if snapshot.Anchor != nil {
+		out.Anchor = &Anchor{
+			Type: snapshot.Anchor.Type,
+			ID:   snapshot.Anchor.ID,
+			Key:  snapshot.Anchor.Key,
+		}
+	}
+	for _, node := range snapshot.Nodes {
+		out.Nodes = append(out.Nodes, *nodeFromSemantic(node))
+	}
+	for _, edge := range snapshot.Edges {
+		out.Edges = append(out.Edges, Edge{
+			ID:           edge.ID,
+			Source:       edge.Source,
+			Target:       edge.Target,
+			Relationship: edge.Relationship,
+			Directed:     edge.Directed,
+		})
+	}
+	return out
+}
+
+func nodeFromSemantic(node graphcontract.Node) *Node {
+	title := truncateText(node.Title, 160)
+	if title == "" {
+		title = node.ID
+	}
+	return &Node{
+		Key:        node.Key,
+		ID:         node.ID,
+		Type:       node.Type,
+		Title:      title,
+		Body:       truncateText(node.Body, maxNodeBodyRunes),
+		Status:     node.Status,
+		RecordedAt: node.RecordedAt,
+	}
+}
+
+func truncateText(value string, maxRunes int) string {
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,4 +1,4 @@
-package graphview
+package graph
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/markhuangai/dense-mem/internal/repository"
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,23 +49,23 @@ func TestNormalizeSemanticQueryDefaultsAndBounds(t *testing.T) {
 
 func TestSemanticServiceGraphNormalizesAndMapsSnapshot(t *testing.T) {
 	recordedAt := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
-	store := &semanticStoreStub{snapshot: &repository.SemanticGraphSnapshot{
+	store := &semanticStoreStub{snapshot: &graphcontract.Snapshot{
 		Scope: ScopeLocal, Query: "project", Depth: MaxDepth, Limit: 181, Truncated: true,
-		Anchor: &repository.SemanticGraphAnchor{Type: "entity", ID: "entity-1", Key: "entity:entity-1"},
-		Nodes: []repository.SemanticGraphNode{
+		Anchor: &graphcontract.Anchor{Type: "entity", ID: "entity-1", Key: "entity:entity-1"},
+		Nodes: []graphcontract.Node{
 			{Key: "entity:entity-1", ID: "entity-1", Type: "entity", Title: strings.Repeat("t", 170), Body: strings.Repeat("b", 430), Status: "active", RecordedAt: &recordedAt},
 			{Key: "value:value-1", ID: "value-1", Type: "value"},
 		},
-		Edges: []repository.SemanticGraphEdge{{ID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "USES", Directed: true}},
+		Edges: []graphcontract.Edge{{ID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "USES", Directed: true}},
 	}}
-	service := NewSemantic(store)
+	service := New(store)
 
 	snapshot, err := service.Graph(context.Background(), " team-1 ", Query{
 		Scope: " LOCAL ", Query: " Project ", Types: []string{"entities", "value", "entity"},
 		AnchorType: "entities", AnchorID: " entity-1 ", Depth: 99, Limit: 181,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, repository.SemanticGraphQuery{
+	assert.Equal(t, graphcontract.Query{
 		TeamID: "team-1", Scope: ScopeLocal, Query: "project", Types: []string{"entity", "value"},
 		AnchorType: "entity", AnchorID: "entity-1", Depth: MaxDepth, Limit: 181,
 	}, store.graphInput)
@@ -90,13 +90,13 @@ func TestSemanticServiceGraphErrorsAndEmptySnapshot(t *testing.T) {
 
 	storeErr := errors.New("store unavailable")
 	store := &semanticStoreStub{graphErr: storeErr}
-	_, err = NewSemantic(store).Graph(context.Background(), "team", Query{})
+	_, err = New(store).Graph(context.Background(), "team", Query{})
 	assert.ErrorIs(t, err, storeErr)
 	assert.ErrorContains(t, err, "semantic graph view")
 
 	store.graphErr = nil
 	store.snapshot = nil
-	snapshot, err := NewSemantic(store).Graph(context.Background(), "team", Query{})
+	snapshot, err := New(store).Graph(context.Background(), "team", Query{})
 	require.NoError(t, err)
 	assert.Empty(t, snapshot.Nodes)
 	assert.Empty(t, snapshot.Edges)
@@ -104,14 +104,14 @@ func TestSemanticServiceGraphErrorsAndEmptySnapshot(t *testing.T) {
 
 func TestSemanticServiceNodeDetail(t *testing.T) {
 	recordedAt := time.Date(2026, time.August, 10, 13, 0, 0, 0, time.UTC)
-	store := &semanticStoreStub{detail: &repository.SemanticGraphNode{
+	store := &semanticStoreStub{detail: &graphcontract.Node{
 		Key: "entity:entity-1", ID: "entity-1", Type: "entity", Title: "Dense-Mem", Body: "project", Status: "active", RecordedAt: &recordedAt,
 	}}
-	service := NewSemantic(store)
+	service := New(store)
 
 	detail, err := service.NodeDetail(context.Background(), " team-1 ", " Entities ", " entity-1 ")
 	require.NoError(t, err)
-	assert.Equal(t, repository.SemanticGraphNodeDetailInput{TeamID: "team-1", NodeType: "entity", NodeID: "entity-1"}, store.detailInput)
+	assert.Equal(t, graphcontract.NodeDetailInput{TeamID: "team-1", NodeType: "entity", NodeID: "entity-1"}, store.detailInput)
 	assert.Equal(t, "Dense-Mem", detail.Title)
 	assert.Equal(t, "project", detail.Body)
 	assert.Equal(t, recordedAt, *detail.RecordedAt)
@@ -136,7 +136,7 @@ func TestSemanticServiceNodeDetailValidation(t *testing.T) {
 	_, err := nilService.NodeDetail(context.Background(), "team", "entity", "id")
 	assert.ErrorContains(t, err, "not configured")
 
-	service := NewSemantic(&semanticStoreStub{})
+	service := New(&semanticStoreStub{})
 	_, err = service.NodeDetail(context.Background(), "team", "evidence", "id")
 	assert.ErrorIs(t, err, ErrInvalidNodeType)
 	_, err = service.NodeDetail(context.Background(), "team", "entity", "")
@@ -146,20 +146,20 @@ func TestSemanticServiceNodeDetailValidation(t *testing.T) {
 }
 
 type semanticStoreStub struct {
-	graphInput  repository.SemanticGraphQuery
-	snapshot    *repository.SemanticGraphSnapshot
+	graphInput  graphcontract.Query
+	snapshot    *graphcontract.Snapshot
 	graphErr    error
-	detailInput repository.SemanticGraphNodeDetailInput
-	detail      *repository.SemanticGraphNode
+	detailInput graphcontract.NodeDetailInput
+	detail      *graphcontract.Node
 	detailErr   error
 }
 
-func (s *semanticStoreStub) SemanticGraph(_ context.Context, input repository.SemanticGraphQuery) (*repository.SemanticGraphSnapshot, error) {
+func (s *semanticStoreStub) SemanticGraph(_ context.Context, input graphcontract.Query) (*graphcontract.Snapshot, error) {
 	s.graphInput = input
 	return s.snapshot, s.graphErr
 }
 
-func (s *semanticStoreStub) SemanticGraphNodeDetail(_ context.Context, input repository.SemanticGraphNodeDetailInput) (*repository.SemanticGraphNode, error) {
+func (s *semanticStoreStub) SemanticGraphNodeDetail(_ context.Context, input graphcontract.NodeDetailInput) (*graphcontract.Node, error) {
 	s.detailInput = input
 	return s.detail, s.detailErr
 }

--- a/internal/graph/postgres/graph_repository.go
+++ b/internal/graph/postgres/graph_repository.go
@@ -189,7 +189,7 @@ func loadSemanticOverviewGraphRows(
 	ctx context.Context,
 	tx *gorm.DB,
 	input graphExecutionQuery,
-) ([]graphEdgeRow, error) {
+) (batch []graphEdgeRow, err error) {
 	extraWhere := ""
 	var extraArgs []any
 	if input.spaceID != "" {
@@ -203,7 +203,12 @@ func loadSemanticOverviewGraphRows(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); err == nil && closeErr != nil {
+			batch = nil
+			err = closeErr
+		}
+	}()
 	return scanSemanticGraphRows(rows, input.Types)
 }
 
@@ -477,10 +482,6 @@ func graphSnapshot(input graphcontract.Query, rows []graphEdgeRow) *graphcontrac
 
 func normalizeSemanticGraphTypes(values []string) []string {
 	return graphread.NormalizeTypes(values)
-}
-
-func semanticGraphTypeSet(values []string) map[string]bool {
-	return graphread.TypeSet(values)
 }
 
 func normalizeSemanticGraphNodeType(raw string) string {

--- a/internal/graph/postgres/graph_repository.go
+++ b/internal/graph/postgres/graph_repository.go
@@ -382,7 +382,7 @@ func scanSemanticGraphRows(rows *sql.Rows, types []string) ([]graphEdgeRow, erro
 	return graphread.ScanRows(rows, types)
 }
 
-func loadSemanticEntityGraphNode(ctx context.Context, tx *gorm.DB, teamID, entityID string) (*graphcontract.Node, error) {
+func loadSemanticEntityGraphNode(ctx context.Context, tx *gorm.DB, teamID, entityID string) (node *graphcontract.Node, err error) {
 	rows, err := tx.WithContext(ctx).Raw(`
 		SELECT ('entity:' || e.entity_id::text), e.entity_id::text,
 		       COALESCE(name.display_name, e.entity_id::text), e.entity_kind,
@@ -413,22 +413,27 @@ func loadSemanticEntityGraphNode(ctx context.Context, tx *gorm.DB, teamID, entit
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); err == nil && closeErr != nil {
+			node = nil
+			err = closeErr
+		}
+	}()
 	if !rows.Next() {
 		return nil, sql.ErrNoRows
 	}
-	var node graphcontract.Node
+	var loaded graphcontract.Node
 	var recordedAt time.Time
-	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
+	if err := rows.Scan(&loaded.Key, &loaded.ID, &loaded.Title, &loaded.Body, &loaded.Status, &loaded.OwnerProfileID, &recordedAt); err != nil {
 		return nil, err
 	}
-	node.Type = "entity"
+	loaded.Type = "entity"
 	t := recordedAt.UTC()
-	node.RecordedAt = &t
-	return &node, rows.Err()
+	loaded.RecordedAt = &t
+	return &loaded, rows.Err()
 }
 
-func loadSemanticValueGraphNode(ctx context.Context, tx *gorm.DB, teamID, valueID string) (*graphcontract.Node, error) {
+func loadSemanticValueGraphNode(ctx context.Context, tx *gorm.DB, teamID, valueID string) (node *graphcontract.Node, err error) {
 	rows, err := tx.WithContext(ctx).Raw(`
 		SELECT ('value:' || value_id::text), value_id::text,
 		       COALESCE(NULLIF(display, ''), canonical_value), value_type,
@@ -446,19 +451,24 @@ func loadSemanticValueGraphNode(ctx context.Context, tx *gorm.DB, teamID, valueI
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); err == nil && closeErr != nil {
+			node = nil
+			err = closeErr
+		}
+	}()
 	if !rows.Next() {
 		return nil, sql.ErrNoRows
 	}
-	var node graphcontract.Node
+	var loaded graphcontract.Node
 	var recordedAt time.Time
-	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
+	if err := rows.Scan(&loaded.Key, &loaded.ID, &loaded.Title, &loaded.Body, &loaded.Status, &loaded.OwnerProfileID, &recordedAt); err != nil {
 		return nil, err
 	}
-	node.Type = "value"
+	loaded.Type = "value"
 	t := recordedAt.UTC()
-	node.RecordedAt = &t
-	return &node, rows.Err()
+	loaded.RecordedAt = &t
+	return &loaded, rows.Err()
 }
 
 func graphSnapshot(input graphcontract.Query, rows []graphEdgeRow) *graphcontract.Snapshot {

--- a/internal/graph/postgres/graph_repository.go
+++ b/internal/graph/postgres/graph_repository.go
@@ -1,0 +1,514 @@
+// Package postgres owns graph view SQL and transaction-bound reads.
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
+	"github.com/markhuangai/dense-mem/internal/storage/postgres/graphread"
+)
+
+type Store struct {
+	db  *gorm.DB
+	rls storagepostgres.RLSHelper
+}
+
+func NewStore(db *gorm.DB, rls storagepostgres.RLSHelper) *Store {
+	return &Store{db: db, rls: rls}
+}
+
+func (r *Store) withTeamTx(ctx context.Context, teamID string, fn func(*gorm.DB) error) error {
+	if r == nil || r.db == nil {
+		return errors.New("graph: database is required")
+	}
+	if r.rls == nil {
+		return errors.New("graph: rls helper is required")
+	}
+	return r.rls.WithTeamTx(ctx, r.db, teamID, fn)
+}
+
+var _ graphcontract.Store = (*Store)(nil)
+
+const (
+	defaultSemanticGraphLimit = 80
+	defaultSemanticGraphDepth = 2
+	maxSemanticGraphDepth     = 5
+)
+
+func NormalizeQuery(input graphcontract.Query) graphcontract.Query {
+	return normalizeSemanticGraphQuery(input)
+}
+
+func NormalizeNodeDetailInput(input graphcontract.NodeDetailInput) graphcontract.NodeDetailInput {
+	return normalizeSemanticGraphNodeDetailInput(input)
+}
+
+func ValidateQuery(input graphcontract.Query) error {
+	return validateSemanticGraphQuery(input)
+}
+
+func ValidateNodeDetailInput(input graphcontract.NodeDetailInput) error {
+	return validateSemanticGraphNodeDetailInput(input)
+}
+
+func LoadLocalRows(ctx context.Context, tx *gorm.DB, input graphcontract.Query, spaceID string) ([]graphread.Row, error) {
+	input = normalizeSemanticGraphQuery(input)
+	if err := validateSemanticGraphQuery(input); err != nil {
+		return nil, err
+	}
+	return loadSemanticLocalGraphRows(ctx, tx, graphExecutionQuery{
+		Query:   input,
+		spaceID: strings.TrimSpace(spaceID),
+	})
+}
+
+func (r *Store) SemanticGraph(
+	ctx context.Context,
+	input graphcontract.Query,
+) (*graphcontract.Snapshot, error) {
+	input = normalizeSemanticGraphQuery(input)
+	if err := validateSemanticGraphQuery(input); err != nil {
+		return nil, err
+	}
+	var rows []graphEdgeRow
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		var err error
+		execution := graphExecutionQuery{Query: input}
+		if input.Scope == "local" {
+			rows, err = loadSemanticLocalGraphRows(ctx, tx, execution)
+		} else {
+			rows, err = loadSemanticOverviewGraphRows(ctx, tx, execution)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph: %w", err)
+	}
+	return graphSnapshot(input, rows), nil
+}
+
+func (r *Store) SemanticGraphNodeDetail(
+	ctx context.Context,
+	input graphcontract.NodeDetailInput,
+) (*graphcontract.Node, error) {
+	input = normalizeSemanticGraphNodeDetailInput(input)
+	if err := validateSemanticGraphNodeDetailInput(input); err != nil {
+		return nil, err
+	}
+	var node *graphcontract.Node
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		var err error
+		switch input.NodeType {
+		case "entity":
+			node, err = loadSemanticEntityGraphNode(ctx, tx, input.TeamID, input.NodeID)
+		case "value":
+			node, err = loadSemanticValueGraphNode(ctx, tx, input.TeamID, input.NodeID)
+		default:
+			return sql.ErrNoRows
+		}
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph node: %w", err)
+	}
+	return node, nil
+}
+
+type graphEdgeRow = graphread.Row
+
+// graphExecutionQuery carries adapter-derived scope separately from
+// the caller-owned graph contract.
+type graphExecutionQuery struct {
+	graphcontract.Query
+	spaceID string
+}
+
+func normalizeSemanticGraphQuery(input graphcontract.Query) graphcontract.Query {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.Scope = strings.ToLower(strings.TrimSpace(input.Scope))
+	if input.Scope == "" || input.Scope != "local" {
+		input.Scope = "overview"
+	}
+	input.Query = strings.ToLower(strings.TrimSpace(input.Query))
+	input.AnchorType = normalizeSemanticGraphNodeType(input.AnchorType)
+	input.AnchorID = strings.TrimSpace(input.AnchorID)
+	input.Types = normalizeSemanticGraphTypes(input.Types)
+	input.Depth = clampInt(input.Depth, defaultSemanticGraphDepth, maxSemanticGraphDepth)
+	input.Limit = defaultPositiveInt(input.Limit, defaultSemanticGraphLimit)
+	input.MinRelevance = normalizeRelevance(input.MinRelevance)
+	return input
+}
+
+func validateSemanticGraphQuery(input graphcontract.Query) error {
+	if _, err := uuid.Parse(input.TeamID); err != nil {
+		return fmt.Errorf("team_id is required: %w", err)
+	}
+	if input.Scope == "local" {
+		if input.AnchorType == "" {
+			return errors.New("anchor_type is required for local graph")
+		}
+		if _, err := uuid.Parse(input.AnchorID); err != nil {
+			return fmt.Errorf("anchor_id is required for local graph: %w", err)
+		}
+	}
+	return nil
+}
+
+func normalizeSemanticGraphNodeDetailInput(input graphcontract.NodeDetailInput) graphcontract.NodeDetailInput {
+	input.TeamID = strings.TrimSpace(input.TeamID)
+	input.NodeType = normalizeSemanticGraphNodeType(input.NodeType)
+	input.NodeID = strings.TrimSpace(input.NodeID)
+	return input
+}
+
+func validateSemanticGraphNodeDetailInput(input graphcontract.NodeDetailInput) error {
+	if _, err := uuid.Parse(input.TeamID); err != nil {
+		return fmt.Errorf("team_id is required: %w", err)
+	}
+	if input.NodeType == "" {
+		return errors.New("node_type must be entity or value")
+	}
+	if _, err := uuid.Parse(input.NodeID); err != nil {
+		return fmt.Errorf("node_id is required: %w", err)
+	}
+	return nil
+}
+
+func loadSemanticOverviewGraphRows(
+	ctx context.Context,
+	tx *gorm.DB,
+	input graphExecutionQuery,
+) ([]graphEdgeRow, error) {
+	extraWhere := ""
+	var extraArgs []any
+	if input.spaceID != "" {
+		extraWhere = " AND edge_record.space_id = ?::uuid"
+		extraArgs = append(extraArgs, input.spaceID)
+	}
+	rows, err := tx.WithContext(ctx).Raw(
+		semanticGraphEdgesSQL(extraWhere),
+		semanticGraphQueryArgs(input, input.Limit, extraArgs...)...,
+	).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSemanticGraphRows(rows, input.Types)
+}
+
+func loadSemanticLocalGraphRows(
+	ctx context.Context,
+	tx *gorm.DB,
+	input graphExecutionQuery,
+) ([]graphEdgeRow, error) {
+	anchor := semanticGraphNodeKey(input.AnchorType, input.AnchorID)
+	if anchor == "" {
+		return nil, sql.ErrNoRows
+	}
+	return graphread.Traverse(ctx, anchor, input.Depth, input.Limit, func(ctx context.Context, frontier []string, limit int) ([]graphread.Row, error) {
+		extraWhere := `
+		  AND (
+		    ('entity:' || e.subject_entity_id::text) = ANY(?::text[])
+		    OR (CASE
+		      WHEN e.object_entity_id IS NOT NULL THEN 'entity:' || e.object_entity_id::text
+		      ELSE 'value:' || e.object_value_id::text
+		    END) = ANY(?::text[])
+		  )
+		`
+		extraArgs := []any{pq.Array(frontier), pq.Array(frontier)}
+		if input.spaceID != "" {
+			extraWhere += " AND edge_record.space_id = ?::uuid"
+			extraArgs = append(extraArgs, input.spaceID)
+		}
+		rows, err := tx.WithContext(ctx).Raw(
+			semanticGraphEdgesSQL(extraWhere),
+			semanticGraphQueryArgs(input, limit, extraArgs...)...,
+		).Rows()
+		if err != nil {
+			return nil, err
+		}
+		batch, err := scanSemanticGraphRows(rows, input.Types)
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return nil, err
+		}
+		return batch, nil
+	})
+}
+
+func semanticGraphEdgesSQL(extraWhere string) string {
+	searchText := semanticGraphSearchTextSQL()
+	return `
+			SELECT e.relationship_id::text,
+			       e.owner_profile_id::text,
+			       e.predicate_key,
+			       e.support_count,
+		       e.source_group_count,
+		       ('entity:' || e.subject_entity_id::text) AS source_key,
+		       e.subject_entity_id::text AS source_id,
+		       COALESCE(subject_name.display_name, e.subject_entity_id::text) AS source_title,
+		       subject.entity_kind AS source_body,
+		       subject.status AS source_status,
+		       e.owner_profile_id::text AS source_owner_profile_id,
+		       subject.updated_at AS source_recorded_at,
+		       CASE
+		         WHEN e.object_entity_id IS NOT NULL THEN 'entity:' || e.object_entity_id::text
+		         ELSE 'value:' || e.object_value_id::text
+		       END AS target_key,
+		       COALESCE(e.object_entity_id::text, e.object_value_id::text) AS target_id,
+		       CASE WHEN e.object_entity_id IS NOT NULL THEN 'entity' ELSE 'value' END AS target_type,
+		       COALESCE(object_name.display_name, NULLIF(value.display, ''), value.canonical_value, e.object_entity_id::text, e.object_value_id::text) AS target_title,
+		       COALESCE(object.entity_kind, value.value_type, '') AS target_body,
+		       COALESCE(object.status, 'active') AS target_status,
+		       e.owner_profile_id::text AS target_owner_profile_id,
+		       COALESCE(object.updated_at, value.created_at, subject.updated_at) AS target_recorded_at
+		FROM semantic_edges e
+		JOIN relationship_records edge_record
+		  ON edge_record.team_id = e.team_id
+		 AND edge_record.relationship_id = e.relationship_id
+		JOIN entity_records subject
+		  ON subject.team_id = e.team_id
+		 AND subject.entity_id = e.subject_entity_id
+		 AND subject.space_id = edge_record.space_id
+		LEFT JOIN LATERAL (
+		  SELECT display_name
+		  FROM entity_names
+		  WHERE team_id = e.team_id
+		    AND entity_id = e.subject_entity_id
+		    AND space_id = edge_record.space_id
+		    AND ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("entity_names") + `
+		    AND name_kind = 'canonical'
+		    AND valid_to IS NULL
+		  ORDER BY created_at DESC, entity_name_id DESC
+		  LIMIT 1
+		) subject_name ON true
+		LEFT JOIN entity_records object
+		  ON object.team_id = e.team_id
+		 AND object.entity_id = e.object_entity_id
+		 AND object.space_id = edge_record.space_id
+		LEFT JOIN LATERAL (
+		  SELECT display_name
+		  FROM entity_names
+		  WHERE team_id = e.team_id
+		    AND entity_id = e.object_entity_id
+		    AND space_id = edge_record.space_id
+		    AND ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("entity_names") + `
+		    AND name_kind = 'canonical'
+		    AND valid_to IS NULL
+		  ORDER BY created_at DESC, entity_name_id DESC
+		  LIMIT 1
+		) object_name ON true
+		LEFT JOIN value_records value
+		  ON value.team_id = e.team_id
+		 AND value.value_id = e.object_value_id
+		 AND value.space_id = edge_record.space_id
+		WHERE e.team_id = ?::uuid
+		  AND (
+		    edge_record.space_id = dense_mem_team_shared_space(edge_record.team_id)
+		    OR dense_mem_space_allowed(edge_record.space_id)
+		  )
+		  AND ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("edge_record") + `
+		  AND ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("subject") + `
+		  AND (
+		    e.object_entity_id IS NULL
+		    OR ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("object") + `
+		  )
+		  AND (
+		    e.object_entity_id IS NOT NULL
+		    OR ` + storagepostgres.ActiveSemanticSpaceGenerationSQL("value") + `
+		  )
+		  AND subject.status = 'active'
+		  AND (
+		    e.object_entity_id IS NULL
+		    OR object.status = 'active'
+		  )
+		  AND (
+		    ? = ''
+		    OR ` + searchText + ` LIKE '%' || ? || '%'
+		    OR to_tsvector('simple', ` + searchText + `) @@ plainto_tsquery('simple', ?)
+		  )
+		  AND (
+		    ? <= 0
+		    OR ? = ''
+		    OR ts_rank_cd(to_tsvector('simple', ` + searchText + `), plainto_tsquery('simple', ?), 32) >= ?
+		  )
+	` + extraWhere + `
+		ORDER BY
+		  CASE
+		    WHEN ? = '' THEN 0
+		    ELSE ts_rank_cd(to_tsvector('simple', ` + searchText + `), plainto_tsquery('simple', ?), 32)
+		  END DESC,
+		  e.relationship_id ASC
+		LIMIT ?
+	`
+}
+
+func semanticGraphSearchTextSQL() string {
+	return `lower(COALESCE(subject_name.display_name, '') || ' ' || e.predicate_key || ' ' ||
+		             COALESCE(object_name.display_name, value.display, value.canonical_value, ''))`
+}
+
+func semanticGraphQueryArgs(input graphExecutionQuery, limit int, extraArgs ...any) []any {
+	queryText := input.Query.Query
+	args := []any{
+		input.TeamID,
+		queryText,
+		queryText,
+		queryText,
+		input.MinRelevance,
+		queryText,
+		queryText,
+		input.MinRelevance,
+	}
+	args = append(args, extraArgs...)
+	args = append(args, queryText, queryText, limit)
+	return args
+}
+
+func scanSemanticGraphRows(rows *sql.Rows, types []string) ([]graphEdgeRow, error) {
+	return graphread.ScanRows(rows, types)
+}
+
+func loadSemanticEntityGraphNode(ctx context.Context, tx *gorm.DB, teamID, entityID string) (*graphcontract.Node, error) {
+	rows, err := tx.WithContext(ctx).Raw(`
+		SELECT ('entity:' || e.entity_id::text), e.entity_id::text,
+		       COALESCE(name.display_name, e.entity_id::text), e.entity_kind,
+		       e.status, COALESCE(name.owner_profile_id::text, ''), e.updated_at
+		FROM entity_records e
+		LEFT JOIN LATERAL (
+		  SELECT display_name, owner_profile_id
+		  FROM entity_names
+		  WHERE team_id = e.team_id
+		    AND entity_id = e.entity_id
+		    AND space_id = e.space_id
+		    AND `+storagepostgres.ActiveSemanticSpaceGenerationSQL("entity_names")+`
+		    AND name_kind = 'canonical'
+		    AND valid_to IS NULL
+		  ORDER BY created_at DESC, entity_name_id DESC
+		  LIMIT 1
+		) name ON true
+		WHERE e.team_id = ?::uuid
+		  AND e.entity_id = ?::uuid
+		  AND e.status = 'active'
+		  AND (
+		    e.space_id = dense_mem_team_shared_space(e.team_id)
+		    OR dense_mem_space_allowed(e.space_id)
+		  )
+		  AND `+storagepostgres.ActiveSemanticSpaceGenerationSQL("e")+`
+		LIMIT 1
+	`, teamID, entityID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, sql.ErrNoRows
+	}
+	var node graphcontract.Node
+	var recordedAt time.Time
+	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
+		return nil, err
+	}
+	node.Type = "entity"
+	t := recordedAt.UTC()
+	node.RecordedAt = &t
+	return &node, rows.Err()
+}
+
+func loadSemanticValueGraphNode(ctx context.Context, tx *gorm.DB, teamID, valueID string) (*graphcontract.Node, error) {
+	rows, err := tx.WithContext(ctx).Raw(`
+		SELECT ('value:' || value_id::text), value_id::text,
+		       COALESCE(NULLIF(display, ''), canonical_value), value_type,
+		       'active', ''::text, created_at
+		FROM value_records AS value
+		WHERE value.team_id = ?::uuid
+		  AND value.value_id = ?::uuid
+		  AND (
+		    value.space_id = dense_mem_team_shared_space(value.team_id)
+		    OR dense_mem_space_allowed(value.space_id)
+		  )
+		  AND `+storagepostgres.ActiveSemanticSpaceGenerationSQL("value")+`
+		LIMIT 1
+	`, teamID, valueID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, sql.ErrNoRows
+	}
+	var node graphcontract.Node
+	var recordedAt time.Time
+	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
+		return nil, err
+	}
+	node.Type = "value"
+	t := recordedAt.UTC()
+	node.RecordedAt = &t
+	return &node, rows.Err()
+}
+
+func graphSnapshot(input graphcontract.Query, rows []graphEdgeRow) *graphcontract.Snapshot {
+	return graphread.Snapshot(input, rows)
+}
+
+func normalizeSemanticGraphTypes(values []string) []string {
+	return graphread.NormalizeTypes(values)
+}
+
+func semanticGraphTypeSet(values []string) map[string]bool {
+	return graphread.TypeSet(values)
+}
+
+func normalizeSemanticGraphNodeType(raw string) string {
+	return graphread.NormalizeNodeType(raw)
+}
+
+func clampInt(value, defaultValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func defaultPositiveInt(value, defaultValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	return value
+}
+
+func normalizeRelevance(value float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value <= 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+func semanticGraphNodeKey(nodeType, id string) string {
+	nodeType = normalizeSemanticGraphNodeType(nodeType)
+	id = strings.TrimSpace(id)
+	if nodeType == "" || id == "" {
+		return ""
+	}
+	return nodeType + ":" + id
+}

--- a/internal/graph/postgres/graph_repository_sqlmock_test.go
+++ b/internal/graph/postgres/graph_repository_sqlmock_test.go
@@ -60,6 +60,33 @@ func TestLoadSemanticOverviewGraphRowsScansAndClosesAdapterRows(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestLoadSemanticOverviewGraphRowsPropagatesRowsCloseError(t *testing.T) {
+	db, mock, gormDB := newGraphSQLMockDB(t)
+	defer db.Close()
+	closeErr := errors.New("overview rows close failed")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT e.relationship_id")).WillReturnRows(
+		sqlmock.NewRows(graphSQLColumns()).
+			AddRow(
+				"edge-1", "owner-1", "uses", 1, 2,
+				"entity:source", "source", "Source", "project", "active", "owner-1", time.Now(),
+				"value:target", "target", "value", "Target", "date", "active", "", time.Now(),
+			).
+			CloseError(closeErr),
+	)
+
+	rows, err := loadSemanticOverviewGraphRows(context.Background(), gormDB, graphExecutionQuery{
+		Query: graphcontract.Query{
+			TeamID: uuid.NewString(),
+			Scope:  "overview",
+			Types:  []string{"value"},
+			Limit:  1,
+		},
+	})
+	assert.Nil(t, rows)
+	assert.ErrorIs(t, err, closeErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestScanSemanticGraphRowsPropagatesRowError(t *testing.T) {
 	db, mock, gormDB := newGraphSQLMockDB(t)
 	defer db.Close()

--- a/internal/graph/postgres/graph_repository_sqlmock_test.go
+++ b/internal/graph/postgres/graph_repository_sqlmock_test.go
@@ -1,0 +1,183 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+)
+
+func TestSemanticGraphQueryArgsPreserveBoundOrder(t *testing.T) {
+	args := semanticGraphQueryArgs(graphExecutionQuery{Query: graphcontract.Query{
+		TeamID:       "team-id",
+		Query:        "needle",
+		MinRelevance: 0.4,
+	}}, 9, "frontier")
+
+	require.Len(t, args, 12)
+	assert.Equal(t, []any{"team-id", "needle", "needle", "needle", 0.4, "needle", "needle", 0.4}, args[:8])
+	assert.Equal(t, "frontier", args[8])
+	assert.Equal(t, []any{"needle", "needle", 9}, args[9:])
+}
+
+func TestLoadSemanticOverviewGraphRowsScansAndClosesAdapterRows(t *testing.T) {
+	db, mock, gormDB := newGraphSQLMockDB(t)
+	defer db.Close()
+	columns := graphSQLColumns()
+	now := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT e.relationship_id")).
+		WillReturnRows(sqlmock.NewRows(columns).AddRow(
+			"edge-1", "owner-1", "uses", 1, 2,
+			"entity:source", "source", "Source", "project", "active", "owner-1", now,
+			"value:target", "target", "value", "Target", "date", "active", "", now,
+		))
+
+	rows, err := loadSemanticOverviewGraphRows(context.Background(), gormDB, graphExecutionQuery{
+		Query: graphcontract.Query{
+			TeamID: uuid.NewString(),
+			Scope:  "overview",
+			Types:  []string{"entity", "value"},
+			Limit:  1,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "edge-1", rows[0].Edge.ID)
+	assert.Equal(t, "value", rows[0].Target.Type)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestScanSemanticGraphRowsPropagatesRowError(t *testing.T) {
+	db, mock, gormDB := newGraphSQLMockDB(t)
+	defer db.Close()
+	rowErr := errors.New("row decode failed")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT graph")).
+		WillReturnRows(sqlmock.NewRows(graphSQLColumns()).
+			AddRow("edge-1", "owner-1", "uses", 1, 2,
+				"entity:source", "source", "Source", "project", "active", "owner-1", time.Now(),
+				"entity:target", "target", "entity", "Target", "project", "active", "owner-1", time.Now()).
+			RowError(0, rowErr))
+	rows, err := gormDB.Raw("SELECT graph").Rows()
+	require.NoError(t, err)
+	_, err = scanSemanticGraphRows(rows, []string{"entity", "value"})
+	assert.ErrorIs(t, err, rowErr)
+	require.NoError(t, rows.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoadSemanticLocalGraphRowsPropagatesQueryError(t *testing.T) {
+	db, mock, gormDB := newGraphSQLMockDB(t)
+	defer db.Close()
+	queryErr := errors.New("local graph query failed")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT e.relationship_id")).WillReturnError(queryErr)
+
+	_, err := loadSemanticLocalGraphRows(context.Background(), gormDB, graphExecutionQuery{
+		Query: graphcontract.Query{
+			TeamID:     uuid.NewString(),
+			Scope:      "local",
+			AnchorType: "entity",
+			AnchorID:   uuid.NewString(),
+			Types:      []string{"entity", "value"},
+			Depth:      2,
+			Limit:      10,
+		},
+	})
+	assert.ErrorIs(t, err, queryErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoadSemanticLocalGraphRowsBatchesFrontiersAndRemainingLimit(t *testing.T) {
+	db, mock, gormDB := newGraphSQLMockDB(t)
+	defer db.Close()
+	rootID := uuid.NewString()
+	childA := uuid.NewString()
+	childB := uuid.NewString()
+	grandchild := uuid.NewString()
+	now := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
+
+	rootRows := sqlmock.NewRows(graphSQLColumns())
+	rootRows.AddRow("edge-a", "owner", "uses", 1, 1, "entity:"+rootID, rootID, "Root", "project", "active", "owner", now, "entity:"+childA, childA, "entity", "Child A", "project", "active", "owner", now)
+	rootRows.AddRow("edge-b", "owner", "uses", 1, 1, "entity:"+rootID, rootID, "Root", "project", "active", "owner", now, "entity:"+childB, childB, "entity", "Child B", "project", "active", "owner", now)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT e.relationship_id")).WithArgs(graphLocalQueryArgs(frontierArgument{items: []string{"entity:" + rootID}}, 3)...).WillReturnRows(rootRows)
+
+	childRows := sqlmock.NewRows(graphSQLColumns())
+	childRows.AddRow("edge-c", "owner", "uses", 1, 1, "entity:"+childA, childA, "Child A", "project", "active", "owner", now, "entity:"+grandchild, grandchild, "entity", "Grandchild", "project", "active", "owner", now)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT e.relationship_id")).WithArgs(graphLocalQueryArgs(frontierArgument{items: []string{"entity:" + childA, "entity:" + childB}}, 1)...).WillReturnRows(childRows)
+
+	rows, err := loadSemanticLocalGraphRows(context.Background(), gormDB, graphExecutionQuery{
+		Query: graphcontract.Query{
+			TeamID:     uuid.NewString(),
+			Scope:      "local",
+			AnchorType: "entity",
+			AnchorID:   rootID,
+			Types:      []string{"entity", "value"},
+			Depth:      2,
+			Limit:      3,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "edge-c", rows[2].Edge.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func newGraphSQLMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *gorm.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	gormDB, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: db, DriverName: "postgres"}), &gorm.Config{})
+	require.NoError(t, err)
+	return db, mock, gormDB
+}
+
+func graphSQLColumns() []string {
+	return []string{
+		"edge_id", "owner_id", "predicate", "support_count", "source_group_count",
+		"source_key", "source_id", "source_title", "source_body", "source_status", "source_owner", "source_recorded_at",
+		"target_key", "target_id", "target_type", "target_title", "target_body", "target_status", "target_owner", "target_recorded_at",
+	}
+}
+
+type frontierArgument struct {
+	items []string
+}
+
+func (argument frontierArgument) Match(value driver.Value) bool {
+	var textValue string
+	switch value := value.(type) {
+	case string:
+		textValue = value
+	case []byte:
+		textValue = string(value)
+	default:
+		return false
+	}
+	for _, item := range argument.items {
+		if !strings.Contains(textValue, item) {
+			return false
+		}
+	}
+	return true
+}
+
+func graphLocalQueryArgs(frontier frontierArgument, limit int) []driver.Value {
+	args := make([]driver.Value, 8)
+	for index := range args {
+		args[index] = sqlmock.AnyArg()
+	}
+	args = append(args, frontier, frontier, sqlmock.AnyArg(), sqlmock.AnyArg(), limit)
+	return args
+}

--- a/internal/graph/postgres/graph_repository_sqlmock_test.go
+++ b/internal/graph/postgres/graph_repository_sqlmock_test.go
@@ -78,6 +78,34 @@ func TestScanSemanticGraphRowsPropagatesRowError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestLoadSemanticGraphNodePropagatesRowsCloseError(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		load  func(context.Context, *gorm.DB, string, string) (*graphcontract.Node, error)
+	}{
+		{name: "entity", query: "SELECT ('entity:'", load: loadSemanticEntityGraphNode},
+		{name: "value", query: "SELECT ('value:'", load: loadSemanticValueGraphNode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, gormDB := newGraphSQLMockDB(t)
+			defer db.Close()
+			closeErr := errors.New("graph node rows close failed")
+			mock.ExpectQuery(regexp.QuoteMeta(tt.query)).WillReturnRows(
+				sqlmock.NewRows([]string{"key", "id", "title", "body", "status", "owner", "recorded_at"}).
+					AddRow(tt.name+":node", "node", "Node", "entity", "active", "owner", time.Now()).
+					CloseError(closeErr),
+			)
+
+			node, err := tt.load(context.Background(), gormDB, uuid.NewString(), uuid.NewString())
+			assert.Nil(t, node)
+			assert.ErrorIs(t, err, closeErr)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestLoadSemanticLocalGraphRowsPropagatesQueryError(t *testing.T) {
 	db, mock, gormDB := newGraphSQLMockDB(t)
 	defer db.Close()

--- a/internal/graph/postgres/graph_repository_test.go
+++ b/internal/graph/postgres/graph_repository_test.go
@@ -1,0 +1,21 @@
+package postgres
+
+import (
+	"testing"
+
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeGraphQueryDefaultsAndBounds(t *testing.T) {
+	defaults := normalizeSemanticGraphQuery(graphcontract.Query{})
+	assert.Equal(t, defaultSemanticGraphDepth, defaults.Depth)
+	assert.Equal(t, defaultSemanticGraphLimit, defaults.Limit)
+
+	explicit := normalizeSemanticGraphQuery(graphcontract.Query{Depth: 99, Limit: 181})
+	assert.Equal(t, maxSemanticGraphDepth, explicit.Depth)
+	assert.Equal(t, 181, explicit.Limit)
+
+	large := normalizeSemanticGraphQuery(graphcontract.Query{Limit: 1_000_000})
+	assert.Equal(t, 1_000_000, large.Limit)
+}

--- a/internal/repository/dream_repository_integration.e2e
+++ b/internal/repository/dream_repository_integration.e2e
@@ -593,28 +593,40 @@ func TestScheduledDreamsAreTeamOwnedAndFeedbackIsActorAudited(t *testing.T) {
 		WindowKey:  "2026-07-31",
 		LeaseUntil: time.Now().UTC().Add(time.Minute),
 	}
-	results := make([]*DreamCycleRun, 2)
-	errs := make([]error, 2)
+	const claimers = 8
+	results := make([]*DreamCycleRun, claimers)
+	errs := make([]error, claimers)
+	ready := make(chan struct{}, claimers)
+	start := make(chan struct{})
 	var group sync.WaitGroup
 	for i := range results {
 		group.Add(1)
 		go func(index int) {
 			defer group.Done()
+			ready <- struct{}{}
+			<-start
 			results[index], errs[index] = semanticRepo.ClaimScheduledDreamCycle(ctx, claim)
 		}(i)
 	}
+	for range results {
+		<-ready
+	}
+	close(start)
 	group.Wait()
-	require.NoError(t, errs[0])
-	require.NoError(t, errs[1])
-	require.Equal(t, results[0].RunID, results[1].RunID)
-	require.NotEqual(t, results[0].Claimed, results[1].Claimed)
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
 
 	var runID string
+	claimed := 0
 	for _, result := range results {
+		require.Equal(t, results[0].RunID, result.RunID)
 		if result.Claimed {
+			claimed++
 			runID = result.RunID
 		}
 	}
+	require.Equal(t, 1, claimed)
 	require.NotEmpty(t, runID)
 
 	hypothesis, inserted, err := semanticRepo.UpsertScheduledHypothesis(ctx, UpsertHypothesisInput{

--- a/internal/repository/semantic_graph_repository.go
+++ b/internal/repository/semantic_graph_repository.go
@@ -2,18 +2,81 @@ package repository
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/lib/pq"
-	"gorm.io/gorm"
-
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
+	graphpostgres "github.com/markhuangai/dense-mem/internal/graph/postgres"
 	"github.com/markhuangai/dense-mem/internal/storage/postgres/graphread"
+	"gorm.io/gorm"
 )
+
+// GraphStore is the narrow construction seam used by graph-owned composition.
+// It returns the graph contract and keeps database handles private to the
+// legacy repository compatibility boundary.
+func (r *SemanticRepositoryImpl) GraphStore() graphcontract.Store {
+	if r == nil || r.db == nil || r.rls == nil {
+		return nil
+	}
+	return graphpostgres.NewStore(r.db, r.rls)
+}
+
+func (r *SemanticRepositoryImpl) graphOwner() (*graphpostgres.Store, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("semantic: database is required")
+	}
+	if r.rls == nil {
+		return nil, errors.New("semantic: rls helper is required")
+	}
+	store := r.GraphStore()
+	owner, ok := store.(*graphpostgres.Store)
+	if !ok || owner == nil {
+		return nil, errors.New("semantic: graph owner is required")
+	}
+	return owner, nil
+}
+
+func (r *SemanticRepositoryImpl) SemanticGraph(ctx context.Context, input SemanticGraphQuery) (*SemanticGraphSnapshot, error) {
+	input = graphpostgres.NormalizeQuery(input)
+	if err := graphpostgres.ValidateQuery(input); err != nil {
+		return nil, err
+	}
+	owner, err := r.graphOwner()
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph: %w", err)
+	}
+	return owner.SemanticGraph(ctx, input)
+}
+
+func (r *SemanticRepositoryImpl) SemanticGraphNodeDetail(ctx context.Context, input SemanticGraphNodeDetailInput) (*SemanticGraphNode, error) {
+	input = graphpostgres.NormalizeNodeDetailInput(input)
+	if err := graphpostgres.ValidateNodeDetailInput(input); err != nil {
+		return nil, err
+	}
+	owner, err := r.graphOwner()
+	if err != nil {
+		return nil, fmt.Errorf("semantic graph node: %w", err)
+	}
+	return owner.SemanticGraphNodeDetail(ctx, input)
+}
+
+// These narrow helpers keep the legacy trace adapter on the same graph read
+// owner while its public compatibility contract remains in repository aliases.
+type semanticGraphEdgeRow = graphread.Row
+
+type semanticGraphExecutionQuery struct {
+	SemanticGraphQuery
+	spaceID string
+}
+
+func loadSemanticLocalGraphRows(ctx context.Context, tx *gorm.DB, input semanticGraphExecutionQuery) ([]semanticGraphEdgeRow, error) {
+	return graphpostgres.LoadLocalRows(ctx, tx, input.SemanticGraphQuery, input.spaceID)
+}
+
+func semanticGraphSnapshot(input SemanticGraphQuery, rows []semanticGraphEdgeRow) *SemanticGraphSnapshot {
+	return graphread.Snapshot(input, rows)
+}
 
 const (
 	defaultSemanticGraphLimit = 80
@@ -21,395 +84,12 @@ const (
 	maxSemanticGraphDepth     = 5
 )
 
-func (r *SemanticRepositoryImpl) SemanticGraph(
-	ctx context.Context,
-	input SemanticGraphQuery,
-) (*SemanticGraphSnapshot, error) {
-	input = normalizeSemanticGraphQuery(input)
-	if err := validateSemanticGraphQuery(input); err != nil {
-		return nil, err
-	}
-	var rows []semanticGraphEdgeRow
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		var err error
-		execution := semanticGraphExecutionQuery{SemanticGraphQuery: input}
-		if input.Scope == "local" {
-			rows, err = loadSemanticLocalGraphRows(ctx, tx, execution)
-		} else {
-			rows, err = loadSemanticOverviewGraphRows(ctx, tx, execution)
-		}
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("semantic graph: %w", err)
-	}
-	return semanticGraphSnapshot(input, rows), nil
-}
-
-func (r *SemanticRepositoryImpl) SemanticGraphNodeDetail(
-	ctx context.Context,
-	input SemanticGraphNodeDetailInput,
-) (*SemanticGraphNode, error) {
-	input = normalizeSemanticGraphNodeDetailInput(input)
-	if err := validateSemanticGraphNodeDetailInput(input); err != nil {
-		return nil, err
-	}
-	var node *SemanticGraphNode
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		var err error
-		switch input.NodeType {
-		case "entity":
-			node, err = loadSemanticEntityGraphNode(ctx, tx, input.TeamID, input.NodeID)
-		case "value":
-			node, err = loadSemanticValueGraphNode(ctx, tx, input.TeamID, input.NodeID)
-		default:
-			return sql.ErrNoRows
-		}
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("semantic graph node: %w", err)
-	}
-	return node, nil
-}
-
-type semanticGraphEdgeRow = graphread.Row
-
-// semanticGraphExecutionQuery carries adapter-derived scope separately from
-// the caller-owned graph contract.
-type semanticGraphExecutionQuery struct {
-	SemanticGraphQuery
-	spaceID string
-}
-
 func normalizeSemanticGraphQuery(input SemanticGraphQuery) SemanticGraphQuery {
-	input.TeamID = strings.TrimSpace(input.TeamID)
-	input.Scope = strings.ToLower(strings.TrimSpace(input.Scope))
-	if input.Scope == "" || input.Scope != "local" {
-		input.Scope = "overview"
-	}
-	input.Query = strings.ToLower(strings.TrimSpace(input.Query))
-	input.AnchorType = normalizeSemanticGraphNodeType(input.AnchorType)
-	input.AnchorID = strings.TrimSpace(input.AnchorID)
-	input.Types = normalizeSemanticGraphTypes(input.Types)
-	input.Depth = clampInt(input.Depth, defaultSemanticGraphDepth, maxSemanticGraphDepth)
-	input.Limit = defaultPositiveInt(input.Limit, defaultSemanticGraphLimit)
-	input.MinRelevance = normalizeRelevance(input.MinRelevance)
-	return input
-}
-
-func validateSemanticGraphQuery(input SemanticGraphQuery) error {
-	if _, err := uuid.Parse(input.TeamID); err != nil {
-		return fmt.Errorf("team_id is required: %w", err)
-	}
-	if input.Scope == "local" {
-		if input.AnchorType == "" {
-			return errors.New("anchor_type is required for local graph")
-		}
-		if _, err := uuid.Parse(input.AnchorID); err != nil {
-			return fmt.Errorf("anchor_id is required for local graph: %w", err)
-		}
-	}
-	return nil
+	return graphpostgres.NormalizeQuery(input)
 }
 
 func normalizeSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) SemanticGraphNodeDetailInput {
-	input.TeamID = strings.TrimSpace(input.TeamID)
-	input.NodeType = normalizeSemanticGraphNodeType(input.NodeType)
-	input.NodeID = strings.TrimSpace(input.NodeID)
-	return input
-}
-
-func validateSemanticGraphNodeDetailInput(input SemanticGraphNodeDetailInput) error {
-	if _, err := uuid.Parse(input.TeamID); err != nil {
-		return fmt.Errorf("team_id is required: %w", err)
-	}
-	if input.NodeType == "" {
-		return errors.New("node_type must be entity or value")
-	}
-	if _, err := uuid.Parse(input.NodeID); err != nil {
-		return fmt.Errorf("node_id is required: %w", err)
-	}
-	return nil
-}
-
-func loadSemanticOverviewGraphRows(
-	ctx context.Context,
-	tx *gorm.DB,
-	input semanticGraphExecutionQuery,
-) ([]semanticGraphEdgeRow, error) {
-	extraWhere := ""
-	var extraArgs []any
-	if input.spaceID != "" {
-		extraWhere = " AND edge_record.space_id = ?::uuid"
-		extraArgs = append(extraArgs, input.spaceID)
-	}
-	rows, err := tx.WithContext(ctx).Raw(
-		semanticGraphEdgesSQL(extraWhere),
-		semanticGraphQueryArgs(input, input.Limit, extraArgs...)...,
-	).Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return scanSemanticGraphRows(rows, input.Types)
-}
-
-func loadSemanticLocalGraphRows(
-	ctx context.Context,
-	tx *gorm.DB,
-	input semanticGraphExecutionQuery,
-) ([]semanticGraphEdgeRow, error) {
-	anchor := semanticGraphNodeKey(input.AnchorType, input.AnchorID)
-	if anchor == "" {
-		return nil, sql.ErrNoRows
-	}
-	return graphread.Traverse(ctx, anchor, input.Depth, input.Limit, func(ctx context.Context, frontier []string, limit int) ([]graphread.Row, error) {
-		extraWhere := `
-		  AND (
-		    ('entity:' || e.subject_entity_id::text) = ANY(?::text[])
-		    OR (CASE
-		      WHEN e.object_entity_id IS NOT NULL THEN 'entity:' || e.object_entity_id::text
-		      ELSE 'value:' || e.object_value_id::text
-		    END) = ANY(?::text[])
-		  )
-		`
-		extraArgs := []any{pq.Array(frontier), pq.Array(frontier)}
-		if input.spaceID != "" {
-			extraWhere += " AND edge_record.space_id = ?::uuid"
-			extraArgs = append(extraArgs, input.spaceID)
-		}
-		rows, err := tx.WithContext(ctx).Raw(
-			semanticGraphEdgesSQL(extraWhere),
-			semanticGraphQueryArgs(input, limit, extraArgs...)...,
-		).Rows()
-		if err != nil {
-			return nil, err
-		}
-		batch, err := scanSemanticGraphRows(rows, input.Types)
-		if closeErr := rows.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-		if err != nil {
-			return nil, err
-		}
-		return batch, nil
-	})
-}
-
-func semanticGraphEdgesSQL(extraWhere string) string {
-	searchText := semanticGraphSearchTextSQL()
-	return `
-			SELECT e.relationship_id::text,
-			       e.owner_profile_id::text,
-			       e.predicate_key,
-			       e.support_count,
-		       e.source_group_count,
-		       ('entity:' || e.subject_entity_id::text) AS source_key,
-		       e.subject_entity_id::text AS source_id,
-		       COALESCE(subject_name.display_name, e.subject_entity_id::text) AS source_title,
-		       subject.entity_kind AS source_body,
-		       subject.status AS source_status,
-		       e.owner_profile_id::text AS source_owner_profile_id,
-		       subject.updated_at AS source_recorded_at,
-		       CASE
-		         WHEN e.object_entity_id IS NOT NULL THEN 'entity:' || e.object_entity_id::text
-		         ELSE 'value:' || e.object_value_id::text
-		       END AS target_key,
-		       COALESCE(e.object_entity_id::text, e.object_value_id::text) AS target_id,
-		       CASE WHEN e.object_entity_id IS NOT NULL THEN 'entity' ELSE 'value' END AS target_type,
-		       COALESCE(object_name.display_name, NULLIF(value.display, ''), value.canonical_value, e.object_entity_id::text, e.object_value_id::text) AS target_title,
-		       COALESCE(object.entity_kind, value.value_type, '') AS target_body,
-		       COALESCE(object.status, 'active') AS target_status,
-		       e.owner_profile_id::text AS target_owner_profile_id,
-		       COALESCE(object.updated_at, value.created_at, subject.updated_at) AS target_recorded_at
-		FROM semantic_edges e
-		JOIN relationship_records edge_record
-		  ON edge_record.team_id = e.team_id
-		 AND edge_record.relationship_id = e.relationship_id
-		JOIN entity_records subject
-		  ON subject.team_id = e.team_id
-		 AND subject.entity_id = e.subject_entity_id
-		 AND subject.space_id = edge_record.space_id
-		LEFT JOIN LATERAL (
-		  SELECT display_name
-		  FROM entity_names
-		  WHERE team_id = e.team_id
-		    AND entity_id = e.subject_entity_id
-		    AND space_id = edge_record.space_id
-		    AND ` + activeSemanticSpaceGenerationSQL("entity_names") + `
-		    AND name_kind = 'canonical'
-		    AND valid_to IS NULL
-		  ORDER BY created_at DESC, entity_name_id DESC
-		  LIMIT 1
-		) subject_name ON true
-		LEFT JOIN entity_records object
-		  ON object.team_id = e.team_id
-		 AND object.entity_id = e.object_entity_id
-		 AND object.space_id = edge_record.space_id
-		LEFT JOIN LATERAL (
-		  SELECT display_name
-		  FROM entity_names
-		  WHERE team_id = e.team_id
-		    AND entity_id = e.object_entity_id
-		    AND space_id = edge_record.space_id
-		    AND ` + activeSemanticSpaceGenerationSQL("entity_names") + `
-		    AND name_kind = 'canonical'
-		    AND valid_to IS NULL
-		  ORDER BY created_at DESC, entity_name_id DESC
-		  LIMIT 1
-		) object_name ON true
-		LEFT JOIN value_records value
-		  ON value.team_id = e.team_id
-		 AND value.value_id = e.object_value_id
-		 AND value.space_id = edge_record.space_id
-		WHERE e.team_id = ?::uuid
-		  AND (
-		    edge_record.space_id = dense_mem_team_shared_space(edge_record.team_id)
-		    OR dense_mem_space_allowed(edge_record.space_id)
-		  )
-		  AND ` + activeSemanticSpaceGenerationSQL("edge_record") + `
-		  AND ` + activeSemanticSpaceGenerationSQL("subject") + `
-		  AND (
-		    e.object_entity_id IS NULL
-		    OR ` + activeSemanticSpaceGenerationSQL("object") + `
-		  )
-		  AND (
-		    e.object_entity_id IS NOT NULL
-		    OR ` + activeSemanticSpaceGenerationSQL("value") + `
-		  )
-		  AND subject.status = 'active'
-		  AND (
-		    e.object_entity_id IS NULL
-		    OR object.status = 'active'
-		  )
-		  AND (
-		    ? = ''
-		    OR ` + searchText + ` LIKE '%' || ? || '%'
-		    OR to_tsvector('simple', ` + searchText + `) @@ plainto_tsquery('simple', ?)
-		  )
-		  AND (
-		    ? <= 0
-		    OR ? = ''
-		    OR ts_rank_cd(to_tsvector('simple', ` + searchText + `), plainto_tsquery('simple', ?), 32) >= ?
-		  )
-	` + extraWhere + `
-		ORDER BY
-		  CASE
-		    WHEN ? = '' THEN 0
-		    ELSE ts_rank_cd(to_tsvector('simple', ` + searchText + `), plainto_tsquery('simple', ?), 32)
-		  END DESC,
-		  e.relationship_id ASC
-		LIMIT ?
-	`
-}
-
-func semanticGraphSearchTextSQL() string {
-	return `lower(COALESCE(subject_name.display_name, '') || ' ' || e.predicate_key || ' ' ||
-		             COALESCE(object_name.display_name, value.display, value.canonical_value, ''))`
-}
-
-func semanticGraphQueryArgs(input semanticGraphExecutionQuery, limit int, extraArgs ...any) []any {
-	args := []any{
-		input.TeamID,
-		input.Query,
-		input.Query,
-		input.Query,
-		input.MinRelevance,
-		input.Query,
-		input.Query,
-		input.MinRelevance,
-	}
-	args = append(args, extraArgs...)
-	args = append(args, input.Query, input.Query, limit)
-	return args
-}
-
-func scanSemanticGraphRows(rows *sql.Rows, types []string) ([]semanticGraphEdgeRow, error) {
-	return graphread.ScanRows(rows, types)
-}
-
-func loadSemanticEntityGraphNode(ctx context.Context, tx *gorm.DB, teamID, entityID string) (*SemanticGraphNode, error) {
-	rows, err := tx.WithContext(ctx).Raw(`
-		SELECT ('entity:' || e.entity_id::text), e.entity_id::text,
-		       COALESCE(name.display_name, e.entity_id::text), e.entity_kind,
-		       e.status, COALESCE(name.owner_profile_id::text, ''), e.updated_at
-		FROM entity_records e
-		LEFT JOIN LATERAL (
-		  SELECT display_name, owner_profile_id
-		  FROM entity_names
-		  WHERE team_id = e.team_id
-		    AND entity_id = e.entity_id
-		    AND space_id = e.space_id
-		    AND `+activeSemanticSpaceGenerationSQL("entity_names")+`
-		    AND name_kind = 'canonical'
-		    AND valid_to IS NULL
-		  ORDER BY created_at DESC, entity_name_id DESC
-		  LIMIT 1
-		) name ON true
-		WHERE e.team_id = ?::uuid
-		  AND e.entity_id = ?::uuid
-		  AND e.status = 'active'
-		  AND (
-		    e.space_id = dense_mem_team_shared_space(e.team_id)
-		    OR dense_mem_space_allowed(e.space_id)
-		  )
-		  AND `+activeSemanticSpaceGenerationSQL("e")+`
-		LIMIT 1
-	`, teamID, entityID).Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	if !rows.Next() {
-		return nil, sql.ErrNoRows
-	}
-	var node SemanticGraphNode
-	var recordedAt time.Time
-	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
-		return nil, err
-	}
-	node.Type = "entity"
-	t := recordedAt.UTC()
-	node.RecordedAt = &t
-	return &node, rows.Err()
-}
-
-func loadSemanticValueGraphNode(ctx context.Context, tx *gorm.DB, teamID, valueID string) (*SemanticGraphNode, error) {
-	rows, err := tx.WithContext(ctx).Raw(`
-		SELECT ('value:' || value_id::text), value_id::text,
-		       COALESCE(NULLIF(display, ''), canonical_value), value_type,
-		       'active', ''::text, created_at
-		FROM value_records AS value
-		WHERE value.team_id = ?::uuid
-		  AND value.value_id = ?::uuid
-		  AND (
-		    value.space_id = dense_mem_team_shared_space(value.team_id)
-		    OR dense_mem_space_allowed(value.space_id)
-		  )
-		  AND `+activeSemanticSpaceGenerationSQL("value")+`
-		LIMIT 1
-	`, teamID, valueID).Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	if !rows.Next() {
-		return nil, sql.ErrNoRows
-	}
-	var node SemanticGraphNode
-	var recordedAt time.Time
-	if err := rows.Scan(&node.Key, &node.ID, &node.Title, &node.Body, &node.Status, &node.OwnerProfileID, &recordedAt); err != nil {
-		return nil, err
-	}
-	node.Type = "value"
-	t := recordedAt.UTC()
-	node.RecordedAt = &t
-	return &node, rows.Err()
-}
-
-func semanticGraphSnapshot(input SemanticGraphQuery, rows []semanticGraphEdgeRow) *SemanticGraphSnapshot {
-	return graphread.Snapshot(input, rows)
+	return graphpostgres.NormalizeNodeDetailInput(input)
 }
 
 func normalizeSemanticGraphTypes(values []string) []string {

--- a/internal/repository/semantic_graph_repository_test.go
+++ b/internal/repository/semantic_graph_repository_test.go
@@ -1,20 +1,37 @@
 package repository
 
 import (
+	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
-func TestNormalizeSemanticGraphQueryDefaultsAndBounds(t *testing.T) {
-	defaults := normalizeSemanticGraphQuery(SemanticGraphQuery{})
-	assert.Equal(t, defaultSemanticGraphDepth, defaults.Depth)
-	assert.Equal(t, defaultSemanticGraphLimit, defaults.Limit)
+func TestSemanticGraphFacadeValidatesBeforeConfiguration(t *testing.T) {
+	ctx := context.Background()
+	repo := &SemanticRepositoryImpl{}
 
-	explicit := normalizeSemanticGraphQuery(SemanticGraphQuery{Depth: 99, Limit: 181})
-	assert.Equal(t, maxSemanticGraphDepth, explicit.Depth)
-	assert.Equal(t, 181, explicit.Limit)
+	_, err := repo.SemanticGraph(ctx, SemanticGraphQuery{TeamID: "not-a-uuid"})
+	require.ErrorContains(t, err, "team_id is required")
 
-	large := normalizeSemanticGraphQuery(SemanticGraphQuery{Limit: 1_000_000})
-	assert.Equal(t, 1_000_000, large.Limit)
+	_, err = repo.SemanticGraphNodeDetail(ctx, SemanticGraphNodeDetailInput{TeamID: "not-a-uuid"})
+	require.ErrorContains(t, err, "team_id is required")
+}
+
+func TestSemanticGraphFacadePreservesRLSConfigurationError(t *testing.T) {
+	ctx := context.Background()
+	repo := &SemanticRepositoryImpl{db: &gorm.DB{}}
+	teamID := uuid.NewString()
+
+	_, err := repo.SemanticGraph(ctx, SemanticGraphQuery{TeamID: teamID})
+	require.EqualError(t, err, "semantic graph: semantic: rls helper is required")
+
+	_, err = repo.SemanticGraphNodeDetail(ctx, SemanticGraphNodeDetailInput{
+		TeamID:   teamID,
+		NodeType: "entity",
+		NodeID:   uuid.NewString(),
+	})
+	require.EqualError(t, err, "semantic graph node: semantic: rls helper is required")
 }

--- a/internal/service/graphview/graphview.go
+++ b/internal/service/graphview/graphview.go
@@ -1,295 +1,33 @@
+// Package graphview preserves the legacy graph application names while the
+// live implementation is owned by internal/graph.
 package graphview
 
-import (
-	"context"
-	"database/sql"
-	"errors"
-	"fmt"
-	"strings"
-	"time"
+import graphapp "github.com/markhuangai/dense-mem/internal/graph"
 
-	"github.com/markhuangai/dense-mem/internal/repository"
-)
+type SemanticStore = graphapp.Store
+type Service = graphapp.Service
+type Query = graphapp.Query
+type Snapshot = graphapp.Snapshot
+type Anchor = graphapp.Anchor
+type Node = graphapp.Node
+type Edge = graphapp.Edge
 
 const (
-	ScopeOverview = "overview"
-	ScopeLocal    = "local"
-
-	DefaultLimit = 80
-	DefaultDepth = 2
-	MaxDepth     = 5
-
-	maxNodeBodyRunes = 420
+	ScopeOverview = graphapp.ScopeOverview
+	ScopeLocal    = graphapp.ScopeLocal
+	DefaultLimit  = graphapp.DefaultLimit
+	DefaultDepth  = graphapp.DefaultDepth
+	MaxDepth      = graphapp.MaxDepth
 )
 
 var (
-	ErrMissingAnchor     = errors.New("graph local view requires anchor_type and anchor_id")
-	ErrInvalidAnchorType = errors.New("unsupported graph anchor_type")
-	ErrMissingNode       = errors.New("graph node detail requires type and id")
-	ErrInvalidNodeType   = errors.New("unsupported graph node type")
-	ErrNodeNotFound      = errors.New("graph node not found")
+	ErrMissingAnchor     = graphapp.ErrMissingAnchor
+	ErrInvalidAnchorType = graphapp.ErrInvalidAnchorType
+	ErrMissingNode       = graphapp.ErrMissingNode
+	ErrInvalidNodeType   = graphapp.ErrInvalidNodeType
+	ErrNodeNotFound      = graphapp.ErrNodeNotFound
 )
 
-type SemanticStore interface {
-	SemanticGraph(ctx context.Context, input repository.SemanticGraphQuery) (*repository.SemanticGraphSnapshot, error)
-	SemanticGraphNodeDetail(ctx context.Context, input repository.SemanticGraphNodeDetailInput) (*repository.SemanticGraphNode, error)
-}
-
-type Service interface {
-	Graph(ctx context.Context, profileID string, query Query) (*Snapshot, error)
-	NodeDetail(ctx context.Context, profileID string, nodeType string, nodeID string) (*Node, error)
-}
-
-type Query struct {
-	Scope      string
-	Query      string
-	Types      []string
-	AnchorType string
-	AnchorID   string
-	Depth      int
-	Limit      int
-}
-
-type Snapshot struct {
-	Scope     string  `json:"scope"`
-	Query     string  `json:"query,omitempty"`
-	Anchor    *Anchor `json:"anchor,omitempty"`
-	Depth     int     `json:"depth"`
-	Limit     int     `json:"limit"`
-	Truncated bool    `json:"truncated"`
-	Nodes     []Node  `json:"nodes"`
-	Edges     []Edge  `json:"edges"`
-}
-
-type Anchor struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Key  string `json:"key"`
-}
-
-type Node struct {
-	Key         string     `json:"key"`
-	ID          string     `json:"id"`
-	Type        string     `json:"type"`
-	Title       string     `json:"title"`
-	Body        string     `json:"body,omitempty"`
-	Status      string     `json:"status,omitempty"`
-	CommunityID string     `json:"community_id,omitempty"`
-	Source      string     `json:"source,omitempty"`
-	Score       float64    `json:"score,omitempty"`
-	RecordedAt  *time.Time `json:"recorded_at,omitempty"`
-}
-
-type Edge struct {
-	ID           string `json:"id"`
-	Source       string `json:"source"`
-	Target       string `json:"target"`
-	Relationship string `json:"relationship"`
-	Directed     bool   `json:"directed"`
-}
-
-type semanticService struct {
-	store SemanticStore
-}
-
-var _ Service = (*semanticService)(nil)
-
 func NewSemantic(store SemanticStore) Service {
-	return &semanticService{store: store}
-}
-
-type normalizedSemanticQuery struct {
-	scope      string
-	search     string
-	types      []string
-	anchorType string
-	anchorID   string
-	depth      int
-	limit      int
-}
-
-func (s *semanticService) Graph(ctx context.Context, teamID string, query Query) (*Snapshot, error) {
-	if s == nil || s.store == nil {
-		return nil, errors.New("graph view semantic store is not configured")
-	}
-	normalized, err := normalizeSemanticQuery(query)
-	if err != nil {
-		return nil, err
-	}
-	snapshot, err := s.store.SemanticGraph(ctx, repository.SemanticGraphQuery{
-		TeamID:     strings.TrimSpace(teamID),
-		Scope:      normalized.scope,
-		Query:      normalized.search,
-		Types:      normalized.types,
-		AnchorType: normalized.anchorType,
-		AnchorID:   normalized.anchorID,
-		Depth:      normalized.depth,
-		Limit:      normalized.limit,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("semantic graph view: %w", err)
-	}
-	return snapshotFromSemantic(snapshot), nil
-}
-
-func (s *semanticService) NodeDetail(ctx context.Context, teamID string, nodeType string, nodeID string) (*Node, error) {
-	if s == nil || s.store == nil {
-		return nil, errors.New("graph view semantic store is not configured")
-	}
-	normalizedType := normalizeSemanticGraphType(nodeType)
-	normalizedID := strings.TrimSpace(nodeID)
-	if normalizedType == "" && strings.TrimSpace(nodeType) != "" {
-		return nil, ErrInvalidNodeType
-	}
-	if normalizedType == "" || normalizedID == "" {
-		return nil, ErrMissingNode
-	}
-	node, err := s.store.SemanticGraphNodeDetail(ctx, repository.SemanticGraphNodeDetailInput{
-		TeamID:   strings.TrimSpace(teamID),
-		NodeType: normalizedType,
-		NodeID:   normalizedID,
-	})
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNodeNotFound
-		}
-		return nil, fmt.Errorf("semantic graph node detail: %w", err)
-	}
-	if node == nil {
-		return nil, ErrNodeNotFound
-	}
-	return nodeFromSemantic(*node), nil
-}
-
-func normalizeSemanticQuery(query Query) (normalizedSemanticQuery, error) {
-	scope := strings.ToLower(strings.TrimSpace(query.Scope))
-	if scope == "" || scope != ScopeLocal {
-		scope = ScopeOverview
-	}
-	normalized := normalizedSemanticQuery{
-		scope:  scope,
-		search: strings.ToLower(strings.TrimSpace(query.Query)),
-		types:  normalizeSemanticGraphTypes(query.Types),
-		limit:  defaultPositive(query.Limit, DefaultLimit),
-		depth:  clamp(query.Depth, DefaultDepth, MaxDepth),
-	}
-	if normalized.scope == ScopeLocal {
-		normalized.anchorType = normalizeSemanticGraphType(query.AnchorType)
-		normalized.anchorID = strings.TrimSpace(query.AnchorID)
-		if normalized.anchorType == "" && strings.TrimSpace(query.AnchorType) != "" {
-			return normalizedSemanticQuery{}, ErrInvalidAnchorType
-		}
-		if normalized.anchorType == "" || normalized.anchorID == "" {
-			return normalizedSemanticQuery{}, ErrMissingAnchor
-		}
-	}
-	return normalized, nil
-}
-
-func normalizeSemanticGraphTypes(values []string) []string {
-	seen := map[string]struct{}{}
-	out := make([]string, 0, len(values))
-	for _, raw := range values {
-		normalized := normalizeSemanticGraphType(raw)
-		if normalized == "" {
-			continue
-		}
-		if _, exists := seen[normalized]; exists {
-			continue
-		}
-		seen[normalized] = struct{}{}
-		out = append(out, normalized)
-	}
-	if len(out) == 0 {
-		return []string{"entity", "value"}
-	}
-	return out
-}
-
-func normalizeSemanticGraphType(raw string) string {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "entity", "entities":
-		return "entity"
-	case "value", "values":
-		return "value"
-	default:
-		return ""
-	}
-}
-
-func clamp(value, defaultValue, maxValue int) int {
-	if value <= 0 {
-		return defaultValue
-	}
-	if value > maxValue {
-		return maxValue
-	}
-	return value
-}
-
-func defaultPositive(value, defaultValue int) int {
-	if value <= 0 {
-		return defaultValue
-	}
-	return value
-}
-
-func snapshotFromSemantic(snapshot *repository.SemanticGraphSnapshot) *Snapshot {
-	if snapshot == nil {
-		return &Snapshot{Nodes: []Node{}, Edges: []Edge{}}
-	}
-	out := &Snapshot{
-		Scope:     snapshot.Scope,
-		Query:     snapshot.Query,
-		Depth:     snapshot.Depth,
-		Limit:     snapshot.Limit,
-		Truncated: snapshot.Truncated,
-		Nodes:     make([]Node, 0, len(snapshot.Nodes)),
-		Edges:     make([]Edge, 0, len(snapshot.Edges)),
-	}
-	if snapshot.Anchor != nil {
-		out.Anchor = &Anchor{
-			Type: snapshot.Anchor.Type,
-			ID:   snapshot.Anchor.ID,
-			Key:  snapshot.Anchor.Key,
-		}
-	}
-	for _, node := range snapshot.Nodes {
-		out.Nodes = append(out.Nodes, *nodeFromSemantic(node))
-	}
-	for _, edge := range snapshot.Edges {
-		out.Edges = append(out.Edges, Edge{
-			ID:           edge.ID,
-			Source:       edge.Source,
-			Target:       edge.Target,
-			Relationship: edge.Relationship,
-			Directed:     edge.Directed,
-		})
-	}
-	return out
-}
-
-func nodeFromSemantic(node repository.SemanticGraphNode) *Node {
-	title := truncateText(node.Title, 160)
-	if title == "" {
-		title = node.ID
-	}
-	return &Node{
-		Key:        node.Key,
-		ID:         node.ID,
-		Type:       node.Type,
-		Title:      title,
-		Body:       truncateText(node.Body, maxNodeBodyRunes),
-		Status:     node.Status,
-		RecordedAt: node.RecordedAt,
-	}
-}
-
-func truncateText(value string, maxRunes int) string {
-	value = strings.TrimSpace(value)
-	runes := []rune(value)
-	if len(runes) <= maxRunes {
-		return value
-	}
-	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
+	return graphapp.New(store)
 }

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -26,7 +26,7 @@ go test ${packages}
 packages="$(
 	go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./internal/... |
 		sed '/^$/d' |
-		grep -Ev '/(evalharness|repository|knowledge/postgres|dream/postgres|trace/postgres)$|/storage/(neo4j|postgres|redis)$'
+		grep -Ev '/(evalharness|repository|knowledge/postgres|dream/postgres|trace/postgres|graph/postgres)$|/storage/(neo4j|postgres|redis)$'
 )"
 
 printf '%s\n' "${packages}"

--- a/scripts/e2e-host-controller-stack.sh
+++ b/scripts/e2e-host-controller-stack.sh
@@ -232,11 +232,12 @@ NODE
 
   if [[ -n "$helpers" ]]; then
     DENSE_MEM_CI_COMPOSE_OVERLAY_FILE="${DENSE_MEM_CI_HELPER_DIR}/compose.yml"
-    node - "$DENSE_MEM_CI_COMPOSE_OVERLAY_FILE" "$helpers" "$oauth_token" "$harness_image" "$provider_dimensions" "$CONFLICT_PROVIDER_EMBEDDING_MODEL" <<'NODE'
+    node - "$DENSE_MEM_CI_COMPOSE_OVERLAY_FILE" "$helpers" "$oauth_token" "$harness_image" "$provider_dimensions" "$CONFLICT_PROVIDER_EMBEDDING_MODEL" "$scenario" <<'NODE'
 const fs = require("node:fs");
-const [destination, helpers, oauthToken, harnessImage, providerDimensions, conflictProviderEmbeddingModel] = process.argv.slice(2);
+const [destination, helpers, oauthToken, harnessImage, providerDimensions, conflictProviderEmbeddingModel, scenario] = process.argv.slice(2);
 const has = (name) => new Set(helpers.split(",").filter(Boolean)).has(name);
 const conflictProviderDimensions = has("synchronous_write") ? (providerDimensions || "1536") : "1536";
+const deterministicEmbeddingProvider = scenario === "community" || has("synchronous_write");
 const lines = ["# dense-mem-ci-e2e.v1 generated helper overlay", "services:"];
 const serverEnvironment = new Map();
 const serverVolumes = [];
@@ -247,6 +248,12 @@ if (has("verifier")) {
     AI_VERIFIER_API_KEY: "dense-mem-e2e-verifier-key",
     AI_VERIFIER_MODEL: "dense-mem-e2e-verifier",
     AI_VERIFIER_DISABLE_TEMPERATURE: "true",
+  })) serverEnvironment.set(key, value);
+}
+if (scenario === "community") {
+  for (const [key, value] of Object.entries({
+    AI_API_URL: "http://synchronous-write-provider:8787/v1",
+    AI_API_KEY: "dense-mem-community-e2e-key",
   })) serverEnvironment.set(key, value);
 }
 if (has("conflict_provider")) {
@@ -273,12 +280,15 @@ if (has("synchronous_write")) {
     AI_VERIFIER_TIMEOUT_SECONDS: "2",
     AI_VERIFIER_DISABLE_TEMPERATURE: "true",
   })) serverEnvironment.set(key, value);
-  helperServices.push(["synchronous-write-provider", [
+}
+if (deterministicEmbeddingProvider) {
+  const providerService = [
     "    command: [\"sh\", \"-c\", \"sleep infinity\"]",
     "    environment:",
     `      DENSE_MEM_E2E_PROVIDER_DIMENSIONS: ${JSON.stringify(providerDimensions || "1536")}`,
-    "      DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS: \"5000\"",
-  ]]);
+  ];
+  if (has("synchronous_write")) providerService.push("      DENSE_MEM_E2E_PROVIDER_TIMEOUT_DELAY_MS: \"5000\"");
+  helperServices.push(["synchronous-write-provider", providerService]);
 }
 if (has("oauth") || has("oauth_compatibility")) {
   serverEnvironment.set("SSL_CERT_FILE", "/e2e/oauth-files/ca.pem");

--- a/scripts/e2e-host-controller-stack.sh
+++ b/scripts/e2e-host-controller-stack.sh
@@ -43,7 +43,7 @@ run_go_source_container() (
       -e "DOCKER_HOST=unix://${docker_socket}"
     )
   fi
-  docker_args+=("${environment_args[@]}" "$image" "${command[@]}")
+  docker_args+=("${environment_args[@]}" -e "GOPROXY=https://proxy.golang.org|direct" "$image" "${command[@]}")
 
   cleanup_go_container() {
     local status=$?

--- a/tests/uat/architecture_conformance.test.mjs
+++ b/tests/uat/architecture_conformance.test.mjs
@@ -487,7 +487,7 @@ test("enforces private visibility and narrow PostgreSQL infrastructure reuse", (
 
 test("retains precise replacement owners and lifecycle obligations", () => {
   const exceptionOwners = [...new Set(productionManifest.exceptions.map((entry) => entry.removal_issue))].sort((a, b) => a - b);
-  assert.deepEqual(exceptionOwners, [366, 367, 370, 375, 376, 377, 379, 380, 382]);
+  assert.deepEqual(exceptionOwners, [367, 370, 375, 376, 377, 379, 380, 382]);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 276), false);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 280), false);
   assert.ok(productionManifest.workers.every((entry) => entry.lifecycle_issue === 381));

--- a/tests/uat/e2e_host_controller.test.mjs
+++ b/tests/uat/e2e_host_controller.test.mjs
@@ -552,12 +552,24 @@ test("verifier scenarios use the deterministic provider without replacing embedd
   assert.match(compose, /profiles: \[synchronous_write, verifier\]/);
   assert.match(realController, /"  synchronous-write-provider:"[\s\S]*"    profiles: \[synchronous_write, verifier\]"/);
   const verifierStart = stack.indexOf('if (has("verifier"))');
-  const verifierEnd = stack.indexOf('if (has("conflict_provider"))', verifierStart);
+  const verifierEnd = stack.indexOf('if (scenario === "community")', verifierStart);
   assert.ok(verifierStart >= 0 && verifierEnd > verifierStart);
   const verifierBlock = stack.slice(verifierStart, verifierEnd);
   assert.match(verifierBlock, /AI_VERIFIER_API_URL: "http:\/\/synchronous-write-provider:8787\/v1"/);
   assert.doesNotMatch(verifierBlock, /\bAI_API_URL:/);
   assert.match(stack, /has_helper "\$helpers" verifier \|\| has_helper "\$helpers" synchronous_write/);
+});
+
+test("community scenarios use the verifier fixture for embeddings without changing the embedding contract", () => {
+  const communityStart = stack.indexOf('if (scenario === "community")');
+  const communityEnd = stack.indexOf('if (has("conflict_provider"))', communityStart);
+  assert.ok(communityStart >= 0 && communityEnd > communityStart);
+  const communityBlock = stack.slice(communityStart, communityEnd);
+  assert.match(communityBlock, /AI_API_URL: "http:\/\/synchronous-write-provider:8787\/v1"/);
+  assert.match(communityBlock, /AI_API_KEY: "dense-mem-community-e2e-key"/);
+  assert.doesNotMatch(communityBlock, /AI_API_EMBEDDING_(MODEL|DIMENSIONS):/);
+  assert.match(stack, /const deterministicEmbeddingProvider = scenario === "community" \|\| has\("synchronous_write"\);/);
+  assert.match(stack, /DENSE_MEM_E2E_PROVIDER_DIMENSIONS: \$\{JSON\.stringify\(providerDimensions \|\| "1536"\)\}/);
 });
 
 test("scenario runner executes Entra and diagnostics through the shared path", () => {

--- a/tests/uat/e2e_host_controller.test.mjs
+++ b/tests/uat/e2e_host_controller.test.mjs
@@ -572,6 +572,10 @@ test("community scenarios use the verifier fixture for embeddings without changi
   assert.match(stack, /DENSE_MEM_E2E_PROVIDER_DIMENSIONS: \$\{JSON\.stringify\(providerDimensions \|\| "1536"\)\}/);
 });
 
+test("Go helper containers fall back from module proxy transport errors", () => {
+  assert.match(stack, /-e "GOPROXY=https:\/\/proxy\.golang\.org\|direct"/);
+});
+
 test("scenario runner executes Entra and diagnostics through the shared path", () => {
   assert.match(scenario, /dense-mem CI scenario \[%s\]/);
   assert.match(scenario, /log "running \$\{script\}"/);

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -15,6 +15,7 @@ const {
   decidePreviewEvent,
   decideRcPreview,
   parseSuccessfulPolicyStatus,
+  resolvePreviewAttempt,
   selectMergedPull,
   validatePinnedProductionImageReference,
   validateProductionImageReference,
@@ -783,6 +784,78 @@ test("owner-admin PR pushes run automatically without an approval label", () => 
     }),
     { mode: "attempt", reason: "owner_admin_pr" },
   );
+});
+
+test("preview resolver falls back to GraphQL after a too-many-files REST response", async () => {
+  const headSHA = "a".repeat(40);
+  const error = Object.assign(new Error("Request failed"), {
+    status: 422,
+    response: { data: { message: "The request could not be processed because too many files changed" } },
+  });
+  let graphQLCalled = false;
+  const resolved = await resolvePreviewAttempt({
+    github: {
+      rest: { pulls: { get: async () => { throw error; } } },
+      graphql: async (_query, variables) => {
+        graphQLCalled = true;
+        assert.deepEqual(variables, { owner: "markhuangai", repo: "dense-mem", number: 42 });
+        return {
+          repository: {
+            pullRequest: {
+              number: 42,
+              state: "OPEN",
+              baseRefName: "main",
+              headRefOid: headSHA,
+              author: { login: "Z-M-Huang" },
+              headRepository: { nameWithOwner: "markhuangai/dense-mem" },
+              labels: { nodes: [{ name: "deploy-test-image" }] },
+            },
+          },
+        };
+      },
+    },
+    context: {
+      repo: { owner: "markhuangai", repo: "dense-mem" },
+      payload: { action: "synchronize", pull_request: { number: 42, head: { sha: headSHA } } },
+    },
+    actorPermission: "admin",
+    authorPermission: "admin",
+  });
+
+  assert.equal(graphQLCalled, true);
+  assert.deepEqual(resolved, {
+    mode: "attempt",
+    reason: "owner_admin_pr",
+    removeLabel: true,
+    pullNumber: 42,
+    headSha: headSHA,
+    headRepository: "markhuangai/dense-mem",
+  });
+});
+
+test("preview resolver does not mask unrelated pull-request API failures", async () => {
+  const error = Object.assign(new Error("service unavailable"), { status: 503 });
+  let graphQLCalled = false;
+
+  await assert.rejects(
+    resolvePreviewAttempt({
+      github: {
+        rest: { pulls: { get: async () => { throw error; } } },
+        graphql: async () => {
+          graphQLCalled = true;
+          return null;
+        },
+      },
+      context: {
+        repo: { owner: "markhuangai", repo: "dense-mem" },
+        payload: { action: "synchronize", pull_request: { number: 42, head: { sha: "b".repeat(40) } } },
+      },
+      actorPermission: "admin",
+      authorPermission: "admin",
+    }),
+    /service unavailable/,
+  );
+  assert.equal(graphQLCalled, false);
 });
 
 test("non-owner pushes wait for a fresh approval", () => {

--- a/tests/uat/image_release_policy.test.mjs
+++ b/tests/uat/image_release_policy.test.mjs
@@ -798,7 +798,7 @@ test("preview resolver falls back to GraphQL after a too-many-files REST respons
       rest: { pulls: { get: async () => { throw error; } } },
       graphql: async (_query, variables) => {
         graphQLCalled = true;
-        assert.deepEqual(variables, { owner: "markhuangai", repo: "dense-mem", number: 42 });
+        assert.deepEqual(variables, { owner: "markhuangai", repo: "dense-mem", number: 42, labelCursor: null });
         return {
           repository: {
             pullRequest: {
@@ -808,7 +808,10 @@ test("preview resolver falls back to GraphQL after a too-many-files REST respons
               headRefOid: headSHA,
               author: { login: "Z-M-Huang" },
               headRepository: { nameWithOwner: "markhuangai/dense-mem" },
-              labels: { nodes: [{ name: "deploy-test-image" }] },
+              labels: {
+                nodes: [{ name: "deploy-test-image" }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
             },
           },
         };
@@ -823,6 +826,62 @@ test("preview resolver falls back to GraphQL after a too-many-files REST respons
   });
 
   assert.equal(graphQLCalled, true);
+  assert.deepEqual(resolved, {
+    mode: "attempt",
+    reason: "owner_admin_pr",
+    removeLabel: true,
+    pullNumber: 42,
+    headSha: headSHA,
+    headRepository: "markhuangai/dense-mem",
+  });
+});
+
+test("preview resolver follows GraphQL label pages after a too-many-files REST response", async () => {
+  const headSHA = "c".repeat(40);
+  const error = Object.assign(new Error("Request failed"), {
+    status: 422,
+    response: { data: { message: "The request could not be processed because too many files changed" } },
+  });
+  const cursors = [];
+  const resolved = await resolvePreviewAttempt({
+    github: {
+      rest: { pulls: { get: async () => { throw error; } } },
+      graphql: async (query, variables) => {
+        assert.match(query, /labels\(first: 100, after: \$labelCursor\)/);
+        cursors.push(variables.labelCursor);
+        const labels = variables.labelCursor === null
+          ? {
+              nodes: Array.from({ length: 100 }, (_, index) => ({ name: `other-label-${index}` })),
+              pageInfo: { hasNextPage: true, endCursor: "labels-page-1" },
+            }
+          : {
+              nodes: [{ name: "deploy-test-image" }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            };
+        return {
+          repository: {
+            pullRequest: {
+              number: 42,
+              state: "OPEN",
+              baseRefName: "main",
+              headRefOid: headSHA,
+              author: { login: "Z-M-Huang" },
+              headRepository: { nameWithOwner: "markhuangai/dense-mem" },
+              labels,
+            },
+          },
+        };
+      },
+    },
+    context: {
+      repo: { owner: "markhuangai", repo: "dense-mem" },
+      payload: { action: "synchronize", pull_request: { number: 42, head: { sha: headSHA } } },
+    },
+    actorPermission: "admin",
+    authorPermission: "admin",
+  });
+
+  assert.deepEqual(cursors, [null, "labels-page-1"]);
   assert.deepEqual(resolved, {
     mode: "attempt",
     reason: "owner_admin_pr",

--- a/web/tests-compose/compose-portal.spec.ts
+++ b/web/tests-compose/compose-portal.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type APIRequestContext, type Locator, type Page, test } from "@playwright/test";
+import "./graph-views";
 
 const controlUrl = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
 const userUrl = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");

--- a/web/tests-compose/graph-views.ts
+++ b/web/tests-compose/graph-views.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+const userUrl = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const seedApiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
+const dreamStatement = requiredEnv("DENSE_MEM_E2E_DREAM_STATEMENT");
+
+export function registerGraphViewTests() {
+  test("graph views preserve scoped reads and adverse boundaries", async ({ request }) => {
+    const headers = { Authorization: `Bearer ${seedApiKey}` };
+    const overviewResponse = await request.get(`${userUrl}/ui/api/graph`, {
+      headers,
+      params: { scope: "overview" },
+    });
+    expect(overviewResponse.status()).toBe(200);
+    const overview = (await overviewResponse.json() as {
+      data?: {
+        scope?: string;
+        depth?: number;
+        limit?: number;
+        nodes?: Array<{ id?: string; key?: string; type?: string }>;
+        edges?: Array<{ id?: string; source?: string; target?: string }>;
+      };
+    }).data;
+    expect(overview?.scope).toBe("overview");
+    expect(overview?.depth).toBe(2);
+    expect(overview?.limit).toBe(80);
+    expect(Array.isArray(overview?.nodes)).toBe(true);
+    expect(Array.isArray(overview?.edges)).toBe(true);
+    for (const node of overview?.nodes ?? []) {
+      expect(["entity", "value"]).toContain(node.type);
+      expect(node.id).toBeTruthy();
+      expect(node.key).toBeTruthy();
+    }
+    for (const edge of overview?.edges ?? []) {
+      expect(edge.id).toBeTruthy();
+      expect(edge.source).toBeTruthy();
+      expect(edge.target).toBeTruthy();
+    }
+
+    const repeatResponse = await request.get(`${userUrl}/ui/api/graph`, {
+      headers,
+      params: { scope: "overview" },
+    });
+    expect(repeatResponse.status()).toBe(200);
+    const repeat = (await repeatResponse.json() as { data?: unknown }).data;
+    expect(JSON.stringify(repeat)).toBe(JSON.stringify(overview));
+
+    const dreamsResponse = await request.get(`${userUrl}/ui/api/dreams`, {
+      headers,
+      params: { limit: "20" },
+    });
+    expect(dreamsResponse.status()).toBe(200);
+    const dreams = (await dreamsResponse.json() as {
+      data?: { items?: Array<{ dream_id?: string; hypothesis?: string }> };
+    }).data?.items ?? [];
+    const seededDream = dreams.find((dream) => dream.hypothesis === dreamStatement);
+    expect(seededDream?.dream_id).toBeTruthy();
+    const graphNodeIDs = new Set((overview?.nodes ?? []).map((node) => node.id));
+    for (const dream of dreams) {
+      expect(dream.dream_id).toBeTruthy();
+      expect(graphNodeIDs.has(dream.dream_id!)).toBe(false);
+    }
+    expect(graphNodeIDs.has(seededDream!.dream_id!)).toBe(false);
+
+    const anchor = (overview?.nodes ?? []).find((node) => node.type === "entity");
+    expect(anchor?.id).toBeTruthy();
+    if (!anchor?.id) return;
+
+    const localResponse = await request.get(`${userUrl}/ui/api/graph`, {
+      headers,
+      params: {
+        scope: "local",
+        anchor_type: "entity",
+        anchor_id: anchor.id,
+        depth: "5",
+        limit: "181",
+      },
+    });
+    expect(localResponse.status()).toBe(200);
+    const local = (await localResponse.json() as { data?: { scope?: string; depth?: number; limit?: number; anchor?: { id?: string } } }).data;
+    expect(local?.scope).toBe("local");
+    expect(local?.depth).toBe(5);
+    expect(local?.limit).toBe(181);
+    expect(local?.anchor?.id).toBe(anchor.id);
+
+    const detailResponse = await request.get(`${userUrl}/ui/api/node-detail`, {
+      headers,
+      params: { type: "entity", id: anchor.id },
+    });
+    expect(detailResponse.status()).toBe(200);
+    const detail = (await detailResponse.json() as { data?: { id?: string; type?: string } }).data;
+    expect(detail?.id).toBe(anchor.id);
+    expect(detail?.type).toBe("entity");
+
+    const invalidTypeResponse = await request.get(`${userUrl}/ui/api/node-detail`, {
+      headers,
+      params: { type: "hypothesis", id: anchor.id },
+    });
+    expect(invalidTypeResponse.status()).toBe(422);
+
+    const missingResponse = await request.get(`${userUrl}/ui/api/node-detail`, {
+      headers,
+      params: { type: "entity", id: "00000000-0000-0000-0000-000000000000" },
+    });
+    expect(missingResponse.status()).toBe(404);
+  });
+}
+
+registerGraphViewTests();
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required for graph e2e`);
+  return value;
+}

--- a/web/tests-compose/graph-views.ts
+++ b/web/tests-compose/graph-views.ts
@@ -1,26 +1,45 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIRequestContext } from "@playwright/test";
 
 const userUrl = requiredEnv("DENSE_MEM_USER_URL").replace(/\/$/, "");
+const controlUrl = requiredEnv("DENSE_MEM_CONTROL_URL").replace(/\/$/, "");
+const controlToken = requiredEnv("DENSE_MEM_CONTROL_TOKEN");
+const seedTeamID = requiredEnv("DENSE_MEM_E2E_TEAM_ID");
 const seedApiKey = requiredEnv("DENSE_MEM_E2E_API_KEY");
 const dreamStatement = requiredEnv("DENSE_MEM_E2E_DREAM_STATEMENT");
+let mcpRequestID = 0;
+
+type GraphNode = {
+  id?: string;
+  key?: string;
+  type?: string;
+  title?: string;
+};
+
+type GraphSnapshot = {
+  scope?: string;
+  depth?: number;
+  limit?: number;
+  anchor?: { id?: string };
+  nodes?: GraphNode[];
+  edges?: Array<{ id?: string; source?: string; target?: string }>;
+};
+
+type GraphEntity = {
+  id: string;
+  key: string;
+  type: "entity";
+};
 
 export function registerGraphViewTests() {
-  test("graph views preserve scoped reads and adverse boundaries", async ({ request }) => {
+  test("graph views preserve scoped reads and adverse boundaries", async ({ request }, testInfo) => {
+    test.setTimeout(120_000);
     const headers = { Authorization: `Bearer ${seedApiKey}` };
     const overviewResponse = await request.get(`${userUrl}/ui/api/graph`, {
       headers,
       params: { scope: "overview" },
     });
     expect(overviewResponse.status()).toBe(200);
-    const overview = (await overviewResponse.json() as {
-      data?: {
-        scope?: string;
-        depth?: number;
-        limit?: number;
-        nodes?: Array<{ id?: string; key?: string; type?: string }>;
-        edges?: Array<{ id?: string; source?: string; target?: string }>;
-      };
-    }).data;
+    const overview = (await overviewResponse.json() as { data?: GraphSnapshot }).data;
     expect(overview?.scope).toBe("overview");
     expect(overview?.depth).toBe(2);
     expect(overview?.limit).toBe(80);
@@ -64,7 +83,7 @@ export function registerGraphViewTests() {
 
     const anchor = (overview?.nodes ?? []).find((node) => node.type === "entity");
     expect(anchor?.id).toBeTruthy();
-    if (!anchor?.id) return;
+    if (!anchor?.id) throw new Error("seeded overview has no entity anchor");
 
     const localResponse = await request.get(`${userUrl}/ui/api/graph`, {
       headers,
@@ -77,7 +96,7 @@ export function registerGraphViewTests() {
       },
     });
     expect(localResponse.status()).toBe(200);
-    const local = (await localResponse.json() as { data?: { scope?: string; depth?: number; limit?: number; anchor?: { id?: string } } }).data;
+    const local = (await localResponse.json() as { data?: GraphSnapshot }).data;
     expect(local?.scope).toBe("local");
     expect(local?.depth).toBe(5);
     expect(local?.limit).toBe(181);
@@ -103,6 +122,8 @@ export function registerGraphViewTests() {
       params: { type: "entity", id: "00000000-0000-0000-0000-000000000000" },
     });
     expect(missingResponse.status()).toBe(404);
+
+    await assertGraphIsolation(request, testInfo, anchor.id);
   });
 }
 
@@ -111,5 +132,192 @@ registerGraphViewTests();
 function requiredEnv(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required for graph e2e`);
+  return value;
+}
+
+async function assertGraphIsolation(
+  request: APIRequestContext,
+  testInfo: { project: { name: string }; workerIndex: number },
+  seedAnchorID: string,
+) {
+  const fixtureID = `graph-isolation-${testInfo.project.name}-${testInfo.workerIndex}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const privateCredential = await createCredential(request, seedTeamID, `${fixtureID}-private`, "credential_private");
+  const foreignTeamID = await createTeam(request, `${fixtureID}-foreign`);
+  const foreignCredential = await createCredential(request, foreignTeamID, `${fixtureID}-foreign`, "credential_private");
+  const privateEntityName = `${fixtureID}-private-entity`;
+  const foreignEntityName = `${fixtureID}-foreign-entity`;
+
+  await rememberGraphEntity(request, privateCredential.apiKey, `${fixtureID}:private`, privateEntityName);
+  await rememberGraphEntity(request, foreignCredential.apiKey, `${fixtureID}:foreign`, foreignEntityName);
+
+  const privateNode = await waitForGraphEntity(request, privateCredential.apiKey, privateEntityName);
+  const foreignNode = await waitForGraphEntity(request, foreignCredential.apiKey, foreignEntityName);
+
+  const privateOverview = await graphSnapshot(request, privateCredential.apiKey, { scope: "overview" });
+  expect(privateOverview.nodes?.map((node) => node.id)).toContain(privateNode.id);
+  const privateDetail = await request.get(`${userUrl}/ui/api/node-detail`, {
+    headers: bearer(privateCredential.apiKey),
+    params: { type: privateNode.type, id: privateNode.id },
+  });
+  expect(privateDetail.status()).toBe(200);
+  const privateDetailBody = await privateDetail.json() as { data?: GraphNode };
+  expect(privateDetailBody.data?.id).toBe(privateNode.id);
+
+  const seedOverview = await graphSnapshot(request, seedApiKey, { scope: "overview" });
+  expectGraphExcludesNode(seedOverview, privateNode);
+  expectGraphExcludesNode(seedOverview, foreignNode);
+  await expectNodeDetailNotFound(request, seedApiKey, privateNode);
+  await expectNodeDetailNotFound(request, seedApiKey, foreignNode);
+
+  const foreignOverview = await graphSnapshot(request, foreignCredential.apiKey, { scope: "overview" });
+  expectGraphExcludesNode(foreignOverview, { id: seedAnchorID, key: `entity:${seedAnchorID}`, type: "entity" });
+  await expectNodeDetailNotFound(request, foreignCredential.apiKey, { id: seedAnchorID, key: `entity:${seedAnchorID}`, type: "entity" });
+
+  await expectInaccessibleLocalGraph(request, seedApiKey, privateNode);
+  await expectInaccessibleLocalGraph(request, seedApiKey, foreignNode);
+  await expectInaccessibleLocalGraph(request, foreignCredential.apiKey, { id: seedAnchorID, key: `entity:${seedAnchorID}`, type: "entity" });
+}
+
+async function createTeam(request: APIRequestContext, name: string): Promise<string> {
+  const response = await request.post(`${controlUrl}/control/api/teams`, {
+    headers: bearer(controlToken),
+    data: { name, description: "graph view isolation fixture" },
+  });
+  expect(response.status()).toBe(201);
+  const body = await response.json() as { data?: { id?: string } };
+  return requiredString(body.data?.id, "created team ID");
+}
+
+async function createCredential(
+  request: APIRequestContext,
+  teamID: string,
+  name: string,
+  memoryBinding: "credential_private",
+): Promise<{ apiKey: string }> {
+  const response = await request.post(`${controlUrl}/control/api/teams/${teamID}/credentials`, {
+    headers: bearer(controlToken),
+    data: { name, scopes: ["read", "write"], rate_limit: 300, memory_binding: memoryBinding },
+  });
+  expect(response.status()).toBe(201);
+  const body = await response.json() as { data?: { api_key?: string } };
+  return { apiKey: requiredString(body.data?.api_key, "created credential API key") };
+}
+
+async function rememberGraphEntity(
+  request: APIRequestContext,
+  apiKey: string,
+  idempotencyKey: string,
+  entityName: string,
+) {
+  const objectName = `${entityName}-target`;
+  const payload = await mcpToolPayload(request, apiKey, "remember", {
+    idempotency_key: idempotencyKey,
+    evidence: [{
+      content: `${entityName} mentions ${objectName}.`,
+      source_type: "manual",
+      source: "graph-view-isolation-e2e",
+      source_group: idempotencyKey,
+    }],
+    relationships: [{
+      ref: `${idempotencyKey}:relationship`,
+      subject: { name: entityName, entity_kind: "project" },
+      predicate: { proposed_key: "mentions" },
+      object: { entity: { name: objectName, entity_kind: "concept" } },
+      polarity: "+",
+      evidence_indices: [0],
+    }],
+  });
+  expect(payload.processing_state).toBe("completed");
+}
+
+async function waitForGraphEntity(
+  request: APIRequestContext,
+  apiKey: string,
+  entityName: string,
+): Promise<GraphEntity> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const snapshot = await graphSnapshot(request, apiKey, { scope: "overview", q: entityName });
+    const node = snapshot.nodes?.find((item) => item.type === "entity" && item.title === entityName);
+    if (node?.id && node.key) return { id: node.id, key: node.key, type: "entity" };
+    if (attempt + 1 < 20) await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("remembered graph entity did not become visible to its owner");
+}
+
+async function graphSnapshot(
+  request: APIRequestContext,
+  apiKey: string,
+  params: Record<string, string>,
+): Promise<GraphSnapshot> {
+  const response = await request.get(`${userUrl}/ui/api/graph`, {
+    headers: bearer(apiKey),
+    params,
+  });
+  expect(response.status()).toBe(200);
+  const body = await response.json() as { data?: GraphSnapshot };
+  if (!body.data) throw new Error("graph response omitted data");
+  return body.data;
+}
+
+function expectGraphExcludesNode(snapshot: GraphSnapshot, node: GraphEntity) {
+  expect(snapshot.nodes?.some((item) => item.id === node.id)).toBe(false);
+  expect(snapshot.edges?.some((edge) => edge.source === node.key || edge.target === node.key)).toBe(false);
+}
+
+async function expectNodeDetailNotFound(request: APIRequestContext, apiKey: string, node: GraphEntity) {
+  const response = await request.get(`${userUrl}/ui/api/node-detail`, {
+    headers: bearer(apiKey),
+    params: { type: node.type, id: node.id },
+  });
+  expect(response.status()).toBe(404);
+}
+
+async function expectInaccessibleLocalGraph(request: APIRequestContext, apiKey: string, node: GraphEntity) {
+  const snapshot = await graphSnapshot(request, apiKey, {
+    scope: "local",
+    anchor_type: node.type,
+    anchor_id: node.id,
+  });
+  expect(snapshot.scope).toBe("local");
+  expect(snapshot.anchor?.id).toBe(node.id);
+  expectGraphExcludesNode(snapshot, node);
+}
+
+async function mcpToolPayload(
+  request: APIRequestContext,
+  apiKey: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ processing_state?: string }> {
+  const response = await request.post(`${userUrl}/mcp`, {
+    headers: {
+      ...bearer(apiKey),
+      Accept: "application/json",
+      "MCP-Protocol-Version": "2025-11-25",
+    },
+    data: {
+      jsonrpc: "2.0",
+      id: ++mcpRequestID,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+  });
+  expect(response.status()).toBe(200);
+  const body = await response.json() as {
+    error?: unknown;
+    result?: { isError?: boolean; content?: Array<{ text?: string }> };
+  };
+  if (body.error || body.result?.isError) throw new Error(`MCP ${name} returned an error`);
+  const text = body.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error(`MCP ${name} omitted JSON content`);
+  return JSON.parse(text) as { processing_state?: string };
+}
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+function requiredString(value: string | undefined, field: string): string {
+  if (!value) throw new Error(`${field} is missing`);
   return value;
 }


### PR DESCRIPTION
Close #366 

## Goal

Implement issue #366 by moving graph view application logic and PostgreSQL graph reads into the native graph capability module while preserving public behavior and bounded compatibility forwarding.

## Implementation

- Added `internal/graph` application API and `internal/graph/postgres` adapter.
- Preserved legacy `graphview` and repository contracts through aliases/forwarding.
- Updated composition to construct the graph module through `GraphStore()`.
- Preserved validation, error wrapping, batch traversal, scoped reads, stable IDs, and node/edge rendering.
- Added native application/sqlmock coverage, compatibility metadata, architecture inventory updates, CI adapter coverage exclusions, and registered desktop/mobile Compose graph coverage.
- Added non-vacuous Hypothesis exclusion checks and retained the authenticated write-only HTTP denial fixture.

## Risk and mitigation

- Graph extraction could alter identity, bounds, or eligible edges; focused tests and the full production E2E graph test assert stable output, traversal limits, scoped IDs, and adverse node-detail boundaries.
- A private PostgreSQL adapter could bypass the aggregate coverage convention; it remains private, uses sqlmock for query logic, is excluded from aggregate unit coverage like the existing PostgreSQL adapters, and is exercised through the production full E2E harness.
- Legacy consumers could lose error identity; facade regressions assert operation-level wrapping and validation precedence.

## Plan audit

- Auditor: gpt-5.6-terra, reasoning_effort max
- Audit base SHA: 99b89b3e8064bc319b96add7e549ddd1bf994186
- Rebased onto origin/main: a5f30bd128ade461ceb430a79a0d0a8620eee36c
- Branch: refactor/366-graph-module
- Final verdict: conformant
- Final audited state: 16 implementation paths plus the staged graph test move; no untracked source changes
- Post-audit source changes: none; all final source paths were covered by the final conformant rescan.

## Verification

- `go test ./internal/graph/... ./internal/repository/... ./internal/service/graphview/... ./internal/http/... ./cmd/internal/serverapp/... -count=1`
- `npm ci --prefix web && npm test --prefix web && npm run typecheck --prefix web`
- `./scripts/ci-check.sh` — architecture, UAT, static analysis, Go tests, and 90.0% coverage gate passed
- `./scripts/e2e.sh full` — Dream/evidence UAT, telemetry, and 42 desktop/mobile Playwright tests passed
- Pre-push hook reran the repository checks successfully

No merge is requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added semantic graph views for overview and local traversal queries.
  - Added graph node details, filtering, anchors, depth limits, result limits, and validation.
  - Added scoped PostgreSQL graph retrieval with relevance-based ordering.

- **Refactor**
  - Consolidated graph functionality behind a dedicated service while maintaining compatibility with existing integrations.

- **Bug Fixes**
  - Improved pull-request release checks when large change sets exceed REST API limits.
  - Improved concurrent scheduled-operation handling and migration test reliability.

- **Tests**
  - Expanded unit, SQL, architecture, browser, and end-to-end coverage for graph views and concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

