### PR TITLE
refactor: move audit capability into native module (#368)

### DIFF
--- a/architecture/modules/audit-application.json
+++ b/architecture/modules/audit-application.json
@@ -5,20 +5,86 @@
     {"path": "cmd/internal/serverapp/audit_composition.go", "issue": 368},
     {"path": "cmd/internal/serverapp/security_rejection_audit.go", "issue": 368},
     {"path": "cmd/internal/serverapp/security_rejection_audit_test.go", "issue": 368},
+    {"path": "internal/audit/contract/ports.go", "issue": 368},
+    {"path": "internal/audit/postgres/store.go", "issue": 368},
+    {"path": "internal/audit/postgres/store_test.go", "issue": 368},
+    {"path": "internal/audit/security_rejection.go", "issue": 368},
+    {"path": "internal/audit/security_rejection_test.go", "issue": 368},
+    {"path": "internal/audit/service.go", "issue": 368},
+    {"path": "internal/audit/service_test.go", "issue": 368},
     {"path": "internal/service/audit_service.e2e", "issue": 368},
     {"path": "internal/service/audit_service.go", "issue": 368},
     {"path": "internal/service/audit_service_unit_test.go", "issue": 368}
   ],
+  "compatibility_bridges": [
+    {
+      "source_path": "internal/service/audit_service.go",
+      "fields": [
+        "AuditLogEntry",
+        "AuditService",
+        "AuditServiceImpl",
+        "NewAuditService",
+        "NewAuditServiceWithLogger",
+        "redactPayload",
+        "auditClientIPValue"
+      ],
+      "consumers": [
+        {"path": "internal/service/audit_service.e2e", "symbol": "TestAuditServiceAppend"},
+        {"path": "internal/service/audit_service_unit_test.go", "symbol": "TestAuditAppendRedactsPayloadsAndWritesInsert"},
+        {"path": "internal/service/team_service.e2e", "symbol": "TestTeamServiceCreate"},
+        {"path": "internal/service/access_compat.go", "symbol": "NewTeamService"},
+        {"path": "internal/service/access_compat.go", "symbol": "NewCredentialService"},
+        {"path": "internal/service/app_config_service.go", "symbol": "NewAppConfigService"},
+        {"path": "internal/service/security_service.go", "symbol": "NewSecurityService"},
+        {"path": "internal/service/invariant_scan_service.go", "symbol": "NewInvariantScanService"},
+        {"path": "internal/service/access_compat_test_helpers_test.go", "symbol": "MockAuditService.Append"},
+        {"path": "internal/service/app_config_service_audit_test.go", "symbol": "appConfigAuditStub.Append"},
+        {"path": "cmd/internal/serverapp/security_rejection_audit_test.go", "symbol": "securityRejectionAuditAppenderStub.Append"},
+        {"path": "cmd/internal/serverapp/access_composition.go", "symbol": "buildAccessApplication"},
+        {"path": "cmd/internal/serverapp/configuration_composition.go", "symbol": "buildConfigurationApplication"},
+        {"path": "cmd/internal/serverapp/security_composition.go", "symbol": "buildSecurityApplication"},
+        {"path": "cmd/internal/serverapp/security_rejection_audit.go", "symbol": "newRememberSecurityRejectionAuditAdapter"},
+        {"path": "internal/http/handler/audit_handler.go", "symbol": "AuditHandler.Get"},
+        {"path": "internal/http/handler/audit_handler_unit_test.go", "symbol": "TestAuditHandlerGetReturnsPaginatedAuditEntries"},
+        {"path": "internal/http/middleware/auth.go", "symbol": "AuthMiddleware"},
+        {"path": "internal/http/middleware/team_authorization.go", "symbol": "NewTeamAuthorizationService"},
+        {"path": "internal/http/middleware/rate_limit.go", "symbol": "RateLimitMiddleware"},
+        {"path": "internal/http/middleware/auth_test.go", "symbol": "TestAuthMiddleware_MissingHeader"},
+        {"path": "internal/http/router_protected.go", "symbol": "ProtectedDeps.GetAuditService"},
+        {"path": "internal/http/mcp_bindings.go", "symbol": "ProtectedDeps.withMCPBindings"},
+        {"path": "internal/http/user_portal_routes.go", "symbol": "RegisterUserPortal"},
+        {"path": "internal/tools/registry/evaluation_tools.go", "symbol": "auditEvaluationTool"},
+        {"path": "internal/tools/registry/toolset.go", "symbol": "BuildActive"},
+        {"path": "internal/tools/registry/test_helpers_test.go", "symbol": "evaluationAuditStub.Append"}
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {"path": "internal/audit/service.go", "symbol": "New"},
+      "removal_condition": "Remove the legacy audit facade after all named producers, transports, and fixtures consume internal/audit contracts directly."
+    }
+  ],
   "completed_issues": [],
-  "go": {"units": []},
+  "go": {
+    "units": [
+      {"id": "github.com/markhuangai/dense-mem/internal/audit", "role": "application_api", "visibility": "public"},
+      {"id": "github.com/markhuangai/dense-mem/internal/audit/contract", "role": "port", "visibility": "private"},
+      {"id": "github.com/markhuangai/dense-mem/internal/audit/postgres", "role": "postgres_adapter", "visibility": "private"}
+    ]
+  },
   "browser": {"units": []},
   "exceptions": [
     {
       "source_path": "internal/service/audit_service.go",
       "source": "github.com/markhuangai/dense-mem/internal/service",
+      "target": "github.com/markhuangai/dense-mem/internal/audit/postgres",
+      "removal_issue": 382,
+      "reason": "The legacy service constructor forwards to the audit PostgreSQL adapter until final compatibility-facade cleanup."
+    },
+    {
+      "source_path": "internal/service/audit_service.go",
+      "source": "github.com/markhuangai/dense-mem/internal/service",
       "target": "github.com/markhuangai/dense-mem/internal/storage/postgres",
-      "removal_issue": 368,
-      "reason": "The operations audit service still uses PostgreSQL directly until operations ownership is isolated."
+      "removal_issue": 382,
+      "reason": "The legacy service facade retains the RLS helper seam for existing compatibility tests until final facade cleanup."
     }
   ],
   "workers": []

--- a/cmd/internal/serverapp/audit_composition.go
+++ b/cmd/internal/serverapp/audit_composition.go
@@ -1,10 +1,11 @@
 package serverapp
 
 import (
-	"github.com/markhuangai/dense-mem/internal/service"
+	auditapp "github.com/markhuangai/dense-mem/internal/audit"
+	auditpostgres "github.com/markhuangai/dense-mem/internal/audit/postgres"
 	"gorm.io/gorm"
 )
 
-func buildAuditApplication(db *gorm.DB) *service.AuditServiceImpl {
-	return service.NewAuditService(db)
+func buildAuditApplication(db *gorm.DB) *auditapp.Service {
+	return auditapp.New(auditpostgres.NewStore(db))
 }

--- a/cmd/internal/serverapp/security_rejection_audit.go
+++ b/cmd/internal/serverapp/security_rejection_audit.go
@@ -2,95 +2,18 @@ package serverapp
 
 import (
 	"context"
-	"errors"
 
+	auditapp "github.com/markhuangai/dense-mem/internal/audit"
 	"github.com/markhuangai/dense-mem/internal/service"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
 )
 
-type securityRejectionAuditAdapter struct {
-	audit securityRejectionAuditAppender
-}
-
+// securityRejectionAuditAppender is retained as a composition seam for the
+// existing server tests. Event construction belongs to the audit capability.
 type securityRejectionAuditAppender interface {
-	Append(ctx context.Context, entry service.AuditLogEntry) error
+	Append(context.Context, service.AuditLogEntry) error
 }
 
 func newRememberSecurityRejectionAuditAdapter(audit securityRejectionAuditAppender) rememberapp.SecurityRejectionAuditor {
-	return rememberSecurityRejectionAuditAdapter{audit: audit}
-}
-
-type rememberSecurityRejectionAuditAdapter struct {
-	audit securityRejectionAuditAppender
-}
-
-func (a rememberSecurityRejectionAuditAdapter) RecordSecurityRejection(
-	ctx context.Context,
-	input rememberapp.SecurityRejectionAuditInput,
-) error {
-	if a.audit == nil {
-		return errors.New("security rejection audit appender is required")
-	}
-	teamID := input.TeamID
-	actorProfileID := input.ActorProfileID
-	return a.audit.Append(ctx, securityRejectionAuditEntry(
-		input.EventID, teamID, actorProfileID, input.ActorRole, input.CorrelationID,
-		input.Surface, input.ReasonCode, input.EvidenceCount, flattenRememberSecuritySignals(input.Signals), input.SignalsTruncated,
-	))
-}
-
-type securityRejectionAuditSignal struct {
-	EvidenceIndex int
-	Source        string
-	Kind          string
-	RuleID        string
-	Severity      string
-	SpanStart     int
-	SpanEnd       int
-}
-
-func flattenRememberSecuritySignals(input []rememberapp.SecurityRejectionAuditSignal) []securityRejectionAuditSignal {
-	result := make([]securityRejectionAuditSignal, 0, len(input))
-	for _, signal := range input {
-		result = append(result, securityRejectionAuditSignal{
-			EvidenceIndex: signal.EvidenceIndex, Source: signal.Source, Kind: signal.Kind,
-			RuleID: signal.RuleID, Severity: signal.Severity, SpanStart: signal.SpanStart, SpanEnd: signal.SpanEnd,
-		})
-	}
-	return result
-}
-
-func securityRejectionAuditEntry(
-	eventID, teamID, actorProfileID, actorRole, correlationID, surface, reasonCode string,
-	evidenceCount int, inputSignals []securityRejectionAuditSignal, signalsTruncated bool,
-) service.AuditLogEntry {
-	signals := make([]any, 0, len(inputSignals))
-	for _, signal := range inputSignals {
-		signals = append(signals, map[string]any{
-			"evidence_index": signal.EvidenceIndex,
-			"source":         signal.Source,
-			"kind":           signal.Kind,
-			"rule_id":        signal.RuleID,
-			"severity":       signal.Severity,
-			"span_start":     signal.SpanStart,
-			"span_end":       signal.SpanEnd,
-		})
-	}
-	return service.AuditLogEntry{
-		ID:            eventID,
-		ProfileID:     &teamID,
-		Operation:     "SECURITY_REJECTED",
-		EntityType:    "memory_intake_attempt",
-		EntityID:      eventID,
-		ActorKeyID:    &actorProfileID,
-		ActorRole:     actorRole,
-		CorrelationID: correlationID,
-		Metadata: map[string]any{
-			"surface":           surface,
-			"reason_code":       reasonCode,
-			"evidence_count":    evidenceCount,
-			"signals":           signals,
-			"signals_truncated": signalsTruncated,
-		},
-	}
+	return auditapp.NewRememberSecurityRejectionAuditor(audit)
 }

--- a/internal/audit/contract/ports.go
+++ b/internal/audit/contract/ports.go
@@ -1,0 +1,45 @@
+// Package contract defines the narrow persistence boundary for audit events.
+package contract
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CredentialMemorySpaceLookup is a validated intent from audit policy. The
+// adapter executes the lookup but does not decide when it is eligible.
+type CredentialMemorySpaceLookup struct {
+	TeamID       uuid.UUID
+	CredentialID uuid.UUID
+}
+
+// Entry is the serialized audit record exchanged between audit policy and its
+// persistence adapter. Payload redaction and JSON validation happen before an
+// Entry reaches the adapter; the adapter only maps it to the audit_log table.
+type Entry struct {
+	ID                          string
+	ProfileID                   *string
+	MemorySpaceID               *string
+	Timestamp                   time.Time
+	Operation                   string
+	EntityType                  string
+	EntityID                    string
+	BeforePayload               []byte
+	AfterPayload                []byte
+	ActorKeyID                  *string
+	ActorRole                   string
+	ClientIP                    any
+	CorrelationID               string
+	Metadata                    []byte
+	CredentialMemorySpaceLookup *CredentialMemorySpaceLookup
+}
+
+// Store persists and reads audit entries without exposing a database handle to
+// the application service.
+type Store interface {
+	Append(context.Context, Entry) error
+	List(context.Context, string, int, int) ([]Entry, error)
+	Count(context.Context, string) (int, error)
+}

--- a/internal/audit/postgres/store.go
+++ b/internal/audit/postgres/store.go
@@ -100,7 +100,7 @@ func (s *Store) List(ctx context.Context, teamID string, limit, offset int) ([]c
 					    AND space.lifecycle_state = 'active'
 				  )
 			  )
-			ORDER BY timestamp DESC
+			ORDER BY audit.timestamp DESC, audit.id DESC
 			LIMIT $2 OFFSET $3
 		`, teamID, limit, offset).Rows()
 		if err != nil {

--- a/internal/audit/postgres/store.go
+++ b/internal/audit/postgres/store.go
@@ -1,0 +1,182 @@
+// Package postgres implements audit persistence and RLS transaction mechanics.
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/audit/contract"
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+// Store is the PostgreSQL implementation of the audit persistence port.
+type Store struct {
+	db  *gorm.DB
+	rls storagepostgres.RLSHelper
+}
+
+var _ contract.Store = (*Store)(nil)
+
+// NewStore constructs an audit PostgreSQL adapter. Callers may provide the
+// shared RLS helper explicitly; the live composition uses the default helper.
+func NewStore(db *gorm.DB, helpers ...storagepostgres.RLSHelper) *Store {
+	rls := storagepostgres.RLSHelper(storagepostgres.NewRLS())
+	if len(helpers) > 0 {
+		rls = helpers[0]
+	}
+	return &Store{db: db, rls: rls}
+}
+
+// Append inserts one already-redacted audit entry. Credential memory-space
+// inference remains inside this transaction so the audit row cannot cross teams.
+func (s *Store) Append(ctx context.Context, entry contract.Entry) error {
+	if s == nil || s.db == nil {
+		return errors.New("audit: database is required")
+	}
+
+	insert := func(tx *gorm.DB) error {
+		memorySpaceID := entry.MemorySpaceID
+		if memorySpaceID == nil && entry.CredentialMemorySpaceLookup != nil {
+			lookup := entry.CredentialMemorySpaceLookup
+			var candidate sql.NullString
+			lookupErr := tx.WithContext(ctx).Raw(`
+					SELECT memory_space_id::text
+					FROM credentials
+					WHERE id = $1 AND team_id = $2
+				`, lookup.CredentialID, lookup.TeamID).Row().Scan(&candidate)
+			if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
+				return lookupErr
+			}
+			if candidate.Valid && strings.TrimSpace(candidate.String) != "" {
+				memorySpaceID = &candidate.String
+			}
+		}
+
+		return tx.WithContext(ctx).Exec(`
+			INSERT INTO audit_log (
+				id, team_id, timestamp, operation, entity_type, entity_id,
+				before_payload, after_payload, actor_profile_id, actor_role,
+				client_ip, correlation_id, metadata, memory_space_id
+			) VALUES (
+				$1, $2, $3, $4, $5, $6,
+				$7, $8, $9, $10, $11, $12, $13, $14
+			)
+		`, entry.ID, entry.ProfileID, entry.Timestamp, entry.Operation, entry.EntityType,
+			entry.EntityID, entry.BeforePayload, entry.AfterPayload, entry.ActorKeyID,
+			entry.ActorRole, entry.ClientIP, entry.CorrelationID, entry.Metadata, memorySpaceID).Error
+	}
+
+	if s.rls != nil {
+		return s.rls.WithSystemTx(ctx, s.db, insert)
+	}
+	return insert(s.db.WithContext(ctx))
+}
+
+// List returns active-space-visible audit entries and the matching total count.
+func (s *Store) List(ctx context.Context, teamID string, limit, offset int) ([]contract.Entry, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("audit: database is required")
+	}
+
+	entries := make([]contract.Entry, 0)
+	query := func(tx *gorm.DB) error {
+		rows, err := tx.WithContext(ctx).Raw(`
+			SELECT id, team_id, timestamp, operation, entity_type, entity_id,
+			       before_payload, after_payload, actor_profile_id, actor_role,
+			       client_ip, correlation_id, metadata, memory_space_id::text
+			FROM audit_log AS audit
+			WHERE audit.team_id = $1
+			  AND (
+				  audit.memory_space_id IS NULL
+				  OR EXISTS (
+					  SELECT 1
+					  FROM memory_spaces AS space
+					  WHERE space.id = audit.memory_space_id
+					    AND space.team_id = audit.team_id
+					    AND space.lifecycle_state = 'active'
+				  )
+			  )
+			ORDER BY timestamp DESC
+			LIMIT $2 OFFSET $3
+		`, teamID, limit, offset).Rows()
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var entry contract.Entry
+			var profileID, actorKeyID, clientIP, memorySpaceID sql.NullString
+			if err := rows.Scan(
+				&entry.ID, &profileID, &entry.Timestamp, &entry.Operation,
+				&entry.EntityType, &entry.EntityID, &entry.BeforePayload,
+				&entry.AfterPayload, &actorKeyID, &entry.ActorRole, &clientIP,
+				&entry.CorrelationID, &entry.Metadata, &memorySpaceID,
+			); err != nil {
+				return err
+			}
+			if profileID.Valid {
+				entry.ProfileID = &profileID.String
+			}
+			if actorKeyID.Valid {
+				entry.ActorKeyID = &actorKeyID.String
+			}
+			if clientIP.Valid {
+				entry.ClientIP = clientIP.String
+			}
+			if memorySpaceID.Valid {
+				entry.MemorySpaceID = &memorySpaceID.String
+			}
+			entries = append(entries, entry)
+		}
+		return rows.Err()
+	}
+
+	if s.rls != nil {
+		if err := s.rls.WithTeamTx(ctx, s.db, teamID, query); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := query(s.db.WithContext(ctx)); err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
+}
+
+// Count returns the active-space-visible total for one team.
+func (s *Store) Count(ctx context.Context, teamID string) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("audit: database is required")
+	}
+	count := 0
+	countQuery := func(tx *gorm.DB) error {
+		return tx.WithContext(ctx).Raw(`
+			SELECT COUNT(*)
+			FROM audit_log AS audit
+			WHERE audit.team_id = $1
+			  AND (
+				  audit.memory_space_id IS NULL
+				  OR EXISTS (
+					  SELECT 1
+					  FROM memory_spaces AS space
+					  WHERE space.id = audit.memory_space_id
+					    AND space.team_id = audit.team_id
+					    AND space.lifecycle_state = 'active'
+				  )
+			  )
+		`, teamID).Scan(&count).Error
+	}
+	if s.rls != nil {
+		if err := s.rls.WithTeamTx(ctx, s.db, teamID, countQuery); err != nil {
+			return 0, err
+		}
+	} else if err := countQuery(s.db.WithContext(ctx)); err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/internal/audit/postgres/store_test.go
+++ b/internal/audit/postgres/store_test.go
@@ -81,7 +81,7 @@ func TestStoreListAndCountUseTheActiveSpacePredicate(t *testing.T) {
 	store, mock, cleanup := newMockStore(t)
 	defer cleanup()
 	when := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
-	mock.ExpectQuery("SELECT id, team_id, timestamp, operation, entity_type, entity_id").
+	mock.ExpectQuery("SELECT id, team_id, timestamp, operation, entity_type, entity_id[\\s\\S]+ORDER BY audit\\.timestamp DESC, audit\\.id DESC[\\s\\S]+LIMIT").
 		WithArgs("team-1", 20, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "team_id", "timestamp", "operation", "entity_type", "entity_id",

--- a/internal/audit/postgres/store_test.go
+++ b/internal/audit/postgres/store_test.go
@@ -1,0 +1,117 @@
+package postgres
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/markhuangai/dense-mem/internal/audit/contract"
+)
+
+func newMockStore(t *testing.T) (*Store, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{
+		Conn:                 sqlDB,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{DisableAutomaticPing: true, SkipDefaultTransaction: true})
+	require.NoError(t, err)
+	return NewStore(db, nil), mock, func() { _ = sqlDB.Close() }
+}
+
+func TestStoreAppendPersistsSerializedEntry(t *testing.T) {
+	store, mock, cleanup := newMockStore(t)
+	defer cleanup()
+
+	args := make([]driver.Value, 0, 14)
+	for i := 0; i < 14; i++ {
+		args = append(args, sqlmock.AnyArg())
+	}
+	mock.ExpectExec("INSERT INTO audit_log").WithArgs(args...).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := store.Append(context.Background(), contract.Entry{
+		ID:            "audit-1",
+		ProfileID:     stringPointer("team-1"),
+		Timestamp:     time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+		Operation:     "CREATE",
+		EntityType:    "profile",
+		EntityID:      "team-1",
+		BeforePayload: []byte(`null`),
+		AfterPayload:  []byte(`{"name":"safe"}`),
+		Metadata:      []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStoreAppendInfersCredentialSpaceOnlyWithinTeam(t *testing.T) {
+	store, mock, cleanup := newMockStore(t)
+	defer cleanup()
+	teamID := uuid.New()
+	credentialID := uuid.New()
+	spaceID := uuid.New()
+	mock.ExpectQuery("SELECT memory_space_id::text\\s+FROM credentials\\s+WHERE id = \\$1 AND team_id = \\$2").
+		WithArgs(credentialID, teamID).
+		WillReturnRows(sqlmock.NewRows([]string{"memory_space_id"}).AddRow(spaceID.String()))
+
+	args := make([]driver.Value, 0, 14)
+	for i := 0; i < 13; i++ {
+		args = append(args, sqlmock.AnyArg())
+	}
+	args = append(args, spaceID.String())
+	mock.ExpectExec("INSERT INTO audit_log").WithArgs(args...).WillReturnResult(sqlmock.NewResult(0, 1))
+	team := teamID.String()
+	err := store.Append(context.Background(), contract.Entry{
+		ProfileID: &team, EntityType: "api_key", EntityID: credentialID.String(), Operation: "DELETE", Metadata: []byte(`{}`),
+		CredentialMemorySpaceLookup: &contract.CredentialMemorySpaceLookup{TeamID: teamID, CredentialID: credentialID},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStoreListAndCountUseTheActiveSpacePredicate(t *testing.T) {
+	store, mock, cleanup := newMockStore(t)
+	defer cleanup()
+	when := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT id, team_id, timestamp, operation, entity_type, entity_id").
+		WithArgs("team-1", 20, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "team_id", "timestamp", "operation", "entity_type", "entity_id",
+			"before_payload", "after_payload", "actor_profile_id", "actor_role",
+			"client_ip", "correlation_id", "metadata", "memory_space_id",
+		}).AddRow("audit-1", "team-1", when, "UPDATE", "profile", "team-1",
+			[]byte(`{"before":true}`), []byte(`{"after":true}`), "profile-1", "admin",
+			"203.0.113.10", "corr-1", []byte(`{"source":"test"}`), "space-1"))
+	entries, err := store.List(context.Background(), "team-1", 20, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "audit-1", entries[0].ID)
+	require.Equal(t, "space-1", *entries[0].MemorySpaceID)
+
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\)\\s+FROM audit_log AS audit\\s+WHERE audit.team_id = \\$1").
+		WithArgs("team-1").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	count, err := store.Count(context.Background(), "team-1")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStoreRequiresDatabase(t *testing.T) {
+	require.ErrorContains(t, NewStore(nil, nil).Append(context.Background(), contract.Entry{}), "database is required")
+	_, err := NewStore(nil, nil).List(context.Background(), "team", 1, 0)
+	require.ErrorContains(t, err, "database is required")
+	_, err = NewStore(nil, nil).Count(context.Background(), "team")
+	require.ErrorContains(t, err, "database is required")
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/internal/audit/security_rejection.go
+++ b/internal/audit/security_rejection.go
@@ -1,0 +1,74 @@
+package audit
+
+import (
+	"context"
+	"errors"
+
+	accessservice "github.com/markhuangai/dense-mem/internal/service/access"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+// AuditAppender is the narrow write port used by the Remember security
+// rejection bridge. It prevents rejected evidence from entering the audit API.
+type AuditAppender interface {
+	Append(context.Context, accessservice.AuditLogEntry) error
+}
+
+type rememberSecurityRejectionAuditor struct {
+	audit AuditAppender
+}
+
+// NewRememberSecurityRejectionAuditor adapts bounded Remember scanner metadata
+// to the existing audit event contract.
+func NewRememberSecurityRejectionAuditor(audit AuditAppender) rememberapp.SecurityRejectionAuditor {
+	return rememberSecurityRejectionAuditor{audit: audit}
+}
+
+func (a rememberSecurityRejectionAuditor) RecordSecurityRejection(
+	ctx context.Context,
+	input rememberapp.SecurityRejectionAuditInput,
+) error {
+	if a.audit == nil {
+		return errors.New("security rejection audit appender is required")
+	}
+	return a.audit.Append(ctx, securityRejectionAuditEntry(
+		input.EventID, input.TeamID, input.ActorProfileID, input.ActorRole,
+		input.CorrelationID, input.Surface, input.ReasonCode, input.EvidenceCount,
+		input.Signals, input.SignalsTruncated,
+	))
+}
+
+func securityRejectionAuditEntry(
+	eventID, teamID, actorProfileID, actorRole, correlationID, surface, reasonCode string,
+	evidenceCount int, inputSignals []rememberapp.SecurityRejectionAuditSignal, signalsTruncated bool,
+) accessservice.AuditLogEntry {
+	signals := make([]any, 0, len(inputSignals))
+	for _, signal := range inputSignals {
+		signals = append(signals, map[string]any{
+			"evidence_index": signal.EvidenceIndex,
+			"source":         signal.Source,
+			"kind":           signal.Kind,
+			"rule_id":        signal.RuleID,
+			"severity":       signal.Severity,
+			"span_start":     signal.SpanStart,
+			"span_end":       signal.SpanEnd,
+		})
+	}
+	return accessservice.AuditLogEntry{
+		ID:            eventID,
+		ProfileID:     &teamID,
+		Operation:     "SECURITY_REJECTED",
+		EntityType:    "memory_intake_attempt",
+		EntityID:      eventID,
+		ActorKeyID:    &actorProfileID,
+		ActorRole:     actorRole,
+		CorrelationID: correlationID,
+		Metadata: map[string]any{
+			"surface":           surface,
+			"reason_code":       reasonCode,
+			"evidence_count":    evidenceCount,
+			"signals":           signals,
+			"signals_truncated": signalsTruncated,
+		},
+	}
+}

--- a/internal/audit/security_rejection_test.go
+++ b/internal/audit/security_rejection_test.go
@@ -1,0 +1,63 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	accessservice "github.com/markhuangai/dense-mem/internal/service/access"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+type rejectionAppenderStub struct {
+	entry accessservice.AuditLogEntry
+	err   error
+}
+
+func (s *rejectionAppenderStub) Append(_ context.Context, entry accessservice.AuditLogEntry) error {
+	s.entry = entry
+	return s.err
+}
+
+func TestRememberSecurityRejectionAuditorWritesBoundedMetadata(t *testing.T) {
+	appender := &rejectionAppenderStub{}
+	auditor := NewRememberSecurityRejectionAuditor(appender)
+	err := auditor.RecordSecurityRejection(context.Background(), rememberapp.SecurityRejectionAuditInput{
+		EventID:          "event-1",
+		TeamID:           "team-1",
+		ActorProfileID:   "profile-1",
+		ActorRole:        "member",
+		CorrelationID:    "corr-1",
+		Surface:          "remember",
+		ReasonCode:       rememberapp.SubmissionSecurityErrorRejected,
+		EvidenceCount:    1,
+		SignalsTruncated: true,
+		Signals: []rememberapp.SecurityRejectionAuditSignal{{
+			EvidenceIndex: 0,
+			Source:        "evidence",
+			Kind:          "instruction_override",
+			RuleID:        "instruction_override",
+			Severity:      "critical",
+			SpanStart:     1,
+			SpanEnd:       9,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "SECURITY_REJECTED", appender.entry.Operation)
+	require.Equal(t, "memory_intake_attempt", appender.entry.EntityType)
+	require.Equal(t, "team-1", *appender.entry.ProfileID)
+	require.Equal(t, "profile-1", *appender.entry.ActorKeyID)
+	require.Equal(t, true, appender.entry.Metadata["signals_truncated"])
+	metadata, err := json.Marshal(appender.entry.Metadata)
+	require.NoError(t, err)
+	require.NotContains(t, string(metadata), "evidence content")
+}
+
+func TestRememberSecurityRejectionAuditorPropagatesAppenderFailure(t *testing.T) {
+	auditor := NewRememberSecurityRejectionAuditor(&rejectionAppenderStub{err: errors.New("storage unavailable")})
+	err := auditor.RecordSecurityRejection(context.Background(), rememberapp.SecurityRejectionAuditInput{})
+	require.ErrorContains(t, err, "storage unavailable")
+}

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -1,0 +1,352 @@
+// Package audit owns audit event construction, redaction, and read policy.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/audit/contract"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+	accessservice "github.com/markhuangai/dense-mem/internal/service/access"
+)
+
+// Service owns the consumer-facing audit policy while Store owns persistence.
+type Service struct {
+	store contract.Store
+}
+
+var _ accessservice.AuditService = (*Service)(nil)
+
+// New constructs the audit application service around its persistence port.
+func New(store contract.Store) *Service {
+	return &Service{store: store}
+}
+
+// sensitiveFields contains exact normalized field names redacted from audit data.
+var sensitiveFields = map[string]struct{}{
+	"access_token":     {},
+	"accesstoken":      {},
+	"ai_api_key":       {},
+	"api_key":          {},
+	"apikey":           {},
+	"authorization":    {},
+	"encrypted_secret": {},
+	"embedding":        {},
+	"embeddings":       {},
+	"key_hash":         {},
+	"password":         {},
+	"raw_key":          {},
+	"refresh_token":    {},
+	"refreshtoken":     {},
+	"secret":           {},
+	"token":            {},
+}
+
+// RedactPayload removes sensitive fields from audit maps and returns a new map.
+func RedactPayload(payload map[string]interface{}) map[string]interface{} {
+	if payload == nil {
+		return nil
+	}
+
+	redacted := make(map[string]interface{}, len(payload))
+	for key, value := range payload {
+		if isSensitiveAuditField(key) {
+			continue
+		}
+		redacted[key] = redactAuditValue(value)
+	}
+	return redacted
+}
+
+func isSensitiveAuditField(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	if _, ok := sensitiveFields[normalized]; ok {
+		return true
+	}
+	compact := strings.ReplaceAll(normalized, "_", "")
+	if _, ok := sensitiveFields[compact]; ok {
+		return true
+	}
+	return strings.HasSuffix(normalized, "_api_key") ||
+		strings.HasSuffix(normalized, "_password") ||
+		strings.HasSuffix(normalized, "_secret") ||
+		strings.HasSuffix(normalized, "_token") ||
+		strings.HasSuffix(compact, "apikey") ||
+		strings.HasSuffix(compact, "password") ||
+		strings.HasSuffix(compact, "secret") ||
+		strings.HasSuffix(compact, "token")
+}
+
+func redactAuditValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return RedactPayload(typed)
+	case []interface{}:
+		redacted := make([]interface{}, len(typed))
+		for i, child := range typed {
+			redacted[i] = redactAuditValue(child)
+		}
+		return redacted
+	}
+
+	reflected := reflect.ValueOf(value)
+	if !reflected.IsValid() {
+		return value
+	}
+	if reflected.Kind() == reflect.Map && reflected.Type().Key().Kind() == reflect.String {
+		fields := make(map[string]interface{}, reflected.Len())
+		iter := reflected.MapRange()
+		for iter.Next() {
+			fields[iter.Key().String()] = iter.Value().Interface()
+		}
+		return RedactPayload(fields)
+	}
+	if reflected.Kind() == reflect.Slice || reflected.Kind() == reflect.Array {
+		if reflected.Type().Elem().Kind() == reflect.Uint8 {
+			return value
+		}
+		redacted := make([]interface{}, reflected.Len())
+		for i := 0; i < reflected.Len(); i++ {
+			redacted[i] = redactAuditValue(reflected.Index(i).Interface())
+		}
+		return redacted
+	}
+	return value
+}
+
+// AuditClientIPValue selects an explicit entry address, then the authenticated
+// request context, and finally SQL NULL when neither is available.
+func AuditClientIPValue(ctx context.Context, entry accessservice.AuditLogEntry) any {
+	clientIP := strings.TrimSpace(entry.ClientIP)
+	if clientIP == "" {
+		clientIP = requestctx.ClientIPFromContext(ctx)
+	}
+	if clientIP == "" {
+		return nil
+	}
+	return clientIP
+}
+
+// Append validates and normalizes an event before handing it to persistence.
+func (s *Service) Append(ctx context.Context, entry accessservice.AuditLogEntry) error {
+	beforeJSON, err := marshalPayload("before_payload", entry.BeforePayload)
+	if err != nil {
+		return err
+	}
+	afterJSON, err := marshalPayload("after_payload", entry.AfterPayload)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalMetadata(entry.Metadata)
+	if err != nil {
+		return err
+	}
+
+	timestamp := entry.Timestamp
+	if timestamp.IsZero() {
+		timestamp = time.Now().UTC()
+	}
+	id := entry.ID
+	if id == "" {
+		id = uuid.New().String()
+	}
+	lookup := credentialMemorySpaceLookup(entry)
+	if s == nil || s.store == nil {
+		return errors.New("audit: store is required")
+	}
+
+	err = s.store.Append(ctx, contract.Entry{
+		ID:                          id,
+		ProfileID:                   entry.ProfileID,
+		MemorySpaceID:               entry.MemorySpaceID,
+		Timestamp:                   timestamp,
+		Operation:                   entry.Operation,
+		EntityType:                  entry.EntityType,
+		EntityID:                    entry.EntityID,
+		BeforePayload:               beforeJSON,
+		AfterPayload:                afterJSON,
+		ActorKeyID:                  entry.ActorKeyID,
+		ActorRole:                   entry.ActorRole,
+		ClientIP:                    AuditClientIPValue(ctx, entry),
+		CorrelationID:               entry.CorrelationID,
+		Metadata:                    metadataJSON,
+		CredentialMemorySpaceLookup: lookup,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to append audit log entry: %w", err)
+	}
+	return nil
+}
+
+func credentialMemorySpaceLookup(entry accessservice.AuditLogEntry) *contract.CredentialMemorySpaceLookup {
+	if entry.MemorySpaceID != nil || entry.EntityType != "api_key" || entry.ProfileID == nil {
+		return nil
+	}
+	teamID, teamErr := uuid.Parse(strings.TrimSpace(*entry.ProfileID))
+	credentialID, credentialErr := uuid.Parse(strings.TrimSpace(entry.EntityID))
+	if teamErr != nil || credentialErr != nil {
+		return nil
+	}
+	return &contract.CredentialMemorySpaceLookup{TeamID: teamID, CredentialID: credentialID}
+}
+
+func marshalPayload(field string, payload map[string]interface{}) ([]byte, error) {
+	if payload == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(RedactPayload(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s: %w", field, err)
+	}
+	return data, nil
+}
+
+func marshalMetadata(metadata map[string]interface{}) ([]byte, error) {
+	if metadata == nil {
+		return []byte("{}"), nil
+	}
+	data, err := json.Marshal(RedactPayload(metadata))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	return data, nil
+}
+
+// List reads team-scoped entries through the persistence port and converts them
+// to the existing producer-facing Access contract.
+func (s *Service) List(ctx context.Context, teamID string, limit, offset int) ([]accessservice.AuditLogEntry, int, error) {
+	if s == nil || s.store == nil {
+		return nil, 0, errors.New("failed to query audit log: audit: store is required")
+	}
+	entries, err := s.store.List(ctx, teamID, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query audit log: %w", err)
+	}
+	total, err := s.store.Count(ctx, teamID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count audit log entries: %w", err)
+	}
+	result := make([]accessservice.AuditLogEntry, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, accessservice.AuditLogEntry{
+			ID:            entry.ID,
+			ProfileID:     entry.ProfileID,
+			MemorySpaceID: entry.MemorySpaceID,
+			Timestamp:     entry.Timestamp,
+			Operation:     entry.Operation,
+			EntityType:    entry.EntityType,
+			EntityID:      entry.EntityID,
+			BeforePayload: decodePayload(entry.BeforePayload),
+			AfterPayload:  decodePayload(entry.AfterPayload),
+			ActorKeyID:    entry.ActorKeyID,
+			ActorRole:     entry.ActorRole,
+			ClientIP:      clientIPString(entry.ClientIP),
+			CorrelationID: entry.CorrelationID,
+			Metadata:      decodePayload(entry.Metadata),
+		})
+	}
+	return result, total, nil
+}
+
+func decodePayload(raw []byte) map[string]interface{} {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func clientIPString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func (s *Service) appendEvent(ctx context.Context, entry accessservice.AuditLogEntry) error {
+	return s.Append(ctx, entry)
+}
+
+// TeamCreated logs a team creation event.
+func (s *Service) TeamCreated(ctx context.Context, teamID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: &teamID, Operation: "CREATE", EntityType: "profile", EntityID: teamID, AfterPayload: afterPayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID})
+}
+
+// TeamUpdated logs a team update event.
+func (s *Service) TeamUpdated(ctx context.Context, teamID string, beforePayload, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: &teamID, Operation: "UPDATE", EntityType: "profile", EntityID: teamID, BeforePayload: beforePayload, AfterPayload: afterPayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID})
+}
+
+// TeamDeleteBlocked logs when a team deletion was blocked.
+func (s *Service) TeamDeleteBlocked(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string, reason string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: &teamID, Operation: "DELETE_BLOCKED", EntityType: "profile", EntityID: teamID, BeforePayload: beforePayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID, Metadata: map[string]interface{}{"reason": reason}})
+}
+
+// TeamDeleted logs a team deletion event.
+func (s *Service) TeamDeleted(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: &teamID, Operation: "DELETE", EntityType: "profile", EntityID: teamID, BeforePayload: beforePayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID})
+}
+
+// CredentialCreated logs credential creation.
+func (s *Service) CredentialCreated(ctx context.Context, teamID *string, credentialID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: teamID, Operation: "CREATE", EntityType: "api_key", EntityID: credentialID, AfterPayload: afterPayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID})
+}
+
+// CredentialRevoked logs credential revocation.
+func (s *Service) CredentialRevoked(ctx context.Context, teamID *string, credentialID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: teamID, Operation: "REVOKE", EntityType: "api_key", EntityID: credentialID, BeforePayload: beforePayload, ActorKeyID: actorCredentialID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID})
+}
+
+// AuthFailure logs an authentication failure event.
+func (s *Service) AuthFailure(ctx context.Context, profileID *string, entityType, entityID string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: profileID, Operation: "AUTH_FAILURE", EntityType: entityType, EntityID: entityID, ClientIP: clientIP, CorrelationID: correlationID, Metadata: metadata})
+}
+
+// CrossTeamDenied logs a cross-team access denial.
+func (s *Service) CrossTeamDenied(ctx context.Context, actorTeamID, targetTeamID string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["actor_profile_id"] = actorTeamID
+	metadata["target_team_id"] = targetTeamID
+	metadata["denied_operation"] = operation
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: &targetTeamID, Operation: "CROSS_PROFILE_DENIED", EntityType: "profile", EntityID: targetTeamID, ClientIP: clientIP, CorrelationID: correlationID, Metadata: metadata})
+}
+
+// RateLimited logs a rate-limiting event.
+func (s *Service) RateLimited(ctx context.Context, profileID *string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["limited_operation"] = operation
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{ProfileID: profileID, Operation: "RATE_LIMITED", EntityType: "request", EntityID: correlationID, ClientIP: clientIP, CorrelationID: correlationID, Metadata: metadata})
+}
+
+// SystemQuery logs a system-scoped query event.
+func (s *Service) SystemQuery(ctx context.Context, queryType string, metadata map[string]interface{}, actorKeyID *string, actorRole, clientIP, correlationID string) error {
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["query_type"] = queryType
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{Operation: "SYSTEM_QUERY", EntityType: "system", EntityID: queryType, ActorKeyID: actorKeyID, ActorRole: actorRole, ClientIP: clientIP, CorrelationID: correlationID, Metadata: metadata})
+}
+
+// InvariantViolation logs an invariant violation event.
+func (s *Service) InvariantViolation(ctx context.Context, entityType, entityID string, violation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["violation_description"] = violation
+	return s.appendEvent(ctx, accessservice.AuditLogEntry{Operation: "INVARIANT_VIOLATION", EntityType: entityType, EntityID: entityID, ClientIP: clientIP, CorrelationID: correlationID, Metadata: metadata})
+}

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -1,0 +1,229 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/markhuangai/dense-mem/internal/audit/contract"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+	accessservice "github.com/markhuangai/dense-mem/internal/service/access"
+)
+
+type storeStub struct {
+	entry       contract.Entry
+	appendErr   error
+	entries     []contract.Entry
+	listErr     error
+	count       int
+	countErr    error
+	appendCalls int
+}
+
+func (s *storeStub) Append(_ context.Context, entry contract.Entry) error {
+	s.entry = entry
+	s.appendCalls++
+	return s.appendErr
+}
+
+func (s *storeStub) List(context.Context, string, int, int) ([]contract.Entry, error) {
+	return s.entries, s.listErr
+}
+
+func (s *storeStub) Count(context.Context, string) (int, error) {
+	return s.count, s.countErr
+}
+
+func TestAppendRedactsPayloadsWithoutMutatingTheCaller(t *testing.T) {
+	store := &storeStub{}
+	svc := New(store)
+	ctx := requestctx.WithClientIP(context.Background(), "192.0.2.10")
+	entry := accessservice.AuditLogEntry{
+		ID:           "audit-1",
+		ProfileID:    stringPointer("team-1"),
+		Timestamp:    time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+		Operation:    "CREATE",
+		EntityType:   "profile",
+		EntityID:     "team-1",
+		AfterPayload: map[string]interface{}{"name": "safe", "api_key": "remove", "nested": map[string]interface{}{"token": "remove", "label": "keep"}},
+		Metadata:     map[string]interface{}{"source": "test", "password": "remove"},
+	}
+
+	require.NoError(t, svc.Append(ctx, entry))
+	require.Equal(t, 1, store.appendCalls)
+	require.Equal(t, "audit-1", store.entry.ID)
+	require.Equal(t, "192.0.2.10", store.entry.ClientIP)
+	require.JSONEq(t, `{"name":"safe","nested":{"label":"keep"}}`, string(store.entry.AfterPayload))
+	require.JSONEq(t, `{"source":"test"}`, string(store.entry.Metadata))
+	require.Contains(t, entry.AfterPayload, "api_key")
+	require.Contains(t, entry.Metadata, "password")
+}
+
+func TestAppendReportsJSONErrorsBeforeStoreAccess(t *testing.T) {
+	store := &storeStub{}
+	svc := New(store)
+	err := svc.Append(context.Background(), accessservice.AuditLogEntry{
+		BeforePayload: map[string]interface{}{"invalid": func() {}},
+	})
+	require.ErrorContains(t, err, "failed to marshal before_payload")
+	require.Zero(t, store.appendCalls)
+
+	err = svc.Append(context.Background(), accessservice.AuditLogEntry{
+		AfterPayload: map[string]interface{}{"invalid": func() {}},
+	})
+	require.ErrorContains(t, err, "failed to marshal after_payload")
+	require.Zero(t, store.appendCalls)
+
+	err = svc.Append(context.Background(), accessservice.AuditLogEntry{
+		Metadata: map[string]interface{}{"invalid": func() {}},
+	})
+	require.ErrorContains(t, err, "failed to marshal metadata")
+	require.Zero(t, store.appendCalls)
+}
+
+func TestAppendOwnsCredentialSpaceLookupEligibility(t *testing.T) {
+	store := &storeStub{}
+	teamID := "adc56b94-9853-45d6-b970-aafadf2d1c5d"
+	credentialID := "b5ca9fc3-60a6-4e65-9227-c22a91f85d5c"
+	require.NoError(t, New(store).Append(context.Background(), accessservice.AuditLogEntry{
+		ProfileID: &teamID, EntityType: "api_key", EntityID: credentialID, Metadata: map[string]interface{}{},
+	}))
+	require.NotNil(t, store.entry.CredentialMemorySpaceLookup)
+	require.Equal(t, teamID, store.entry.CredentialMemorySpaceLookup.TeamID.String())
+	require.Equal(t, credentialID, store.entry.CredentialMemorySpaceLookup.CredentialID.String())
+
+	store = &storeStub{}
+	require.NoError(t, New(store).Append(context.Background(), accessservice.AuditLogEntry{
+		ProfileID: stringPointer("not-a-uuid"), EntityType: "api_key", EntityID: credentialID, Metadata: map[string]interface{}{},
+	}))
+	require.Nil(t, store.entry.CredentialMemorySpaceLookup)
+}
+
+func TestEventHelpersPreserveOperationsAndMetadata(t *testing.T) {
+	store := &storeStub{}
+	svc := New(store)
+	ctx := context.Background()
+
+	require.NoError(t, svc.TeamDeleteBlocked(ctx, "team-1", nil, nil, "admin", "", "corr", "active keys"))
+	require.Equal(t, "DELETE_BLOCKED", store.entry.Operation)
+	metadata := decodePayload(store.entry.Metadata)
+	require.Equal(t, "active keys", metadata["reason"])
+
+	require.NoError(t, svc.CrossTeamDenied(ctx, "actor", "target", "read", nil, "", "corr"))
+	require.Equal(t, "CROSS_PROFILE_DENIED", store.entry.Operation)
+	metadata = decodePayload(store.entry.Metadata)
+	require.Equal(t, "actor", metadata["actor_profile_id"])
+	require.Equal(t, "target", metadata["target_team_id"])
+	require.Equal(t, "read", metadata["denied_operation"])
+}
+
+func TestEventHelpersCoverTheRemainingAuditOperations(t *testing.T) {
+	store := &storeStub{}
+	svc := New(store)
+	ctx := context.Background()
+	teamID := "team-1"
+	credentialID := "credential-1"
+	actorID := "actor-1"
+
+	require.NoError(t, svc.TeamCreated(ctx, teamID, nil, &actorID, "admin", "", "created"))
+	require.Equal(t, "CREATE", store.entry.Operation)
+	require.Equal(t, teamID, store.entry.EntityID)
+
+	require.NoError(t, svc.TeamUpdated(ctx, teamID, nil, nil, &actorID, "admin", "", "updated"))
+	require.Equal(t, "UPDATE", store.entry.Operation)
+
+	require.NoError(t, svc.TeamDeleted(ctx, teamID, nil, &actorID, "admin", "", "deleted"))
+	require.Equal(t, "DELETE", store.entry.Operation)
+
+	require.NoError(t, svc.CredentialCreated(ctx, &teamID, credentialID, nil, &actorID, "admin", "", "credential-created"))
+	require.Equal(t, "CREATE", store.entry.Operation)
+	require.Equal(t, "api_key", store.entry.EntityType)
+
+	require.NoError(t, svc.CredentialRevoked(ctx, &teamID, credentialID, nil, &actorID, "admin", "", "credential-revoked"))
+	require.Equal(t, "REVOKE", store.entry.Operation)
+
+	require.NoError(t, svc.AuthFailure(ctx, &teamID, "api_key", credentialID, nil, "", "auth-failed"))
+	require.Equal(t, "AUTH_FAILURE", store.entry.Operation)
+
+	require.NoError(t, svc.RateLimited(ctx, &teamID, "read", nil, "", "rate-limited"))
+	require.Equal(t, "RATE_LIMITED", store.entry.Operation)
+	require.Equal(t, "read", decodePayload(store.entry.Metadata)["limited_operation"])
+
+	require.NoError(t, svc.SystemQuery(ctx, "list_profiles", nil, &actorID, "system", "", "system-query"))
+	require.Equal(t, "SYSTEM_QUERY", store.entry.Operation)
+	require.Equal(t, "list_profiles", decodePayload(store.entry.Metadata)["query_type"])
+
+	require.NoError(t, svc.InvariantViolation(ctx, "profile", teamID, "missing owner", nil, "", "invariant"))
+	require.Equal(t, "INVARIANT_VIOLATION", store.entry.Operation)
+	require.Equal(t, "missing owner", decodePayload(store.entry.Metadata)["violation_description"])
+}
+
+func TestListConvertsEntriesAndSeparatesCountFailure(t *testing.T) {
+	store := &storeStub{
+		entries: []contract.Entry{{
+			ID:            "audit-1",
+			ProfileID:     stringPointer("team-1"),
+			MemorySpaceID: stringPointer("space-1"),
+			Timestamp:     time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC),
+			Operation:     "UPDATE",
+			EntityType:    "profile",
+			EntityID:      "team-1",
+			BeforePayload: []byte(`{"name":"before"}`),
+			AfterPayload:  []byte(`{"name":"after"}`),
+			ActorKeyID:    stringPointer("key-1"),
+			ActorRole:     "admin",
+			ClientIP:      "203.0.113.10",
+			CorrelationID: "corr-1",
+			Metadata:      []byte(`{"source":"test"}`),
+		}},
+		count: 3,
+	}
+	entries, total, err := New(store).List(context.Background(), "team-1", 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+	require.Len(t, entries, 1)
+	require.Equal(t, "space-1", *entries[0].MemorySpaceID)
+	require.Equal(t, "before", entries[0].BeforePayload["name"])
+	require.Equal(t, "after", entries[0].AfterPayload["name"])
+
+	store.countErr = errors.New("count failed")
+	_, _, err = New(store).List(context.Background(), "team-1", 20, 0)
+	require.ErrorContains(t, err, "failed to count audit log entries")
+}
+
+func TestListBoundsMalformedPayloadsAndNilClientIP(t *testing.T) {
+	store := &storeStub{entries: []contract.Entry{{
+		ID:            "audit-invalid",
+		BeforePayload: []byte("not-json"),
+		AfterPayload:  []byte("not-json"),
+		Metadata:      []byte("not-json"),
+	}}, count: 1}
+	entries, total, err := New(store).List(context.Background(), "team-1", 1, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, entries, 1)
+	require.Nil(t, entries[0].BeforePayload)
+	require.Nil(t, entries[0].AfterPayload)
+	require.Nil(t, entries[0].Metadata)
+	require.Empty(t, entries[0].ClientIP)
+}
+
+func TestRedactPayloadHandlesTypedNestedValues(t *testing.T) {
+	redacted := RedactPayload(map[string]interface{}{
+		"safe":   "keep",
+		"nested": map[string]string{"clientSecret": "remove", "value": "keep"},
+		"items":  []map[string]interface{}{{"refresh_token": "remove", "value": "keep"}},
+	})
+	raw, err := json.Marshal(redacted)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "remove")
+	require.Contains(t, string(raw), "keep")
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/internal/service/audit_service.e2e
+++ b/internal/service/audit_service.e2e
@@ -752,9 +752,15 @@ func TestAuditServiceListIsolatesTeamsForNonSuperuser(t *testing.T) {
 	roleCreated := false
 	defer func() {
 		if roleCreated {
-			_ = rlss.WithSystemTx(context.Background(), adminDB, func(tx *gorm.DB) error {
-				return tx.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", roleName)).Error
+			err := rlss.WithSystemTx(context.Background(), adminDB, func(tx *gorm.DB) error {
+				return tx.Exec(fmt.Sprintf(`
+					REVOKE ALL ON ALL TABLES IN SCHEMA public FROM %s;
+					REVOKE ALL ON SCHEMA public FROM %s;
+					DROP OWNED BY %s;
+					DROP ROLE IF EXISTS %s;
+				`, roleName, roleName, roleName, roleName)).Error
 			})
+			require.NoError(t, err, "clean up audit RLS test role")
 		}
 	}()
 	require.NoError(t, rlss.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
@@ -797,4 +803,10 @@ func TestAuditServiceListIsolatesTeamsForNonSuperuser(t *testing.T) {
 	require.Equal(t, 1, total)
 	require.Len(t, entries, 1)
 	require.Equal(t, "test-audit-rls-a", entries[0].EntityID)
+
+	var visibleEntityIDs []string
+	require.NoError(t, rlss.WithTeamTx(ctx, appDB, teamAString, func(tx *gorm.DB) error {
+		return tx.Raw(`SELECT entity_id FROM audit_log ORDER BY entity_id`).Scan(&visibleEntityIDs).Error
+	}))
+	require.Equal(t, []string{"test-audit-rls-a"}, visibleEntityIDs)
 }

--- a/internal/service/audit_service.e2e
+++ b/internal/service/audit_service.e2e
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,7 +48,7 @@ func skipIfNoPostgres(t *testing.T, ctx context.Context) (string, func()) {
 			testcontainers.WithWaitStrategy(
 				wait.ForLog("database system is ready to accept connections").
 					WithOccurrence(2).
-					WithStartupTimeout(30*time.Second),
+					WithStartupTimeout(30 * time.Second),
 			),
 		}
 		if networkName := os.Getenv("DENSE_MEM_CI_PRECHECK_NETWORK"); networkName != "" {
@@ -725,4 +728,73 @@ func TestAuditServiceHelperMethods(t *testing.T) {
 		clientIP, correlationID)
 	require.NoError(t, err, "InvariantViolation should succeed")
 	verifyAuditEntry(t, sqlDB, ctx, profileID, "INVARIANT_VIOLATION")
+}
+
+// TestAuditServiceListIsolatesTeamsForNonSuperuser proves the audit read path
+// applies PostgreSQL RLS rather than relying on the service-side team filter.
+func TestAuditServiceListIsolatesTeamsForNonSuperuser(t *testing.T) {
+	ctx := context.Background()
+	dsn, cleanup := skipIfNoPostgres(t, ctx)
+	defer cleanup()
+
+	adminDB, err := postgres.Open(ctx, &testConfig{dsn: dsn})
+	require.NoError(t, err)
+	adminSQL, err := adminDB.DB()
+	require.NoError(t, err)
+	defer adminSQL.Close()
+
+	migrator, err := postgres.NewMigrator(adminDB)
+	require.NoError(t, err)
+	require.NoError(t, migrator.RunUp(ctx))
+	rlss := postgres.NewRLS()
+	roleName := "densemem_audit_rls_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	rolePassword := "densemem_audit_rls_password"
+	roleCreated := false
+	defer func() {
+		if roleCreated {
+			_ = rlss.WithSystemTx(context.Background(), adminDB, func(tx *gorm.DB) error {
+				return tx.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", roleName)).Error
+			})
+		}
+	}()
+	require.NoError(t, rlss.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(fmt.Sprintf(`
+			CREATE ROLE %s LOGIN PASSWORD '%s' NOSUPERUSER NOBYPASSRLS;
+			GRANT USAGE ON SCHEMA public TO %s;
+			GRANT SELECT ON ALL TABLES IN SCHEMA public TO %s;
+		`, roleName, rolePassword, roleName, roleName)).Error
+	}))
+	roleCreated = true
+
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		t.Skip("audit RLS integration test requires a URL-form PostgreSQL DSN")
+	}
+	parsed.User = url.UserPassword(roleName, rolePassword)
+	appDB, err := postgres.Open(ctx, &testConfig{dsn: parsed.String()})
+	require.NoError(t, err)
+	appSQL, err := appDB.DB()
+	require.NoError(t, err)
+	defer appSQL.Close()
+
+	teamA := uuid.New()
+	teamB := uuid.New()
+	require.NoError(t, rlss.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		if err := tx.Exec("INSERT INTO teams (id, name) VALUES (?, ?), (?, ?)", teamA, "Test Audit RLS A", teamB, "Test Audit RLS B").Error; err != nil {
+			return err
+		}
+		return nil
+	}))
+
+	adminAudit := NewAuditService(adminDB)
+	teamAString := teamA.String()
+	teamBString := teamB.String()
+	require.NoError(t, adminAudit.Append(ctx, AuditLogEntry{ProfileID: &teamAString, Operation: "CREATE", EntityType: "test", EntityID: "test-audit-rls-a"}))
+	require.NoError(t, adminAudit.Append(ctx, AuditLogEntry{ProfileID: &teamBString, Operation: "CREATE", EntityType: "test", EntityID: "test-audit-rls-b"}))
+
+	entries, total, err := NewAuditService(appDB).List(ctx, teamAString, 20, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, entries, 1)
+	require.Equal(t, "test-audit-rls-a", entries[0].EntityID)
 }

--- a/internal/service/audit_service.go
+++ b/internal/service/audit_service.go
@@ -1,596 +1,124 @@
+// Package service keeps the historical audit import path as a compatibility
+// facade. Audit policy and persistence live in internal/audit.
 package service
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
-	"strings"
-	"time"
 
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/markhuangai/dense-mem/internal/requestctx"
+	auditapp "github.com/markhuangai/dense-mem/internal/audit"
+	auditpostgres "github.com/markhuangai/dense-mem/internal/audit/postgres"
 	accessservice "github.com/markhuangai/dense-mem/internal/service/access"
-	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
 )
 
-// AuditLogEntry and AuditService remain source-compatible aliases while the
-// access capability owns the consumer-facing audit port.
+// AuditLogEntry and AuditService remain source-compatible aliases for callers
+// that have not yet migrated to the capability-owned API.
 type AuditLogEntry = accessservice.AuditLogEntry
 type AuditService = accessservice.AuditService
 
-// AuditServiceImpl implements the AuditService interface.
+// AuditServiceImpl forwards the historical constructor and methods to the
+// capability owner. Its fields are retained only for old in-package tests and
+// compatibility callers that configure the legacy SQL seam.
 type AuditServiceImpl struct {
 	db     *gorm.DB
 	logger *slog.Logger
-	rls    postgres.RLSHelper
+	rls    storagepostgres.RLSHelper
+	inner  *auditapp.Service
 }
 
-// Ensure AuditServiceImpl implements AuditService
 var _ AuditService = (*AuditServiceImpl)(nil)
 
-// NewAuditService creates a new audit service instance.
+// NewAuditService creates the compatibility facade around the native audit
+// service and PostgreSQL adapter.
 func NewAuditService(db *gorm.DB) *AuditServiceImpl {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-	return &AuditServiceImpl{db: db, logger: logger, rls: postgres.NewRLS()}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	rls := storagepostgres.NewRLS()
+	return &AuditServiceImpl{db: db, logger: logger, rls: rls, inner: auditapp.New(auditpostgres.NewStore(db, rls))}
 }
 
-// NewAuditServiceWithLogger creates a new audit service instance with a custom logger.
+// NewAuditServiceWithLogger preserves the historical test and integration
+// constructor while forwarding all behavior to internal/audit.
 func NewAuditServiceWithLogger(db *gorm.DB, logger *slog.Logger) *AuditServiceImpl {
-	return &AuditServiceImpl{db: db, logger: logger, rls: postgres.NewRLS()}
+	rls := storagepostgres.NewRLS()
+	return &AuditServiceImpl{db: db, logger: logger, rls: rls, inner: auditapp.New(auditpostgres.NewStore(db, rls))}
 }
 
-// sensitiveFields contains exact normalized field names redacted from audit data.
-var sensitiveFields = map[string]struct{}{
-	"access_token":     {},
-	"accesstoken":      {},
-	"ai_api_key":       {},
-	"api_key":          {},
-	"apikey":           {},
-	"authorization":    {},
-	"encrypted_secret": {},
-	"embedding":        {},
-	"embeddings":       {},
-	"key_hash":         {},
-	"password":         {},
-	"raw_key":          {},
-	"refresh_token":    {},
-	"refreshtoken":     {},
-	"secret":           {},
-	"token":            {},
+func (s *AuditServiceImpl) native() *auditapp.Service {
+	if s == nil {
+		return auditapp.New(nil)
+	}
+	if s.inner == nil {
+		if s.db == nil {
+			s.inner = auditapp.New(nil)
+		} else {
+			s.inner = auditapp.New(auditpostgres.NewStore(s.db, s.rls))
+		}
+	}
+	return s.inner
 }
 
-// redactPayload removes sensitive fields from audit maps.
-// It returns a new map and does not modify the original.
+func (s *AuditServiceImpl) Append(ctx context.Context, entry AuditLogEntry) error {
+	return s.native().Append(ctx, entry)
+}
+
+func (s *AuditServiceImpl) List(ctx context.Context, teamID string, limit, offset int) ([]AuditLogEntry, int, error) {
+	return s.native().List(ctx, teamID, limit, offset)
+}
+
+func (s *AuditServiceImpl) TeamCreated(ctx context.Context, teamID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().TeamCreated(ctx, teamID, afterPayload, actorCredentialID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) TeamUpdated(ctx context.Context, teamID string, beforePayload, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().TeamUpdated(ctx, teamID, beforePayload, afterPayload, actorCredentialID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) TeamDeleteBlocked(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string, reason string) error {
+	return s.native().TeamDeleteBlocked(ctx, teamID, beforePayload, actorCredentialID, actorRole, clientIP, correlationID, reason)
+}
+
+func (s *AuditServiceImpl) TeamDeleted(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().TeamDeleted(ctx, teamID, beforePayload, actorCredentialID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) CredentialCreated(ctx context.Context, teamID *string, credentialID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().CredentialCreated(ctx, teamID, credentialID, afterPayload, actorCredentialID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) CredentialRevoked(ctx context.Context, teamID *string, credentialID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().CredentialRevoked(ctx, teamID, credentialID, beforePayload, actorCredentialID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) AuthFailure(ctx context.Context, profileID *string, entityType, entityID string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	return s.native().AuthFailure(ctx, profileID, entityType, entityID, metadata, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) CrossTeamDenied(ctx context.Context, actorTeamID, targetTeamID string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	return s.native().CrossTeamDenied(ctx, actorTeamID, targetTeamID, operation, metadata, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) RateLimited(ctx context.Context, profileID *string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	return s.native().RateLimited(ctx, profileID, operation, metadata, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) SystemQuery(ctx context.Context, queryType string, metadata map[string]interface{}, actorKeyID *string, actorRole, clientIP, correlationID string) error {
+	return s.native().SystemQuery(ctx, queryType, metadata, actorKeyID, actorRole, clientIP, correlationID)
+}
+
+func (s *AuditServiceImpl) InvariantViolation(ctx context.Context, entityType, entityID string, violation string, metadata map[string]interface{}, clientIP, correlationID string) error {
+	return s.native().InvariantViolation(ctx, entityType, entityID, violation, metadata, clientIP, correlationID)
+}
+
+// These helpers preserve the old package's narrow in-package test seam while
+// delegating redaction and request-context policy to the native owner.
 func redactPayload(payload map[string]interface{}) map[string]interface{} {
-	if payload == nil {
-		return nil
-	}
-
-	redacted := make(map[string]interface{}, len(payload))
-	for key, value := range payload {
-		if isSensitiveAuditField(key) {
-			continue
-		}
-		redacted[key] = redactAuditValue(value)
-	}
-	return redacted
-}
-
-func isSensitiveAuditField(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
-	normalized = strings.ReplaceAll(normalized, "-", "_")
-	if _, ok := sensitiveFields[normalized]; ok {
-		return true
-	}
-	compact := strings.ReplaceAll(normalized, "_", "")
-	if _, ok := sensitiveFields[compact]; ok {
-		return true
-	}
-	return strings.HasSuffix(normalized, "_api_key") ||
-		strings.HasSuffix(normalized, "_password") ||
-		strings.HasSuffix(normalized, "_secret") ||
-		strings.HasSuffix(normalized, "_token") ||
-		strings.HasSuffix(compact, "apikey") ||
-		strings.HasSuffix(compact, "password") ||
-		strings.HasSuffix(compact, "secret") ||
-		strings.HasSuffix(compact, "token")
-}
-
-func redactAuditValue(value interface{}) interface{} {
-	switch typed := value.(type) {
-	case map[string]interface{}:
-		return redactPayload(typed)
-	case []interface{}:
-		redacted := make([]interface{}, len(typed))
-		for i, child := range typed {
-			redacted[i] = redactAuditValue(child)
-		}
-		return redacted
-	}
-
-	reflected := reflect.ValueOf(value)
-	if !reflected.IsValid() {
-		return value
-	}
-	if reflected.Kind() == reflect.Map && reflected.Type().Key().Kind() == reflect.String {
-		fields := make(map[string]interface{}, reflected.Len())
-		iter := reflected.MapRange()
-		for iter.Next() {
-			fields[iter.Key().String()] = iter.Value().Interface()
-		}
-		return redactPayload(fields)
-	}
-	if reflected.Kind() == reflect.Slice || reflected.Kind() == reflect.Array {
-		if reflected.Type().Elem().Kind() == reflect.Uint8 {
-			return value
-		}
-		redacted := make([]interface{}, reflected.Len())
-		for i := 0; i < reflected.Len(); i++ {
-			redacted[i] = redactAuditValue(reflected.Index(i).Interface())
-		}
-		return redacted
-	}
-	return value
+	return auditapp.RedactPayload(payload)
 }
 
 func auditClientIPValue(ctx context.Context, entry AuditLogEntry) any {
-	clientIP := strings.TrimSpace(entry.ClientIP)
-	if clientIP == "" {
-		clientIP = requestctx.ClientIPFromContext(ctx)
-	}
-	if clientIP == "" {
-		return nil
-	}
-	return clientIP
-}
-
-// Append writes an audit log entry to the database.
-// Payloads are automatically redacted to remove sensitive fields.
-func (s *AuditServiceImpl) Append(ctx context.Context, entry AuditLogEntry) error {
-	// Redact sensitive fields from payloads
-	beforePayload := redactPayload(entry.BeforePayload)
-	afterPayload := redactPayload(entry.AfterPayload)
-
-	// Convert payloads to JSON
-	var beforeJSON, afterJSON interface{}
-	if beforePayload != nil {
-		data, err := json.Marshal(beforePayload)
-		if err != nil {
-			return fmt.Errorf("failed to marshal before_payload: %w", err)
-		}
-		beforeJSON = data
-	}
-	if afterPayload != nil {
-		data, err := json.Marshal(afterPayload)
-		if err != nil {
-			return fmt.Errorf("failed to marshal after_payload: %w", err)
-		}
-		afterJSON = data
-	}
-
-	// Convert metadata to JSON
-	metadataJSON := []byte("{}")
-	if entry.Metadata != nil {
-		data, err := json.Marshal(redactPayload(entry.Metadata))
-		if err != nil {
-			return fmt.Errorf("failed to marshal metadata: %w", err)
-		}
-		metadataJSON = data
-	}
-
-	// Use the current timestamp if not provided
-	timestamp := entry.Timestamp
-	if timestamp.IsZero() {
-		timestamp = time.Now().UTC()
-	}
-
-	// Generate UUID in Go if not provided (not in SQL via COALESCE)
-	id := entry.ID
-	if id == "" {
-		id = uuid.New().String()
-	}
-	clientIP := auditClientIPValue(ctx, entry)
-
-	insertFn := func(tx *gorm.DB) error {
-		memorySpaceID := entry.MemorySpaceID
-		if memorySpaceID == nil && entry.EntityType == "api_key" && entry.ProfileID != nil {
-			teamID, teamParseErr := uuid.Parse(strings.TrimSpace(*entry.ProfileID))
-			if credentialID, credentialParseErr := uuid.Parse(strings.TrimSpace(entry.EntityID)); teamParseErr == nil && credentialParseErr == nil {
-				var candidate sql.NullString
-				lookupErr := tx.WithContext(ctx).Raw(`
-					SELECT memory_space_id::text
-					FROM credentials
-					WHERE id = $1 AND team_id = $2
-				`, credentialID, teamID).Row().Scan(&candidate)
-				if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
-					return lookupErr
-				}
-				if candidate.Valid && strings.TrimSpace(candidate.String) != "" {
-					memorySpaceID = &candidate.String
-				}
-			}
-		}
-		return tx.Exec(`
-			INSERT INTO audit_log (
-				id, team_id, timestamp, operation, entity_type, entity_id,
-				before_payload, after_payload, actor_profile_id, actor_role,
-				client_ip, correlation_id, metadata, memory_space_id
-			) VALUES (
-				$1, $2, $3, $4, $5, $6,
-				$7, $8, $9, $10, $11, $12, $13, $14
-			)
-		`,
-			id,
-			entry.ProfileID,
-			timestamp,
-			entry.Operation,
-			entry.EntityType,
-			entry.EntityID,
-			beforeJSON,
-			afterJSON,
-			entry.ActorKeyID,
-			entry.ActorRole,
-			clientIP,
-			entry.CorrelationID,
-			metadataJSON,
-			memorySpaceID,
-		).Error
-	}
-
-	var err error
-	if s.rls != nil {
-		err = s.rls.WithSystemTx(ctx, s.db, insertFn)
-	} else {
-		err = insertFn(s.db.WithContext(ctx))
-	}
-	if err != nil {
-		return fmt.Errorf("failed to append audit log entry: %w", err)
-	}
-
-	return nil
-}
-
-// List retrieves audit log entries for a specific team with pagination.
-// Entries are returned in descending order by timestamp (most recent first).
-func (s *AuditServiceImpl) List(ctx context.Context, teamID string, limit, offset int) ([]AuditLogEntry, int, error) {
-	var entries []AuditLogEntry
-	queryFn := func(tx *gorm.DB) error {
-		rows, err := tx.Raw(`
-			SELECT id, team_id, timestamp, operation, entity_type, entity_id,
-			       before_payload, after_payload, actor_profile_id, actor_role,
-			       client_ip, correlation_id, metadata, memory_space_id::text
-			FROM audit_log AS audit
-			WHERE audit.team_id = $1
-			  AND (
-				  audit.memory_space_id IS NULL
-				  OR EXISTS (
-					  SELECT 1
-					  FROM memory_spaces AS space
-					  WHERE space.id = audit.memory_space_id
-					    AND space.team_id = audit.team_id
-					    AND space.lifecycle_state = 'active'
-				  )
-			  )
-			ORDER BY timestamp DESC
-			LIMIT $2 OFFSET $3
-		`, teamID, limit, offset).Rows()
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var entry AuditLogEntry
-			var beforePayloadJSON, afterPayloadJSON, metadataJSON []byte
-			var profileIDNullable sql.NullString
-			var actorKeyIDNullable sql.NullString
-			var clientIPNullable sql.NullString
-			var memorySpaceIDNullable sql.NullString
-
-			err := rows.Scan(
-				&entry.ID,
-				&profileIDNullable,
-				&entry.Timestamp,
-				&entry.Operation,
-				&entry.EntityType,
-				&entry.EntityID,
-				&beforePayloadJSON,
-				&afterPayloadJSON,
-				&actorKeyIDNullable,
-				&entry.ActorRole,
-				&clientIPNullable,
-				&entry.CorrelationID,
-				&metadataJSON,
-				&memorySpaceIDNullable,
-			)
-			if err != nil {
-				return err
-			}
-
-			// Handle nullable fields
-			if profileIDNullable.Valid {
-				entry.ProfileID = &profileIDNullable.String
-			}
-			if actorKeyIDNullable.Valid {
-				entry.ActorKeyID = &actorKeyIDNullable.String
-			}
-			if clientIPNullable.Valid {
-				entry.ClientIP = clientIPNullable.String
-			}
-			if memorySpaceIDNullable.Valid {
-				entry.MemorySpaceID = &memorySpaceIDNullable.String
-			}
-
-			// Parse JSON payloads
-			if len(beforePayloadJSON) > 0 {
-				if err := json.Unmarshal(beforePayloadJSON, &entry.BeforePayload); err != nil {
-					entry.BeforePayload = nil
-				}
-			}
-			if len(afterPayloadJSON) > 0 {
-				if err := json.Unmarshal(afterPayloadJSON, &entry.AfterPayload); err != nil {
-					entry.AfterPayload = nil
-				}
-			}
-			if len(metadataJSON) > 0 {
-				if err := json.Unmarshal(metadataJSON, &entry.Metadata); err != nil {
-					entry.Metadata = nil
-				}
-			}
-
-			entries = append(entries, entry)
-		}
-
-		return rows.Err()
-	}
-
-	var total int
-	if s.rls != nil {
-		if err := s.rls.WithTeamTx(ctx, s.db, teamID, queryFn); err != nil {
-			return nil, 0, fmt.Errorf("failed to query audit log: %w", err)
-		}
-		if err := s.rls.WithTeamTx(ctx, s.db, teamID, func(tx *gorm.DB) error {
-			return tx.Raw(`
-				SELECT COUNT(*)
-				FROM audit_log AS audit
-				WHERE audit.team_id = $1
-				  AND (
-					  audit.memory_space_id IS NULL
-					  OR EXISTS (
-						  SELECT 1
-						  FROM memory_spaces AS space
-						  WHERE space.id = audit.memory_space_id
-						    AND space.team_id = audit.team_id
-						    AND space.lifecycle_state = 'active'
-					  )
-				  )
-			`, teamID).Scan(&total).Error
-		}); err != nil {
-			return nil, 0, fmt.Errorf("failed to count audit log entries: %w", err)
-		}
-	} else {
-		if err := queryFn(s.db.WithContext(ctx)); err != nil {
-			return nil, 0, fmt.Errorf("failed to query audit log: %w", err)
-		}
-		if err := s.db.WithContext(ctx).Raw(`
-			SELECT COUNT(*)
-			FROM audit_log AS audit
-			WHERE audit.team_id = $1
-			  AND (
-				  audit.memory_space_id IS NULL
-				  OR EXISTS (
-					  SELECT 1
-					  FROM memory_spaces AS space
-					  WHERE space.id = audit.memory_space_id
-					    AND space.team_id = audit.team_id
-					    AND space.lifecycle_state = 'active'
-				  )
-			  )
-		`, teamID).Scan(&total).Error; err != nil {
-			return nil, 0, fmt.Errorf("failed to count audit log entries: %w", err)
-		}
-	}
-
-	return entries, total, nil
-}
-
-// TeamCreated logs a team creation event using retained audit schema values.
-func (s *AuditServiceImpl) TeamCreated(ctx context.Context, teamID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     &teamID,
-		Operation:     "CREATE",
-		EntityType:    "profile",
-		EntityID:      teamID,
-		AfterPayload:  afterPayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-	}
-	return s.Append(ctx, entry)
-}
-
-// TeamUpdated logs a team update event using retained audit schema values.
-func (s *AuditServiceImpl) TeamUpdated(ctx context.Context, teamID string, beforePayload, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     &teamID,
-		Operation:     "UPDATE",
-		EntityType:    "profile",
-		EntityID:      teamID,
-		BeforePayload: beforePayload,
-		AfterPayload:  afterPayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-	}
-	return s.Append(ctx, entry)
-}
-
-// TeamDeleteBlocked logs when a team deletion was blocked.
-func (s *AuditServiceImpl) TeamDeleteBlocked(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string, reason string) error {
-	entry := AuditLogEntry{
-		ProfileID:     &teamID,
-		Operation:     "DELETE_BLOCKED",
-		EntityType:    "profile",
-		EntityID:      teamID,
-		BeforePayload: beforePayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata: map[string]interface{}{
-			"reason": reason,
-		},
-	}
-	return s.Append(ctx, entry)
-}
-
-// TeamDeleted logs a team deletion event using retained audit schema values.
-func (s *AuditServiceImpl) TeamDeleted(ctx context.Context, teamID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     &teamID,
-		Operation:     "DELETE",
-		EntityType:    "profile",
-		EntityID:      teamID,
-		BeforePayload: beforePayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-	}
-	return s.Append(ctx, entry)
-}
-
-// CredentialCreated logs credential creation using retained audit schema values.
-func (s *AuditServiceImpl) CredentialCreated(ctx context.Context, teamID *string, credentialID string, afterPayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     teamID,
-		Operation:     "CREATE",
-		EntityType:    "api_key",
-		EntityID:      credentialID,
-		AfterPayload:  afterPayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-	}
-	return s.Append(ctx, entry)
-}
-
-// CredentialRevoked logs credential revocation using retained audit schema values.
-func (s *AuditServiceImpl) CredentialRevoked(ctx context.Context, teamID *string, credentialID string, beforePayload map[string]interface{}, actorCredentialID *string, actorRole, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     teamID,
-		Operation:     "REVOKE",
-		EntityType:    "api_key",
-		EntityID:      credentialID,
-		BeforePayload: beforePayload,
-		ActorKeyID:    actorCredentialID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-	}
-	return s.Append(ctx, entry)
-}
-
-// AuthFailure logs an authentication failure event.
-func (s *AuditServiceImpl) AuthFailure(ctx context.Context, profileID *string, entityType, entityID string, metadata map[string]interface{}, clientIP, correlationID string) error {
-	entry := AuditLogEntry{
-		ProfileID:     profileID,
-		Operation:     "AUTH_FAILURE",
-		EntityType:    entityType,
-		EntityID:      entityID,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata:      metadata,
-	}
-	return s.Append(ctx, entry)
-}
-
-// CrossTeamDenied logs a cross-team access denial using retained audit values.
-func (s *AuditServiceImpl) CrossTeamDenied(ctx context.Context, actorTeamID, targetTeamID string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
-	if metadata == nil {
-		metadata = make(map[string]interface{})
-	}
-	metadata["actor_profile_id"] = actorTeamID
-	metadata["target_team_id"] = targetTeamID
-	metadata["denied_operation"] = operation
-
-	entry := AuditLogEntry{
-		ProfileID:     &targetTeamID,
-		Operation:     "CROSS_PROFILE_DENIED",
-		EntityType:    "profile",
-		EntityID:      targetTeamID,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata:      metadata,
-	}
-	return s.Append(ctx, entry)
-}
-
-// RateLimited logs a rate limiting event.
-func (s *AuditServiceImpl) RateLimited(ctx context.Context, profileID *string, operation string, metadata map[string]interface{}, clientIP, correlationID string) error {
-	if metadata == nil {
-		metadata = make(map[string]interface{})
-	}
-	metadata["limited_operation"] = operation
-
-	entry := AuditLogEntry{
-		ProfileID:     profileID,
-		Operation:     "RATE_LIMITED",
-		EntityType:    "request",
-		EntityID:      correlationID,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata:      metadata,
-	}
-	return s.Append(ctx, entry)
-}
-
-// SystemQuery logs a system-scoped query event.
-func (s *AuditServiceImpl) SystemQuery(ctx context.Context, queryType string, metadata map[string]interface{}, actorKeyID *string, actorRole, clientIP, correlationID string) error {
-	if metadata == nil {
-		metadata = make(map[string]interface{})
-	}
-	metadata["query_type"] = queryType
-
-	entry := AuditLogEntry{
-		Operation:     "SYSTEM_QUERY",
-		EntityType:    "system",
-		EntityID:      queryType,
-		ActorKeyID:    actorKeyID,
-		ActorRole:     actorRole,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata:      metadata,
-	}
-	return s.Append(ctx, entry)
-}
-
-// InvariantViolation logs an invariant violation event.
-func (s *AuditServiceImpl) InvariantViolation(ctx context.Context, entityType, entityID string, violation string, metadata map[string]interface{}, clientIP, correlationID string) error {
-	if metadata == nil {
-		metadata = make(map[string]interface{})
-	}
-	metadata["violation_description"] = violation
-
-	entry := AuditLogEntry{
-		Operation:     "INVARIANT_VIOLATION",
-		EntityType:    entityType,
-		EntityID:      entityID,
-		ClientIP:      clientIP,
-		CorrelationID: correlationID,
-		Metadata:      metadata,
-	}
-	return s.Append(ctx, entry)
+	return auditapp.AuditClientIPValue(ctx, entry)
 }

--- a/internal/service/audit_service_unit_test.go
+++ b/internal/service/audit_service_unit_test.go
@@ -17,6 +17,8 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
+	auditapp "github.com/markhuangai/dense-mem/internal/audit"
+	auditpostgres "github.com/markhuangai/dense-mem/internal/audit/postgres"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
 )
 
@@ -91,6 +93,7 @@ func newMockAuditService(t *testing.T) (*AuditServiceImpl, sqlmock.Sqlmock, func
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	svc := NewAuditServiceWithLogger(gormDB, logger)
 	svc.rls = nil
+	svc.inner = auditapp.New(auditpostgres.NewStore(gormDB, nil))
 	return svc, mock, func() {
 		_ = sqlDB.Close()
 	}

--- a/scripts/e2e-db-cases/audit.json
+++ b/scripts/e2e-db-cases/audit.json
@@ -57,6 +57,13 @@
       "run": "^TestAuditServiceRedactsSecrets$",
       "phase": "precheck",
       "source": "internal/service/audit_service.e2e"
+    },
+    {
+      "id": "service/TestAuditServiceListIsolatesTeamsForNonSuperuser",
+      "package": "./internal/service",
+      "run": "^TestAuditServiceListIsolatesTeamsForNonSuperuser$",
+      "phase": "precheck",
+      "source": "internal/service/audit_service.e2e"
     }
   ]
 }

--- a/tests/uat/architecture_conformance.test.mjs
+++ b/tests/uat/architecture_conformance.test.mjs
@@ -487,7 +487,7 @@ test("enforces private visibility and narrow PostgreSQL infrastructure reuse", (
 
 test("retains precise replacement owners and lifecycle obligations", () => {
   const exceptionOwners = [...new Set(productionManifest.exceptions.map((entry) => entry.removal_issue))].sort((a, b) => a - b);
-  assert.deepEqual(exceptionOwners, [366, 367, 368, 370, 375, 376, 377, 379, 380, 382]);
+  assert.deepEqual(exceptionOwners, [366, 367, 370, 375, 376, 377, 379, 380, 382]);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 276), false);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 280), false);
   assert.ok(productionManifest.workers.every((entry) => entry.lifecycle_issue === 381));


### PR DESCRIPTION
## Goal

Move audit event policy and PostgreSQL persistence behind the native `internal/audit` capability while preserving the existing audit schema, event names, payload bounds, actor fields, history, and failure behavior.

## Implementation

- Added `internal/audit` application policy for event construction, redaction, JSON validation, client-IP selection, list conversion, and Remember security-rejection projection.
- Added a private audit persistence contract and PostgreSQL adapter with transaction-local RLS, active-space filtering, and team-scoped credential memory-space lookup.
- Switched live server composition and security-rejection composition to the native service.
- Reduced `internal/service/audit_service.go` to a single-hop compatibility facade and recorded its remaining consumers/removal owner `#382` in the audit architecture fragment.
- Registered and executed the non-superuser PostgreSQL isolation case.
- Added native policy/adapter/security-rejection tests and coverage for all event helpers and malformed list payload handling.

## Risks and mitigations

- Splitting policy from persistence could break transaction-linked audit lineage or team isolation. Credential memory-space inference remains inside the adapter transaction with the team predicate, and the registered PostgreSQL RLS case plus production E2E scenarios passed.
- Event projection or redaction could expose sensitive/provider data. Redaction and bounded metadata are tested with adversarial payloads, and `security_intake` and `full` production-image E2E scenarios passed.
- Legacy callers could diverge from the native implementation. The facade forwards through one delegate, all remaining consumers are listed with removal owner `#382`, and compatibility/service suites passed.

## Plan-audit receipt

- Auditor: `gpt-5.6-terra`, reasoning effort `max`
- Verdict: `conformant`
- Base SHA: `a5f30bd128ade461ceb430a79a0d0a8620eee36c`
- Final audited state: branch `refactor/368-audit-module`, 14 approved implementation paths, no untracked files, clean diff check.
- Audit rounds: initial findings were closed for private contract visibility, policy-owned credential lookup eligibility, single native forwarding, registered non-superuser isolation, a sanitized PostgreSQL role identifier, and complete compatibility consumers; the final whole-plan rescan returned `conformant` with no findings.

Post-audit paths changed before the final commit were `internal/audit/postgres/store.go` (unused-import correction), `internal/audit/service_test.go` (coverage tests), and `tests/uat/architecture_conformance.test.mjs` (updated lifecycle-owner expectation required by the new manifest).

## Verification

- `go test ./internal/audit/... ./internal/service/... ./cmd/internal/serverapp/... -count=1` — passed.
- `./scripts/e2e.sh security_intake` — passed.
- `./scripts/e2e.sh full` — passed; 40 Playwright specs passed across Chromium and mobile.
- `./scripts/ci-check.sh` — passed; architecture, static analysis, evaluation checks, Go suites, and aggregate coverage `90.0%` passed.

Does not merge the PR; human review and merge remain required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized audit service for recording and listing team-scoped events.
  * Added PostgreSQL-backed audit storage with team isolation and active memory-space filtering.
  * Added automatic redaction of sensitive fields in audit payloads.
  * Added security-rejection audit records with bounded metadata and error propagation.

* **Bug Fixes**
  * Improved client IP resolution using request context fallback.
  * Strengthened credential memory-space association to remain team-scoped.
  * Verified audit reads are isolated between teams for restricted users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->