### PR TITLE
refactor: move lifecycle application capability[#374]

### DIFF
--- a/architecture/modules/memory-application.json
+++ b/architecture/modules/memory-application.json
@@ -27,7 +27,23 @@
       "issue": 374
     },
     {
-      "path": "internal/service/memoryservice/lifecycle_test.go",
+      "path": "internal/service/memoryservice/lifecycle_test_helpers_test.go",
+      "issue": 374
+    },
+    {
+      "path": "internal/repository/lifecycle_repository.go",
+      "issue": 374
+    },
+    {
+      "path": "internal/lifecycle/service.go",
+      "issue": 374
+    },
+    {
+      "path": "internal/lifecycle/service_test.go",
+      "issue": 374
+    },
+    {
+      "path": "internal/lifecycle/status.go",
       "issue": 374
     }
   ],
@@ -38,12 +54,70 @@
         "id": "github.com/markhuangai/dense-mem/internal/service/memoryservice",
         "role": "application_api",
         "visibility": "public"
+      },
+      {
+        "id": "github.com/markhuangai/dense-mem/internal/lifecycle",
+        "role": "application_api",
+        "visibility": "public"
       }
     ]
   },
   "browser": {
     "units": []
   },
+  "compatibility_bridges": [
+    {
+      "source_path": "internal/service/memoryservice/lifecycle.go",
+      "fields": [
+        "LifecycleService",
+        "LifecycleDependencies",
+        "LifecycleSemanticRepository",
+        "LifecycleCorrectionExecutor",
+        "LifecycleEvidenceRepository",
+        "CorrectRelationshipRequest",
+        "CorrectRelationshipReceipt",
+        "RetractEvidenceRequest",
+        "RetractEvidenceResult",
+        "NewLifecycleService"
+      ],
+      "consumers": [
+        {
+          "path": "internal/tools/registry/contract_result_errors.go",
+          "symbol": "ActionableErrorData"
+        },
+        {
+          "path": "internal/tools/registry/contract_result_errors_test.go",
+          "symbol": "TestCorrectionToolResultErrorMapsLifecycleAndHTTPFailures"
+        },
+        {
+          "path": "internal/tools/registry/contract_result_errors_test.go",
+          "symbol": "TestCorrectionToolResultErrorPreservesTypedConflictReasons"
+        },
+        {
+          "path": "internal/tools/registry/contract_schema_helpers.go",
+          "symbol": "submissionStatusErrorSchema"
+        },
+        {
+          "path": "internal/tools/registry/uat_lifecycle_test.go",
+          "symbol": "stubLifecycleService.CorrectRelationship"
+        },
+        {
+          "path": "internal/tools/registry/uat_lifecycle_test.go",
+          "symbol": "stubLifecycleService.RetractEvidence"
+        },
+        {
+          "path": "cmd/internal/serverapp/application_composition.go",
+          "symbol": "buildApplicationBundle"
+        }
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {
+        "path": "internal/lifecycle/service.go",
+        "symbol": "NewLifecycleService"
+      },
+      "removal_condition": "Remove the compatibility aliases after the remaining lifecycle consumers use internal/lifecycle directly."
+    }
+  ],
   "exceptions": [
     {
       "source": "github.com/markhuangai/dense-mem/internal/service/memoryservice",

--- a/cmd/internal/serverapp/lifecycle_composition.go
+++ b/cmd/internal/serverapp/lifecycle_composition.go
@@ -1,22 +1,30 @@
 package serverapp
 
 import (
+	"context"
 	"time"
 
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
+	"github.com/markhuangai/dense-mem/internal/repository"
 )
 
 type lifecycleApplicationDependencies struct {
-	Semantic                   memoryservice.LifecycleSemanticRepository
-	Evidence                   memoryservice.LifecycleEvidenceRepository
-	CorrectionExecutor         memoryservice.LifecycleCorrectionExecutor
+	Semantic *repository.SemanticRepositoryImpl
+	Evidence interface {
+		RetractEvidence(context.Context, knowledgecontract.RetractEvidenceInput) (*knowledgecontract.EvidenceLifecycleResult, error)
+	}
+	CorrectionExecutor         lifecycle.LifecycleCorrectionExecutor
 	CorrectionEmbeddingTimeout time.Duration
 }
 
-func buildLifecycleApplication(deps lifecycleApplicationDependencies) memoryservice.LifecycleService {
-	return memoryservice.NewLifecycleService(memoryservice.LifecycleDependencies{
-		Semantic:                   deps.Semantic,
-		Evidence:                   deps.Evidence,
+func buildLifecycleApplication(deps lifecycleApplicationDependencies) lifecycle.LifecycleService {
+	var semantic lifecycle.LifecycleSemanticRepository
+	if deps.Semantic != nil {
+		semantic = deps.Semantic.LifecycleStore()
+	}
+	return lifecycle.NewLifecycleService(lifecycle.LifecycleDependencies{
+		Port:                       semantic,
 		CorrectionExecutor:         deps.CorrectionExecutor,
 		CorrectionEmbeddingTimeout: deps.CorrectionEmbeddingTimeout,
 	})

--- a/cmd/internal/serverapp/semanticwrite_composition.go
+++ b/cmd/internal/serverapp/semanticwrite_composition.go
@@ -2,9 +2,9 @@ package serverapp
 
 import (
 	embeddingcontract "github.com/markhuangai/dense-mem/internal/embedding/contract"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
 )
 
-func buildSemanticWriteCorrectionExecutor(provider embeddingcontract.EmbeddingProviderInterface) memoryservice.LifecycleCorrectionExecutor {
+func buildSemanticWriteCorrectionExecutor(provider embeddingcontract.EmbeddingProviderInterface) lifecycle.LifecycleCorrectionExecutor {
 	return newSemanticwriteEmbeddingExecutor(provider)
 }

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -1,0 +1,398 @@
+package lifecycle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/correlation"
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/httperr"
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+	semanticwritecontract "github.com/markhuangai/dense-mem/internal/semanticwrite/contract"
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	semanticwriteapp "github.com/markhuangai/dense-mem/internal/service/semanticwrite"
+)
+
+var (
+	ErrLifecycleAuthContext           = errors.New("memory lifecycle: authenticated actor context is required")
+	ErrLifecyclePersistence           = errors.New("memory lifecycle: persistence failed")
+	ErrLifecycleEmbeddingUnavailable  = errors.New("memory lifecycle: embedding provider unavailable")
+	ErrLifecycleEmbeddingInvalid      = errors.New("memory lifecycle: embedding response invalid")
+	ErrLifecycleEmbeddingTimeout      = errors.New("memory lifecycle: embedding provider timed out")
+	errLifecycleCorrectionCommitFence = errors.New("memory lifecycle: correction commit search fence conflict")
+)
+
+// CorrectionConfirmationInvalidReason identifies a pending confirmation that
+// remains awaiting confirmation after the legacy lifecycle rejects a token or
+// candidate selection.
+const CorrectionConfirmationInvalidReason = "confirmation_invalid"
+
+type LifecycleService interface {
+	CorrectRelationship(ctx context.Context, req CorrectRelationshipRequest) (*CorrectRelationshipReceipt, error)
+	RetractEvidence(ctx context.Context, req RetractEvidenceRequest) (*RetractEvidenceResult, error)
+}
+
+// Service is the lifecycle application boundary used by transports and composition.
+type Service = LifecycleService
+type Dependencies = LifecycleDependencies
+
+// New constructs the lifecycle application from narrow canonical mutation ports.
+func New(deps Dependencies) Service { return NewLifecycleService(deps) }
+
+type LifecycleDependencies struct {
+	Port                       knowledgecontract.LifecyclePort
+	CorrectionExecutor         LifecycleCorrectionExecutor
+	CorrectionEmbeddingTimeout time.Duration
+}
+
+// These aliases preserve the former names while exposing the single canonical
+// lifecycle mutation port.
+type LifecycleSemanticRepository = knowledgecontract.LifecyclePort
+type LifecycleEvidenceRepository = knowledgecontract.LifecyclePort
+
+type LifecycleCorrectionExecutor interface {
+	Execute(context.Context, semanticwritecontract.Plan) (semanticwritecontract.Result, error)
+}
+
+type lifecycleService struct {
+	port             knowledgecontract.LifecyclePort
+	executor         LifecycleCorrectionExecutor
+	embeddingTimeout time.Duration
+}
+
+func NewLifecycleService(deps LifecycleDependencies) LifecycleService {
+	timeout := deps.CorrectionEmbeddingTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &lifecycleService{port: deps.Port, executor: deps.CorrectionExecutor, embeddingTimeout: timeout}
+}
+
+type CorrectRelationshipRequest struct {
+	Action            string                                            `json:"action"`
+	RelationshipID    string                                            `json:"relationship_id,omitempty"`
+	ExpectedVersion   int                                               `json:"expected_version,omitempty"`
+	Patch             knowledgecontract.RelationshipCorrectionPatch     `json:"patch,omitempty"`
+	Supports          []knowledgecontract.RelationshipCorrectionSupport `json:"supports,omitempty"`
+	Reason            string                                            `json:"reason,omitempty"`
+	SubmissionID      string                                            `json:"submission_id,omitempty"`
+	ConfirmationToken string                                            `json:"confirmation_token,omitempty"`
+	Selection         knowledgecontract.RelationshipCorrectionSelection `json:"selection,omitempty"`
+	IdempotencyKey    string                                            `json:"idempotency_key"`
+}
+
+type CorrectRelationshipReceipt struct {
+	ContractVersion      string                                          `json:"contract_version"`
+	SubmissionID         string                                          `json:"submission_id"`
+	SubmissionKind       string                                          `json:"submission_kind"`
+	ProcessingState      string                                          `json:"processing_state"`
+	SearchState          string                                          `json:"search_state"`
+	CorrelationID        string                                          `json:"correlation_id"`
+	AwaitingConfirmation *SubmissionAwaitingConfirmation                 `json:"awaiting_confirmation,omitempty"`
+	CorrectionResult     *knowledgecontract.RelationshipCorrectionResult `json:"correction_result,omitempty"`
+	Errors               []SubmissionStatusError                         `json:"errors"`
+}
+
+type RetractEvidenceRequest struct {
+	EvidenceIDs    []string `json:"evidence_ids"`
+	Reason         string   `json:"reason"`
+	IdempotencyKey string   `json:"idempotency_key"`
+}
+
+type RetractEvidenceResult struct {
+	DecisionID                      string   `json:"decision_id"`
+	ProcessingState                 string   `json:"processing_state"`
+	RetractedEvidenceIDs            []string `json:"retracted_evidence_ids"`
+	AffectedRelationshipCount       int      `json:"affected_relationship_count"`
+	PendingRelationshipCount        int      `json:"pending_relationship_count"`
+	RetainedActiveRelationshipCount int      `json:"retained_active_relationship_count"`
+}
+
+func (s *lifecycleService) CorrectRelationship(
+	ctx context.Context,
+	req CorrectRelationshipRequest,
+) (*CorrectRelationshipReceipt, error) {
+	if s.port == nil {
+		return nil, errors.New("memory lifecycle: semantic repository is required")
+	}
+	actor, ok := requestctx.ActorFromContext(ctx)
+	if !ok || actor.TeamID == uuid.Nil || actor.OwnerID == uuid.Nil {
+		return nil, ErrLifecycleAuthContext
+	}
+	if req.Action != "submit" && req.Action != "confirm" {
+		return nil, errors.New("memory lifecycle: action must be submit or confirm")
+	}
+	input := knowledgecontract.CorrectRelationshipInput{
+		TeamID:            actor.TeamID.String(),
+		OwnerProfileID:    actor.OwnerID.String(),
+		Action:            req.Action,
+		RelationshipID:    req.RelationshipID,
+		ExpectedVersion:   req.ExpectedVersion,
+		Patch:             req.Patch,
+		Supports:          req.Supports,
+		Reason:            req.Reason,
+		SubmissionID:      req.SubmissionID,
+		ConfirmationToken: req.ConfirmationToken,
+		Selection:         req.Selection,
+		IdempotencyKey:    req.IdempotencyKey,
+	}
+	plan, err := s.port.PlanRelationshipCorrectionEmbeddings(ctx, input)
+	if err == nil && plan == nil {
+		err = ErrLifecyclePersistence
+	}
+	var embeddings []knowledgecontract.RelationshipCorrectionEmbedding
+	if err == nil && len(plan.Documents) > 0 {
+		if s.executor == nil {
+			err = ErrLifecycleEmbeddingUnavailable
+		} else {
+			executionCtx := observability.WithMetricIdentity(ctx, input.TeamID, input.OwnerProfileID)
+			embeddingCtx, cancel := context.WithTimeout(executionCtx, s.embeddingTimeout)
+			result, executeErr := s.executor.Execute(embeddingCtx, semanticwritecontract.Plan{
+				Documents: correctionPlanDocuments(plan.Documents),
+				Fence:     semanticwritecontract.Fence{Model: plan.EmbeddingModel, Dimensions: plan.EmbeddingDimensions, EmbeddingContractID: plan.EmbeddingContractID, SearchGenerationID: plan.SearchIndexGenerationID, SearchGenerationVersion: int64(plan.IndexGeneration)},
+				Timeout:   s.embeddingTimeout,
+			})
+			if executeErr != nil {
+				err = translateCorrectionEmbeddingErrorWithContext(ctx, embeddingCtx, executeErr)
+			} else {
+				embeddings = correctionEmbeddingsFromResult(result)
+			}
+			cancel()
+		}
+	}
+	var result *knowledgecontract.CorrectRelationshipResult
+	if err == nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		} else {
+			result, err = s.port.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
+			if isCorrectionCommitSearchFenceError(err) {
+				err = fmt.Errorf("%w: %w", errLifecycleCorrectionCommitFence, err)
+			}
+		}
+	}
+	if err != nil {
+		return nil, translateRelationshipCorrectionError(err)
+	}
+	if result == nil {
+		return nil, ErrLifecyclePersistence
+	}
+	receipt := &CorrectRelationshipReceipt{
+		ContractVersion:  domain.ContractVersion,
+		SubmissionID:     result.SubmissionID,
+		SubmissionKind:   "relationship_correction",
+		ProcessingState:  result.ProcessingState,
+		SearchState:      result.SearchState,
+		CorrelationID:    rememberapp.NormalizeTerminalCorrelationID(correlation.FromContext(ctx)),
+		CorrectionResult: result.Correction,
+		Errors:           []SubmissionStatusError{},
+	}
+	if receipt.SearchState == "" {
+		receipt.SearchState = string(domain.SearchProjectionNotRequired)
+	}
+	if result.Confirmation != nil {
+		receipt.AwaitingConfirmation = &SubmissionAwaitingConfirmation{
+			ConfirmationToken: result.Confirmation.Token,
+			ExpiresAt:         result.Confirmation.ExpiresAt,
+		}
+		for _, candidate := range result.Confirmation.Candidates {
+			receipt.AwaitingConfirmation.Candidates = append(receipt.AwaitingConfirmation.Candidates, rememberapp.RelationshipCorrectionCandidate{
+				Endpoint: candidate.Endpoint, EntityID: candidate.EntityID, EntityKind: candidate.EntityKind, CanonicalName: candidate.CanonicalName,
+			})
+		}
+	}
+	if result.ErrorCode != "" {
+		receipt.Errors = append(receipt.Errors, correctionStatusErrorForCode(result.ErrorCode, result.ProcessingState))
+	}
+	if (result.ProcessingState == "rejected" || result.ProcessingState == "failed") && len(receipt.Errors) == 0 {
+		receipt.Errors = append(receipt.Errors, correctionStatusErrorForCode("", result.ProcessingState))
+	}
+	return receipt, nil
+}
+
+func correctionPlanDocuments(documents []knowledgecontract.RelationshipCorrectionEmbeddingDocument) []semanticwritecontract.Document {
+	result := make([]semanticwritecontract.Document, 0, len(documents))
+	for _, document := range documents {
+		result = append(result, semanticwritecontract.Document{Hash: document.DocumentHash, Text: document.DocumentText})
+	}
+	return result
+}
+
+func correctionEmbeddingsFromResult(result semanticwritecontract.Result) []knowledgecontract.RelationshipCorrectionEmbedding {
+	embeddings := make([]knowledgecontract.RelationshipCorrectionEmbedding, 0, len(result.Embeddings))
+	for _, embedding := range result.Embeddings {
+		embeddings = append(embeddings, knowledgecontract.RelationshipCorrectionEmbedding{DocumentHash: embedding.DocumentHash, Embedding: append([]float32(nil), embedding.Vector...), EmbeddingContractID: result.Fence.EmbeddingContractID, EmbeddingDimensions: result.Fence.Dimensions, EmbeddingModel: result.Fence.Model, SearchIndexGenerationID: result.Fence.SearchGenerationID, IndexGeneration: int(result.Fence.SearchGenerationVersion)})
+	}
+	return embeddings
+}
+
+func translateCorrectionEmbeddingError(err error) error {
+	switch {
+	case errors.Is(err, semanticwriteapp.ErrProviderUnavailable):
+		return ErrLifecycleEmbeddingUnavailable
+	case errors.Is(err, semanticwriteapp.ErrProviderResponseInvalid), errors.Is(err, semanticwriteapp.ErrInvalidPlan):
+		return ErrLifecycleEmbeddingInvalid
+	case errors.Is(err, semanticwriteapp.ErrProviderTimeout):
+		return ErrLifecycleEmbeddingTimeout
+	default:
+		return err
+	}
+}
+
+func translateCorrectionEmbeddingErrorWithContext(callerCtx, embeddingCtx context.Context, err error) error {
+	if errors.Is(err, context.DeadlineExceeded) && correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx) {
+		return ErrLifecycleEmbeddingTimeout
+	}
+	return translateCorrectionEmbeddingError(err)
+}
+
+func correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx context.Context) bool {
+	if !errors.Is(embeddingCtx.Err(), context.DeadlineExceeded) {
+		return false
+	}
+	callerDeadline, callerHasDeadline := callerCtx.Deadline()
+	embeddingDeadline, embeddingHasDeadline := embeddingCtx.Deadline()
+	if !embeddingHasDeadline {
+		return false
+	}
+	if !callerHasDeadline {
+		return true
+	}
+	return embeddingDeadline.Before(callerDeadline)
+}
+
+func translateRelationshipCorrectionError(err error) error {
+	if errors.Is(err, ErrLifecycleEmbeddingUnavailable) {
+		return httperr.New(httperr.ErrEmbeddingUnavailable, "embedding provider unavailable")
+	}
+	if errors.Is(err, ErrLifecycleEmbeddingInvalid) {
+		return httperr.New(httperr.ErrEmbeddingResponseInvalid, "embedding provider response invalid")
+	}
+	if errors.Is(err, ErrLifecycleEmbeddingTimeout) {
+		return httperr.New(httperr.ErrEmbeddingTimeout, "embedding provider timed out")
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if errors.Is(err, knowledgecontract.ErrSemanticOwnerMismatch) || errors.Is(err, knowledgecontract.ErrRelationshipCorrectionNotFound) {
+		return httperr.New(httperr.NOT_FOUND, "submission not found")
+	}
+	if errors.Is(err, knowledgecontract.ErrSemanticIdempotencyConflict) {
+		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: "idempotency_conflict",
+		}}), "idempotency_conflict", "correct_and_resubmit", "Use a new idempotency key for the changed correction request, then submit again.", false, nil, "")
+	}
+	if errors.Is(err, knowledgecontract.ErrRelationshipCorrectionConfirmationExpired) {
+		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: string(SubmissionErrorConfirmationExpired),
+		}}), "confirmation_expired", "correct_and_resubmit", "Start a new correction submission and use its fresh confirmation token.", false, nil, "")
+	}
+	if errors.Is(err, knowledgecontract.ErrRelationshipCorrectionConfirmation) {
+		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: CorrectionConfirmationInvalidReason,
+		}}), "confirmation_invalid", "correct_and_resubmit", "Start a new correction submission and use its current confirmation token.", false, nil, "")
+	}
+	if errors.Is(err, errLifecycleCorrectionCommitFence) {
+		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
+			Field: "reason", Message: string(rememberapp.TerminalErrorCommitConflict),
+		}}), "commit_conflict", "refresh_state", "Refresh the current relationship state, then submit the correction again with a new idempotency key.", false, nil, "")
+	}
+	if errors.Is(err, knowledgecontract.ErrRelationshipCorrectionStateConflict) {
+		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "state_conflict", "refresh_state", "Refresh the current relationship state, then submit the correction again.", false, nil, "")
+	}
+	if errors.Is(err, knowledgecontract.ErrSearchEmbeddingRequired) || errors.Is(err, knowledgecontract.ErrSearchContractMismatch) {
+		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "search_configuration_invalid", "contact_operator", "Contact an operator to restore the configured search contract before retrying.", false, nil, "")
+	}
+	if errors.Is(err, knowledgecontract.ErrSearchStaleVersion) {
+		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "search_state_stale", "refresh_state", "Refresh the current relationship state, then submit the correction again.", false, nil, "")
+	}
+	return ErrLifecyclePersistence
+}
+
+func isCorrectionCommitSearchFenceError(err error) bool {
+	return errors.Is(err, knowledgecontract.ErrSearchEmbeddingRequired) ||
+		errors.Is(err, knowledgecontract.ErrSearchContractMismatch) ||
+		errors.Is(err, knowledgecontract.ErrSearchStaleVersion)
+}
+
+func (s *lifecycleService) RetractEvidence(
+	ctx context.Context,
+	req RetractEvidenceRequest,
+) (*RetractEvidenceResult, error) {
+	if s.port == nil {
+		return nil, errors.New("memory lifecycle: evidence repository is required")
+	}
+	actor, ok := requestctx.ActorFromContext(ctx)
+	if !ok || actor.TeamID == uuid.Nil || actor.OwnerID == uuid.Nil {
+		return nil, ErrLifecycleAuthContext
+	}
+	requestHash, err := retractEvidenceRequestHash(req)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.port.RetractEvidence(ctx, knowledgecontract.RetractEvidenceInput{
+		TeamID:         actor.TeamID.String(),
+		OwnerProfileID: actor.OwnerID.String(),
+		EvidenceIDs:    append([]string(nil), req.EvidenceIDs...),
+		Reason:         req.Reason,
+		IdempotencyKey: req.IdempotencyKey,
+		RequestHash:    requestHash,
+	})
+	if err != nil {
+		return nil, translateEvidenceLifecycleError(err)
+	}
+	return &RetractEvidenceResult{
+		DecisionID:                      result.DecisionID,
+		ProcessingState:                 result.ProcessingState,
+		RetractedEvidenceIDs:            append([]string(nil), result.RetractedEvidenceIDs...),
+		AffectedRelationshipCount:       result.AffectedRelationshipCount,
+		PendingRelationshipCount:        result.PendingRelationshipCount,
+		RetainedActiveRelationshipCount: result.RetainedActiveRelationshipCount,
+	}, nil
+}
+
+// Retract's unchanged request contract must replay hashes written before v2.6.
+const retractEvidenceRequestHashContractVersion = "dense-mem.v2.4"
+
+func retractEvidenceRequestHash(req RetractEvidenceRequest) (string, error) {
+	evidenceIDs := make([]string, len(req.EvidenceIDs))
+	for index, evidenceID := range req.EvidenceIDs {
+		evidenceIDs[index] = strings.TrimSpace(evidenceID)
+	}
+	sort.Strings(evidenceIDs)
+	payload, err := json.Marshal(map[string]any{
+		"contract_version": retractEvidenceRequestHashContractVersion,
+		"evidence_ids":     evidenceIDs,
+		"reason":           strings.TrimSpace(req.Reason),
+		"idempotency_key":  strings.TrimSpace(req.IdempotencyKey),
+	})
+	if err != nil {
+		return "", fmt.Errorf("memory lifecycle: canonical retract request hash: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func translateEvidenceLifecycleError(err error) error {
+	switch {
+	case errors.Is(err, knowledgecontract.ErrEvidenceLifecycleNotFound), errors.Is(err, knowledgecontract.ErrTeamInactive):
+		return httperr.New(httperr.NOT_FOUND, "evidence not found")
+	case errors.Is(err, knowledgecontract.ErrIdempotencyConflict):
+		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "evidence lifecycle conflict"), "idempotency_conflict", "correct_and_resubmit", "Use a new idempotency key for the changed retraction request, then submit again.", false, nil, "")
+	case errors.Is(err, knowledgecontract.ErrEvidenceLifecycleConflict):
+		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "evidence lifecycle conflict"), "evidence_lifecycle_conflict", "refresh_state", "Refresh the current evidence state, then submit the retraction again with a new idempotency key.", false, nil, "")
+	default:
+		return err
+	}
+}

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -1,4 +1,4 @@
-package memoryservice
+package lifecycle
 
 import (
 	"context"
@@ -13,10 +13,11 @@ import (
 	"github.com/markhuangai/dense-mem/internal/correlation"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/httperr"
-	"github.com/markhuangai/dense-mem/internal/repository"
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
+	semanticwritecontract "github.com/markhuangai/dense-mem/internal/semanticwrite/contract"
 	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
-	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
+	semanticwriteapp "github.com/markhuangai/dense-mem/internal/service/semanticwrite"
 )
 
 func authenticatedRememberContext(teamID, profileID, credentialID uuid.UUID) context.Context {
@@ -33,15 +34,15 @@ func TestLifecycleCorrectRelationshipUsesAuthenticatedOwner(t *testing.T) {
 	profileID := uuid.New()
 	relationshipID := uuid.NewString()
 	evidenceID := uuid.NewString()
-	semantic := &lifecycleSemanticStub{correctResult: &repository.CorrectRelationshipResult{
+	semantic := &lifecycleSemanticStub{correctResult: &knowledgecontract.CorrectRelationshipResult{
 		SubmissionID: uuid.NewString(), ProcessingState: "completed",
 	}}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic})
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic})
 
 	result, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{
 		Action: "submit", RelationshipID: relationshipID, ExpectedVersion: 3,
-		Patch:    repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_with"}},
-		Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: evidenceID, Start: 0, End: 8}},
+		Patch:    knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_with"}},
+		Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: evidenceID, Start: 0, End: 8}},
 		Reason:   "predicate was resolved incorrectly", IdempotencyKey: "relationship-correction-1",
 	})
 	require.NoError(t, err)
@@ -57,15 +58,15 @@ func TestLifecycleCorrectRelationshipUsesAuthenticatedOwner(t *testing.T) {
 
 func TestLifecycleCorrectRelationshipNormalizesOversizedCorrelationID(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	semantic := &lifecycleSemanticStub{correctResult: &repository.CorrectRelationshipResult{
+	semantic := &lifecycleSemanticStub{correctResult: &knowledgecontract.CorrectRelationshipResult{
 		SubmissionID: uuid.NewString(), ProcessingState: "completed",
 	}}
 	ctx := correlation.WithID(authenticatedRememberContext(teamID, profileID, uuid.New()), strings.Repeat("x", 129))
 
-	result, err := NewLifecycleService(LifecycleDependencies{Semantic: semantic}).CorrectRelationship(ctx, CorrectRelationshipRequest{
+	result, err := NewLifecycleService(LifecycleDependencies{Port: semantic}).CorrectRelationship(ctx, CorrectRelationshipRequest{
 		Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1,
-		Patch:    repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_with"}},
-		Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 8}},
+		Patch:    knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_with"}},
+		Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 8}},
 		Reason:   "predicate was resolved incorrectly", IdempotencyKey: "oversized-correlation",
 	})
 
@@ -79,15 +80,15 @@ func TestLifecycleCorrectRelationshipNormalizesOversizedCorrelationID(t *testing
 func TestLifecycleCorrectRelationshipExecutesOnePlannedBatchBeforeCommit(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
 	semantic := &lifecycleSemanticStub{
-		plan: &repository.RelationshipCorrectionEmbeddingPlan{
-			Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+		plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+			Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 			EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
 		},
-		correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"},
+		correctResult: &knowledgecontract.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"},
 	}
-	executor := &lifecycleExecutorStub{result: semanticwrite.Result{Fence: semanticwrite.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwrite.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor})
-	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "planned-correction"})
+	executor := &lifecycleExecutorStub{result: semanticwritecontract.Result{Fence: semanticwritecontract.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwritecontract.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: executor})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "planned-correction"})
 	require.NoError(t, err)
 	require.Equal(t, 1, executor.calls)
 	require.Len(t, semantic.embeddings, 1)
@@ -95,12 +96,12 @@ func TestLifecycleCorrectRelationshipExecutesOnePlannedBatchBeforeCommit(t *test
 
 func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingFails(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
-		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+	semantic := &lifecycleSemanticStub{plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
-	}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwrite.ErrProviderUnavailable}})
-	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "failed-planned-correction"})
+	}, correctResult: &knowledgecontract.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwriteapp.ErrProviderUnavailable}})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "failed-planned-correction"})
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
 	require.Equal(t, httperr.ErrEmbeddingUnavailable, publicErr.Code)
@@ -109,13 +110,13 @@ func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingFails(t *testing.
 
 func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingTimesOut(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
-		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+	semantic := &lifecycleSemanticStub{plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
-	}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwrite.ErrProviderTimeout}})
+	}, correctResult: &knowledgecontract.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}}
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: &lifecycleExecutorStub{err: semanticwriteapp.ErrProviderTimeout}})
 
-	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "timed-out-planned-correction"})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "timed-out-planned-correction"})
 
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
@@ -125,16 +126,16 @@ func TestLifecycleCorrectRelationshipDoesNotCommitWhenEmbeddingTimesOut(t *testi
 
 func TestLifecycleCorrectRelationshipPreservesCommitFenceClassification(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	for _, cause := range []error{repository.ErrSearchEmbeddingRequired, repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
+	for _, cause := range []error{knowledgecontract.ErrSearchEmbeddingRequired, knowledgecontract.ErrSearchContractMismatch, knowledgecontract.ErrSearchStaleVersion} {
 		t.Run(cause.Error(), func(t *testing.T) {
-			semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
-				Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+			semantic := &lifecycleSemanticStub{plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+				Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 				EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
-			}, correctResult: &repository.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}, commitErr: cause}
-			executor := &lifecycleExecutorStub{result: semanticwrite.Result{Fence: semanticwrite.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwrite.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
-			svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor})
+			}, correctResult: &knowledgecontract.CorrectRelationshipResult{SubmissionID: uuid.NewString(), ProcessingState: "completed"}, commitErr: cause}
+			executor := &lifecycleExecutorStub{result: semanticwritecontract.Result{Fence: semanticwritecontract.Fence{Model: semantic.plan.EmbeddingModel, Dimensions: 2, EmbeddingContractID: semantic.plan.EmbeddingContractID, SearchGenerationID: semantic.plan.SearchIndexGenerationID, SearchGenerationVersion: 1}, Embeddings: []semanticwritecontract.Embedding{{DocumentHash: "hash", Vector: []float32{1, 2}}}}}
+			svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: executor})
 
-			_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "commit-fence-correction"})
+			_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "commit-fence-correction"})
 			var publicErr *httperr.APIError
 			require.ErrorAs(t, err, &publicErr)
 			require.Equal(t, httperr.CONFLICT, publicErr.Code)
@@ -145,13 +146,13 @@ func TestLifecycleCorrectRelationshipPreservesCommitFenceClassification(t *testi
 
 func TestLifecycleCorrectRelationshipClassifiesConfiguredEmbeddingDeadline(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
-		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+	semantic := &lifecycleSemanticStub{plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
 	}}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: &lifecycleExecutorStub{waitForContext: true}, CorrectionEmbeddingTimeout: 10 * time.Millisecond})
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: &lifecycleExecutorStub{waitForContext: true}, CorrectionEmbeddingTimeout: 10 * time.Millisecond})
 
-	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "configured-timeout-correction"})
+	_, err := svc.CorrectRelationship(authenticatedRememberContext(teamID, profileID, uuid.New()), CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "configured-timeout-correction"})
 
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
@@ -161,16 +162,16 @@ func TestLifecycleCorrectRelationshipClassifiesConfiguredEmbeddingDeadline(t *te
 
 func TestLifecycleCorrectRelationshipPreservesCallerDeadline(t *testing.T) {
 	teamID, profileID := uuid.New(), uuid.New()
-	semantic := &lifecycleSemanticStub{plan: &repository.RelationshipCorrectionEmbeddingPlan{
-		Documents:           []repository.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
+	semantic := &lifecycleSemanticStub{plan: &knowledgecontract.RelationshipCorrectionEmbeddingPlan{
+		Documents:           []knowledgecontract.RelationshipCorrectionEmbeddingDocument{{DocumentHash: "hash", DocumentText: "relationship"}},
 		EmbeddingContractID: uuid.NewString(), EmbeddingDimensions: 2, EmbeddingModel: "model", SearchIndexGenerationID: uuid.NewString(), IndexGeneration: 1,
 	}}
 	executor := &lifecycleExecutorStub{waitForContext: true}
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: semantic, CorrectionExecutor: executor, CorrectionEmbeddingTimeout: time.Second})
+	svc := NewLifecycleService(LifecycleDependencies{Port: semantic, CorrectionExecutor: executor, CorrectionEmbeddingTimeout: time.Second})
 	callerCtx, cancel := context.WithTimeout(authenticatedRememberContext(teamID, profileID, uuid.New()), 10*time.Millisecond)
 	defer cancel()
 
-	_, err := svc.CorrectRelationship(callerCtx, CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "caller-deadline-correction"})
+	_, err := svc.CorrectRelationship(callerCtx, CorrectRelationshipRequest{Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1, Patch: knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}}, Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}}, Reason: "incorrect predicate", IdempotencyKey: "caller-deadline-correction"})
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	var publicErr *httperr.APIError
@@ -181,7 +182,7 @@ func TestLifecycleCorrectRelationshipPreservesCallerDeadline(t *testing.T) {
 func TestLifecycleRelationshipCorrectionErrorsAreBounded(t *testing.T) {
 	ctx := authenticatedRememberContext(uuid.New(), uuid.New(), uuid.New())
 	repositoryFailure := errors.New("database host and query details")
-	svc := NewLifecycleService(LifecycleDependencies{Semantic: &lifecycleSemanticStub{err: repositoryFailure}})
+	svc := NewLifecycleService(LifecycleDependencies{Port: &lifecycleSemanticStub{err: repositoryFailure}})
 	_, err := svc.CorrectRelationship(ctx, CorrectRelationshipRequest{Action: "submit"})
 	require.ErrorIs(t, err, ErrLifecyclePersistence)
 	require.NotContains(t, err.Error(), repositoryFailure.Error())
@@ -193,7 +194,7 @@ func TestLifecycleRelationshipCorrectionErrorsAreBounded(t *testing.T) {
 }
 
 func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testing.T) {
-	for _, cause := range []error{repository.ErrSearchEmbeddingRequired, repository.ErrSearchContractMismatch, repository.ErrSearchStaleVersion} {
+	for _, cause := range []error{knowledgecontract.ErrSearchEmbeddingRequired, knowledgecontract.ErrSearchContractMismatch, knowledgecontract.ErrSearchStaleVersion} {
 		err := translateRelationshipCorrectionError(cause)
 		var publicErr *httperr.APIError
 		require.ErrorAs(t, err, &publicErr)
@@ -202,7 +203,7 @@ func TestTranslateRelationshipCorrectionErrorMapsSearchFencesToConflict(t *testi
 }
 
 func TestTranslateRelationshipCorrectionIdempotencyConflictPreservesTerminalClassification(t *testing.T) {
-	err := translateRelationshipCorrectionError(repository.ErrSemanticIdempotencyConflict)
+	err := translateRelationshipCorrectionError(knowledgecontract.ErrSemanticIdempotencyConflict)
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
 	require.Equal(t, httperr.CONFLICT, publicErr.Code)
@@ -210,7 +211,7 @@ func TestTranslateRelationshipCorrectionIdempotencyConflictPreservesTerminalClas
 }
 
 func TestTranslateRelationshipCorrectionConfirmationPreservesTypedConflict(t *testing.T) {
-	err := translateRelationshipCorrectionError(repository.ErrRelationshipCorrectionConfirmation)
+	err := translateRelationshipCorrectionError(knowledgecontract.ErrRelationshipCorrectionConfirmation)
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
 	require.Equal(t, httperr.CONFLICT, publicErr.Code)
@@ -218,7 +219,7 @@ func TestTranslateRelationshipCorrectionConfirmationPreservesTypedConflict(t *te
 }
 
 func TestTranslateRelationshipCorrectionConfirmationExpiryPreservesTerminalClassification(t *testing.T) {
-	err := translateRelationshipCorrectionError(repository.ErrRelationshipCorrectionConfirmationExpired)
+	err := translateRelationshipCorrectionError(knowledgecontract.ErrRelationshipCorrectionConfirmationExpired)
 	var publicErr *httperr.APIError
 	require.ErrorAs(t, err, &publicErr)
 	require.Equal(t, httperr.CONFLICT, publicErr.Code)
@@ -245,13 +246,13 @@ func TestLifecycleCorrectRelationshipRequiresAuthAndRepository(t *testing.T) {
 	ctx := authenticatedRememberContext(uuid.New(), uuid.New(), uuid.New())
 	req := CorrectRelationshipRequest{
 		Action: "submit", RelationshipID: uuid.NewString(), ExpectedVersion: 1,
-		Patch:    repository.RelationshipCorrectionPatch{Predicate: &repository.RelationshipCorrectionPredicatePatch{Key: "works_on"}},
-		Supports: []repository.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}},
+		Patch:    knowledgecontract.RelationshipCorrectionPatch{Predicate: &knowledgecontract.RelationshipCorrectionPredicatePatch{Key: "works_on"}},
+		Supports: []knowledgecontract.RelationshipCorrectionSupport{{EvidenceID: uuid.NewString(), Start: 0, End: 1}},
 		Reason:   "incorrect predicate", IdempotencyKey: "correction-1",
 	}
 	_, err := NewLifecycleService(LifecycleDependencies{}).CorrectRelationship(ctx, req)
 	require.ErrorContains(t, err, "semantic repository is required")
-	_, err = NewLifecycleService(LifecycleDependencies{Semantic: &lifecycleSemanticStub{}}).CorrectRelationship(context.Background(), req)
+	_, err = NewLifecycleService(LifecycleDependencies{Port: &lifecycleSemanticStub{}}).CorrectRelationship(context.Background(), req)
 	require.ErrorIs(t, err, ErrLifecycleAuthContext)
 }
 
@@ -259,11 +260,11 @@ func TestLifecycleRetractEvidenceUsesAuthenticatedOwner(t *testing.T) {
 	teamID := uuid.New()
 	profileID := uuid.New()
 	evidenceID := uuid.NewString()
-	evidence := &lifecycleEvidenceStub{result: &repository.EvidenceLifecycleResult{
+	evidence := &lifecycleEvidenceStub{result: &knowledgecontract.EvidenceLifecycleResult{
 		DecisionID: "decision-canonical", ProcessingState: "completed", RetractedEvidenceIDs: []string{evidenceID},
 		AffectedRelationshipCount: 1, PendingRelationshipCount: 1,
 	}}
-	svc := NewLifecycleService(LifecycleDependencies{Evidence: evidence})
+	svc := NewLifecycleService(LifecycleDependencies{Port: evidence})
 	result, err := svc.RetractEvidence(authenticatedRememberContext(teamID, profileID, uuid.New()), RetractEvidenceRequest{
 		EvidenceIDs: []string{evidenceID}, Reason: "entered in error", IdempotencyKey: "retract-1",
 	})
@@ -309,12 +310,12 @@ func TestLifecycleRetractEvidenceMapsRepositoryErrors(t *testing.T) {
 		err  error
 		code httperr.ErrorCode
 	}{
-		{repository.ErrEvidenceLifecycleNotFound, httperr.NOT_FOUND},
-		{repository.ErrTeamInactive, httperr.NOT_FOUND},
-		{repository.ErrEvidenceLifecycleConflict, httperr.CONFLICT},
-		{repository.ErrIdempotencyConflict, httperr.CONFLICT},
+		{knowledgecontract.ErrEvidenceLifecycleNotFound, httperr.NOT_FOUND},
+		{knowledgecontract.ErrTeamInactive, httperr.NOT_FOUND},
+		{knowledgecontract.ErrEvidenceLifecycleConflict, httperr.CONFLICT},
+		{knowledgecontract.ErrIdempotencyConflict, httperr.CONFLICT},
 	} {
-		_, err := NewLifecycleService(LifecycleDependencies{Evidence: &lifecycleEvidenceStub{err: test.err}}).RetractEvidence(ctx, req)
+		_, err := NewLifecycleService(LifecycleDependencies{Port: &lifecycleEvidenceStub{err: test.err}}).RetractEvidence(ctx, req)
 		var apiErr *httperr.APIError
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, test.code, apiErr.Code)
@@ -322,16 +323,16 @@ func TestLifecycleRetractEvidenceMapsRepositoryErrors(t *testing.T) {
 }
 
 type lifecycleSemanticStub struct {
-	correctInput  repository.CorrectRelationshipInput
-	correctResult *repository.CorrectRelationshipResult
+	correctInput  knowledgecontract.CorrectRelationshipInput
+	correctResult *knowledgecontract.CorrectRelationshipResult
 	err           error
-	plan          *repository.RelationshipCorrectionEmbeddingPlan
-	embeddings    []repository.RelationshipCorrectionEmbedding
+	plan          *knowledgecontract.RelationshipCorrectionEmbeddingPlan
+	embeddings    []knowledgecontract.RelationshipCorrectionEmbedding
 	commitErr     error
 	commitCalls   int
 }
 
-func (s *lifecycleSemanticStub) CorrectRelationship(_ context.Context, input repository.CorrectRelationshipInput) (*repository.CorrectRelationshipResult, error) {
+func (s *lifecycleSemanticStub) CorrectRelationship(_ context.Context, input knowledgecontract.CorrectRelationshipInput) (*knowledgecontract.CorrectRelationshipResult, error) {
 	s.correctInput = input
 	if s.err != nil {
 		return nil, s.err
@@ -342,7 +343,7 @@ func (s *lifecycleSemanticStub) CorrectRelationship(_ context.Context, input rep
 	return s.correctResult, nil
 }
 
-func (s *lifecycleSemanticStub) PlanRelationshipCorrectionEmbeddings(_ context.Context, input repository.CorrectRelationshipInput) (*repository.RelationshipCorrectionEmbeddingPlan, error) {
+func (s *lifecycleSemanticStub) PlanRelationshipCorrectionEmbeddings(_ context.Context, input knowledgecontract.CorrectRelationshipInput) (*knowledgecontract.RelationshipCorrectionEmbeddingPlan, error) {
 	s.correctInput = input
 	if s.err != nil {
 		return nil, s.err
@@ -350,12 +351,16 @@ func (s *lifecycleSemanticStub) PlanRelationshipCorrectionEmbeddings(_ context.C
 	if s.plan != nil {
 		return s.plan, nil
 	}
-	return &repository.RelationshipCorrectionEmbeddingPlan{}, nil
+	return &knowledgecontract.RelationshipCorrectionEmbeddingPlan{}, nil
 }
 
-func (s *lifecycleSemanticStub) CorrectRelationshipWithEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput, embeddings []repository.RelationshipCorrectionEmbedding) (*repository.CorrectRelationshipResult, error) {
+func (s *lifecycleSemanticStub) RetractEvidence(_ context.Context, _ knowledgecontract.RetractEvidenceInput) (*knowledgecontract.EvidenceLifecycleResult, error) {
+	return nil, errors.New("retraction not configured")
+}
+
+func (s *lifecycleSemanticStub) CorrectRelationshipWithEmbeddings(ctx context.Context, input knowledgecontract.CorrectRelationshipInput, embeddings []knowledgecontract.RelationshipCorrectionEmbedding) (*knowledgecontract.CorrectRelationshipResult, error) {
 	s.commitCalls++
-	s.embeddings = append([]repository.RelationshipCorrectionEmbedding(nil), embeddings...)
+	s.embeddings = append([]knowledgecontract.RelationshipCorrectionEmbedding(nil), embeddings...)
 	if s.commitErr != nil {
 		return nil, s.commitErr
 	}
@@ -363,28 +368,36 @@ func (s *lifecycleSemanticStub) CorrectRelationshipWithEmbeddings(ctx context.Co
 }
 
 type lifecycleEvidenceStub struct {
-	input  repository.RetractEvidenceInput
-	result *repository.EvidenceLifecycleResult
+	input  knowledgecontract.RetractEvidenceInput
+	result *knowledgecontract.EvidenceLifecycleResult
 	err    error
 }
 
 type lifecycleExecutorStub struct {
-	result         semanticwrite.Result
+	result         semanticwritecontract.Result
 	err            error
 	calls          int
 	waitForContext bool
 }
 
-func (s *lifecycleExecutorStub) Execute(ctx context.Context, _ semanticwrite.Plan) (semanticwrite.Result, error) {
+func (s *lifecycleExecutorStub) Execute(ctx context.Context, _ semanticwritecontract.Plan) (semanticwritecontract.Result, error) {
 	s.calls++
 	if s.waitForContext {
 		<-ctx.Done()
-		return semanticwrite.Result{}, ctx.Err()
+		return semanticwritecontract.Result{}, ctx.Err()
 	}
 	return s.result, s.err
 }
 
-func (s *lifecycleEvidenceStub) RetractEvidence(_ context.Context, input repository.RetractEvidenceInput) (*repository.EvidenceLifecycleResult, error) {
+func (s *lifecycleEvidenceStub) PlanRelationshipCorrectionEmbeddings(_ context.Context, _ knowledgecontract.CorrectRelationshipInput) (*knowledgecontract.RelationshipCorrectionEmbeddingPlan, error) {
+	return nil, errors.New("correction not configured")
+}
+
+func (s *lifecycleEvidenceStub) CorrectRelationshipWithEmbeddings(_ context.Context, _ knowledgecontract.CorrectRelationshipInput, _ []knowledgecontract.RelationshipCorrectionEmbedding) (*knowledgecontract.CorrectRelationshipResult, error) {
+	return nil, errors.New("correction not configured")
+}
+
+func (s *lifecycleEvidenceStub) RetractEvidence(_ context.Context, input knowledgecontract.RetractEvidenceInput) (*knowledgecontract.EvidenceLifecycleResult, error) {
 	s.input = input
 	if s.err != nil {
 		return nil, s.err

--- a/internal/lifecycle/status.go
+++ b/internal/lifecycle/status.go
@@ -1,0 +1,87 @@
+package lifecycle
+
+import (
+	"strings"
+
+	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+)
+
+// Status projection policy lives in the Remember application boundary. These
+// aliases keep the broader memory-service package wired to the same contract.
+type SubmissionErrorCode = rememberapp.SubmissionErrorCode
+type SubmissionStatusError = rememberapp.SubmissionStatusError
+type SubmissionNextAction = rememberapp.SubmissionNextAction
+type SubmissionAwaitingConfirmation = rememberapp.SubmissionAwaitingConfirmation
+
+const submissionStatusMaxIssueMessageLength = 512
+
+const (
+	SubmissionErrorStaleInput = rememberapp.SubmissionErrorStaleInput
+
+	SubmissionErrorProviderUnavailable      = rememberapp.SubmissionErrorProviderUnavailable
+	SubmissionErrorProviderResponseInvalid  = rememberapp.SubmissionErrorProviderResponseInvalid
+	SubmissionErrorInputBudgetExceeded      = rememberapp.SubmissionErrorInputBudgetExceeded
+	SubmissionErrorConfigurationInvalid     = rememberapp.SubmissionErrorConfigurationInvalid
+	SubmissionErrorIdempotencyConflict      = rememberapp.SubmissionErrorIdempotencyConflict
+	SubmissionErrorEmbeddingUnavailable     = rememberapp.SubmissionErrorEmbeddingUnavailable
+	SubmissionErrorEmbeddingResponseInvalid = rememberapp.SubmissionErrorEmbeddingResponseInvalid
+	SubmissionErrorCommitConflict           = rememberapp.SubmissionErrorCommitConflict
+	SubmissionErrorDatabaseFailure          = rememberapp.SubmissionErrorDatabaseFailure
+	SubmissionErrorRequestTimeout           = rememberapp.SubmissionErrorRequestTimeout
+	SubmissionErrorRequestCancelled         = rememberapp.SubmissionErrorRequestCancelled
+	SubmissionErrorInternalFailure          = rememberapp.SubmissionErrorInternalFailure
+
+	SubmissionErrorPolicyRejected      = rememberapp.SubmissionErrorPolicyRejected
+	SubmissionErrorAssessorInvalid     = rememberapp.SubmissionErrorAssessorInvalid
+	SubmissionErrorAssessorUnavailable = rememberapp.SubmissionErrorAssessorUnavailable
+	SubmissionErrorProcessingFailed    = rememberapp.SubmissionErrorProcessingFailed
+
+	SubmissionErrorRelationshipVersionStale      = rememberapp.SubmissionErrorRelationshipVersionStale
+	SubmissionErrorRelationshipNotActive         = rememberapp.SubmissionErrorRelationshipNotActive
+	SubmissionErrorObjectKindChangeForbidden     = rememberapp.SubmissionErrorObjectKindChangeForbidden
+	SubmissionErrorSupportSetMismatch            = rememberapp.SubmissionErrorSupportSetMismatch
+	SubmissionErrorEntityNotFound                = rememberapp.SubmissionErrorEntityNotFound
+	SubmissionErrorTooManyEntityCandidates       = rememberapp.SubmissionErrorTooManyEntityCandidates
+	SubmissionErrorPredicateNotFound             = rememberapp.SubmissionErrorPredicateNotFound
+	SubmissionErrorPredicateSubjectKindMismatch  = rememberapp.SubmissionErrorPredicateSubjectKindMismatch
+	SubmissionErrorPredicateObjectKindMismatch   = rememberapp.SubmissionErrorPredicateObjectKindMismatch
+	SubmissionErrorNoChange                      = rememberapp.SubmissionErrorNoChange
+	SubmissionErrorConfirmationExpired           = rememberapp.SubmissionErrorConfirmationExpired
+	SubmissionErrorRelationshipChanged           = rememberapp.SubmissionErrorRelationshipChanged
+	SubmissionErrorSupportSetChanged             = rememberapp.SubmissionErrorSupportSetChanged
+	SubmissionErrorPersistentAmbiguity           = rememberapp.SubmissionErrorPersistentAmbiguity
+	SubmissionErrorInactiveRelationshipCollision = rememberapp.SubmissionErrorInactiveRelationshipCollision
+
+	SubmissionNextActionRetrySameRequest = rememberapp.SubmissionNextActionRetrySameRequest
+	SubmissionNextActionResubmitRemember = rememberapp.SubmissionNextActionResubmitRemember
+	SubmissionNextActionRetryCorrection  = rememberapp.SubmissionNextActionRetryCorrection
+	SubmissionNextActionContactOperator  = rememberapp.SubmissionNextActionContactOperator
+	SubmissionNextActionNone             = rememberapp.SubmissionNextActionNone
+)
+
+func SubmissionErrorCodes() []string {
+	return rememberapp.SubmissionErrorCodes()
+}
+func SubmissionNextActions() []string {
+	return rememberapp.SubmissionNextActions()
+}
+
+func submissionStatusError(code SubmissionErrorCode) SubmissionStatusError {
+	return rememberapp.StatusError(code)
+}
+
+func submissionStatusErrorForCode(rawCode string, fallbackState string) SubmissionStatusError {
+	return rememberapp.StatusErrorForCode(rawCode, fallbackState)
+}
+
+func correctionStatusErrorForCode(rawCode string, fallbackState string) SubmissionStatusError {
+	if strings.TrimSpace(rawCode) == string(SubmissionErrorPolicyRejected) ||
+		(strings.TrimSpace(rawCode) == "" && strings.TrimSpace(fallbackState) == "rejected") {
+		return submissionStatusError(SubmissionErrorPolicyRejected)
+	}
+	return submissionStatusErrorForCode(rawCode, fallbackState)
+}
+
+func submissionFailureCode(stage, class string) SubmissionErrorCode {
+	return rememberapp.FailureCode(stage, class)
+}

--- a/internal/lifecycle/status.go
+++ b/internal/lifecycle/status.go
@@ -13,8 +13,6 @@ type SubmissionStatusError = rememberapp.SubmissionStatusError
 type SubmissionNextAction = rememberapp.SubmissionNextAction
 type SubmissionAwaitingConfirmation = rememberapp.SubmissionAwaitingConfirmation
 
-const submissionStatusMaxIssueMessageLength = 512
-
 const (
 	SubmissionErrorStaleInput = rememberapp.SubmissionErrorStaleInput
 
@@ -80,8 +78,4 @@ func correctionStatusErrorForCode(rawCode string, fallbackState string) Submissi
 		return submissionStatusError(SubmissionErrorPolicyRejected)
 	}
 	return submissionStatusErrorForCode(rawCode, fallbackState)
-}
-
-func submissionFailureCode(stage, class string) SubmissionErrorCode {
-	return rememberapp.FailureCode(stage, class)
 }

--- a/internal/repository/lifecycle_repository.go
+++ b/internal/repository/lifecycle_repository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	knowledgepostgres "github.com/markhuangai/dense-mem/internal/knowledge/postgres"
+)
+
+// LifecycleStore is the native construction seam for lifecycle mutations.
+// Lifecycle application policy consumes this port directly; the historical
+// repository methods remain compatibility-only forwarders.
+func (r *SemanticRepositoryImpl) LifecycleStore() knowledgecontract.LifecyclePort {
+	if r == nil || r.db == nil || r.rls == nil {
+		return nil
+	}
+	return knowledgepostgres.NewStore(r.db, r.rls, knowledgecontract.ConflictRuntimeConfig{})
+}

--- a/internal/service/memoryservice/lifecycle.go
+++ b/internal/service/memoryservice/lifecycle.go
@@ -2,403 +2,45 @@ package memoryservice
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"sort"
-	"strings"
-	"time"
 
-	"github.com/google/uuid"
-
-	"github.com/markhuangai/dense-mem/internal/correlation"
-	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/httperr"
-	"github.com/markhuangai/dense-mem/internal/observability"
-	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/requestctx"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
-	"github.com/markhuangai/dense-mem/internal/service/semanticwrite"
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	lifecycleapp "github.com/markhuangai/dense-mem/internal/lifecycle"
 )
+
+// Lifecycle names remain single-hop aliases while callers migrate to the
+// capability-owned application package.
+type LifecycleService = lifecycleapp.LifecycleService
+type LifecycleDependencies = lifecycleapp.LifecycleDependencies
+type LifecycleSemanticRepository = knowledgecontract.LifecyclePort
+type LifecycleCorrectionExecutor = lifecycleapp.LifecycleCorrectionExecutor
+type LifecycleEvidenceRepository = knowledgecontract.LifecyclePort
+type CorrectRelationshipRequest = lifecycleapp.CorrectRelationshipRequest
+type CorrectRelationshipReceipt = lifecycleapp.CorrectRelationshipReceipt
+type RetractEvidenceRequest = lifecycleapp.RetractEvidenceRequest
+type RetractEvidenceResult = lifecycleapp.RetractEvidenceResult
 
 var (
-	ErrLifecycleAuthContext           = errors.New("memory lifecycle: authenticated actor context is required")
-	ErrLifecyclePersistence           = errors.New("memory lifecycle: persistence failed")
-	ErrLifecycleEmbeddingUnavailable  = errors.New("memory lifecycle: embedding provider unavailable")
-	ErrLifecycleEmbeddingInvalid      = errors.New("memory lifecycle: embedding response invalid")
-	ErrLifecycleEmbeddingTimeout      = errors.New("memory lifecycle: embedding provider timed out")
-	errLifecycleCorrectionCommitFence = errors.New("memory lifecycle: correction commit search fence conflict")
+	ErrLifecycleAuthContext          = lifecycleapp.ErrLifecycleAuthContext
+	ErrLifecyclePersistence          = lifecycleapp.ErrLifecyclePersistence
+	ErrLifecycleEmbeddingUnavailable = lifecycleapp.ErrLifecycleEmbeddingUnavailable
+	ErrLifecycleEmbeddingInvalid     = lifecycleapp.ErrLifecycleEmbeddingInvalid
+	ErrLifecycleEmbeddingTimeout     = lifecycleapp.ErrLifecycleEmbeddingTimeout
 )
 
-// CorrectionConfirmationInvalidReason identifies a pending confirmation that
-// remains awaiting confirmation after the legacy lifecycle rejects a token or
-// candidate selection.
-const CorrectionConfirmationInvalidReason = "confirmation_invalid"
-
-type LifecycleService interface {
-	CorrectRelationship(ctx context.Context, req CorrectRelationshipRequest) (*CorrectRelationshipReceipt, error)
-	RetractEvidence(ctx context.Context, req RetractEvidenceRequest) (*RetractEvidenceResult, error)
-}
-
-type LifecycleDependencies struct {
-	Semantic                   LifecycleSemanticRepository
-	Evidence                   LifecycleEvidenceRepository
-	CorrectionExecutor         LifecycleCorrectionExecutor
-	CorrectionEmbeddingTimeout time.Duration
-}
-
-type LifecycleSemanticRepository interface {
-	PlanRelationshipCorrectionEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput) (*repository.RelationshipCorrectionEmbeddingPlan, error)
-	CorrectRelationshipWithEmbeddings(ctx context.Context, input repository.CorrectRelationshipInput, embeddings []repository.RelationshipCorrectionEmbedding) (*repository.CorrectRelationshipResult, error)
-}
-
-type LifecycleCorrectionExecutor interface {
-	Execute(context.Context, semanticwrite.Plan) (semanticwrite.Result, error)
-}
-
-type LifecycleEvidenceRepository interface {
-	RetractEvidence(ctx context.Context, input repository.RetractEvidenceInput) (*repository.EvidenceLifecycleResult, error)
-}
+const CorrectionConfirmationInvalidReason = lifecycleapp.CorrectionConfirmationInvalidReason
 
 type lifecycleService struct {
-	semantic         LifecycleSemanticRepository
-	evidence         LifecycleEvidenceRepository
-	executor         LifecycleCorrectionExecutor
-	embeddingTimeout time.Duration
+	delegate lifecycleapp.LifecycleService
+}
+
+func (s *lifecycleService) CorrectRelationship(ctx context.Context, req CorrectRelationshipRequest) (*CorrectRelationshipReceipt, error) {
+	return s.delegate.CorrectRelationship(ctx, req)
+}
+
+func (s *lifecycleService) RetractEvidence(ctx context.Context, req RetractEvidenceRequest) (*RetractEvidenceResult, error) {
+	return s.delegate.RetractEvidence(ctx, req)
 }
 
 func NewLifecycleService(deps LifecycleDependencies) LifecycleService {
-	timeout := deps.CorrectionEmbeddingTimeout
-	if timeout <= 0 {
-		timeout = 10 * time.Second
-	}
-	return &lifecycleService{semantic: deps.Semantic, evidence: deps.Evidence, executor: deps.CorrectionExecutor, embeddingTimeout: timeout}
-}
-
-func correctionStatusErrorForCode(rawCode string, fallbackState string) SubmissionStatusError {
-	if strings.TrimSpace(rawCode) == string(SubmissionErrorPolicyRejected) ||
-		(strings.TrimSpace(rawCode) == "" && strings.TrimSpace(fallbackState) == "rejected") {
-		return submissionStatusError(SubmissionErrorPolicyRejected)
-	}
-	return submissionStatusErrorForCode(rawCode, fallbackState)
-}
-
-type CorrectRelationshipRequest struct {
-	Action            string                                     `json:"action"`
-	RelationshipID    string                                     `json:"relationship_id,omitempty"`
-	ExpectedVersion   int                                        `json:"expected_version,omitempty"`
-	Patch             repository.RelationshipCorrectionPatch     `json:"patch,omitempty"`
-	Supports          []repository.RelationshipCorrectionSupport `json:"supports,omitempty"`
-	Reason            string                                     `json:"reason,omitempty"`
-	SubmissionID      string                                     `json:"submission_id,omitempty"`
-	ConfirmationToken string                                     `json:"confirmation_token,omitempty"`
-	Selection         repository.RelationshipCorrectionSelection `json:"selection,omitempty"`
-	IdempotencyKey    string                                     `json:"idempotency_key"`
-}
-
-type CorrectRelationshipReceipt struct {
-	ContractVersion      string                                   `json:"contract_version"`
-	SubmissionID         string                                   `json:"submission_id"`
-	SubmissionKind       string                                   `json:"submission_kind"`
-	ProcessingState      string                                   `json:"processing_state"`
-	SearchState          string                                   `json:"search_state"`
-	CorrelationID        string                                   `json:"correlation_id"`
-	AwaitingConfirmation *SubmissionAwaitingConfirmation          `json:"awaiting_confirmation,omitempty"`
-	CorrectionResult     *repository.RelationshipCorrectionResult `json:"correction_result,omitempty"`
-	Errors               []SubmissionStatusError                  `json:"errors"`
-}
-
-type RetractEvidenceRequest struct {
-	EvidenceIDs    []string `json:"evidence_ids"`
-	Reason         string   `json:"reason"`
-	IdempotencyKey string   `json:"idempotency_key"`
-}
-
-type RetractEvidenceResult struct {
-	DecisionID                      string   `json:"decision_id"`
-	ProcessingState                 string   `json:"processing_state"`
-	RetractedEvidenceIDs            []string `json:"retracted_evidence_ids"`
-	AffectedRelationshipCount       int      `json:"affected_relationship_count"`
-	PendingRelationshipCount        int      `json:"pending_relationship_count"`
-	RetainedActiveRelationshipCount int      `json:"retained_active_relationship_count"`
-}
-
-func (s *lifecycleService) CorrectRelationship(
-	ctx context.Context,
-	req CorrectRelationshipRequest,
-) (*CorrectRelationshipReceipt, error) {
-	if s.semantic == nil {
-		return nil, errors.New("memory lifecycle: semantic repository is required")
-	}
-	actor, ok := requestctx.ActorFromContext(ctx)
-	if !ok || actor.TeamID == uuid.Nil || actor.OwnerID == uuid.Nil {
-		return nil, ErrLifecycleAuthContext
-	}
-	if req.Action != "submit" && req.Action != "confirm" {
-		return nil, errors.New("memory lifecycle: action must be submit or confirm")
-	}
-	input := repository.CorrectRelationshipInput{
-		TeamID:            actor.TeamID.String(),
-		OwnerProfileID:    actor.OwnerID.String(),
-		Action:            req.Action,
-		RelationshipID:    req.RelationshipID,
-		ExpectedVersion:   req.ExpectedVersion,
-		Patch:             req.Patch,
-		Supports:          req.Supports,
-		Reason:            req.Reason,
-		SubmissionID:      req.SubmissionID,
-		ConfirmationToken: req.ConfirmationToken,
-		Selection:         req.Selection,
-		IdempotencyKey:    req.IdempotencyKey,
-	}
-	plan, err := s.semantic.PlanRelationshipCorrectionEmbeddings(ctx, input)
-	if err == nil && plan == nil {
-		err = ErrLifecyclePersistence
-	}
-	var embeddings []repository.RelationshipCorrectionEmbedding
-	if err == nil && len(plan.Documents) > 0 {
-		if s.executor == nil {
-			err = ErrLifecycleEmbeddingUnavailable
-		} else {
-			executionCtx := observability.WithMetricIdentity(ctx, input.TeamID, input.OwnerProfileID)
-			embeddingCtx, cancel := context.WithTimeout(executionCtx, s.embeddingTimeout)
-			result, executeErr := s.executor.Execute(embeddingCtx, semanticwrite.Plan{
-				Documents: correctionPlanDocuments(plan.Documents),
-				Fence:     semanticwrite.Fence{Model: plan.EmbeddingModel, Dimensions: plan.EmbeddingDimensions, EmbeddingContractID: plan.EmbeddingContractID, SearchGenerationID: plan.SearchIndexGenerationID, SearchGenerationVersion: int64(plan.IndexGeneration)},
-				Timeout:   s.embeddingTimeout,
-			})
-			if executeErr != nil {
-				err = translateCorrectionEmbeddingErrorWithContext(ctx, embeddingCtx, executeErr)
-			} else {
-				embeddings = correctionEmbeddingsFromResult(result)
-			}
-			cancel()
-		}
-	}
-	var result *repository.CorrectRelationshipResult
-	if err == nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			err = ctxErr
-		} else {
-			result, err = s.semantic.CorrectRelationshipWithEmbeddings(ctx, input, embeddings)
-			if isCorrectionCommitSearchFenceError(err) {
-				err = fmt.Errorf("%w: %w", errLifecycleCorrectionCommitFence, err)
-			}
-		}
-	}
-	if err != nil {
-		return nil, translateRelationshipCorrectionError(err)
-	}
-	if result == nil {
-		return nil, ErrLifecyclePersistence
-	}
-	receipt := &CorrectRelationshipReceipt{
-		ContractVersion:  domain.ContractVersion,
-		SubmissionID:     result.SubmissionID,
-		SubmissionKind:   "relationship_correction",
-		ProcessingState:  result.ProcessingState,
-		SearchState:      result.SearchState,
-		CorrelationID:    rememberapp.NormalizeTerminalCorrelationID(correlation.FromContext(ctx)),
-		CorrectionResult: result.Correction,
-		Errors:           []SubmissionStatusError{},
-	}
-	if receipt.SearchState == "" {
-		receipt.SearchState = string(domain.SearchProjectionNotRequired)
-	}
-	if result.Confirmation != nil {
-		receipt.AwaitingConfirmation = &SubmissionAwaitingConfirmation{
-			ConfirmationToken: result.Confirmation.Token,
-			ExpiresAt:         result.Confirmation.ExpiresAt,
-		}
-		for _, candidate := range result.Confirmation.Candidates {
-			receipt.AwaitingConfirmation.Candidates = append(receipt.AwaitingConfirmation.Candidates, rememberapp.RelationshipCorrectionCandidate{
-				Endpoint: candidate.Endpoint, EntityID: candidate.EntityID, EntityKind: candidate.EntityKind, CanonicalName: candidate.CanonicalName,
-			})
-		}
-	}
-	if result.ErrorCode != "" {
-		receipt.Errors = append(receipt.Errors, correctionStatusErrorForCode(result.ErrorCode, result.ProcessingState))
-	}
-	if (result.ProcessingState == "rejected" || result.ProcessingState == "failed") && len(receipt.Errors) == 0 {
-		receipt.Errors = append(receipt.Errors, correctionStatusErrorForCode("", result.ProcessingState))
-	}
-	return receipt, nil
-}
-
-func correctionPlanDocuments(documents []repository.RelationshipCorrectionEmbeddingDocument) []semanticwrite.Document {
-	result := make([]semanticwrite.Document, 0, len(documents))
-	for _, document := range documents {
-		result = append(result, semanticwrite.Document{Hash: document.DocumentHash, Text: document.DocumentText})
-	}
-	return result
-}
-
-func correctionEmbeddingsFromResult(result semanticwrite.Result) []repository.RelationshipCorrectionEmbedding {
-	embeddings := make([]repository.RelationshipCorrectionEmbedding, 0, len(result.Embeddings))
-	for _, embedding := range result.Embeddings {
-		embeddings = append(embeddings, repository.RelationshipCorrectionEmbedding{DocumentHash: embedding.DocumentHash, Embedding: append([]float32(nil), embedding.Vector...), EmbeddingContractID: result.Fence.EmbeddingContractID, EmbeddingDimensions: result.Fence.Dimensions, EmbeddingModel: result.Fence.Model, SearchIndexGenerationID: result.Fence.SearchGenerationID, IndexGeneration: int(result.Fence.SearchGenerationVersion)})
-	}
-	return embeddings
-}
-
-func translateCorrectionEmbeddingError(err error) error {
-	switch {
-	case errors.Is(err, semanticwrite.ErrProviderUnavailable):
-		return ErrLifecycleEmbeddingUnavailable
-	case errors.Is(err, semanticwrite.ErrProviderResponseInvalid), errors.Is(err, semanticwrite.ErrInvalidPlan):
-		return ErrLifecycleEmbeddingInvalid
-	case errors.Is(err, semanticwrite.ErrProviderTimeout):
-		return ErrLifecycleEmbeddingTimeout
-	default:
-		return err
-	}
-}
-
-func translateCorrectionEmbeddingErrorWithContext(callerCtx, embeddingCtx context.Context, err error) error {
-	if errors.Is(err, context.DeadlineExceeded) && correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx) {
-		return ErrLifecycleEmbeddingTimeout
-	}
-	return translateCorrectionEmbeddingError(err)
-}
-
-func correctionEmbeddingContextOwnsDeadline(callerCtx, embeddingCtx context.Context) bool {
-	if !errors.Is(embeddingCtx.Err(), context.DeadlineExceeded) {
-		return false
-	}
-	callerDeadline, callerHasDeadline := callerCtx.Deadline()
-	embeddingDeadline, embeddingHasDeadline := embeddingCtx.Deadline()
-	if !embeddingHasDeadline {
-		return false
-	}
-	if !callerHasDeadline {
-		return true
-	}
-	return embeddingDeadline.Before(callerDeadline)
-}
-
-func translateRelationshipCorrectionError(err error) error {
-	if errors.Is(err, ErrLifecycleEmbeddingUnavailable) {
-		return httperr.New(httperr.ErrEmbeddingUnavailable, "embedding provider unavailable")
-	}
-	if errors.Is(err, ErrLifecycleEmbeddingInvalid) {
-		return httperr.New(httperr.ErrEmbeddingResponseInvalid, "embedding provider response invalid")
-	}
-	if errors.Is(err, ErrLifecycleEmbeddingTimeout) {
-		return httperr.New(httperr.ErrEmbeddingTimeout, "embedding provider timed out")
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return err
-	}
-	if errors.Is(err, repository.ErrSemanticOwnerMismatch) || errors.Is(err, repository.ErrRelationshipCorrectionNotFound) {
-		return httperr.New(httperr.NOT_FOUND, "submission not found")
-	}
-	if errors.Is(err, repository.ErrSemanticIdempotencyConflict) {
-		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
-			Field: "reason", Message: "idempotency_conflict",
-		}}), "idempotency_conflict", "correct_and_resubmit", "Use a new idempotency key for the changed correction request, then submit again.", false, nil, "")
-	}
-	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmationExpired) {
-		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
-			Field: "reason", Message: string(SubmissionErrorConfirmationExpired),
-		}}), "confirmation_expired", "correct_and_resubmit", "Start a new correction submission and use its fresh confirmation token.", false, nil, "")
-	}
-	if errors.Is(err, repository.ErrRelationshipCorrectionConfirmation) {
-		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
-			Field: "reason", Message: CorrectionConfirmationInvalidReason,
-		}}), "confirmation_invalid", "correct_and_resubmit", "Start a new correction submission and use its current confirmation token.", false, nil, "")
-	}
-	if errors.Is(err, errLifecycleCorrectionCommitFence) {
-		return httperr.WithGuidance(httperr.NewWithDetails(httperr.CONFLICT, "relationship correction conflict", []httperr.ErrorDetail{{
-			Field: "reason", Message: string(rememberapp.TerminalErrorCommitConflict),
-		}}), "commit_conflict", "refresh_state", "Refresh the current relationship state, then submit the correction again with a new idempotency key.", false, nil, "")
-	}
-	if errors.Is(err, repository.ErrRelationshipCorrectionStateConflict) {
-		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "state_conflict", "refresh_state", "Refresh the current relationship state, then submit the correction again.", false, nil, "")
-	}
-	if errors.Is(err, repository.ErrSearchEmbeddingRequired) || errors.Is(err, repository.ErrSearchContractMismatch) {
-		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "search_configuration_invalid", "contact_operator", "Contact an operator to restore the configured search contract before retrying.", false, nil, "")
-	}
-	if errors.Is(err, repository.ErrSearchStaleVersion) {
-		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "relationship correction conflict"), "search_state_stale", "refresh_state", "Refresh the current relationship state, then submit the correction again.", false, nil, "")
-	}
-	return ErrLifecyclePersistence
-}
-
-func isCorrectionCommitSearchFenceError(err error) bool {
-	return errors.Is(err, repository.ErrSearchEmbeddingRequired) ||
-		errors.Is(err, repository.ErrSearchContractMismatch) ||
-		errors.Is(err, repository.ErrSearchStaleVersion)
-}
-
-func (s *lifecycleService) RetractEvidence(
-	ctx context.Context,
-	req RetractEvidenceRequest,
-) (*RetractEvidenceResult, error) {
-	if s.evidence == nil {
-		return nil, errors.New("memory lifecycle: evidence repository is required")
-	}
-	actor, ok := requestctx.ActorFromContext(ctx)
-	if !ok || actor.TeamID == uuid.Nil || actor.OwnerID == uuid.Nil {
-		return nil, ErrLifecycleAuthContext
-	}
-	requestHash, err := retractEvidenceRequestHash(req)
-	if err != nil {
-		return nil, err
-	}
-	result, err := s.evidence.RetractEvidence(ctx, repository.RetractEvidenceInput{
-		TeamID:         actor.TeamID.String(),
-		OwnerProfileID: actor.OwnerID.String(),
-		EvidenceIDs:    append([]string(nil), req.EvidenceIDs...),
-		Reason:         req.Reason,
-		IdempotencyKey: req.IdempotencyKey,
-		RequestHash:    requestHash,
-	})
-	if err != nil {
-		return nil, translateEvidenceLifecycleError(err)
-	}
-	return &RetractEvidenceResult{
-		DecisionID:                      result.DecisionID,
-		ProcessingState:                 result.ProcessingState,
-		RetractedEvidenceIDs:            append([]string(nil), result.RetractedEvidenceIDs...),
-		AffectedRelationshipCount:       result.AffectedRelationshipCount,
-		PendingRelationshipCount:        result.PendingRelationshipCount,
-		RetainedActiveRelationshipCount: result.RetainedActiveRelationshipCount,
-	}, nil
-}
-
-// Retract's unchanged request contract must replay hashes written before v2.6.
-const retractEvidenceRequestHashContractVersion = "dense-mem.v2.4"
-
-func retractEvidenceRequestHash(req RetractEvidenceRequest) (string, error) {
-	evidenceIDs := make([]string, len(req.EvidenceIDs))
-	for index, evidenceID := range req.EvidenceIDs {
-		evidenceIDs[index] = strings.TrimSpace(evidenceID)
-	}
-	sort.Strings(evidenceIDs)
-	payload, err := json.Marshal(map[string]any{
-		"contract_version": retractEvidenceRequestHashContractVersion,
-		"evidence_ids":     evidenceIDs,
-		"reason":           strings.TrimSpace(req.Reason),
-		"idempotency_key":  strings.TrimSpace(req.IdempotencyKey),
-	})
-	if err != nil {
-		return "", fmt.Errorf("memory lifecycle: canonical retract request hash: %w", err)
-	}
-	sum := sha256.Sum256(payload)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
-}
-
-func translateEvidenceLifecycleError(err error) error {
-	switch {
-	case errors.Is(err, repository.ErrEvidenceLifecycleNotFound), errors.Is(err, repository.ErrTeamInactive):
-		return httperr.New(httperr.NOT_FOUND, "evidence not found")
-	case errors.Is(err, repository.ErrIdempotencyConflict):
-		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "evidence lifecycle conflict"), "idempotency_conflict", "correct_and_resubmit", "Use a new idempotency key for the changed retraction request, then submit again.", false, nil, "")
-	case errors.Is(err, repository.ErrEvidenceLifecycleConflict):
-		return httperr.WithGuidance(httperr.New(httperr.CONFLICT, "evidence lifecycle conflict"), "evidence_lifecycle_conflict", "refresh_state", "Refresh the current evidence state, then submit the retraction again with a new idempotency key.", false, nil, "")
-	default:
-		return err
-	}
+	return &lifecycleService{delegate: lifecycleapp.NewLifecycleService(deps)}
 }

--- a/internal/service/memoryservice/lifecycle_test_helpers_test.go
+++ b/internal/service/memoryservice/lifecycle_test_helpers_test.go
@@ -1,0 +1,19 @@
+package memoryservice
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/markhuangai/dense-mem/internal/correlation"
+	"github.com/markhuangai/dense-mem/internal/requestctx"
+)
+
+func authenticatedRememberContext(teamID, profileID, credentialID uuid.UUID) context.Context {
+	ctx := correlation.WithID(context.Background(), "corr-canonical")
+	return requestctx.WithActor(ctx, requestctx.Actor{
+		TeamID: teamID, TeamName: "team", IdentityID: credentialID, MembershipID: credentialID,
+		OwnerID: profileID, OwnerName: "owner", CredentialID: &credentialID,
+		AuthMethod: "api_key", Role: "member", Grants: []string{"read", "write"},
+	})
+}

--- a/internal/tools/registry/capability_bindings.go
+++ b/internal/tools/registry/capability_bindings.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"github.com/markhuangai/dense-mem/internal/dream"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
@@ -23,7 +24,7 @@ type RememberBindings struct {
 }
 
 type LifecycleBindings struct {
-	Service memoryservice.LifecycleService
+	Service lifecycle.LifecycleService
 }
 
 type RecallBindings struct {

--- a/internal/tools/registry/lifecycle_bindings.go
+++ b/internal/tools/registry/lifecycle_bindings.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
 )
 
 func bindLifecycleTool(tool Tool, deps Dependencies) Tool {
@@ -18,7 +18,7 @@ func bindLifecycleTool(tool Tool, deps Dependencies) Tool {
 			if err := ValidateContractInput(tool, input, authenticatedScopes(ctx)); err != nil {
 				return nil, fmt.Errorf("retract_evidence: invalid input: %w", err)
 			}
-			var req memoryservice.RetractEvidenceRequest
+			var req lifecycle.RetractEvidenceRequest
 			if err := remapInput(input, &req); err != nil {
 				return nil, fmt.Errorf("retract_evidence: invalid input: %w", err)
 			}
@@ -36,7 +36,7 @@ func bindLifecycleTool(tool Tool, deps Dependencies) Tool {
 			if err := ValidateContractInput(tool, input, authenticatedScopes(ctx)); err != nil {
 				return nil, fmt.Errorf("correct_relationship: invalid input: %w", err)
 			}
-			var req memoryservice.CorrectRelationshipRequest
+			var req lifecycle.CorrectRelationshipRequest
 			if err := remapInput(input, &req); err != nil {
 				return nil, fmt.Errorf("correct_relationship: invalid input: %w", err)
 			}

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/dream"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/service"
@@ -36,7 +37,7 @@ type Dependencies struct {
 	Context        contextservice.Service
 	Remember       memoryservice.RememberService
 	Recall         memoryservice.RecallService
-	Lifecycle      memoryservice.LifecycleService
+	Lifecycle      lifecycle.LifecycleService
 	RecallDreaming DreamingConfigProvider
 	Evaluation     repository.EvaluationRepository
 	Communities    repository.CommunityRepository


### PR DESCRIPTION
Close #374 

## Goal

Activate the lifecycle application module for relationship correction and evidence retraction while preserving the existing authenticated-owner, synchronous-write, replay, and append-only lifecycle behavior.

## Implementation

- Added `internal/lifecycle` as the capability-owned application boundary using `knowledgecontract.LifecyclePort` and the semantic-write contract.
- Added the canonical PostgreSQL lifecycle construction seam and wired lifecycle composition and registry bindings to the native API.
- Kept `memoryservice/lifecycle.go` as a single-hop compatibility facade and recorded its remaining consumers under #382.
- Migrated lifecycle tests and retained the shared authenticated-context helper.
- Left the central application assembler and canonical PostgreSQL writer implementation unchanged.

## Audit receipt

- Auditor: `gpt-5.6-terra`, reasoning `max`
- Base SHA: `69ab7d4f463d24bf42e264a06ed6d0093ae13c3d`
- Final verdict: `conformant`
- Final audit state: branch `refactor/374-lifecycle-capability`, implementation relative to the recorded base, no staged changes at audit time, tests not run during audit.
- Audit rounds: the initial audit identified four bounded gaps; corrections were applied and the complete rescans cleared all findings. The final rescan verified the canonical port, synchronous owner-authorized lifecycle behavior, unchanged PostgreSQL writer and shared paths, native registry callers, and complete #382 compatibility accounting.

Post-audit validation corrections were limited to importing the semantic-write application error sentinels from their owning package and using the architecture checker’s callable `buildApplicationBundle` consumer symbol. The final full rescan covered those corrections.

## Validation

- `go test ./internal/lifecycle/... ./internal/service/memoryservice/... -count=1`
- `go test ./cmd/internal/serverapp/... ./internal/tools/registry/... -count=1`
- `./scripts/e2e.sh synchronous_write`
- `./scripts/e2e.sh conflict`
- `./scripts/ci-check.sh`

All passed. Repository coverage was `90.0%`, meeting the configured threshold. The push hook reran `ci-check.sh` successfully.

## Risk and mitigation

- A same-team non-owner could be authorized if actor ownership were lost during port conversion; lifecycle unit tests and the real synchronous-write/conflict E2E scenarios exercise owner isolation.
- A correction could commit without its planned embedding fence if orchestration changed; lifecycle tests cover provider failure, timeout, and commit-fence paths, and the E2E scenarios cover rollback and stale concurrency behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for correcting relationships and retracting evidence.
  - Added clear confirmation, status, and next-action outcomes for lifecycle requests.
  - Added handling for authentication, persistence, embedding, timeout, and validation errors.
  - Added database-backed lifecycle mutations.

- **Bug Fixes**
  - Improved lifecycle request processing and error translation.
  - Preserved compatibility for existing lifecycle integrations while supporting the updated lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->