### PR TITLE
fix: retire the verified deprecated ANN index (#350)

### DIFF
--- a/architecture/modules/index-retirement.json
+++ b/architecture/modules/index-retirement.json
@@ -1,6 +1,10 @@
 {
   "schema_version": 1,
   "capability": "index-retirement",
+  "source_ownership": [
+    {"path": "migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql", "issue": 350},
+    {"path": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e", "issue": 350}
+  ],
   "completed_issues": [],
   "go": {"units": []},
   "browser": {"units": []},

--- a/cmd/e2e/main_test.go
+++ b/cmd/e2e/main_test.go
@@ -319,11 +319,8 @@ func TestDatabaseCaseFragmentsPreserveInventoryAndWave6Partition(t *testing.T) {
 		if fragment.Capability != capability {
 			t.Fatalf("fragment %s declares capability %q", capability, fragment.Capability)
 		}
-		if capability != "index-retirement" && len(fragment.Cases) == 0 {
+		if len(fragment.Cases) == 0 {
 			t.Fatalf("wave 7 fragment %s is unexpectedly empty", capability)
-		}
-		if capability == "index-retirement" && len(fragment.Cases) != 0 {
-			t.Fatalf("index-retirement fragment unexpectedly owns cases")
 		}
 	}
 }

--- a/internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e
+++ b/internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e
@@ -61,6 +61,21 @@ func TestDeprecatedANNIndexMigrationIsIdempotentWhenTargetAbsent(t *testing.T) {
 	assert.True(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
 }
 
+func TestDeprecatedANNIndexMigrationIgnoresSessionIdentifierQuoting(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	_, err := db.ExecContext(ctx, `SET quote_all_identifiers = on`)
+	require.NoError(t, err)
+
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+}
+
 func TestDeprecatedANNIndexMigrationFailsClosedOnDefinitionMismatch(t *testing.T) {
 	ctx := context.Background()
 	db := setupDeprecatedANNRetirementDB(t, ctx)
@@ -148,7 +163,8 @@ func TestDeprecatedANNIndexMigrationDownRequiresCatalogRecovery(t *testing.T) {
 
 	err := migrationDownTo(ctx, db, deprecatedANNRetirementBaseVersion)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot automatically roll back")
+	assert.Contains(t, strings.ToLower(err.Error()), "irreversible")
+	assert.Contains(t, strings.ToLower(err.Error()), "do not retry")
 	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
 
 	restoreDeprecatedANNIndex(t, ctx, db)

--- a/internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e
+++ b/internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e
@@ -1,0 +1,499 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	deprecatedANNRetirementBaseVersion int64 = 20260910010001
+	deprecatedANNRetirementVersion     int64 = 20260910020001
+	deprecatedANNContractID                  = "1a06f88d-e92e-4f3c-8d27-0b747bd8cf17"
+	deprecatedANNTargetIndex                 = "v2_search_1a06f88de92e_3072_halfvec_hnsw_idx"
+	deprecatedANNActiveIndex                 = "search_1a06f88de92e_3072_halfvec_hnsw_idx"
+)
+
+func TestDeprecatedANNIndexMigrationRetiresExactDuplicate(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+
+	beforeDefinition := indexDefinition(t, ctx, db, deprecatedANNActiveIndex)
+	beforeGenerations := searchGenerationSnapshot(t, ctx, db)
+	documentID := insertDeprecatedANNSearchDocument(t, ctx, db)
+	beforeDocument := searchDocumentSnapshot(t, ctx, db, documentID)
+	beforePlan := deprecatedANNQueryPlan(t, ctx, db)
+	require.Contains(t, beforePlan, "Index Scan using ")
+	beforeResults := deprecatedANNQueryResults(t, ctx, db)
+	require.Equal(t, []string{documentID}, beforeResults)
+
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.Equal(t, beforeDefinition, indexDefinition(t, ctx, db, deprecatedANNActiveIndex))
+	assert.Equal(t, beforeGenerations, searchGenerationSnapshot(t, ctx, db))
+	assert.Equal(t, beforeDocument, searchDocumentSnapshot(t, ctx, db, documentID))
+
+	afterPlan := deprecatedANNQueryPlan(t, ctx, db)
+	assert.Equal(t, normalizeDeprecatedANNPlan(beforePlan), normalizeDeprecatedANNPlan(afterPlan))
+	assert.Contains(t, afterPlan, "Index Scan using "+deprecatedANNActiveIndex)
+	assert.NotContains(t, afterPlan, deprecatedANNTargetIndex)
+	assert.Equal(t, beforeResults, deprecatedANNQueryResults(t, ctx, db))
+}
+
+func TestDeprecatedANNIndexMigrationIsIdempotentWhenTargetAbsent(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.True(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func TestDeprecatedANNIndexMigrationFailsClosedOnDefinitionMismatch(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "failed")
+
+	err := migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "physical definition")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsMissing(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+	require.NoError(t, dropDeprecatedANNIndex(t, ctx, db, deprecatedANNActiveIndex))
+
+	err := migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active replacement is missing")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsInvalid(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+	require.NoError(t, dropDeprecatedANNIndex(t, ctx, db, deprecatedANNActiveIndex))
+	createDeprecatedANNIndex(t, ctx, db, deprecatedANNActiveIndex, "failed")
+
+	err := migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "physical definition")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func TestDeprecatedANNIndexMigrationFailsClosedOnActiveTarget(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "active", "current")
+
+	err := migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deprecated generation metadata")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func TestDeprecatedANNIndexMigrationReleasesLockAfterBoundedFailure(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+
+	blockerConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	blockerTx, err := blockerConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = blockerTx.ExecContext(ctx, `LOCK TABLE public.search_documents IN ROW EXCLUSIVE MODE`)
+	require.NoError(t, err)
+
+	err = migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "lock")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+
+	require.NoError(t, blockerTx.Rollback())
+	require.NoError(t, blockerConn.Close())
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+}
+
+func TestDeprecatedANNIndexMigrationDownRequiresCatalogRecovery(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+
+	err := migrationDownTo(ctx, db, deprecatedANNRetirementBaseVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot automatically roll back")
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+
+	restoreDeprecatedANNIndex(t, ctx, db)
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.Equal(t,
+		normalizeDeprecatedANNDefinition(indexDefinition(t, ctx, db, deprecatedANNTargetIndex)),
+		normalizeDeprecatedANNDefinition(indexDefinition(t, ctx, db, deprecatedANNActiveIndex)),
+	)
+}
+
+func TestDeprecatedANNIndexMigrationChecksCatalogDependencies(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+
+	assert.Zero(t, incomingIndexDependencyCount(t, ctx, db, deprecatedANNTargetIndex))
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementVersion)
+	assert.False(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+}
+
+func TestDeprecatedANNIndexMigrationRejectsDependentTarget(t *testing.T) {
+	ctx := context.Background()
+	db := setupDeprecatedANNRetirementDB(t, ctx)
+	installDeprecatedANNFixture(t, ctx, db, "deprecated", "current")
+	require.NoError(t, dropDeprecatedANNIndex(t, ctx, db, deprecatedANNTargetIndex))
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE UNIQUE INDEX %s ON public.search_documents (document_hash)
+	`, deprecatedANNTargetIndex))
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		ALTER TABLE public.search_documents
+			ADD CONSTRAINT %s UNIQUE USING INDEX %s
+	`, deprecatedANNTargetIndex, deprecatedANNTargetIndex))
+	require.NoError(t, err)
+	assert.Greater(t, dependentIndexConstraintCount(t, ctx, db, deprecatedANNTargetIndex), 0)
+
+	err = migrationUpTo(ctx, db, deprecatedANNRetirementVersion)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "constraints")
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNTargetIndex))
+	assert.True(t, indexExists(t, ctx, db, deprecatedANNActiveIndex))
+	assert.False(t, migrationVersionApplied(t, ctx, db, deprecatedANNRetirementVersion))
+}
+
+func setupDeprecatedANNRetirementDB(t *testing.T, ctx context.Context) *sql.DB {
+	t.Helper()
+	db, cleanup := openMigrationSQLDB(t, ctx)
+	t.Cleanup(cleanup)
+	runGooseUpTo(t, ctx, db, deprecatedANNRetirementBaseVersion)
+	return db
+}
+
+func installDeprecatedANNFixture(t *testing.T, ctx context.Context, db *sql.DB, targetState, targetPredicate string) {
+	t.Helper()
+	require.Contains(t, []string{"current", "failed"}, targetPredicate)
+	require.Contains(t, []string{"deprecated", "active"}, targetState)
+	targetGenerationID := uuid.NewString()
+	activeGenerationID := uuid.NewString()
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO embedding_contracts (
+				embedding_contract_id, contract_key, version, provider, model,
+				dimensions, distance_metric, vector_normalization,
+				document_format_version, query_format_version, lifecycle_state
+			) VALUES ($1::uuid, 'deprecated-ann-fixture', 1, 'openai', 'text-embedding-3-large',
+				3072, 'cosine', 'provider', 1, 1, 'active')
+		`, deprecatedANNContractID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO search_index_generations (
+				search_index_generation_id, generation, embedding_contract_id,
+				embedding_dimensions, ann_strategy, operator_class,
+				indexed_expression, physical_index_name, hnsw_m,
+				hnsw_ef_construction, query_ef_search, exact_max_rows,
+				candidate_limit, allow_exact_fallback, activation_state,
+				activated_at, metadata
+			) VALUES ($1::uuid, 1, $2::uuid, 3072, 'halfvec_hnsw', 'halfvec_cosine_ops',
+				'embedding::halfvec(3072)', $3, 16, 64, 40, 10000, 200, false, $4, now(), '{}'::jsonb)
+		`, targetGenerationID, deprecatedANNContractID, deprecatedANNTargetIndex, targetState); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO search_index_generations (
+				search_index_generation_id, generation, embedding_contract_id,
+				embedding_dimensions, ann_strategy, operator_class,
+				indexed_expression, physical_index_name, hnsw_m,
+				hnsw_ef_construction, query_ef_search, exact_max_rows,
+				candidate_limit, allow_exact_fallback, activation_state,
+				activated_at, metadata
+			) VALUES ($1::uuid, 2, $2::uuid, 3072, 'halfvec_hnsw', 'halfvec_cosine_ops',
+				'embedding::halfvec(3072)', $3, 16, 64, 40, 10000, 200, false, 'active', now(), '{}'::jsonb)
+		`, activeGenerationID, deprecatedANNContractID, deprecatedANNActiveIndex)
+		return err
+	}))
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX %s
+		    ON public.search_documents
+		    USING hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops)
+		    WITH (m=16, ef_construction=64)
+		    WHERE embedding_contract_id = '%s'::uuid
+		      AND embedding_dimensions = 3072
+		      AND search_state = 'current'
+		      AND embedding IS NOT NULL
+	`, deprecatedANNActiveIndex, deprecatedANNContractID))
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX %s
+		    ON public.search_documents
+		    USING hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops)
+		    WITH (m=16, ef_construction=64)
+		    WHERE embedding_contract_id = '%s'::uuid
+		      AND embedding_dimensions = 3072
+		      AND search_state = '%s'
+		      AND embedding IS NOT NULL
+	`, deprecatedANNTargetIndex, deprecatedANNContractID, targetPredicate))
+	require.NoError(t, err)
+}
+
+func dropDeprecatedANNIndex(t *testing.T, ctx context.Context, db *sql.DB, name string) error {
+	t.Helper()
+	_, err := db.ExecContext(ctx, "DROP INDEX public."+name)
+	return err
+}
+
+func createDeprecatedANNIndex(t *testing.T, ctx context.Context, db *sql.DB, name, predicate string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX %s
+		    ON public.search_documents
+		    USING hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops)
+		    WITH (m=16, ef_construction=64)
+		    WHERE embedding_contract_id = '%s'::uuid
+		      AND embedding_dimensions = 3072
+		      AND search_state = '%s'
+		      AND embedding IS NOT NULL
+	`, name, deprecatedANNContractID, predicate))
+	require.NoError(t, err)
+}
+
+func restoreDeprecatedANNIndex(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX %s
+		    ON public.search_documents
+		    USING hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops)
+		    WITH (m=16, ef_construction=64)
+		    WHERE embedding_contract_id = '%s'::uuid
+		      AND embedding_dimensions = 3072
+		      AND search_state = 'current'
+		      AND embedding IS NOT NULL
+	`, deprecatedANNTargetIndex, deprecatedANNContractID))
+	require.NoError(t, err)
+}
+
+func indexDefinition(t *testing.T, ctx context.Context, db *sql.DB, name string) string {
+	t.Helper()
+	var definition string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT pg_get_indexdef(indexrelid)
+		FROM pg_index
+		WHERE indexrelid = to_regclass($1)
+	`, "public."+name).Scan(&definition))
+	return definition
+}
+
+func normalizeDeprecatedANNDefinition(definition string) string {
+	definition = strings.ToLower(strings.Join(strings.Fields(definition), " "))
+	definition = strings.ReplaceAll(definition, deprecatedANNTargetIndex, "<ann-index>")
+	definition = strings.ReplaceAll(definition, deprecatedANNActiveIndex, "<ann-index>")
+	return definition
+}
+
+func insertDeprecatedANNSearchDocument(t *testing.T, ctx context.Context, db *sql.DB) string {
+	t.Helper()
+	teamID, profileID := insertMigrationTeamProfile(t, ctx, db)
+	documentID := uuid.NewString()
+	sourceID := uuid.NewString()
+	require.NoError(t, execPostgresTxMode(ctx, db, "system", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO search_documents (
+				team_id, search_document_id, owner_profile_id, source_kind, source_id,
+				source_version, document_version, embedding_contract_id, embedding_dimensions,
+				search_state, document_text, document_hash, embedding
+			) VALUES (
+				$1::uuid, $2::uuid, $3::uuid, 'entity', $4::uuid,
+				1, 1, $5::uuid, 3072, 'current', 'ANN retirement fixture',
+				'sha256:ann-retirement-fixture', ('[1,' || repeat('0,', 3070) || '0]')::vector
+			)
+		`, teamID, documentID, profileID, sourceID, deprecatedANNContractID)
+		return err
+	}))
+	return documentID
+}
+
+func searchDocumentSnapshot(t *testing.T, ctx context.Context, db *sql.DB, documentID string) string {
+	t.Helper()
+	var snapshot string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT search_document_id::text || '|' || source_version || '|' || document_version
+		       || '|' || search_state || '|' || document_text || '|' || document_hash
+		       || '|' || md5(embedding::text)
+		FROM search_documents
+		WHERE search_document_id = $1::uuid
+	`, documentID).Scan(&snapshot))
+	return snapshot
+}
+
+func deprecatedANNQueryResults(t *testing.T, ctx context.Context, db *sql.DB) []string {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, func() error {
+		_, err := tx.ExecContext(ctx, `
+			SELECT set_config('app.tx_mode', 'system', true),
+			       set_config('app.current_team_id', '', true),
+			       set_config('app.current_profile_id', '', true),
+			       set_config('enable_seqscan', 'off', true)
+		`)
+		return err
+	}())
+	rows, err := tx.QueryContext(ctx, `
+		SELECT search_document_id::text
+		FROM public.search_documents
+		WHERE embedding_contract_id = $1::uuid
+		  AND embedding_dimensions = 3072
+		  AND search_state = 'current'
+		  AND embedding IS NOT NULL
+		ORDER BY embedding::halfvec(3072) <=>
+		         ('[1,' || repeat('0,', 3070) || '0]')::vector::halfvec(3072)
+		LIMIT 1
+	`, deprecatedANNContractID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var results []string
+	for rows.Next() {
+		var value string
+		require.NoError(t, rows.Scan(&value))
+		results = append(results, value)
+	}
+	require.NoError(t, rows.Err())
+	return results
+}
+
+func searchGenerationSnapshot(t *testing.T, ctx context.Context, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, `
+		SELECT generation || '|' || embedding_contract_id::text || '|' || embedding_dimensions
+		       || '|' || ann_strategy || '|' || operator_class || '|' || indexed_expression
+		       || '|' || physical_index_name || '|' || activation_state
+		FROM search_index_generations
+		WHERE embedding_contract_id = $1::uuid
+		ORDER BY generation
+	`, deprecatedANNContractID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var snapshot []string
+	for rows.Next() {
+		var value string
+		require.NoError(t, rows.Scan(&value))
+		snapshot = append(snapshot, value)
+	}
+	require.NoError(t, rows.Err())
+	return snapshot
+}
+
+func deprecatedANNQueryPlan(t *testing.T, ctx context.Context, db *sql.DB) string {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, func() error {
+		_, err := tx.ExecContext(ctx, `
+			SELECT set_config('app.tx_mode', 'system', true),
+			       set_config('app.current_team_id', '', true),
+			       set_config('app.current_profile_id', '', true),
+			       set_config('enable_seqscan', 'off', true)
+		`)
+		return err
+	}())
+	rows, err := tx.QueryContext(ctx, `
+		EXPLAIN (COSTS OFF)
+		SELECT search_document_id
+		FROM public.search_documents
+		WHERE embedding_contract_id = $1::uuid
+		  AND embedding_dimensions = 3072
+		  AND search_state = 'current'
+		  AND embedding IS NOT NULL
+		ORDER BY embedding::halfvec(3072) <=>
+		         ('[1,' || repeat('0,', 3070) || '0]')::vector::halfvec(3072)
+		LIMIT 1
+	`, deprecatedANNContractID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(lines, "\n")
+}
+
+func normalizeDeprecatedANNPlan(plan string) string {
+	plan = strings.ReplaceAll(plan, deprecatedANNTargetIndex, "<ann-index>")
+	plan = strings.ReplaceAll(plan, deprecatedANNActiveIndex, "<ann-index>")
+	return plan
+}
+
+func incomingIndexDependencyCount(t *testing.T, ctx context.Context, db *sql.DB, name string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM pg_depend
+		WHERE refclassid = 'pg_class'::regclass
+		  AND refobjid = to_regclass($1)
+	`, "public."+name).Scan(&count))
+	return count
+}
+
+func dependentIndexConstraintCount(t *testing.T, ctx context.Context, db *sql.DB, name string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM pg_constraint
+		WHERE conindid = to_regclass($1)
+	`, "public."+name).Scan(&count))
+	return count
+}
+
+func migrationVersionApplied(t *testing.T, ctx context.Context, db *sql.DB, version int64) bool {
+	t.Helper()
+	var applied bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM goose_db_version
+			WHERE version_id = $1 AND is_applied
+		)
+	`, version).Scan(&applied))
+	return applied
+}

--- a/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
+++ b/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
@@ -1,0 +1,284 @@
+-- Lock/rewrite impact: the guarded transactional drop takes short table locks;
+-- it does not rewrite search_documents or change any canonical rows.
+-- RLS impact: migration mode is used only for catalog inspection; no row-level
+-- visibility or application policy is changed.
+-- Recovery: the exact CREATE INDEX statement is recorded below. Down refuses
+-- automatic recreation because the target may have been intentionally absent.
+
+-- +goose Up
+-- +goose StatementBegin
+
+SELECT set_config('app.tx_mode', 'migration', true);
+SELECT set_config('app.current_team_id', '', true);
+SELECT set_config('app.current_profile_id', '', true);
+SET LOCAL lock_timeout = '1s';
+SET LOCAL statement_timeout = '30s';
+
+LOCK TABLE public.search_index_generations IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.search_documents IN SHARE ROW EXCLUSIVE MODE;
+
+DO $$
+DECLARE
+    expected_contract CONSTANT uuid := '1a06f88d-e92e-4f3c-8d27-0b747bd8cf17';
+    target_name CONSTANT text := 'v2_search_1a06f88de92e_3072_halfvec_hnsw_idx';
+    active_name CONSTANT text := 'search_1a06f88de92e_3072_halfvec_hnsw_idx';
+    target_oid oid;
+    active_oid oid;
+    target_generation_count integer;
+    active_generation_count integer;
+    target_generation integer;
+    active_generation integer;
+    target_contract uuid;
+    active_contract uuid;
+    target_dimensions integer;
+    active_dimensions integer;
+    target_strategy text;
+    active_strategy text;
+    target_operator_class text;
+    active_operator_class text;
+    target_expression text;
+    active_expression text;
+    target_state text;
+    active_state text;
+    target_activated_at timestamptz;
+    active_activated_at timestamptz;
+    active_contract_state text;
+    physical record;
+    physical_count integer := 0;
+    incoming_dependency_count bigint;
+    constraint_count bigint;
+    inheritance_count bigint;
+    normalized_definition text;
+    expected_definition text;
+BEGIN
+    target_oid := to_regclass(format('public.%I', target_name));
+    IF target_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    active_oid := to_regclass(format('public.%I', active_name));
+    IF active_oid IS NULL OR active_oid = target_oid THEN
+        RAISE EXCEPTION
+            'cannot retire deprecated ANN index %: the expected active replacement is missing',
+            target_name;
+    END IF;
+
+    SELECT count(*)
+      INTO target_generation_count
+      FROM public.search_index_generations
+     WHERE physical_index_name = target_name;
+    IF target_generation_count <> 1 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: expected one matching deprecated generation, found %',
+            target_name, target_generation_count;
+    END IF;
+
+    SELECT generation, embedding_contract_id, embedding_dimensions,
+           ann_strategy, operator_class, indexed_expression, activation_state,
+           activated_at
+      INTO target_generation, target_contract, target_dimensions,
+           target_strategy, target_operator_class, target_expression,
+           target_state, target_activated_at
+      FROM public.search_index_generations
+     WHERE physical_index_name = target_name;
+
+    IF target_generation <> 1
+       OR target_contract <> expected_contract
+       OR target_dimensions <> 3072
+       OR target_strategy <> 'halfvec_hnsw'
+       OR target_operator_class <> 'halfvec_cosine_ops'
+       OR target_expression <> 'embedding::halfvec(3072)'
+       OR target_state <> 'deprecated'
+       OR target_activated_at IS NULL
+    THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: deprecated generation metadata does not match the verified target',
+            target_name;
+    END IF;
+
+    SELECT count(*)
+      INTO active_generation_count
+      FROM public.search_index_generations
+     WHERE embedding_contract_id = expected_contract
+       AND activation_state = 'active';
+    IF active_generation_count <> 1 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: expected one active generation for the verified contract, found %',
+            target_name, active_generation_count;
+    END IF;
+
+    SELECT count(*)
+      INTO active_generation_count
+      FROM public.search_index_generations
+     WHERE physical_index_name = active_name;
+    IF active_generation_count <> 1 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: expected one matching active generation, found %',
+            target_name, active_generation_count;
+    END IF;
+
+    SELECT generation, embedding_contract_id, embedding_dimensions,
+           ann_strategy, operator_class, indexed_expression, activation_state,
+           activated_at
+      INTO active_generation, active_contract, active_dimensions,
+           active_strategy, active_operator_class, active_expression,
+           active_state, active_activated_at
+      FROM public.search_index_generations
+     WHERE physical_index_name = active_name;
+
+    IF active_generation <> 2
+       OR active_contract <> expected_contract
+       OR active_dimensions <> 3072
+       OR active_strategy <> 'halfvec_hnsw'
+       OR active_operator_class <> 'halfvec_cosine_ops'
+       OR active_expression <> 'embedding::halfvec(3072)'
+       OR active_state <> 'active'
+       OR active_activated_at IS NULL
+    THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: active replacement metadata does not match the verified target',
+            target_name;
+    END IF;
+
+    SELECT lifecycle_state
+      INTO active_contract_state
+      FROM public.embedding_contracts
+     WHERE embedding_contract_id = expected_contract
+       AND dimensions = 3072;
+    IF active_contract_state IS DISTINCT FROM 'active' THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: the verified embedding contract is not active',
+            target_name;
+    END IF;
+
+    expected_definition := format(
+        'create index __dense_mem_index__ on public.search_documents using hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops) with (m=''16'', ef_construction=''64'') where ((embedding_contract_id = ''%s''::uuid) and (embedding_dimensions = 3072) and (search_state = ''current''::text) and (embedding is not null))',
+        expected_contract
+    );
+
+    SELECT count(*)
+      INTO incoming_dependency_count
+      FROM pg_depend
+     WHERE refclassid = 'pg_class'::regclass
+       AND refobjid = target_oid;
+    IF incoming_dependency_count <> 0 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: unexpected dependent objects exist (% dependencies)',
+            target_name, incoming_dependency_count;
+    END IF;
+
+    SELECT count(*)
+      INTO constraint_count
+      FROM pg_constraint
+     WHERE conindid = target_oid;
+    IF constraint_count <> 0 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: it backs % constraints',
+            target_name, constraint_count;
+    END IF;
+
+    SELECT count(*)
+      INTO inheritance_count
+      FROM pg_inherits
+     WHERE inhrelid = target_oid
+        OR inhparent = target_oid;
+    IF inheritance_count <> 0 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: it participates in index inheritance',
+            target_name;
+    END IF;
+
+    FOR physical IN
+        SELECT c.oid AS index_oid,
+               c.relkind::text AS relkind,
+               n.nspname AS schema_name,
+               t.relname AS table_name,
+               am.amname AS access_method,
+               op.opcname AS operator_class,
+               i.indisvalid,
+               i.indisready,
+               i.indislive,
+               i.indisunique,
+               i.indnatts,
+               i.indnkeyatts,
+               pg_get_expr(i.indexprs, i.indrelid) AS indexed_expression,
+               pg_get_expr(i.indpred, i.indrelid) AS predicate,
+               c.reloptions,
+               pg_get_indexdef(c.oid) AS definition
+          FROM pg_class AS c
+          JOIN pg_namespace AS n ON n.oid = c.relnamespace
+          JOIN pg_index AS i ON i.indexrelid = c.oid
+          JOIN pg_class AS t ON t.oid = i.indrelid
+          JOIN pg_am AS am ON am.oid = c.relam
+          JOIN pg_opclass AS op ON op.oid = i.indclass[0]
+         WHERE c.oid IN (target_oid, active_oid)
+    LOOP
+        physical_count := physical_count + 1;
+        IF physical.relkind <> 'i'
+           OR physical.schema_name <> 'public'
+           OR physical.table_name <> 'search_documents'
+           OR physical.access_method <> 'hnsw'
+           OR physical.operator_class <> 'halfvec_cosine_ops'
+           OR NOT physical.indisvalid
+           OR NOT physical.indisready
+           OR NOT physical.indislive
+           OR physical.indisunique
+           OR physical.indnatts <> 1
+           OR physical.indnkeyatts <> 1
+           OR physical.indexed_expression <> '(embedding)::halfvec(3072)'
+           OR physical.predicate <> format(
+               '((embedding_contract_id = ''%s''::uuid) AND (embedding_dimensions = 3072) AND (search_state = ''current''::text) AND (embedding IS NOT NULL))',
+               expected_contract
+           )
+           OR physical.reloptions IS DISTINCT FROM ARRAY['m=16', 'ef_construction=64']::text[]
+        THEN
+            RAISE EXCEPTION
+                'cannot retire ANN index %: physical definition is not the verified halfvec HNSW definition',
+                target_name;
+        END IF;
+
+        normalized_definition := regexp_replace(
+            regexp_replace(lower(physical.definition), '\s+', ' ', 'g'),
+            '^create index [^ ]+ on ',
+            'create index __dense_mem_index__ on '
+        );
+        IF normalized_definition <> expected_definition THEN
+            RAISE EXCEPTION
+                'cannot retire ANN index %: catalog definition mismatch',
+                target_name;
+        END IF;
+    END LOOP;
+
+    IF physical_count <> 2 THEN
+        RAISE EXCEPTION
+            'cannot retire ANN index %: expected both target and active catalog objects, found %',
+            target_name, physical_count;
+    END IF;
+
+    DROP INDEX public.v2_search_1a06f88de92e_3072_halfvec_hnsw_idx RESTRICT;
+END
+$$;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DO $$
+BEGIN
+    RAISE EXCEPTION
+        'cannot automatically roll back 20260910020001: restore the captured catalog definition for v2_search_1a06f88de92e_3072_halfvec_hnsw_idx before retrying';
+END
+$$;
+
+-- Exact restoration definition (run only after verifying the target is absent):
+-- CREATE INDEX v2_search_1a06f88de92e_3072_halfvec_hnsw_idx
+--     ON public.search_documents
+--     USING hnsw (((embedding)::halfvec(3072)) halfvec_cosine_ops)
+--     WITH (m='16', ef_construction='64')
+--     WHERE ((embedding_contract_id = '1a06f88d-e92e-4f3c-8d27-0b747bd8cf17'::uuid)
+--        AND (embedding_dimensions = 3072)
+--        AND (search_state = 'current'::text)
+--        AND (embedding IS NOT NULL));
+
+-- +goose StatementEnd

--- a/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
+++ b/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
@@ -2,6 +2,10 @@
 -- it does not rewrite search_documents or change any canonical rows.
 -- RLS impact: migration mode is used only for catalog inspection; no row-level
 -- visibility or application policy is changed.
+-- Backfill: none; this migration changes only the verified physical index.
+-- Backward compatibility: the active generation and canonical search contract
+-- remain unchanged while the deprecated duplicate is removed.
+-- Rollback: automatic recreation is refused; use the exact recovery DDL below.
 -- Recovery: the exact CREATE INDEX statement is recorded below. Down refuses
 -- automatic recreation because the target may have been intentionally absent.
 

--- a/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
+++ b/migrations/postgres/v2_6/20260910020001_retire_deprecated_duplicate_ann_index.sql
@@ -17,6 +17,7 @@ SELECT set_config('app.current_team_id', '', true);
 SELECT set_config('app.current_profile_id', '', true);
 SET LOCAL lock_timeout = '1s';
 SET LOCAL statement_timeout = '30s';
+SET LOCAL quote_all_identifiers = off;
 
 LOCK TABLE public.search_index_generations IN SHARE ROW EXCLUSIVE MODE;
 LOCK TABLE public.search_documents IN SHARE ROW EXCLUSIVE MODE;
@@ -271,7 +272,7 @@ $$;
 DO $$
 BEGIN
     RAISE EXCEPTION
-        'cannot automatically roll back 20260910020001: restore the captured catalog definition for v2_search_1a06f88de92e_3072_halfvec_hnsw_idx before retrying';
+        '20260910020001 is irreversible: restore v2_search_1a06f88de92e_3072_halfvec_hnsw_idx with the exact definition below or a new ordered recovery migration; do not retry this Down operation';
 END
 $$;
 

--- a/scripts/e2e-db-cases/index-retirement.json
+++ b/scripts/e2e-db-cases/index-retirement.json
@@ -1,5 +1,76 @@
 {
   "version": 1,
   "capability": "index-retirement",
-  "cases": []
+  "cases": [
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationRetiresExactDuplicate",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationRetiresExactDuplicate$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationIsIdempotentWhenTargetAbsent",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationIsIdempotentWhenTargetAbsent$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationFailsClosedOnDefinitionMismatch",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationFailsClosedOnDefinitionMismatch$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsMissing",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsMissing$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsInvalid",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsInvalid$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationFailsClosedOnActiveTarget",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationFailsClosedOnActiveTarget$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationReleasesLockAfterBoundedFailure",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationReleasesLockAfterBoundedFailure$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationDownRequiresCatalogRecovery",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationDownRequiresCatalogRecovery$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationChecksCatalogDependencies",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationChecksCatalogDependencies$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
+      "id": "postgres/TestDeprecatedANNIndexMigrationRejectsDependentTarget",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationRejectsDependentTarget$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    }
+  ]
 }

--- a/scripts/e2e-db-cases/index-retirement.json
+++ b/scripts/e2e-db-cases/index-retirement.json
@@ -24,6 +24,13 @@
       "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
     },
     {
+      "id": "postgres/TestDeprecatedANNIndexMigrationIgnoresSessionIdentifierQuoting",
+      "package": "./internal/storage/postgres",
+      "run": "^TestDeprecatedANNIndexMigrationIgnoresSessionIdentifierQuoting$",
+      "phase": "precheck",
+      "source": "internal/storage/postgres/deprecated_ann_index_retirement_integration.e2e"
+    },
+    {
       "id": "postgres/TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsMissing",
       "package": "./internal/storage/postgres",
       "run": "^TestDeprecatedANNIndexMigrationFailsClosedWhenReplacementIsMissing$",


### PR DESCRIPTION
## Summary

Closes #350.

Retire the verified deprecated `v2_search_1a06f88de92e_3072_halfvec_hnsw_idx` ANN duplicate while preserving the active generation, index, metadata, canonical rows, and query behavior.

## Implementation

- Added ordered migration `20260910020001_retire_deprecated_duplicate_ann_index.sql`.
- Revalidates exact generation metadata, active replacement metadata, pg_catalog definitions, predicates, dimensions, operator classes, options, validity, dependencies, constraints, and inheritance inside bounded transactional locks.
- Drops only the exact deprecated object with `RESTRICT`; an absent target is idempotent, and `Down` refuses automatic recreation while documenting the exact restoration DDL.
- Added ten disposable PostgreSQL/pgvector cases covering upgrade, absent target, active/missing/invalid replacements, definition and dependency rejection, lock recovery, idempotence, down recovery, and populated ANN plan/result preservation.
- Registered the cases under the index-retirement capability.

## Scope amendment

The shared database-case inventory test now permits the newly populated Wave 7 index-retirement fragment. This test-only assertion change is the only post-audit scope addition; production harness, Search code, APIs, and migration behavior remain unchanged.

## Audit

- Base SHA: `e3a0f71b418b7e4b5e6db7d35f2ab9dc363d3459`
- Independent `plan-audit`: `conformant`, `gpt-5.6-terra/max`, no findings.
- Final amended-scope rescan included `cmd/e2e/main_test.go` and remained `conformant`.

## Verification

- Registered index-retirement precheck: all 10 real PostgreSQL cases passed.
- `go test ./internal/storage/postgres/... ./internal/search/... -count=1`
- `./scripts/e2e.sh space_aware_recall`
- `./scripts/ci-check.sh` (architecture, static analysis, Go tests, E2E registry, and 90.0% coverage)
- Push hook reran `./scripts/ci-check.sh` successfully.
- The deterministic 1k evaluation remains waived because supported ranking and retrieval behavior is unchanged.

## Recovery and risk

Metadata and catalog identity are checked under transaction-local locks before the drop. Lock and statement timeouts bound deployment impact. Automatic down migration is rejected; restore only the documented definition after verifying the target is absent.

The final-head production-image full-matrix E2E gate remains required by the repository workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL migration to safely retire deprecated duplicate ANN indexes after validating their metadata, definitions, replacements, and dependencies.
  * Added comprehensive end-to-end coverage for successful retirement, idempotency, validation failures, lock handling, dependency checks, and recovery scenarios.
  * Added nine database precheck scenarios for index-retirement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->