### PR TITLE
refactor: prepare wave 8 shared readiness

### DIFF
--- a/architecture/capability-contracts.md
+++ b/architecture/capability-contracts.md
@@ -130,6 +130,31 @@ The central registry loader, architecture manifest, composition root, and
 canonical Knowledge writes remain shared read-only infrastructure during the
 adoptions.
 
+## Wave 8 shared-readiness ownership
+
+Wave 8 begins only after the shared evaluation and transport composition seams
+are established. The evaluation build is selected by the existing `evaluation`
+Go profile: production composition supplies no offline evaluation repository or
+audit binding, while the evaluation composition creates the evaluation reader
+with Dream's Hypothesis query injected through the existing contract. The
+production catalog remains ten tools and the evaluation catalog adds only the
+three existing evaluation tools.
+
+The transport composition owns the construction of MCP, SSE, public HTTP, user
+portal, control portal, and their coordination backends through existing
+application and adapter ports. The central server lifecycle, worker starts,
+shutdown ordering, and public route contracts remain shared read-only
+infrastructure for #378 and #379 after this preparation.
+
+Issue #378 owns the evaluation composition profile files, registry evaluation
+bindings, generic evaluation reader compatibility seam, and its PostgreSQL
+case. Dream retains the Hypothesis SQL query and Dream application contracts.
+Issue #379 owns the transport composition and backend wiring; HTTP, portal,
+proxy, SSE, Redis, and browser implementations remain in its later cutover.
+The existing registry, architecture manifest/checker, and E2E host controller
+are shared read-only infrastructure. Both adopters must preserve exact existing
+database-case identities and may add only capability-specific registry entries.
+
 ## Wave 5 shared-readiness ownership
 
 Issue #389 freezes the writable partition for the eight Wave 5 adopters. The

--- a/architecture/modules/dream-application.json
+++ b/architecture/modules/dream-application.json
@@ -17,8 +17,6 @@
     {"path": "internal/service/dreamservice/compat_test.go", "issue": 365},
     {"path": "internal/repository/dream_compat.go", "issue": 365},
     {"path": "internal/repository/dream_types.go", "issue": 365},
-    {"path": "internal/repository/evaluation_repository.go", "issue": 365},
-    {"path": "internal/repository/evaluation_repository_test.go", "issue": 365},
     {"path": "internal/storage/postgres/dream_helpers.go", "issue": 365},
     {"path": "internal/storage/postgres/dream_helpers_test.go", "issue": 365},
     {

--- a/architecture/modules/http-transport.json
+++ b/architecture/modules/http-transport.json
@@ -2,6 +2,9 @@
   "schema_version": 1,
   "capability": "http-transport",
   "source_ownership": [
+    {"path": "cmd/internal/serverapp/backends.go", "issue": 379},
+    {"path": "cmd/internal/serverapp/transport_composition.go", "issue": 379},
+    {"path": "cmd/internal/serverapp/transport_composition_test.go", "issue": 379},
     {"path": "internal/http/mcp_bindings.go", "issue": 379},
     {"path": "internal/http/user_portal_bindings.go", "issue": 379},
     {"path": "internal/http/control_portal_bindings.go", "issue": 379},

--- a/architecture/modules/offline-evaluation.json
+++ b/architecture/modules/offline-evaluation.json
@@ -2,7 +2,34 @@
   "schema_version": 1,
   "capability": "offline-evaluation",
   "source_ownership": [
-    {"path": "internal/tools/registry/evaluation_bindings.go", "issue": 378}
+    {"path": "cmd/internal/serverapp/evaluation_composition_evaluation.go", "issue": 378},
+    {"path": "cmd/internal/serverapp/evaluation_composition_production.go", "issue": 378},
+    {"path": "cmd/internal/serverapp/evaluation_composition_evaluation_test.go", "issue": 378},
+    {"path": "cmd/internal/serverapp/evaluation_composition_production_test.go", "issue": 378},
+    {"path": "internal/repository/evaluation_reader.go", "issue": 378},
+    {"path": "internal/repository/evaluation_compat.go", "issue": 378},
+    {"path": "internal/repository/evaluation_reader_test.go", "issue": 378},
+    {"path": "internal/repository/evaluation_reader_integration.e2e", "issue": 378},
+    {"path": "internal/repository/evaluation_repository.go", "issue": 378},
+    {"path": "internal/repository/evaluation_repository_test.go", "issue": 378},
+    {"path": "internal/tools/registry/evaluation_bindings.go", "issue": 378},
+    {"path": "internal/tools/registry/evaluation_bindings_test.go", "issue": 378},
+    {"path": "internal/tools/registry/evaluation_audit_failure_test.go", "issue": 378}
+  ],
+  "compatibility_bridges": [
+    {
+      "source_path": "internal/repository/evaluation_compat.go",
+      "fields": ["newCompatibilityEvaluationReader", "compatibilityHypothesisQuery"],
+      "consumers": [
+        {"path": "internal/repository/semantic_repository.go", "symbol": "NewSemanticRepository"},
+        {"path": "internal/repository/evaluation_repository.go", "symbol": "SemanticRepositoryImpl.evaluationReader"},
+        {"path": "internal/repository/evaluation_repository.go", "symbol": "evaluationQuery"},
+        {"path": "internal/repository/evaluation_repository.go", "symbol": "queryEvaluationItems"}
+      ],
+      "removal_issue": 382,
+      "implementation_owner": {"path": "internal/dream/postgres/evaluation_hypothesis.go", "symbol": "HypothesisEvaluationQuery"},
+      "removal_condition": "Remove the compatibility reader and query forward after SemanticRepositoryImpl and retained evaluation callers consume the evaluation-owned reader directly."
+    }
   ],
   "completed_issues": [],
   "go": {

--- a/cmd/internal/serverapp/evaluation_composition_evaluation.go
+++ b/cmd/internal/serverapp/evaluation_composition_evaluation.go
@@ -1,0 +1,30 @@
+//go:build evaluation
+
+package serverapp
+
+import (
+	"errors"
+
+	dreampostgres "github.com/markhuangai/dense-mem/internal/dream/postgres"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+// buildEvaluationRegistryBindings is compiled only into the dedicated
+// evaluation image. Dream remains the owner of Hypothesis SQL while the
+// evaluation reader owns the generic read model and its transaction boundary.
+func buildEvaluationRegistryBindings(semantic *repository.SemanticRepositoryImpl, audit service.AuditService) (registry.EvaluationBindings, error) {
+	if semantic == nil {
+		return registry.EvaluationBindings{}, errors.New("evaluation: semantic repository is required")
+	}
+	return registry.EvaluationBindings{
+		Repository: repository.NewEvaluationReader(
+			semantic.DreamDatabase(),
+			semantic.DreamRLS(),
+			dreampostgres.HypothesisEvaluationQuery,
+		),
+		Communities: semantic,
+		Audit:       audit,
+	}, nil
+}

--- a/cmd/internal/serverapp/evaluation_composition_evaluation_test.go
+++ b/cmd/internal/serverapp/evaluation_composition_evaluation_test.go
@@ -1,0 +1,37 @@
+//go:build evaluation
+
+package serverapp
+
+import (
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestEvaluationCompositionUsesDedicatedReader(t *testing.T) {
+	semantic := repository.NewSemanticRepository(nil, nil)
+	bindings, err := buildEvaluationRegistryBindings(semantic, nil)
+	if err != nil {
+		t.Fatalf("evaluation composition: %v", err)
+	}
+	if _, ok := bindings.Repository.(*repository.EvaluationReader); !ok {
+		t.Fatalf("evaluation repository = %T; want *repository.EvaluationReader", bindings.Repository)
+	}
+	if bindings.Communities != semantic {
+		t.Fatal("evaluation composition did not preserve the community reader")
+	}
+	reg, err := registry.BuildActive(registry.Dependencies{EvaluationBindings: bindings})
+	if err != nil {
+		t.Fatalf("evaluation registry: %v", err)
+	}
+	if got := len(reg.List()); got != 13 {
+		t.Fatalf("evaluation catalog size = %d; want 13", got)
+	}
+}
+
+func TestEvaluationCompositionRejectsMissingSemanticRepository(t *testing.T) {
+	if _, err := buildEvaluationRegistryBindings(nil, nil); err == nil {
+		t.Fatal("missing semantic repository did not fail evaluation composition")
+	}
+}

--- a/cmd/internal/serverapp/evaluation_composition_production.go
+++ b/cmd/internal/serverapp/evaluation_composition_production.go
@@ -1,0 +1,15 @@
+//go:build !evaluation
+
+package serverapp
+
+import (
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+// buildEvaluationRegistryBindings keeps offline evaluation implementations out
+// of the production composition while preserving the shared registry API.
+func buildEvaluationRegistryBindings(_ *repository.SemanticRepositoryImpl, _ service.AuditService) (registry.EvaluationBindings, error) {
+	return registry.EvaluationBindings{}, nil
+}

--- a/cmd/internal/serverapp/evaluation_composition_production_test.go
+++ b/cmd/internal/serverapp/evaluation_composition_production_test.go
@@ -1,0 +1,26 @@
+//go:build !evaluation
+
+package serverapp
+
+import (
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestProductionEvaluationCompositionIsEmpty(t *testing.T) {
+	bindings, err := buildEvaluationRegistryBindings(nil, nil)
+	if err != nil {
+		t.Fatalf("production evaluation composition: %v", err)
+	}
+	if bindings.Repository != nil || bindings.Communities != nil || bindings.Audit != nil {
+		t.Fatal("production composition wired offline evaluation dependencies")
+	}
+	reg, err := registry.BuildActive(registry.Dependencies{EvaluationBindings: bindings})
+	if err != nil {
+		t.Fatalf("production registry: %v", err)
+	}
+	if got := len(reg.List()); got != 10 {
+		t.Fatalf("production catalog size = %d; want 10", got)
+	}
+}

--- a/cmd/internal/serverapp/server.go
+++ b/cmd/internal/serverapp/server.go
@@ -12,20 +12,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/labstack/echo/v4"
-
 	"github.com/markhuangai/dense-mem/internal/config"
 	"github.com/markhuangai/dense-mem/internal/conflictassessment"
 	"github.com/markhuangai/dense-mem/internal/http"
-	"github.com/markhuangai/dense-mem/internal/http/handler"
-	"github.com/markhuangai/dense-mem/internal/http/middleware"
 	"github.com/markhuangai/dense-mem/internal/modelprovider"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	assessorprovider "github.com/markhuangai/dense-mem/internal/provider/assessor"
 	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/service/communityservice"
 	"github.com/markhuangai/dense-mem/internal/service/dreamservice"
-	"github.com/markhuangai/dense-mem/internal/sse"
 	"github.com/markhuangai/dense-mem/internal/storage/postgres"
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
 	"github.com/markhuangai/dense-mem/internal/verifier"
@@ -152,7 +147,6 @@ func RunActiveServer(
 	if err != nil {
 		log.Fatalf("private-memory erasure boot blocked: %v", err)
 	}
-	rateLimitService := backend.rateLimitService
 	runtimeCtx := RuntimeContext{
 		Config:            &cfg,
 		TeamService:       teamService,
@@ -170,10 +164,7 @@ func RunActiveServer(
 		go refreshTelemetryPricingCacheUntilCanceled(telemetry.PricingRefreshContext, appConfigService, logger)
 	}
 	discoverabilityMetrics := telemetry.Metrics
-	telemetryReader := telemetry.Reader
 	telemetryPrometheusService := telemetry.Prometheus
-	telemetryHTTPMetrics := telemetry.HTTPMetrics
-	telemetryScrapeHandler := telemetry.ScrapeHandler
 	pricingRefreshCancel := telemetry.PricingRefreshCancel
 	searchApplication := buildSearchProviders(cfg, searchRepo, searchContract, discoverabilityMetrics, logger)
 	openaiProvider := searchApplication.EmbeddingProvider
@@ -232,12 +223,15 @@ func RunActiveServer(
 	recallFeedbackEventService := applications.RecallFeedback
 	recallFeedbackEventService.Start(context.Background())
 
+	evaluationBindings, err := buildEvaluationRegistryBindings(semanticRepo, auditService)
+	if err != nil {
+		log.Fatalf("failed to build evaluation registry bindings: %v", err)
+	}
 	toolRegistry, err := registry.BuildActive(registry.Dependencies{
 		Core: registry.CoreDependencies{
 			Metrics:              discoverabilityMetrics,
 			RecallFeedbackConfig: appConfigService,
 			RecallFeedbackEvents: recallFeedbackEventService,
-			EvaluationAudit:      auditService,
 		},
 		RememberBindings:   registry.RememberBindings{Service: rememberSvc},
 		RecallBindings:     registry.RecallBindings{Service: recallSvc, Dreams: dreamSvc},
@@ -245,10 +239,7 @@ func RunActiveServer(
 		TraceBindings:      registry.TraceBindings{Service: contextSvc},
 		DreamBindings:      registry.DreamBindings{Service: dreamSvc},
 		MemoryPackBindings: registry.MemoryPackBindings{Service: memoryPackSvc},
-		EvaluationBindings: registry.EvaluationBindings{
-			Repository:  semanticRepo,
-			Communities: semanticRepo,
-		},
+		EvaluationBindings: evaluationBindings,
 	})
 	if err != nil {
 		log.Fatalf("failed to build active tool registry: %v", err)
@@ -259,157 +250,62 @@ func RunActiveServer(
 			log.Fatalf("failed to configure runtime tool registry: %v", err)
 		}
 	}
-	streamLifecycle := sse.NewStreamLifecycleWithConfig(
-		backend.concurrencyLimiter,
-		sse.NewHeartbeatSenderWithInterval(time.Duration(cfg.GetSSEHeartbeatSeconds())*time.Second),
-		time.Duration(cfg.GetSSEMaxDurationSeconds())*time.Second,
-		backend.streamCleanupRepo,
-	)
-	mcpHandler := handler.NewMCPHandlerWithLifecycleAndRuntimeConfig(toolRegistry, logger, streamLifecycle, appConfigService, dreamSvc)
-
-	checks := []http.HealthCheck{
-		{Name: "postgres", Check: func(ctx context.Context) error {
-			return pgDB.Ping(ctx)
-		}},
-		{Name: "postgres_topology", Check: func(ctx context.Context) error {
-			return postgres.ValidateSinglePrimaryTopology(ctx, pgDB.GetDB())
-		}},
-		{Name: "pgvector", Check: func(ctx context.Context) error {
-			return postgres.CheckPGVectorExtension(ctx, pgDB.GetDB())
-		}},
-		{Name: "authority", Check: func(ctx context.Context) error {
-			return checkActiveAuthority(authority)
-		}},
-		{Name: "search_readiness", Check: func(ctx context.Context) error {
-			return checkSearchReadiness(ctx, searchRepo)
-		}},
-	}
-	if backend.redisPingFn != nil {
-		checks = append(checks, http.HealthCheck{Name: "redis", Check: backend.redisPingFn})
-	}
-	healthConfig := (http.HealthConfig{
-		Checks:   checks,
-		Degraded: backend.degraded,
-		Reason:   backend.reason,
-	}).WithSharedDependencyChecks()
-	e := http.NewServer(cfg, logger, healthConfig)
-	e.Use(middleware.CorrelationIDMiddleware(), middleware.ClientIPMiddleware())
-	e.Use(middleware.SecurityBanMiddleware(securityService))
-	http.RegisterOAuthProtectedResourceRoutes(e, ssoService)
-	if err := http.RegisterDirectorySCIM(e, directoryIdentityService, http.DirectorySCIMConfig{
-		RuntimeConfig: appConfigService,
-		Security:      securityService,
-		RateLimitSvc:  rateLimitService,
-		Config:        &cfg,
-	}); err != nil {
-		log.Fatalf("failed to register directory SCIM routes: %v", err)
-	}
-	runtimeCtx.Echo = e
-	if options.RegisterRoutes != nil {
-		if err := options.RegisterRoutes(runtimeCtx); err != nil {
-			log.Fatalf("failed to register runtime routes: %v", err)
-		}
-	}
-	protectedDeps := http.ProtectedDeps{
-		MCP: http.MCPBindings{
-			CredentialRepo:     credentialRepo,
-			TeamSvc:            teamService,
-			RateLimitService:   rateLimitService,
-			UsageMetrics:       usageMetricsService,
-			AuditService:       auditService,
-			SecurityService:    securityService,
-			SSOAuthenticator:   ssoService,
-			OAuthAuthenticator: ssoService,
-			OAuthMetadata:      ssoService,
-			Config:             &cfg,
-			Logger:             logger,
-			CredentialVerifier: credentialVerifier,
-			LastUsedRecorder:   activityWriter,
-		},
-	}
-	protectedDeps.PostAuthMiddleware = append(protectedDeps.PostAuthMiddleware, options.PostAuthMiddleware...)
-	if telemetryHTTPMetrics != nil {
-		protectedDeps.PostAuthMiddleware = append(protectedDeps.PostAuthMiddleware, middleware.TelemetryHTTPMiddleware(telemetryHTTPMetrics))
-	}
-	http.RegisterProtectedRoutesWithHandlers(e, protectedDeps, http.ProtectedHandlers{
-		MCPPost: mcpHandler.HandlePost,
-		MCPGet:  mcpHandler.HandleGet,
+	transport, err := buildTransportComposition(transportCompositionInputs{
+		startupCtx:         startupCtx,
+		cfg:                cfg,
+		pgDB:               pgDB,
+		authority:          authority,
+		backend:            backend,
+		rls:                rlsHelper,
+		options:            options,
+		logger:             logger,
+		searchRepo:         searchRepo,
+		telemetry:          telemetry,
+		toolRegistry:       toolRegistry,
+		convergence:        searchApplication.Convergence,
+		rememberAttempts:   buildRememberAttemptDiagnostics(ledgerRepo),
+		credentialRepo:     credentialRepo,
+		credentialVerifier: credentialVerifier,
+		activityWriter:     activityWriter,
+		teamService:        teamService,
+		credentialService:  credentialService,
+		ssoService:         ssoService,
+		portalSession:      portalSessionService,
+		directoryIdentity:  directoryIdentityService,
+		controlIdentity:    controlIdentityService,
+		privateMemory:      privateMemoryService,
+		auditService:       auditService,
+		securityService:    securityService,
+		appConfig:          appConfigService,
+		operationLogs:      operationLogService,
+		usageMetrics:       usageMetricsService,
+		conflictQueue:      conflictQueueService,
+		evidenceConflicts:  evidenceConflictService,
+		recallFeedback:     recallFeedbackEventService,
+		community:          communitySvc,
+		controlDream:       controlDreamSvc,
+		graph:              graphViewSvc,
+		recall:             recallSvc,
+		dream:              dreamSvc,
 	})
-	userPortalDeps := http.UserPortalDeps{
-		CredentialRepo: credentialRepo,
-		TeamSvc:        teamService,
-		CredentialSvc:  credentialService,
-		RateLimitSvc:   rateLimitService,
-		UsageMetrics:   usageMetricsService,
-		Telemetry:      telemetryReader,
-		Memory: http.MemoryPortalBindings{
-			GraphView:     graphViewSvc,
-			RecallSvc:     recallSvc,
-			DreamSvc:      dreamSvc,
-			PrivateMemory: privateMemoryService,
-		},
-		AuditSvc:           auditService,
-		SecuritySvc:        securityService,
-		SSOService:         ssoService,
-		PortalSession:      portalSessionService,
-		AppConfig:          appConfigService,
-		Config:             &cfg,
-		CredentialVerifier: credentialVerifier,
-		LastUsedRecorder:   activityWriter,
+	if err != nil {
+		log.Fatalf("failed to build transport composition: %v", err)
 	}
-	userPortalDeps.ExtraMiddleware = append(userPortalDeps.ExtraMiddleware, options.UserPortalMiddleware...)
-	if telemetryHTTPMetrics != nil {
-		userPortalDeps.ExtraMiddleware = append(userPortalDeps.ExtraMiddleware, middleware.TelemetryHTTPMiddleware(telemetryHTTPMetrics))
-	}
-	http.RegisterUserPortal(e, userPortalDeps)
-	var controlServer *echo.Echo
-	var telemetryServer *echo.Echo
-	if !options.DisableControlPortal {
-		controlServer, err = http.NewControlPortalServerWithCapabilityBindings(
-			&cfg,
-			teamService,
-			credentialService,
-			usageMetricsService,
-			http.ControlPortalBindings{Telemetry: http.ControlPortalTelemetry{
-				Reader:            telemetryReader,
-				HTTPMetrics:       telemetryHTTPMetrics,
-				ScrapeHandler:     telemetryScrapeHandler,
-				ScrapeToken:       cfg.GetTelemetryScrapeToken(),
-				SSO:               ssoService,
-				Directory:         directoryIdentityService,
-				ControlIdentity:   controlIdentityService,
-				Config:            appConfigService,
-				Logs:              operationLogService,
-				RecallFeedback:    recallFeedbackEventService,
-				Dreams:            controlDreamSvc,
-				Communities:       communitySvc,
-				ConflictQueue:     conflictQueueService,
-				EvidenceConflicts: evidenceConflictService,
-				Convergence:       searchApplication.Convergence,
-				RememberAttempts:  buildRememberAttemptDiagnostics(ledgerRepo),
-				PrivateMemory:     privateMemoryService,
-			}},
-			healthConfig,
-			logger,
-			securityService,
-		)
-		if err != nil {
-			log.Fatalf("failed to build control portal server: %v", err)
-		}
+	e := transport.e
+	runtimeCtx.Echo = e
+	controlServer := transport.controlServer
+	telemetryServer := transport.telemetryServer
+	if controlServer != nil {
 		logger.Info("starting control portal", observability.String("addr", cfg.GetControlHTTPAddr()))
 		go func() {
 			if err := controlServer.Start(cfg.GetControlHTTPAddr()); err != nil {
 				logServerStartError(logger, "control portal server error", err)
 			}
 		}()
-	} else if telemetryScrapeHandler != nil {
-		addr := strings.TrimSpace(options.MetricsOnlyAddr)
+	} else if telemetryServer != nil {
+		addr := strings.TrimSpace(transport.telemetryServerAddr)
 		if addr == "" {
 			addr = ":8091"
-		}
-		telemetryServer, err = newTelemetryScrapeServer(telemetryScrapeHandler, cfg.GetTelemetryScrapeToken())
-		if err != nil {
-			log.Fatalf("failed to build telemetry scrape server: %v", err)
 		}
 		logger.Info("starting telemetry scrape server", observability.String("addr", addr))
 		go func() {

--- a/cmd/internal/serverapp/transport_composition.go
+++ b/cmd/internal/serverapp/transport_composition.go
@@ -1,0 +1,249 @@
+package serverapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	conflictevidence "github.com/markhuangai/dense-mem/internal/conflict/evidence"
+	conflictqueue "github.com/markhuangai/dense-mem/internal/conflict/queue"
+	"github.com/markhuangai/dense-mem/internal/crypto"
+	"github.com/markhuangai/dense-mem/internal/dream"
+	densehttp "github.com/markhuangai/dense-mem/internal/http"
+	"github.com/markhuangai/dense-mem/internal/http/handler"
+	"github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/recall"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/service/communityservice"
+	"github.com/markhuangai/dense-mem/internal/service/graphview"
+	"github.com/markhuangai/dense-mem/internal/sse"
+	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+// transportCompositionInputs contains the already-built application and
+// infrastructure ports needed to bind supported HTTP, portal, MCP, and SSE
+// surfaces. It deliberately contains no transport policy beyond these ports.
+type transportCompositionInputs struct {
+	startupCtx       context.Context
+	cfg              config.Config
+	pgDB             *postgres.DB
+	authority        authorityBootstrap
+	backend          *backendBundle
+	rls              postgres.RLSHelper
+	options          RuntimeOptions
+	logger           observability.LogProvider
+	searchRepo       *repository.SearchRepositoryImpl
+	telemetry        telemetryComposition
+	toolRegistry     registry.Registry
+	convergence      service.SearchConvergenceReader
+	rememberAttempts service.RememberAttemptDiagnosticsReader
+
+	credentialRepo     repository.CredentialRepository
+	credentialVerifier crypto.CredentialVerifier
+	activityWriter     *service.CredentialActivityWriter
+	teamService        service.TeamService
+	credentialService  service.CredentialService
+	ssoService         *service.SSOService
+	portalSession      service.UserPortalSessionManager
+	directoryIdentity  *service.DirectoryIdentityService
+	controlIdentity    *service.ControlIdentityService
+	privateMemory      densehttp.PrivateMemoryServiceInterface
+	auditService       service.AuditService
+	securityService    service.SecurityService
+	appConfig          service.AppConfigService
+	operationLogs      service.OperationLogReader
+	usageMetrics       service.UsageMetricsService
+	conflictQueue      conflictqueue.Reader
+	evidenceConflicts  conflictevidence.Reader
+	recallFeedback     recall.RecallFeedbackEventReader
+	community          communityservice.Service
+	controlDream       dream.ControlService
+	graph              graphview.Service
+	recall             recall.RecallService
+	dream              dream.Service
+}
+
+type transportComposition struct {
+	e                   *echo.Echo
+	controlServer       *echo.Echo
+	telemetryServer     *echo.Echo
+	telemetryServerAddr string
+}
+
+func buildTransportComposition(deps transportCompositionInputs) (*transportComposition, error) {
+	if deps.backend == nil {
+		return nil, fmt.Errorf("transport: backend is required")
+	}
+
+	streamLifecycle := sse.NewStreamLifecycleWithConfig(
+		deps.backend.concurrencyLimiter,
+		sse.NewHeartbeatSenderWithInterval(time.Duration(deps.cfg.GetSSEHeartbeatSeconds())*time.Second),
+		time.Duration(deps.cfg.GetSSEMaxDurationSeconds())*time.Second,
+		deps.backend.streamCleanupRepo,
+	)
+	mcpHandler := handler.NewMCPHandlerWithLifecycleAndRuntimeConfig(
+		deps.toolRegistry,
+		deps.logger,
+		streamLifecycle,
+		deps.appConfig,
+		deps.dream,
+	)
+
+	checks := []densehttp.HealthCheck{
+		{Name: "postgres", Check: func(ctx context.Context) error {
+			return deps.pgDB.Ping(ctx)
+		}},
+		{Name: "postgres_topology", Check: func(ctx context.Context) error {
+			return postgres.ValidateSinglePrimaryTopology(ctx, deps.pgDB.GetDB())
+		}},
+		{Name: "pgvector", Check: func(ctx context.Context) error {
+			return postgres.CheckPGVectorExtension(ctx, deps.pgDB.GetDB())
+		}},
+		{Name: "authority", Check: func(context.Context) error {
+			return checkActiveAuthority(deps.authority)
+		}},
+		{Name: "search_readiness", Check: func(ctx context.Context) error {
+			return checkSearchReadiness(ctx, deps.searchRepo)
+		}},
+	}
+	if deps.backend.redisPingFn != nil {
+		checks = append(checks, densehttp.HealthCheck{Name: "redis", Check: deps.backend.redisPingFn})
+	}
+	healthConfig := (densehttp.HealthConfig{
+		Checks:   checks,
+		Degraded: deps.backend.degraded,
+		Reason:   deps.backend.reason,
+	}).WithSharedDependencyChecks()
+	e := densehttp.NewServer(deps.cfg, deps.logger, healthConfig)
+	e.Use(middleware.CorrelationIDMiddleware(), middleware.ClientIPMiddleware())
+	e.Use(middleware.SecurityBanMiddleware(deps.securityService))
+	densehttp.RegisterOAuthProtectedResourceRoutes(e, deps.ssoService)
+	if err := densehttp.RegisterDirectorySCIM(e, deps.directoryIdentity, densehttp.DirectorySCIMConfig{
+		RuntimeConfig: deps.appConfig,
+		Security:      deps.securityService,
+		RateLimitSvc:  deps.backend.rateLimitService,
+		Config:        &deps.cfg,
+	}); err != nil {
+		return nil, fmt.Errorf("register directory SCIM routes: %w", err)
+	}
+
+	runtimeCtx := RuntimeContext{
+		Echo:              e,
+		Config:            &deps.cfg,
+		TeamService:       deps.teamService,
+		CredentialService: deps.credentialService,
+		CounterStore:      deps.backend.counterStore,
+		PostgresDB:        deps.pgDB.GetDB(),
+		RLS:               deps.rls,
+		Logger:            deps.logger,
+	}
+	if deps.options.RegisterRoutes != nil {
+		if err := deps.options.RegisterRoutes(runtimeCtx); err != nil {
+			return nil, fmt.Errorf("register runtime routes: %w", err)
+		}
+	}
+
+	protectedDeps := densehttp.ProtectedDeps{
+		MCP: densehttp.MCPBindings{
+			CredentialRepo:     deps.credentialRepo,
+			TeamSvc:            deps.teamService,
+			RateLimitService:   deps.backend.rateLimitService,
+			UsageMetrics:       deps.usageMetrics,
+			AuditService:       deps.auditService,
+			SecurityService:    deps.securityService,
+			SSOAuthenticator:   deps.ssoService,
+			OAuthAuthenticator: deps.ssoService,
+			OAuthMetadata:      deps.ssoService,
+			Config:             &deps.cfg,
+			Logger:             deps.logger,
+			CredentialVerifier: deps.credentialVerifier,
+			LastUsedRecorder:   deps.activityWriter,
+		},
+	}
+	protectedDeps.PostAuthMiddleware = append(protectedDeps.PostAuthMiddleware, deps.options.PostAuthMiddleware...)
+	if deps.telemetry.HTTPMetrics != nil {
+		protectedDeps.PostAuthMiddleware = append(protectedDeps.PostAuthMiddleware, middleware.TelemetryHTTPMiddleware(deps.telemetry.HTTPMetrics))
+	}
+	densehttp.RegisterProtectedRoutesWithHandlers(e, protectedDeps, densehttp.ProtectedHandlers{
+		MCPPost: mcpHandler.HandlePost,
+		MCPGet:  mcpHandler.HandleGet,
+	})
+
+	userPortalDeps := densehttp.UserPortalDeps{
+		CredentialRepo:     deps.credentialRepo,
+		TeamSvc:            deps.teamService,
+		CredentialSvc:      deps.credentialService,
+		RateLimitSvc:       deps.backend.rateLimitService,
+		UsageMetrics:       deps.usageMetrics,
+		Telemetry:          deps.telemetry.Reader,
+		Memory:             densehttp.MemoryPortalBindings{GraphView: deps.graph, RecallSvc: deps.recall, DreamSvc: deps.dream, PrivateMemory: deps.privateMemory},
+		AuditSvc:           deps.auditService,
+		SecuritySvc:        deps.securityService,
+		SSOService:         deps.ssoService,
+		PortalSession:      deps.portalSession,
+		AppConfig:          deps.appConfig,
+		Config:             &deps.cfg,
+		CredentialVerifier: deps.credentialVerifier,
+		LastUsedRecorder:   deps.activityWriter,
+	}
+	userPortalDeps.ExtraMiddleware = append(userPortalDeps.ExtraMiddleware, deps.options.UserPortalMiddleware...)
+	if deps.telemetry.HTTPMetrics != nil {
+		userPortalDeps.ExtraMiddleware = append(userPortalDeps.ExtraMiddleware, middleware.TelemetryHTTPMiddleware(deps.telemetry.HTTPMetrics))
+	}
+	densehttp.RegisterUserPortal(e, userPortalDeps)
+
+	composition := &transportComposition{e: e}
+	if !deps.options.DisableControlPortal {
+		controlServer, err := densehttp.NewControlPortalServerWithCapabilityBindings(
+			&deps.cfg,
+			deps.teamService,
+			deps.credentialService,
+			deps.usageMetrics,
+			densehttp.ControlPortalBindings{Telemetry: densehttp.ControlPortalTelemetry{
+				Reader:            deps.telemetry.Reader,
+				HTTPMetrics:       deps.telemetry.HTTPMetrics,
+				ScrapeHandler:     deps.telemetry.ScrapeHandler,
+				ScrapeToken:       deps.cfg.GetTelemetryScrapeToken(),
+				SSO:               deps.ssoService,
+				Directory:         deps.directoryIdentity,
+				ControlIdentity:   deps.controlIdentity,
+				Config:            deps.appConfig,
+				Logs:              deps.operationLogs,
+				RecallFeedback:    deps.recallFeedback,
+				Dreams:            deps.controlDream,
+				Communities:       deps.community,
+				ConflictQueue:     deps.conflictQueue,
+				EvidenceConflicts: deps.evidenceConflicts,
+				Convergence:       deps.convergence,
+				RememberAttempts:  deps.rememberAttempts,
+				PrivateMemory:     deps.privateMemory,
+			}},
+			healthConfig,
+			deps.logger,
+			deps.securityService,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("build control portal server: %w", err)
+		}
+		composition.controlServer = controlServer
+	} else if deps.telemetry.ScrapeHandler != nil {
+		addr := strings.TrimSpace(deps.options.MetricsOnlyAddr)
+		if addr == "" {
+			addr = ":8091"
+		}
+		telemetryServer, err := newTelemetryScrapeServer(deps.telemetry.ScrapeHandler, deps.cfg.GetTelemetryScrapeToken())
+		if err != nil {
+			return nil, fmt.Errorf("build telemetry scrape server: %w", err)
+		}
+		composition.telemetryServer = telemetryServer
+		composition.telemetryServerAddr = addr
+	}
+	return composition, nil
+}

--- a/cmd/internal/serverapp/transport_composition_test.go
+++ b/cmd/internal/serverapp/transport_composition_test.go
@@ -1,0 +1,151 @@
+package serverapp
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/markhuangai/dense-mem/internal/config"
+	"github.com/markhuangai/dense-mem/internal/crypto"
+	"github.com/markhuangai/dense-mem/internal/domain"
+	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
+	"github.com/markhuangai/dense-mem/internal/storage/postgres"
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+func TestTransportCompositionPreservesRouteAndUserHookOrder(t *testing.T) {
+	backend, err := buildInMemoryBackend(config.Config{SSEMaxConcurrentStreams: 2})
+	if err != nil {
+		t.Fatalf("build in-memory backend: %v", err)
+	}
+	var routeRegistered bool
+	var mcpPresentDuringRegister bool
+	var userHooks []string
+	var postAuthHooks []string
+	markHook := func(marker string) echo.MiddlewareFunc {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				userHooks = append(userHooks, marker)
+				return next(c)
+			}
+		}
+	}
+	markPostAuthHook := func(marker string) echo.MiddlewareFunc {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				postAuthHooks = append(postAuthHooks, marker)
+				return next(c)
+			}
+		}
+	}
+	teamID := uuid.New()
+	credential := &domain.Credential{
+		ID:              uuid.New(),
+		ActorIdentityID: uuid.New(),
+		MembershipID:    uuid.New(),
+		OwnerID:         uuid.New(),
+		TeamID:          teamID,
+		KeyPrefix:       "dm_live_transport-test",
+		Scopes:          []string{"read", "write"},
+		Role:            "manager",
+	}
+	composition, err := buildTransportComposition(transportCompositionInputs{
+		cfg:                config.Config{},
+		pgDB:               &postgres.DB{},
+		backend:            backend,
+		logger:             observability.New(slog.LevelInfo),
+		toolRegistry:       registry.New(),
+		directoryIdentity:  service.NewDirectoryIdentityService(nil, service.DirectoryIdentityConfig{}),
+		credentialRepo:     transportCredentialRepository{credential: credential},
+		credentialVerifier: transportCredentialVerifier{},
+		teamService:        transportTeamService{team: &domain.Team{ID: teamID, Name: "transport-test"}},
+		options: RuntimeOptions{
+			DisableControlPortal: true,
+			RegisterRoutes: func(runtime RuntimeContext) error {
+				routeRegistered = true
+				for _, route := range runtime.Echo.Routes() {
+					if route.Path == "/mcp" {
+						mcpPresentDuringRegister = true
+					}
+				}
+				runtime.Echo.GET("/registered-before-protected", func(echo.Context) error { return nil })
+				return nil
+			},
+			PostAuthMiddleware:   []echo.MiddlewareFunc{markPostAuthHook("post-auth-1"), markPostAuthHook("post-auth-2")},
+			UserPortalMiddleware: []echo.MiddlewareFunc{markHook("user-1"), markHook("user-2")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build transport composition: %v", err)
+	}
+	if !routeRegistered {
+		t.Fatal("RegisterRoutes hook was not called")
+	}
+
+	routes := composition.e.Routes()
+	mcpRegistered := false
+	var sessionRoute *echo.Route
+	for _, route := range routes {
+		if route.Path == "/mcp" && route.Method == http.MethodPost {
+			mcpRegistered = true
+		}
+		if route.Path == "/ui/api/session" && route.Method == http.MethodGet {
+			sessionRoute = route
+		}
+	}
+	if mcpPresentDuringRegister || !mcpRegistered {
+		t.Fatalf("protected route registration order: present during callback=%t registered afterward=%t", mcpPresentDuringRegister, mcpRegistered)
+	}
+	if sessionRoute == nil {
+		t.Fatal("user portal session route was not registered")
+	}
+
+	postAuthRequest := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	postAuthRequest.Header.Set("Authorization", "Bearer dm_live_transport-test-key-1234567890")
+	postAuthRequest.Header.Set("MCP-Protocol-Version", "2025-06-18")
+	postAuthRequest.Header.Set("Accept", "application/json")
+	composition.e.ServeHTTP(httptest.NewRecorder(), postAuthRequest)
+	if got, want := postAuthHooks, []string{"post-auth-1", "post-auth-2"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("post-auth middleware order = %v; want %v", got, want)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/ui/api/session", nil)
+	composition.e.ServeHTTP(httptest.NewRecorder(), request)
+	if got, want := userHooks, []string{"user-1", "user-2"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("user middleware order = %v; want %v", got, want)
+	}
+}
+
+type transportCredentialRepository struct {
+	repository.CredentialRepository
+	credential *domain.Credential
+}
+
+func (r transportCredentialRepository) GetActiveByPrefix(context.Context, string) (*domain.Credential, error) {
+	return r.credential, nil
+}
+
+type transportCredentialVerifier struct{}
+
+func (transportCredentialVerifier) Verify(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
+type transportTeamService struct {
+	service.TeamService
+	team *domain.Team
+}
+
+func (s transportTeamService) GetByID(context.Context, uuid.UUID) (*domain.Team, error) {
+	return s.team, nil
+}
+
+var _ crypto.CredentialVerifier = transportCredentialVerifier{}

--- a/internal/evalharness/client_contract.go
+++ b/internal/evalharness/client_contract.go
@@ -111,7 +111,9 @@ func matchesContractToolSet(names map[string]struct{}, expected []string) bool {
 	}
 	for _, name := range expected {
 		if _, ok := names[name]; !ok {
-			return false
+			if !registry.ContractToolRuntimeOptional(name) {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/evalharness/client_contract_test.go
+++ b/internal/evalharness/client_contract_test.go
@@ -138,6 +138,19 @@ func TestClassifyContractAllowsEvaluationToolsAndRejectsUnknownTools(t *testing.
 	require.ErrorContains(t, err, "unsupported or mixed MCP contract")
 }
 
+func TestClassifyContractAllowsOmittedRuntimeOptionalTools(t *testing.T) {
+	definitions := make([]mcpToolDefinition, 0, len(registry.ContractTools()))
+	for _, tool := range registry.ContractTools() {
+		if registry.ContractToolRuntimeOptional(tool.Name) {
+			continue
+		}
+		definitions = append(definitions, mcpToolDefinition{Name: tool.Name, OutputSchema: tool.OutputSchema})
+	}
+	mode, err := classifyContract(definitions)
+	require.NoError(t, err)
+	require.Equal(t, contractModeV263, mode)
+}
+
 func TestClassifyContractAcceptsRetainedV262Schema(t *testing.T) {
 	definitions := make([]mcpToolDefinition, 0, len(registry.ContractTools()))
 	for _, tool := range registry.ContractTools() {

--- a/internal/repository/evaluation_compat.go
+++ b/internal/repository/evaluation_compat.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"gorm.io/gorm"
+
+	dreampostgres "github.com/markhuangai/dense-mem/internal/dream/postgres"
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+// The legacy SemanticRepository surface remains a bounded compatibility
+// forward until the final compatibility cleanup in #382.
+func newCompatibilityEvaluationReader(db *gorm.DB, rls storagepostgres.RLSHelper) *EvaluationReader {
+	return NewEvaluationReader(db, rls, compatibilityHypothesisQuery)
+}
+
+func compatibilityHypothesisQuery(input EvaluationListInput, limit, offset int, ids ...string) (string, []any, error) {
+	return dreampostgres.HypothesisEvaluationQuery(input, limit, offset, ids...)
+}

--- a/internal/repository/evaluation_reader.go
+++ b/internal/repository/evaluation_reader.go
@@ -1,0 +1,107 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"gorm.io/gorm"
+
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+// EvaluationHypothesisQuery is the Dream-owned SQL seam used by the
+// evaluation reader. Evaluation can move without copying Dream's query or
+// making the registry depend on a concrete adapter.
+type EvaluationHypothesisQuery func(EvaluationListInput, int, int, ...string) (string, []any, error)
+
+// EvaluationReader exposes the team-scoped evaluation read model while the
+// legacy SemanticRepositoryImpl remains a compatibility facade.
+type EvaluationReader struct {
+	db              *gorm.DB
+	rls             storagepostgres.RLSHelper
+	hypothesisQuery EvaluationHypothesisQuery
+}
+
+var _ EvaluationRepository = (*EvaluationReader)(nil)
+
+func NewEvaluationReader(db *gorm.DB, rls storagepostgres.RLSHelper, hypothesisQuery EvaluationHypothesisQuery) *EvaluationReader {
+	return &EvaluationReader{db: db, rls: rls, hypothesisQuery: hypothesisQuery}
+}
+
+func (r *EvaluationReader) ListEvaluationRefs(ctx context.Context, input EvaluationListInput) (*EvaluationPage, error) {
+	input = normalizeEvaluationListInput(input)
+	if err := validateEvaluationListInput(input); err != nil {
+		return nil, err
+	}
+	offset := evaluationCursorOffset(input.Cursor)
+	limit := input.Limit + 1
+	var items []map[string]any
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		var err error
+		items, err = queryEvaluationItemsWithHypothesis(ctx, tx, input, limit, offset, r.hypothesisQuery)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("evaluation: list %s: %w", input.Type, err)
+	}
+	hasMore := len(items) > input.Limit
+	if hasMore {
+		items = items[:input.Limit]
+	}
+	nextCursor := ""
+	if hasMore {
+		nextCursor = strconv.Itoa(offset + input.Limit)
+	}
+	return &EvaluationPage{Items: items, NextCursor: nextCursor, HasMore: hasMore}, nil
+}
+
+func (r *EvaluationReader) GetEvaluationItem(ctx context.Context, input EvaluationGetInput) (map[string]any, error) {
+	input = normalizeEvaluationGetInput(input)
+	if err := validateEvaluationGetInput(input); err != nil {
+		return nil, err
+	}
+	var item map[string]any
+	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
+		items, err := queryEvaluationItemsWithHypothesis(ctx, tx, EvaluationListInput{
+			TeamID: input.TeamID,
+			Type:   input.Type,
+			Limit:  1,
+			Status: "",
+		}, 1, 0, r.hypothesisQuery, input.ID)
+		if err != nil {
+			return err
+		}
+		if len(items) == 0 {
+			return sql.ErrNoRows
+		}
+		item = items[0]
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("evaluation: get %s: %w", input.Type, err)
+	}
+	return item, nil
+}
+
+func (r *EvaluationReader) withTeamTx(ctx context.Context, teamID string, fn func(*gorm.DB) error) error {
+	if err := r.validateDependencies(); err != nil {
+		return err
+	}
+	return r.rls.WithTeamTx(ctx, r.db, teamID, fn)
+}
+
+func (r *EvaluationReader) validateDependencies() error {
+	if r == nil || r.db == nil {
+		return errors.New("semantic: database is required")
+	}
+	if r.rls == nil {
+		return errors.New("semantic: rls helper is required")
+	}
+	if r.hypothesisQuery == nil {
+		return errors.New("evaluation: hypothesis query is required")
+	}
+	return nil
+}

--- a/internal/repository/evaluation_reader_integration.e2e
+++ b/internal/repository/evaluation_reader_integration.e2e
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	dreampostgres "github.com/markhuangai/dense-mem/internal/dream/postgres"
+)
+
+func TestEvaluationReaderPreservesTeamIsolationPaginationAndHypothesisFilter(t *testing.T) {
+	adminDB, appDB, rls, cleanup := setupLedgerRepositoryDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	teamID := createLedgerTeam(t, adminDB, rls, "evaluation-reader-team")
+	ownerID := createLedgerProfile(t, adminDB, rls, teamID, "evaluation-reader-owner")
+	otherTeamID := createLedgerTeam(t, adminDB, rls, "evaluation-reader-other-team")
+	otherOwnerID := createLedgerProfile(t, adminDB, rls, otherTeamID, "evaluation-reader-other-owner")
+	semantic := NewSemanticRepository(appDB, rls)
+
+	firstID, err := semantic.CreateHypothesis(ctx, CreateHypothesisInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Payload: map[string]any{"text": "first"},
+	})
+	require.NoError(t, err)
+	secondID, err := semantic.CreateHypothesis(ctx, CreateHypothesisInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Payload: map[string]any{"text": "second"},
+	})
+	require.NoError(t, err)
+	thirdID, err := semantic.CreateHypothesis(ctx, CreateHypothesisInput{
+		TeamID: teamID, OwnerProfileID: ownerID, Payload: map[string]any{"text": "third"},
+	})
+	require.NoError(t, err)
+	otherID, err := semantic.CreateHypothesis(ctx, CreateHypothesisInput{
+		TeamID: otherTeamID, OwnerProfileID: otherOwnerID, Payload: map[string]any{"text": "other team"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, rls.WithSystemTx(ctx, adminDB, func(tx *gorm.DB) error {
+		return tx.Exec(`
+			UPDATE hypotheses
+			SET canonical_hypothesis_id = ?::uuid
+			WHERE team_id = ?::uuid AND hypothesis_id = ?::uuid
+		`, firstID, teamID, secondID).Error
+	}))
+
+	queryCalls := 0
+	reader := NewEvaluationReader(appDB, rls, func(input EvaluationListInput, limit, offset int, ids ...string) (string, []any, error) {
+		queryCalls++
+		return dreampostgres.HypothesisEvaluationQuery(input, limit, offset, ids...)
+	})
+
+	page, err := reader.ListEvaluationRefs(ctx, EvaluationListInput{TeamID: teamID, Type: "dream", Limit: 1})
+	require.NoError(t, err)
+	require.True(t, page.HasMore)
+	require.Equal(t, "1", page.NextCursor)
+	require.Len(t, page.Items, 1)
+	require.Equal(t, "hypothesis", page.Items[0]["type"])
+	firstPageID, ok := page.Items[0]["id"].(string)
+	require.True(t, ok)
+	require.NotEqual(t, secondID, firstPageID)
+
+	page, err = reader.ListEvaluationRefs(ctx, EvaluationListInput{TeamID: teamID, Type: "hypothesis", Limit: 1, Cursor: page.NextCursor})
+	require.NoError(t, err)
+	require.False(t, page.HasMore)
+	require.Len(t, page.Items, 1)
+	secondPageID, ok := page.Items[0]["id"].(string)
+	require.True(t, ok)
+	require.NotEqual(t, secondID, secondPageID)
+	require.Contains(t, []string{firstID, thirdID}, firstPageID)
+	require.Contains(t, []string{firstID, thirdID}, secondPageID)
+
+	item, err := reader.GetEvaluationItem(ctx, EvaluationGetInput{TeamID: teamID, Type: "hypothesis", ID: firstID})
+	require.NoError(t, err)
+	require.Equal(t, firstID, item["id"])
+	_, err = reader.GetEvaluationItem(ctx, EvaluationGetInput{TeamID: teamID, Type: "hypothesis", ID: otherID})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, sql.ErrNoRows), "error = %v", err)
+	_, err = reader.GetEvaluationItem(ctx, EvaluationGetInput{TeamID: teamID, Type: "hypothesis", ID: secondID})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, sql.ErrNoRows), "canonical alias error = %v", err)
+	require.GreaterOrEqual(t, queryCalls, 3)
+}

--- a/internal/repository/evaluation_reader_test.go
+++ b/internal/repository/evaluation_reader_test.go
@@ -1,0 +1,115 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	storagepostgres "github.com/markhuangai/dense-mem/internal/storage/postgres"
+)
+
+type evaluationReaderTestRLS struct {
+	storagepostgres.RLSHelper
+}
+
+func (evaluationReaderTestRLS) WithTeamTx(_ context.Context, db *gorm.DB, _ string, fn func(*gorm.DB) error) error {
+	return fn(db)
+}
+
+func newEvaluationReaderSQLMock(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	db, err := gorm.Open(gormpostgres.New(gormpostgres.Config{Conn: sqlDB}), &gorm.Config{})
+	require.NoError(t, err)
+	return db, mock
+}
+
+func evaluationReaderHypothesisQuery(EvaluationListInput, int, int, ...string) (string, []any, error) {
+	return "SELECT $1::jsonb", []any{[]byte(`{"type":"hypothesis","id":"hypothesis-id"}`)}, nil
+}
+
+func TestEvaluationReaderUsesInjectedQueryAndDecodesRows(t *testing.T) {
+	db, mock := newEvaluationReaderSQLMock(t)
+	mock.ExpectQuery(`SELECT \$1::jsonb`).
+		WithArgs([]byte(`{"type":"hypothesis","id":"hypothesis-id"}`)).
+		WillReturnRows(sqlmock.NewRows([]string{"item"}).AddRow([]byte(`{"type":"hypothesis","id":"hypothesis-id"}`)))
+
+	reader := NewEvaluationReader(db, evaluationReaderTestRLS{}, evaluationReaderHypothesisQuery)
+	page, err := reader.ListEvaluationRefs(t.Context(), EvaluationListInput{
+		TeamID: "00000000-0000-0000-0000-000000000101",
+		Type:   "hypothesis",
+		Limit:  1,
+	})
+	require.NoError(t, err)
+	require.False(t, page.HasMore)
+	require.Equal(t, "hypothesis-id", page.Items[0]["id"])
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEvaluationReaderReturnsQueryAndDecodeErrors(t *testing.T) {
+	databaseErr := errors.New("database unavailable")
+	tests := []struct {
+		name       string
+		rows       *sqlmock.Rows
+		queryError error
+		decode     bool
+	}{
+		{name: "query error", queryError: databaseErr},
+		{name: "decode error", rows: sqlmock.NewRows([]string{"item"}).AddRow([]byte("{")), decode: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock := newEvaluationReaderSQLMock(t)
+			expectation := mock.ExpectQuery(`SELECT \$1::jsonb`)
+			expectation.WithArgs([]byte(`{"type":"hypothesis","id":"hypothesis-id"}`))
+			if test.queryError != nil {
+				expectation.WillReturnError(test.queryError)
+			} else {
+				expectation.WillReturnRows(test.rows)
+			}
+
+			reader := NewEvaluationReader(db, evaluationReaderTestRLS{}, evaluationReaderHypothesisQuery)
+			_, err := reader.ListEvaluationRefs(t.Context(), EvaluationListInput{
+				TeamID: "00000000-0000-0000-0000-000000000101",
+				Type:   "hypothesis",
+				Limit:  1,
+			})
+			if test.queryError != nil {
+				require.ErrorIs(t, err, test.queryError)
+			} else if test.decode {
+				require.ErrorContains(t, err, "decode evaluation item")
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestEvaluationReaderRejectsMissingDependencies(t *testing.T) {
+	_, err := (&EvaluationReader{}).ListEvaluationRefs(t.Context(), EvaluationListInput{
+		TeamID: "00000000-0000-0000-0000-000000000101",
+		Type:   "hypothesis",
+	})
+	require.EqualError(t, err, "evaluation: list hypothesis: semantic: database is required")
+
+	db, _ := newEvaluationReaderSQLMock(t)
+	reader := NewEvaluationReader(db, evaluationReaderTestRLS{}, nil)
+	_, err = reader.ListEvaluationRefs(t.Context(), EvaluationListInput{
+		TeamID: "00000000-0000-0000-0000-000000000101",
+		Type:   "hypothesis",
+	})
+	require.EqualError(t, err, "evaluation: list hypothesis: evaluation: hypothesis query is required")
+
+	reader = NewEvaluationReader(db, nil, evaluationReaderHypothesisQuery)
+	_, err = reader.ListEvaluationRefs(t.Context(), EvaluationListInput{
+		TeamID: "00000000-0000-0000-0000-000000000101",
+		Type:   "hypothesis",
+	})
+	require.EqualError(t, err, "evaluation: list hypothesis: semantic: rls helper is required")
+}

--- a/internal/repository/evaluation_repository.go
+++ b/internal/repository/evaluation_repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	dreamcontract "github.com/markhuangai/dense-mem/internal/dream/contract"
-	dreampostgres "github.com/markhuangai/dense-mem/internal/dream/postgres"
 	"gorm.io/gorm"
 )
 
@@ -23,58 +21,29 @@ type EvaluationPage = dreamcontract.EvaluationPage
 var _ EvaluationRepository = (*SemanticRepositoryImpl)(nil)
 
 func (r *SemanticRepositoryImpl) ListEvaluationRefs(ctx context.Context, input EvaluationListInput) (*EvaluationPage, error) {
-	input = normalizeEvaluationListInput(input)
-	if err := validateEvaluationListInput(input); err != nil {
-		return nil, err
+	reader := r.evaluationReader()
+	if reader == nil {
+		return nil, errors.New("semantic: database is required")
 	}
-	offset := evaluationCursorOffset(input.Cursor)
-	limit := input.Limit + 1
-	var items []map[string]any
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		var err error
-		items, err = queryEvaluationItems(ctx, tx, input, limit, offset)
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("evaluation: list %s: %w", input.Type, err)
-	}
-	hasMore := len(items) > input.Limit
-	if hasMore {
-		items = items[:input.Limit]
-	}
-	nextCursor := ""
-	if hasMore {
-		nextCursor = strconv.Itoa(offset + input.Limit)
-	}
-	return &EvaluationPage{Items: items, NextCursor: nextCursor, HasMore: hasMore}, nil
+	return reader.ListEvaluationRefs(ctx, input)
 }
 
 func (r *SemanticRepositoryImpl) GetEvaluationItem(ctx context.Context, input EvaluationGetInput) (map[string]any, error) {
-	input = normalizeEvaluationGetInput(input)
-	if err := validateEvaluationGetInput(input); err != nil {
-		return nil, err
+	reader := r.evaluationReader()
+	if reader == nil {
+		return nil, errors.New("semantic: database is required")
 	}
-	var item map[string]any
-	err := r.withTeamTx(ctx, input.TeamID, func(tx *gorm.DB) error {
-		items, err := queryEvaluationItems(ctx, tx, EvaluationListInput{
-			TeamID: input.TeamID,
-			Type:   input.Type,
-			Limit:  1,
-			Status: "",
-		}, 1, 0, input.ID)
-		if err != nil {
-			return err
-		}
-		if len(items) == 0 {
-			return sql.ErrNoRows
-		}
-		item = items[0]
+	return reader.GetEvaluationItem(ctx, input)
+}
+
+func (r *SemanticRepositoryImpl) evaluationReader() *EvaluationReader {
+	if r == nil {
 		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("evaluation: get %s: %w", input.Type, err)
 	}
-	return item, nil
+	if r.evaluation != nil {
+		return r.evaluation
+	}
+	return newCompatibilityEvaluationReader(r.db, r.rls)
 }
 
 func normalizeEvaluationListInput(input EvaluationListInput) EvaluationListInput {
@@ -160,7 +129,19 @@ func queryEvaluationItems(
 	offset int,
 	ids ...string,
 ) ([]map[string]any, error) {
-	query, args, err := evaluationQuery(input, limit, offset, ids...)
+	return queryEvaluationItemsWithHypothesis(ctx, tx, input, limit, offset, compatibilityHypothesisQuery, ids...)
+}
+
+func queryEvaluationItemsWithHypothesis(
+	ctx context.Context,
+	tx *gorm.DB,
+	input EvaluationListInput,
+	limit int,
+	offset int,
+	hypothesisQuery EvaluationHypothesisQuery,
+	ids ...string,
+) ([]map[string]any, error) {
+	query, args, err := evaluationQueryWithHypothesis(input, limit, offset, hypothesisQuery, ids...)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +166,15 @@ func queryEvaluationItems(
 }
 
 func evaluationQuery(input EvaluationListInput, limit int, offset int, ids ...string) (string, []any, error) {
+	return evaluationQueryWithHypothesis(input, limit, offset, compatibilityHypothesisQuery, ids...)
+}
+
+func evaluationQueryWithHypothesis(input EvaluationListInput, limit int, offset int, hypothesisQuery EvaluationHypothesisQuery, ids ...string) (string, []any, error) {
 	if len(ids) > 1 {
 		return "", nil, errors.New("only one id lookup is supported")
+	}
+	if hypothesisQuery == nil {
+		return "", nil, errors.New("hypothesis evaluation query is required")
 	}
 	args := evaluationQueryArgs{values: []any{input.TeamID}}
 	idFilter := args.idFilter(ids)
@@ -334,7 +322,7 @@ func evaluationQuery(input EvaluationListInput, limit int, offset int, ids ...st
 			ORDER BY created_at DESC, id
 			LIMIT ? OFFSET ?`, args.values, nil
 	case "hypothesis":
-		return dreampostgres.HypothesisEvaluationQuery(input, limit, offset, ids...)
+		return hypothesisQuery(input, limit, offset, ids...)
 	default:
 		return "", nil, fmt.Errorf("unsupported type %q", input.Type)
 	}

--- a/internal/repository/evaluation_repository_test.go
+++ b/internal/repository/evaluation_repository_test.go
@@ -53,3 +53,32 @@ func TestEvaluationHypothesisQueryExcludesCanonicalAliases(t *testing.T) {
 		t.Fatalf("hypothesis query did not exclude canonical aliases:\n%s", query)
 	}
 }
+
+func TestEvaluationQueryUsesInjectedHypothesisProvider(t *testing.T) {
+	called := false
+	query, args, err := evaluationQueryWithHypothesis(
+		EvaluationListInput{TeamID: "00000000-0000-0000-0000-000000000101", Type: "hypothesis"},
+		2,
+		3,
+		func(input EvaluationListInput, limit, offset int, ids ...string) (string, []any, error) {
+			called = true
+			if input.Type != "hypothesis" || limit != 2 || offset != 3 || len(ids) != 1 || ids[0] != "hypothesis-id" {
+				t.Fatalf("injected query input = %+v limit=%d offset=%d ids=%v", input, limit, offset, ids)
+			}
+			return "SELECT injected", []any{"team-id", "hypothesis-id"}, nil
+		},
+		"hypothesis-id",
+	)
+	if err != nil {
+		t.Fatalf("evaluationQueryWithHypothesis: %v", err)
+	}
+	if !called {
+		t.Fatal("injected Hypothesis query was not called")
+	}
+	if query != "SELECT injected" {
+		t.Fatalf("query = %q", query)
+	}
+	if len(args) != 2 || args[0] != "team-id" || args[1] != "hypothesis-id" {
+		t.Fatalf("args = %#v", args)
+	}
+}

--- a/internal/repository/semantic_repository.go
+++ b/internal/repository/semantic_repository.go
@@ -24,16 +24,19 @@ type SemanticRepositoryImpl struct {
 	rls            rLSHelper
 	knowledgeOwner *knowledgepostgres.Store
 	dreamAdapter   *dreampostgres.Store
+	evaluation     *EvaluationReader
 }
 
 var _ SemanticRepository = (*SemanticRepositoryImpl)(nil)
 
 func NewSemanticRepository(db *gorm.DB, rls *postgres.RLS) *SemanticRepositoryImpl {
-	return &SemanticRepositoryImpl{
+	repository := &SemanticRepositoryImpl{
 		db: db, rls: rls,
 		knowledgeOwner: knowledgepostgres.NewStore(db, rls, knowledgecontract.ConflictRuntimeConfig{}),
 		dreamAdapter:   dreampostgres.NewStore(db, rls),
 	}
+	repository.evaluation = newCompatibilityEvaluationReader(db, rls)
+	return repository
 }
 
 // DreamDatabase and DreamRLS expose the narrow construction seam used by the

--- a/internal/tools/registry/evaluation_audit_failure_test.go
+++ b/internal/tools/registry/evaluation_audit_failure_test.go
@@ -1,0 +1,38 @@
+//go:build evaluation
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appservice "github.com/markhuangai/dense-mem/internal/service"
+)
+
+type failingEvaluationAudit struct {
+	err error
+}
+
+func (s failingEvaluationAudit) Append(context.Context, appservice.AuditLogEntry) error {
+	return s.err
+}
+
+func TestEvaluationAuditFailureBlocksEvaluationTool(t *testing.T) {
+	sentinel := errors.New("audit unavailable")
+	reg, err := BuildActive(Dependencies{
+		Dreams:          &stubDreamService{},
+		EvaluationAudit: failingEvaluationAudit{err: sentinel},
+	})
+	if err != nil {
+		t.Fatalf("BuildActive: %v", err)
+	}
+	tool, ok := reg.Get("eval_run_dream_cycle")
+	if !ok {
+		t.Fatal("evaluation build omitted eval_run_dream_cycle")
+	}
+	_, err = tool.Invoke(context.Background(), "team-id", map[string]any{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("evaluation audit error = %v; want %v", err, sentinel)
+	}
+}

--- a/internal/tools/registry/evaluation_bindings.go
+++ b/internal/tools/registry/evaluation_bindings.go
@@ -1,13 +1,24 @@
 package registry
 
 import (
+	"context"
+
+	communitycontract "github.com/markhuangai/dense-mem/internal/community/contract"
 	dreamcontract "github.com/markhuangai/dense-mem/internal/dream/contract"
-	"github.com/markhuangai/dense-mem/internal/repository"
+	"github.com/markhuangai/dense-mem/internal/service"
 )
 
+type EvaluationRepository = dreamcontract.EvaluationRepository
+type CommunityRepository = communitycontract.CommunityRepository
+
+type EvaluationAuditAppender interface {
+	Append(ctx context.Context, entry service.AuditLogEntry) error
+}
+
 type EvaluationBindings struct {
-	Repository  dreamcontract.EvaluationRepository
-	Communities repository.CommunityRepository
+	Repository  EvaluationRepository
+	Communities CommunityRepository
+	Audit       EvaluationAuditAppender
 }
 
 func (d Dependencies) withEvaluationBindings() Dependencies {
@@ -16,6 +27,9 @@ func (d Dependencies) withEvaluationBindings() Dependencies {
 	}
 	if d.Communities == nil {
 		d.Communities = d.EvaluationBindings.Communities
+	}
+	if d.EvaluationAudit == nil {
+		d.EvaluationAudit = d.EvaluationBindings.Audit
 	}
 	return d
 }

--- a/internal/tools/registry/evaluation_bindings_test.go
+++ b/internal/tools/registry/evaluation_bindings_test.go
@@ -1,0 +1,67 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/repository"
+)
+
+func TestEvaluationFacetSuppliesAuditAppender(t *testing.T) {
+	audit := &evaluationAuditStub{}
+	deps := (Dependencies{
+		EvaluationBindings: EvaluationBindings{Audit: audit},
+	}).withCapabilityBindings()
+	if deps.EvaluationAudit != audit {
+		t.Fatal("evaluation capability facet did not supply its audit appender")
+	}
+}
+
+func TestEvaluationBindingsPreserveFlatCoreAndFacetPrecedence(t *testing.T) {
+	flatEval := repository.NewSemanticRepository(nil, nil)
+	facetEval := repository.NewSemanticRepository(nil, nil)
+	flatCommunity := repository.NewSemanticRepository(nil, nil)
+	facetCommunity := repository.NewSemanticRepository(nil, nil)
+	flatAudit := &evaluationAuditStub{}
+	coreAudit := &evaluationAuditStub{}
+	facetAudit := &evaluationAuditStub{}
+
+	wired := (Dependencies{
+		Core: CoreDependencies{
+			EvaluationAudit: coreAudit,
+		},
+		Evaluation:      flatEval,
+		Communities:     flatCommunity,
+		EvaluationAudit: flatAudit,
+		EvaluationBindings: EvaluationBindings{
+			Repository:  facetEval,
+			Communities: facetCommunity,
+			Audit:       facetAudit,
+		},
+	}).withCapabilityBindings()
+	if wired.Evaluation != flatEval || wired.Communities != flatCommunity || wired.EvaluationAudit != flatAudit {
+		t.Fatal("flat evaluation dependencies did not take precedence")
+	}
+
+	wired = (Dependencies{
+		Core: CoreDependencies{
+			EvaluationAudit: coreAudit,
+		},
+		EvaluationBindings: EvaluationBindings{
+			Repository:  facetEval,
+			Communities: facetCommunity,
+			Audit:       facetAudit,
+		},
+	}).withCapabilityBindings()
+	if wired.Evaluation != facetEval || wired.Communities != facetCommunity || wired.EvaluationAudit != coreAudit {
+		t.Fatal("core audit dependency did not take precedence")
+	}
+
+	wired = (Dependencies{EvaluationBindings: EvaluationBindings{
+		Repository:  facetEval,
+		Communities: facetCommunity,
+		Audit:       facetAudit,
+	}}).withCapabilityBindings()
+	if wired.Evaluation != facetEval || wired.Communities != facetCommunity || wired.EvaluationAudit != facetAudit {
+		t.Fatal("evaluation facet dependencies were not used as fallback")
+	}
+}

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -10,9 +10,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/dream"
 	"github.com/markhuangai/dense-mem/internal/lifecycle"
 	"github.com/markhuangai/dense-mem/internal/observability"
-	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/service"
 	"github.com/markhuangai/dense-mem/internal/service/contextservice"
 	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
@@ -40,18 +38,14 @@ type Dependencies struct {
 	Recall         recall.RecallService
 	Lifecycle      lifecycle.LifecycleService
 	RecallDreaming DreamingConfigProvider
-	Evaluation     repository.EvaluationRepository
-	Communities    repository.CommunityRepository
+	Evaluation     EvaluationRepository
+	Communities    CommunityRepository
 	MemoryPack     skillpackservice.MemoryPackService
 	Dreams         dream.Service
 }
 type RecallFeedbackEventRecorder interface {
 	RecordRecallSnapshot(ctx context.Context, event domain.RecallFeedbackEvent) error
 	RecordRecallFeedback(ctx context.Context, feedback domain.RecallFeedbackSubmission) error
-}
-
-type EvaluationAuditAppender interface {
-	Append(ctx context.Context, entry service.AuditLogEntry) error
 }
 
 // ErrToolUnavailable is the defensive fallback returned when a tool dependency

--- a/scripts/e2e-db-cases/evaluation.json
+++ b/scripts/e2e-db-cases/evaluation.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "capability": "evaluation",
+  "cases": [
+    {
+      "id": "evaluation/TestEvaluationReaderPreservesTeamIsolationPaginationAndHypothesisFilter",
+      "package": "./internal/repository",
+      "run": "^TestEvaluationReaderPreservesTeamIsolationPaginationAndHypothesisFilter$",
+      "phase": "precheck",
+      "source": "internal/repository/evaluation_reader_integration.e2e"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares the shared seams needed to start Wave 8 issues #378 and #379 in parallel.

- Adds an evaluation reader with an injected Dream Hypothesis query, evaluation-only build composition, audited evaluation bindings, and PostgreSQL isolation coverage.
- Extracts transport construction while retaining lifecycle, listener, and route ownership in the server entrypoint.
- Records capability ownership and the bounded #382 compatibility bridge.
- Keeps production at the ten-tool catalog and evaluation at the three additional harness tools.
- Makes evaluation contract discovery tolerate only explicitly runtime-optional tools omitted by feature gates.

## Verification

- Full Compose E2E: 42/42 Chromium/mobile tests passed.
- `local_eval_100`: 100/100 terminal Remember rows, zero failed rows, 25/25 retrieval cases passed.
- Architecture checker, architecture UAT, focused/evaluation-tagged Go tests, static analysis, vulnerability policy, and repository CI passed.

This PR is a prerequisite only; it does not implement the #378 or #379 cutovers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated evaluation-mode composition with team-scoped evaluation reading, pagination, filtering, and audit support.
  - Added compatibility handling so existing evaluation access continues to work during the transition.
  - Consolidated HTTP, MCP, portal, health, and telemetry server setup for more consistent runtime behavior.
  - Runtime-optional evaluation tools may now be omitted without invalidating the tool contract.

- **Documentation**
  - Documented shared ownership and composition boundaries for evaluation and transport capabilities.

- **Tests**
  - Expanded coverage for team isolation, pagination, route and middleware ordering, evaluation wiring, and audit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->