### PR TITLE
refactor: isolate MCP protocol and registry (#380)

### DIFF
--- a/architecture/modules/context-application.json
+++ b/architecture/modules/context-application.json
@@ -49,10 +49,7 @@
         {"path": "internal/service/contextservice/semantic_trace_test.go", "symbol": "TestSemanticTraceMapsMissingRelationship"},
         {"path": "internal/service/contextservice/semantic_trace_test.go", "symbol": "TestSemanticTracePreservesRepositoryFailures"},
         {"path": "internal/service/skillpackservice/memory_pack_export_test.go", "symbol": "exportSemanticStub.TraceRelationship"},
-        {"path": "internal/service/skillpackservice/memory_pack_export_test.go", "symbol": "TestMemoryPackExportRejectsMissingInputsAndUnavailableRelationships"},
-        {"path": "internal/tools/registry/contract_result_errors.go", "symbol": "ActionableErrorData"},
-        {"path": "internal/tools/registry/contract_result_errors_test.go", "symbol": "TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance"},
-        {"path": "internal/tools/registry/contract_result_errors_test.go", "symbol": "TestActionableErrorDataMapsHTTPStatusesAndBudgetMeasurements"}
+        {"path": "internal/service/skillpackservice/memory_pack_export_test.go", "symbol": "TestMemoryPackExportRejectsMissingInputsAndUnavailableRelationships"}
       ],
       "removal_issue": 382,
       "implementation_owner": {"path": "internal/trace/postgres/semantic_trace_repository.go", "symbol": "Store.TraceRelationship"},
@@ -73,12 +70,6 @@
       ],
       "consumers": [
         {"path": "cmd/internal/serverapp/application_composition.go", "symbol": "buildApplicationBundle"},
-        {"path": "internal/tools/registry/capability_bindings.go", "symbol": "Dependencies.withCapabilityBindings"},
-        {"path": "internal/tools/registry/toolset.go", "symbol": "BuildActive"},
-        {"path": "internal/tools/registry/contract_outputs.go", "symbol": "traceContractOutput"},
-        {"path": "internal/tools/registry/contract_result_errors.go", "symbol": "ActionableErrorData"},
-        {"path": "internal/tools/registry/contract_outputs_trace_test.go", "symbol": "TestTraceContractOutputPreservesPublicSubmissionAndLineageIDs"},
-        {"path": "internal/tools/registry/contract_test_helpers_test.go", "symbol": "stubTraceContext.Trace"},
         {"path": "internal/service/contextservice/semantic_trace_test.go", "symbol": "TestSemanticTraceMapsMissingRelationship"},
         {"path": "internal/service/contextservice/semantic_trace_test.go", "symbol": "TestSemanticTracePreservesRepositoryFailures"},
         {"path": "internal/service/contextservice/semantic_trace_test.go", "symbol": "TestSemanticTraceRejectsMismatchedConflictTeam"},

--- a/architecture/modules/http-transport.json
+++ b/architecture/modules/http-transport.json
@@ -12,7 +12,9 @@
     {"path": "internal/http/server.go", "issue": 379},
     {"path": "internal/http/router_protected.go", "issue": 379},
     {"path": "internal/http/user_portal.go", "issue": 379},
-    {"path": "internal/http/control_portal.go", "issue": 379}
+    {"path": "internal/http/control_portal.go", "issue": 379},
+    {"path": "internal/http/handler/mcp_logger.go", "issue": 380},
+    {"path": "internal/http/handler/mcp_logger_test.go", "issue": 380}
   ],
   "compatibility_bridges": [
     {

--- a/architecture/modules/mcp-transport.json
+++ b/architecture/modules/mcp-transport.json
@@ -1,6 +1,13 @@
 {
   "schema_version": 1,
   "capability": "mcp-transport",
+  "source_ownership": [
+    {"path": "internal/mcp/server.go", "issue": 380},
+    {"path": "internal/mcp/logger.go", "issue": 380},
+    {"path": "internal/mcp/conformance_harness_test.go", "issue": 380},
+    {"path": "internal/mcp/conformance_catalog_production_test.go", "issue": 380},
+    {"path": "internal/mcp/conformance_catalog_evaluation_test.go", "issue": 380}
+  ],
   "completed_issues": [],
   "go": {
     "units": [
@@ -14,13 +21,6 @@
   "browser": {
     "units": []
   },
-  "exceptions": [
-    {
-      "source": "github.com/markhuangai/dense-mem/internal/mcp",
-      "target": "github.com/markhuangai/dense-mem/internal/observability",
-      "removal_issue": 380,
-      "reason": "MCP transport still consumes the shared observability implementation until transport consolidation."
-    }
-  ],
+  "exceptions": [],
   "workers": []
 }

--- a/architecture/modules/memory-application.json
+++ b/architecture/modules/memory-application.json
@@ -115,30 +115,6 @@
       ],
       "consumers": [
         {
-          "path": "internal/tools/registry/contract_result_errors.go",
-          "symbol": "ActionableErrorData"
-        },
-        {
-          "path": "internal/tools/registry/contract_result_errors_test.go",
-          "symbol": "TestCorrectionToolResultErrorMapsLifecycleAndHTTPFailures"
-        },
-        {
-          "path": "internal/tools/registry/contract_result_errors_test.go",
-          "symbol": "TestCorrectionToolResultErrorPreservesTypedConflictReasons"
-        },
-        {
-          "path": "internal/tools/registry/contract_schema_helpers.go",
-          "symbol": "submissionStatusErrorSchema"
-        },
-        {
-          "path": "internal/tools/registry/uat_lifecycle_test.go",
-          "symbol": "stubLifecycleService.CorrectRelationship"
-        },
-        {
-          "path": "internal/tools/registry/uat_lifecycle_test.go",
-          "symbol": "stubLifecycleService.RetractEvidence"
-        },
-        {
           "path": "cmd/internal/serverapp/application_composition.go",
           "symbol": "buildApplicationBundle"
         }

--- a/architecture/modules/observability-port.json
+++ b/architecture/modules/observability-port.json
@@ -1,6 +1,9 @@
 {
   "schema_version": 1,
   "capability": "observability-port",
+  "source_ownership": [
+    {"path": "internal/observability/metrics_discoverability.go", "issue": 380}
+  ],
   "completed_issues": [],
   "go": {
     "units": [
@@ -11,6 +14,29 @@
       }
     ]
   },
+  "compatibility_bridges": [
+    {
+      "source_path": "internal/observability/metrics_discoverability.go",
+      "fields": ["RecallFeedback"],
+      "consumers": [
+        {"path": "internal/observability/metrics_discoverability.go", "symbol": "NoopDiscoverabilityMetrics"},
+        {"path": "internal/observability/metrics_discoverability.go", "symbol": "InMemoryDiscoverabilityMetrics.ObserveRecallFeedback"},
+        {"path": "internal/observability/prometheus_metrics.go", "symbol": "PrometheusMetrics.ObserveRecallFeedback"},
+        {"path": "internal/observability/prometheus_metrics.go", "symbol": "PrometheusMetrics.ObserveRecallFeedbackFor"},
+        {"path": "internal/observability/prometheus_metrics.go", "symbol": "RecordRecallFeedback"},
+        {"path": "internal/observability/metrics_discoverability_test.go", "symbol": "TestNoopDiscoverabilityMetricsNeverPanics"},
+        {"path": "internal/observability/metrics_discoverability_test.go", "symbol": "TestInMemoryDiscoverabilityMetricsRecordsActiveSignals"},
+        {"path": "internal/observability/metrics_discoverability_test.go", "symbol": "TestRecordDiscoverabilityMetricsUsesUnscopedRecorder"},
+        {"path": "internal/observability/metrics_discoverability_test.go", "symbol": "TestInMemoryDiscoverabilityMetricsIsConcurrentSafe"},
+        {"path": "internal/observability/prometheus_metrics_test.go", "symbol": "TestPrometheusMetricsRecordsActiveScopedSignals"},
+        {"path": "internal/observability/prometheus_metrics_test.go", "symbol": "TestPrometheusMetricsRecordsUnknownLabelsAndHelpers"},
+        {"path": "internal/observability/prometheus_metrics_test.go", "symbol": "TestNoopDiscoverabilityMetrics_ConsumesCalls"},
+        {"path": "internal/observability/prometheus_metrics_test.go", "symbol": "exerciseNilMetricHelpers"}
+      ],
+      "removal_issue": 382,
+      "removal_condition": "Remove the observability RecallFeedback alias after metric implementations and retained callers consume internal/recall/contract.FeedbackObservation directly."
+    }
+  ],
   "browser": {
     "units": []
   },

--- a/architecture/modules/recall-contract.json
+++ b/architecture/modules/recall-contract.json
@@ -1,6 +1,9 @@
 {
   "schema_version": 1,
   "capability": "recall-contract",
+  "source_ownership": [
+    {"path": "internal/recall/contract/feedback.go", "issue": 380}
+  ],
   "completed_issues": [],
   "go": {
     "units": [

--- a/architecture/modules/remember-application.json
+++ b/architecture/modules/remember-application.json
@@ -269,24 +269,11 @@
         {"path": "internal/knowledge/postgres/remember_result_test.go", "symbol": "TestRememberPublicResultUsesCanonicalCompletedProjection"},
         {"path": "internal/lifecycle/service_test.go", "symbol": "authenticatedRememberContext"},
         {"path": "internal/service/remember_attempt_diagnostics_service_test.go", "symbol": "TestRememberAttemptDiagnosticsServiceProjectsExchangesAndSafeResult"},
-        {"path": "internal/storage/postgres/synchronous_remember_cutover_migration_integration.e2e", "symbol": "TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement"},
-        {"path": "internal/tools/registry/contract_result_errors_test.go", "symbol": "TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance"},
-        {"path": "internal/tools/registry/contract_uat_test.go", "symbol": "TestBuildActiveWiresExecutableRemember"},
-        {"path": "internal/tools/registry/dream_tools_test.go", "symbol": "TestResolveDreamFeedbackReturnsStructuredTerminalFailure"}
+        {"path": "internal/storage/postgres/synchronous_remember_cutover_migration_integration.e2e", "symbol": "TestRememberSynchronousCutoverPreservesTerminalHistoryBeforeRetirement"}
       ],
       "removal_issue": 382,
       "implementation_owner": {"path": "internal/remember/service/service.go", "symbol": "NewService"},
       "removal_condition": "Remove the compatibility aliases after all named callers consume the native Remember service and contract packages."
-    },
-    {
-      "source_path": "internal/service/memoryservice/remember.go",
-      "fields": ["SynchronousAssessmentFailureDetails"],
-      "consumers": [
-        {"path": "internal/tools/registry/contract_result_errors.go", "symbol": "ActionableErrorData"}
-      ],
-      "removal_issue": 382,
-      "implementation_owner": {"path": "internal/remember/service/submission_assessment_shared.go", "symbol": "SynchronousAssessmentFailureDetails"},
-      "removal_condition": "Remove the memoryservice forwarder after registry error projection consumes the native helper directly."
     }
   ],
   "workers": []

--- a/architecture/modules/skill-pack-application.json
+++ b/architecture/modules/skill-pack-application.json
@@ -34,13 +34,6 @@
       ],
       "consumers": [
         {"path": "cmd/internal/serverapp/application_composition.go", "symbol": "buildApplicationBundle"},
-        {"path": "internal/tools/registry/capability_bindings.go", "symbol": "Dependencies.withCapabilityBindings"},
-        {"path": "internal/tools/registry/toolset.go", "symbol": "BuildActive"},
-        {"path": "internal/tools/registry/contract_outputs.go", "symbol": "exportMemoryPackContractOutput"},
-        {"path": "internal/tools/registry/contract_result_errors.go", "symbol": "ActionableErrorData"},
-        {"path": "internal/tools/registry/contract_output_validation_test.go", "symbol": "TestExportMemoryPackContractOutputMatchesClosedSchema"},
-        {"path": "internal/tools/registry/contract_result_errors_test.go", "symbol": "TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance"},
-        {"path": "internal/tools/registry/uat_memory_pack_test.go", "symbol": "TestBuildActiveWiresExportMemoryPackOnly"},
         {"path": "internal/service/skillpackservice/memory_pack_export_test.go", "symbol": "TestMemoryPackExportRejectsMissingInputsAndUnavailableRelationships"}
       ],
       "removal_issue": 382,

--- a/architecture/modules/tool-registry-application-api.json
+++ b/architecture/modules/tool-registry-application-api.json
@@ -33,13 +33,6 @@
   "browser": {
     "units": []
   },
-  "exceptions": [
-    {
-      "source": "github.com/markhuangai/dense-mem/internal/tools/registry",
-      "target": "github.com/markhuangai/dense-mem/internal/repository",
-      "removal_issue": 380,
-      "reason": "The tool registry still consumes the legacy repository until transport-owned production and evaluation registries are separated."
-    }
-  ],
+  "exceptions": [],
   "workers": []
 }

--- a/cmd/internal/serverapp/transport_composition.go
+++ b/cmd/internal/serverapp/transport_composition.go
@@ -142,7 +142,7 @@ func buildTransportComposition(deps transportCompositionInputs) (*transportCompo
 	)
 	mcpHandler := handler.NewMCPHandlerWithLifecycleAndRuntimeConfig(
 		deps.toolRegistry,
-		deps.logger,
+		handler.NewMCPLogger(deps.logger),
 		streamLifecycle,
 		deps.appConfig,
 		deps.dream,

--- a/internal/http/handler/mcp_handler.go
+++ b/internal/http/handler/mcp_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/markhuangai/dense-mem/internal/http/middleware"
 	"github.com/markhuangai/dense-mem/internal/httperr"
 	"github.com/markhuangai/dense-mem/internal/mcp"
-	"github.com/markhuangai/dense-mem/internal/observability"
 	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
 	"github.com/markhuangai/dense-mem/internal/sse"
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
@@ -25,7 +24,7 @@ import (
 // MCPHandler serves the MCP Streamable HTTP endpoint at /mcp.
 type MCPHandler struct {
 	reg                  registry.Registry
-	logger               observability.LogProvider
+	logger               mcp.Logger
 	lifecycle            sse.StreamLifecycle
 	recallFeedbackConfig registry.RecallFeedbackConfigProvider
 	dreams               registry.DreamingConfigProvider
@@ -40,17 +39,17 @@ type MCPHandlerInterface interface {
 var _ MCPHandlerInterface = (*MCPHandler)(nil)
 
 // NewMCPHandler constructs a Streamable HTTP MCP handler.
-func NewMCPHandler(reg registry.Registry, logger observability.LogProvider) *MCPHandler {
+func NewMCPHandler(reg registry.Registry, logger mcp.Logger) *MCPHandler {
 	return &MCPHandler{reg: reg, logger: logger}
 }
 
-func NewMCPHandlerWithLifecycle(reg registry.Registry, logger observability.LogProvider, lifecycle sse.StreamLifecycle) *MCPHandler {
+func NewMCPHandlerWithLifecycle(reg registry.Registry, logger mcp.Logger, lifecycle sse.StreamLifecycle) *MCPHandler {
 	return &MCPHandler{reg: reg, logger: logger, lifecycle: lifecycle}
 }
 
 // NewMCPHandlerWithLifecycleAndRuntimeConfig constructs a Streamable HTTP MCP
 // handler with runtime feature visibility.
-func NewMCPHandlerWithLifecycleAndRuntimeConfig(reg registry.Registry, logger observability.LogProvider, lifecycle sse.StreamLifecycle, recallFeedbackConfig registry.RecallFeedbackConfigProvider, dreams ...registry.DreamingConfigProvider) *MCPHandler {
+func NewMCPHandlerWithLifecycleAndRuntimeConfig(reg registry.Registry, logger mcp.Logger, lifecycle sse.StreamLifecycle, recallFeedbackConfig registry.RecallFeedbackConfigProvider, dreams ...registry.DreamingConfigProvider) *MCPHandler {
 	var dreamConfig registry.DreamingConfigProvider
 	if len(dreams) > 0 {
 		dreamConfig = dreams[0]

--- a/internal/http/handler/mcp_handler_test.go
+++ b/internal/http/handler/mcp_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/markhuangai/dense-mem/internal/http/middleware"
+	"github.com/markhuangai/dense-mem/internal/mcp"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/sse"
 	"github.com/markhuangai/dense-mem/internal/tools/registry"
@@ -435,6 +436,6 @@ func mcpTestContext(ctx context.Context, profileID uuid.UUID, scopes []string) c
 	return middleware.SetPrincipalForTest(ctx, &middleware.Principal{TeamID: profileID, OwnerID: profileID, Grants: scopes})
 }
 
-func testMCPLogger() observability.LogProvider {
-	return observability.NewWithHandler(slog.NewJSONHandler(io.Discard, nil))
+func testMCPLogger() mcp.Logger {
+	return NewMCPLogger(observability.NewWithHandler(slog.NewJSONHandler(io.Discard, nil)))
 }

--- a/internal/http/handler/mcp_logger.go
+++ b/internal/http/handler/mcp_logger.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"github.com/markhuangai/dense-mem/internal/mcp"
+	"github.com/markhuangai/dense-mem/internal/observability"
+)
+
+// NewMCPLogger adapts the shared sanitized logger at the HTTP-to-MCP
+// composition boundary. MCP itself depends only on its narrow transport port.
+func NewMCPLogger(logger observability.LogProvider) mcp.Logger {
+	if logger == nil {
+		return nil
+	}
+	return mcpLoggerAdapter{logger: logger}
+}
+
+type mcpLoggerAdapter struct {
+	logger observability.LogProvider
+}
+
+func (a mcpLoggerAdapter) Error(message string, err error, fields ...mcp.LogField) {
+	a.logger.Error(message, err, observabilityFields(fields)...)
+}
+
+func (a mcpLoggerAdapter) Warn(message string, fields ...mcp.LogField) {
+	a.logger.Warn(message, observabilityFields(fields)...)
+}
+
+func observabilityFields(fields []mcp.LogField) []observability.LogAttr {
+	converted := make([]observability.LogAttr, 0, len(fields))
+	for _, field := range fields {
+		converted = append(converted, observability.LogAttr{Key: field.Key, Value: field.Value})
+	}
+	return converted
+}

--- a/internal/http/handler/mcp_logger_test.go
+++ b/internal/http/handler/mcp_logger_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/markhuangai/dense-mem/internal/mcp"
+	"github.com/markhuangai/dense-mem/internal/observability"
+)
+
+func TestNewMCPLoggerPreservesSanitizedLogging(t *testing.T) {
+	var output bytes.Buffer
+	logger := observability.NewWithHandler(slog.NewJSONHandler(&output, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	adapted := NewMCPLogger(logger)
+
+	adapted.Warn("mcp_tool_input_rejected", mcp.LogField{Key: "token", Value: "secret-token"}, mcp.LogField{Key: "tool", Value: "remember"})
+	adapted.Error("mcp tool failed", errors.New("upstream password=secret-password"), mcp.LogField{Key: "team_id", Value: "team-a"})
+
+	text := output.String()
+	if !strings.Contains(text, `"msg":"mcp_tool_input_rejected"`) || !strings.Contains(text, `"tool":"remember"`) {
+		t.Fatalf("adapted warning = %s", text)
+	}
+	if strings.Contains(text, "secret-token") || strings.Contains(text, "secret-password") {
+		t.Fatalf("adapted logger leaked sensitive data: %s", text)
+	}
+}
+
+func TestNewMCPLoggerNilIsSafe(t *testing.T) {
+	if NewMCPLogger(nil) != nil {
+		t.Fatal("nil logger should remain nil")
+	}
+}

--- a/internal/mcp/conformance_catalog_evaluation_test.go
+++ b/internal/mcp/conformance_catalog_evaluation_test.go
@@ -1,0 +1,5 @@
+//go:build evaluation
+
+package mcp
+
+func conformanceCatalogSize() int { return 13 }

--- a/internal/mcp/conformance_catalog_production_test.go
+++ b/internal/mcp/conformance_catalog_production_test.go
@@ -1,0 +1,5 @@
+//go:build !evaluation
+
+package mcp
+
+func conformanceCatalogSize() int { return 10 }

--- a/internal/mcp/conformance_harness_test.go
+++ b/internal/mcp/conformance_harness_test.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/markhuangai/dense-mem/internal/tools/registry"
+)
+
+// TestConformanceHarness is the production-entry proof used by the MCP SDK
+// parity scenario. It keeps registry metadata and SDK execution on one path.
+func TestConformanceHarness(t *testing.T) {
+	active, err := registry.BuildActive(registry.Dependencies{})
+	if err != nil {
+		t.Fatalf("BuildActive: %v", err)
+	}
+	if got := len(active.List()); got != conformanceCatalogSize() {
+		t.Fatalf("active catalog size = %d, want %d", got, conformanceCatalogSize())
+	}
+
+	probeCalls := 0
+	probe := registry.Tool{
+		Name: "probe",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"required":             []string{"value"},
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"value": map[string]any{"type": "string", "minLength": 1},
+			},
+		},
+		OutputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties":           map[string]any{"value": map[string]any{"type": "string"}},
+		},
+		RequiredScopes: []string{"read"},
+		Invoke: func(_ context.Context, _ string, input map[string]any) (map[string]any, error) {
+			probeCalls++
+			return map[string]any{"value": input["value"]}, nil
+		},
+	}
+	reg := registry.New()
+	if err := reg.Register(probe); err != nil {
+		t.Fatalf("register probe: %v", err)
+	}
+	server := NewServerWithScopes(reg, "team-a", []string{"read"}, nil)
+
+	list := conformanceRPC(t, server, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	if list.Error != nil {
+		t.Fatalf("tools/list error = %+v", list.Error)
+	}
+	var listed struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(list.Result, &listed); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	if len(listed.Tools) != 1 || listed.Tools[0].Name != "probe" {
+		t.Fatalf("tools/list = %+v, want probe", listed.Tools)
+	}
+
+	call := conformanceRPC(t, server, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"probe","arguments":{"value":"ok"}}}`)
+	if call.Error != nil {
+		t.Fatalf("tools/call error = %+v", call.Error)
+	}
+	var result struct {
+		StructuredContent map[string]any `json:"structuredContent"`
+		IsError           bool           `json:"isError"`
+	}
+	if err := json.Unmarshal(call.Result, &result); err != nil {
+		t.Fatalf("decode tools/call: %v", err)
+	}
+	if result.IsError || result.StructuredContent["value"] != "ok" || probeCalls != 1 {
+		t.Fatalf("tools/call result = %+v, calls = %d", result, probeCalls)
+	}
+
+	invalid := conformanceRPC(t, server, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"probe","arguments":{"value":"ok","unexpected":true}}}`)
+	if invalid.Error == nil || invalid.Error.Code != errCodeInvalidParams {
+		t.Fatalf("invalid tools/call = %+v, want invalid params", invalid.Error)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("invalid call invoked probe %d times", probeCalls)
+	}
+
+	unknown := conformanceRPC(t, server, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"missing","arguments":{}}}`)
+	if unknown.Error == nil || unknown.Error.Code != errCodeMethodNotFound {
+		t.Fatalf("unknown tools/call = %+v, want method not found", unknown.Error)
+	}
+
+	unauthorized := NewServerWithScopes(reg, "team-a", []string{"write"}, nil)
+	unauthorizedList := conformanceRPC(t, unauthorized, `{"jsonrpc":"2.0","id":5,"method":"tools/list","params":{}}`)
+	var unauthorizedPayload struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(unauthorizedList.Result, &unauthorizedPayload); err != nil {
+		t.Fatalf("decode unauthorized tools/list: %v", err)
+	}
+	if len(unauthorizedPayload.Tools) != 0 {
+		t.Fatalf("unauthorized tools/list = %+v, want empty", unauthorizedPayload.Tools)
+	}
+	unauthorizedCall := conformanceRPC(t, unauthorized, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"probe","arguments":{"value":"ok"}}}`)
+	if unauthorizedCall.Error == nil || unauthorizedCall.Error.Code != errCodeToolFailure {
+		t.Fatalf("unauthorized tools/call = %+v, want bounded authorization failure", unauthorizedCall.Error)
+	}
+	if unauthorizedCall.Error.Data == nil {
+		t.Fatal("unauthorized tools/call omitted actionable authorization data")
+	}
+
+	testConformanceCancellation(t)
+}
+
+func conformanceRPC(t *testing.T, server *Server, payload string) rpcResp {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", ProtocolVersion)
+	response := httptest.NewRecorder()
+	server.NewSDKHTTPHandler(true).ServeHTTP(response, req)
+	var decoded rpcResp
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode MCP response: %v; body=%q", err, response.Body.String())
+	}
+	return decoded
+}
+
+func testConformanceCancellation(t *testing.T) {
+	t.Helper()
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	reg := registry.New()
+	if err := reg.Register(registry.Tool{
+		Name:           "wait_for_cancel",
+		InputSchema:    map[string]any{"type": "object", "additionalProperties": false},
+		OutputSchema:   map[string]any{"type": "object"},
+		RequiredScopes: []string{"read"},
+		Invoke: func(ctx context.Context, _ string, _ map[string]any) (map[string]any, error) {
+			close(started)
+			<-ctx.Done()
+			close(finished)
+			return nil, ctx.Err()
+		},
+	}); err != nil {
+		t.Fatalf("register cancellation tool: %v", err)
+	}
+	server := NewServerWithScopes(reg, "team-a", []string{"read"}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"wait_for_cancel","arguments":{},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	// Request cancellation propagation is defined for the current stateless
+	// protocol, whose POST owns the complete request lifecycle.
+	req.Header.Set("MCP-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "wait_for_cancel")
+	response := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		server.NewSDKHTTPHandler(true).ServeHTTP(response, req)
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation tool did not start")
+	}
+	cancel()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation was not propagated to the registry invoker")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SDK handler did not return after cancellation")
+	}
+}

--- a/internal/mcp/logger.go
+++ b/internal/mcp/logger.go
@@ -1,0 +1,16 @@
+package mcp
+
+// LogField is the bounded attribute shape accepted by the MCP transport
+// logger. The transport owns this shape so it does not depend on a logging
+// implementation or backend package.
+type LogField struct {
+	Key   string
+	Value any
+}
+
+// Logger is the minimal logging surface needed by MCP protocol handling.
+// Implementations remain responsible for redaction and sink behavior.
+type Logger interface {
+	Error(string, error, ...LogField)
+	Warn(string, ...LogField)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/markhuangai/dense-mem/internal/correlation"
-	"github.com/markhuangai/dense-mem/internal/observability"
 	"github.com/markhuangai/dense-mem/internal/promptcatalog"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
 	"github.com/markhuangai/dense-mem/internal/tools"
@@ -49,7 +48,7 @@ type Server struct {
 	teamID            string
 	scopes            []string
 	team              TeamContext
-	logger            observability.LogProvider
+	logger            Logger
 	runtimeToolPolicy registry.RuntimeToolPolicy
 	prompts           promptcatalog.Catalog
 }
@@ -62,24 +61,24 @@ type TeamContext struct {
 }
 
 // NewServer constructs a Server bound to a registry and a fixed team ID.
-func NewServer(reg registry.Registry, teamID string, logger observability.LogProvider) *Server {
+func NewServer(reg registry.Registry, teamID string, logger Logger) *Server {
 	return NewServerWithScopesAndTeamContext(reg, teamID, nil, TeamContext{}, logger)
 }
 
 // NewServerWithScopes constructs a Server that filters visible/callable tools by scope.
-func NewServerWithScopes(reg registry.Registry, teamID string, scopes []string, logger observability.LogProvider) *Server {
+func NewServerWithScopes(reg registry.Registry, teamID string, scopes []string, logger Logger) *Server {
 	return NewServerWithScopesAndTeamContext(reg, teamID, scopes, TeamContext{}, logger)
 }
 
 // NewServerWithScopesAndTeamContext constructs a Server with request-scoped team
 // metadata for MCP discovery surfaces.
-func NewServerWithScopesAndTeamContext(reg registry.Registry, teamID string, scopes []string, team TeamContext, logger observability.LogProvider) *Server {
+func NewServerWithScopesAndTeamContext(reg registry.Registry, teamID string, scopes []string, team TeamContext, logger Logger) *Server {
 	return NewServerWithScopesTeamContextAndRuntimeConfig(reg, teamID, scopes, team, logger, nil)
 }
 
 // NewServerWithScopesTeamContextAndRuntimeConfig constructs a Server with
 // request-scoped team metadata and runtime feature visibility.
-func NewServerWithScopesTeamContextAndRuntimeConfig(reg registry.Registry, teamID string, scopes []string, team TeamContext, logger observability.LogProvider, recallFeedbackConfig registry.RecallFeedbackConfigProvider, dreams ...registry.DreamingConfigProvider) *Server {
+func NewServerWithScopesTeamContextAndRuntimeConfig(reg registry.Registry, teamID string, scopes []string, team TeamContext, logger Logger, recallFeedbackConfig registry.RecallFeedbackConfigProvider, dreams ...registry.DreamingConfigProvider) *Server {
 	var dreamConfig registry.DreamingConfigProvider
 	if len(dreams) > 0 {
 		dreamConfig = dreams[0]
@@ -196,8 +195,8 @@ func (s *Server) invokeTool(ctx context.Context, name string, args map[string]an
 		}
 		if s.logger != nil {
 			s.logger.Error("mcp: tool invocation failed", errors.New(safeMessage),
-				observability.String("tool", name),
-				observability.String("team_id", s.teamID),
+				LogField{Key: "tool", Value: name},
+				LogField{Key: "team_id", Value: s.teamID},
 			)
 		}
 		return nil, &rpcError{Code: errCodeToolFailure, Message: boundedRPCText(safeMessage), Data: actionable}
@@ -206,7 +205,7 @@ func (s *Server) invokeTool(ctx context.Context, name string, args map[string]an
 	payload, err := json.Marshal(result)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Error("mcp: tool result marshal failed", errors.New("tool result serialization failed"), observability.String("tool", name))
+			s.logger.Error("mcp: tool result marshal failed", errors.New("tool result serialization failed"), LogField{Key: "tool", Value: name})
 		}
 		data := registry.ActionableSerializationFailureData(ctx, tool.Name)
 		return nil, &rpcError{Code: errCodeToolFailure, Message: "Dense-Mem could not serialize the result for this operation.", Data: data}
@@ -222,18 +221,18 @@ func (s *Server) logToolInputRejected(ctx context.Context, toolName, reasonCode 
 	if s.logger == nil {
 		return
 	}
-	attrs := []observability.LogAttr{
-		observability.String("tool", toolName),
-		observability.String("team_id", s.teamID),
-		observability.String("reference_type", "mcp_tool"),
-		observability.String("reference_id", toolName),
-		observability.String("reason_code", reasonCode),
+	attrs := []LogField{
+		{Key: "tool", Value: toolName},
+		{Key: "team_id", Value: s.teamID},
+		{Key: "reference_type", Value: "mcp_tool"},
+		{Key: "reference_id", Value: toolName},
+		{Key: "reason_code", Value: reasonCode},
 	}
 	if correlationID := correlation.FromContext(ctx); correlationID != "" {
-		attrs = append(attrs, observability.CorrelationID(correlationID))
+		attrs = append(attrs, LogField{Key: "correlation_id", Value: correlationID})
 	}
 	if actor, ok := requestctx.ActorFromContext(ctx); ok && actor.OwnerID != uuid.Nil {
-		attrs = append(attrs, observability.ProfileID(actor.OwnerID.String()))
+		attrs = append(attrs, LogField{Key: "profile_id", Value: actor.OwnerID.String()})
 	}
 	s.logger.Warn("mcp_tool_input_rejected", attrs...)
 }
@@ -358,15 +357,15 @@ func slugifyMCPName(value string) string {
 	return strings.Trim(b.String(), "-")
 }
 
-func defaultPromptCatalog(logger observability.LogProvider) promptcatalog.Catalog {
+func defaultPromptCatalog(logger Logger) promptcatalog.Catalog {
 	return promptCatalogOrEmpty(logger, promptcatalog.Default)
 }
 
-func promptCatalogOrEmpty(logger observability.LogProvider, load func() (promptcatalog.Catalog, error)) promptcatalog.Catalog {
+func promptCatalogOrEmpty(logger Logger, load func() (promptcatalog.Catalog, error)) promptcatalog.Catalog {
 	catalog, err := load()
 	if err != nil {
 		if logger != nil {
-			logger.Warn("mcp: prompt catalog unavailable", observability.String("error", tools.SanitizeError(err)))
+			logger.Warn("mcp: prompt catalog unavailable", LogField{Key: "error", Value: tools.SanitizeError(err)})
 		}
 		return promptcatalog.Catalog{}
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -46,11 +46,31 @@ func (s dreamingConfigStub) EffectiveConfig(context.Context, string) (dream.Effe
 }
 
 // testLogger returns a LogProvider that writes to a bytes.Buffer.
-func testLogger(t *testing.T) (observability.LogProvider, *bytes.Buffer) {
+func testLogger(t *testing.T) (Logger, *bytes.Buffer) {
 	t.Helper()
 	buf := &bytes.Buffer{}
 	h := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	return observability.NewWithHandler(h), buf
+	return testLoggerAdapter{delegate: observability.NewWithHandler(h)}, buf
+}
+
+type testLoggerAdapter struct {
+	delegate observability.LogProvider
+}
+
+func (l testLoggerAdapter) Error(message string, err error, fields ...LogField) {
+	l.delegate.Error(message, err, testObservabilityFields(fields)...)
+}
+
+func (l testLoggerAdapter) Warn(message string, fields ...LogField) {
+	l.delegate.Warn(message, testObservabilityFields(fields)...)
+}
+
+func testObservabilityFields(fields []LogField) []observability.LogAttr {
+	converted := make([]observability.LogAttr, 0, len(fields))
+	for _, field := range fields {
+		converted = append(converted, observability.LogAttr{Key: field.Key, Value: field.Value})
+	}
+	return converted
 }
 
 // runRPC feeds one frozen protocol fixture through the official SDK transport.

--- a/internal/observability/metrics_discoverability.go
+++ b/internal/observability/metrics_discoverability.go
@@ -3,6 +3,8 @@ package observability
 import (
 	"strings"
 	"sync"
+
+	recallcontract "github.com/markhuangai/dense-mem/internal/recall/contract"
 )
 
 // DiscoverabilityMetrics is the concurrency-safe metrics contract used by
@@ -105,14 +107,9 @@ type RecallSample struct {
 	Outcome     string
 }
 
-// RecallFeedback is one host-LLM online quality judgment for a recall result set.
-type RecallFeedback struct {
-	Used            bool
-	AnswerSupported bool
-	Quality         string
-	MissingContext  bool
-	Irrelevant      bool
-}
+// RecallFeedback is retained as a source-compatible alias for the Recall
+// capability's metrics port shape.
+type RecallFeedback = recallcontract.FeedbackObservation
 
 // RecallFeedbackSample is one recorded online recall-feedback event.
 type RecallFeedbackSample struct {

--- a/internal/recall/contract/feedback.go
+++ b/internal/recall/contract/feedback.go
@@ -10,6 +10,31 @@ import (
 
 var ErrRecallFeedbackEventNotFound = errors.New("recall feedback event not found")
 
+// FeedbackObservation is the bounded metric projection for one accepted
+// recall-feedback submission. It contains no request identity or free-form
+// text, so the feedback port cannot create sensitive metric labels.
+type FeedbackObservation struct {
+	Used            bool
+	AnswerSupported bool
+	Quality         string
+	MissingContext  bool
+	Irrelevant      bool
+}
+
+// FeedbackMetrics records accepted recall feedback for the Recall capability.
+// Implementations may attach request identity through the optional contextual
+// extension below.
+type FeedbackMetrics interface {
+	ObserveRecallFeedback(FeedbackObservation)
+}
+
+// ContextualFeedbackMetrics preserves request-scoped metric attribution when
+// an implementation supports it without widening the required port.
+type ContextualFeedbackMetrics interface {
+	FeedbackMetrics
+	ObserveRecallFeedbackFor(context.Context, FeedbackObservation)
+}
+
 // FeedbackEventRepository is the persistence port for Recall session
 // snapshots and their subsequent feedback.
 type FeedbackEventRepository interface {

--- a/internal/recall/feedback.go
+++ b/internal/recall/feedback.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/observability"
 	recallcontract "github.com/markhuangai/dense-mem/internal/recall/contract"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
 )
@@ -81,7 +80,7 @@ type RecallFeedbackBatchFailure struct {
 func SubmitRecallFeedbackBatch(
 	ctx context.Context,
 	recorder RecallFeedbackEventRecorder,
-	metrics observability.DiscoverabilityMetrics,
+	metrics recallcontract.FeedbackMetrics,
 	submissions []domain.RecallFeedbackSubmission,
 ) RecallFeedbackBatchResult {
 	result := RecallFeedbackBatchResult{}
@@ -106,7 +105,7 @@ func SubmitRecallFeedbackBatch(
 			result.Recorded = result.RecordedCount > 0
 			return result
 		}
-		observability.RecordRecallFeedback(ctx, metrics, observability.RecallFeedback{
+		recordRecallFeedbackMetric(ctx, metrics, recallcontract.FeedbackObservation{
 			Used:            submission.Used,
 			AnswerSupported: submission.AnswerSupported,
 			Quality:         submission.Quality,
@@ -117,6 +116,17 @@ func SubmitRecallFeedbackBatch(
 	}
 	result.Recorded = result.RecordedCount > 0
 	return result
+}
+
+func recordRecallFeedbackMetric(ctx context.Context, metrics recallcontract.FeedbackMetrics, observation recallcontract.FeedbackObservation) {
+	if metrics == nil {
+		return
+	}
+	if contextual, ok := metrics.(recallcontract.ContextualFeedbackMetrics); ok {
+		contextual.ObserveRecallFeedbackFor(ctx, observation)
+		return
+	}
+	metrics.ObserveRecallFeedback(observation)
 }
 
 type recallFeedbackFailureGuidanceResult struct {

--- a/internal/recall/feedback_test.go
+++ b/internal/recall/feedback_test.go
@@ -83,6 +83,16 @@ func TestSubmitRecallFeedbackBatchClassifiesInvalidInput(t *testing.T) {
 	assert.Equal(t, "correct_and_resubmit", result.Failure.NextAction)
 }
 
+func TestSubmitRecallFeedbackBatchUsesContextualMetrics(t *testing.T) {
+	ctx := recallFeedbackActorContext(uuid.New(), uuid.New(), uuid.New(), 1)
+	metrics := &contextualFeedbackMetrics{}
+	result := SubmitRecallFeedbackBatch(ctx, &recallFeedbackBatchRecorder{}, metrics, []domain.RecallFeedbackSubmission{{RecallID: "rec-1", Quality: "high"}})
+
+	require.True(t, result.Recorded)
+	require.Equal(t, ctx, metrics.ctx)
+	require.Equal(t, "high", metrics.observation.Quality)
+}
+
 func TestRecallFeedbackEventServiceRecordsSnapshotWithActorContext(t *testing.T) {
 	ctx := context.Background()
 	teamID := uuid.New()
@@ -444,6 +454,20 @@ type recallFeedbackBatchRecorder struct {
 	failAt      int
 	err         error
 	submissions []domain.RecallFeedbackSubmission
+}
+
+type contextualFeedbackMetrics struct {
+	ctx         context.Context
+	observation recallcontract.FeedbackObservation
+}
+
+func (m *contextualFeedbackMetrics) ObserveRecallFeedback(observation recallcontract.FeedbackObservation) {
+	m.observation = observation
+}
+
+func (m *contextualFeedbackMetrics) ObserveRecallFeedbackFor(ctx context.Context, observation recallcontract.FeedbackObservation) {
+	m.ctx = ctx
+	m.observation = observation
 }
 
 func (r *recallFeedbackBatchRecorder) RecordRecallSnapshot(context.Context, domain.RecallFeedbackEvent) error {

--- a/internal/tools/registry/capability_bindings.go
+++ b/internal/tools/registry/capability_bindings.go
@@ -3,25 +3,25 @@ package registry
 import (
 	"github.com/markhuangai/dense-mem/internal/dream"
 	"github.com/markhuangai/dense-mem/internal/lifecycle"
-	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 	"github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	recallcontract "github.com/markhuangai/dense-mem/internal/recall/contract"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
 )
 
 // CoreDependencies are shared immutable inputs used by multiple registry
 // capabilities. They carry providers and policy owners; they do not contain
 // capability-specific invokers.
 type CoreDependencies struct {
-	Metrics              observability.DiscoverabilityMetrics
+	Metrics              recallcontract.FeedbackMetrics
 	RecallFeedbackConfig RecallFeedbackConfigProvider
 	RecallFeedbackEvents RecallFeedbackEventRecorder
 	EvaluationAudit      EvaluationAuditAppender
 }
 
 type RememberBindings struct {
-	Service memoryservice.RememberService
+	Service rememberapp.Service
 }
 
 type LifecycleBindings struct {
@@ -34,7 +34,7 @@ type RecallBindings struct {
 }
 
 type TraceBindings struct {
-	Service contextservice.Service
+	Service traceapp.Service
 }
 
 type DreamBindings struct {
@@ -42,7 +42,7 @@ type DreamBindings struct {
 }
 
 type MemoryPackBindings struct {
-	Service skillpackservice.MemoryPackService
+	Service memorypack.MemoryPackService
 }
 
 func (d Dependencies) withCapabilityBindings() Dependencies {

--- a/internal/tools/registry/contract_output_validation_test.go
+++ b/internal/tools/registry/contract_output_validation_test.go
@@ -3,18 +3,18 @@ package registry
 import (
 	"testing"
 
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 )
 
 func TestExportMemoryPackContractOutputMatchesClosedSchema(t *testing.T) {
-	output := exportMemoryPackContractOutput(&skillpackservice.ExportResult{
+	output := exportMemoryPackContractOutput(&memorypack.ExportResult{
 		CanonicalJSON: `{"format":"dense-mem.memory-pack.v2.4"}`,
 		SHA256:        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		Filename:      "pack.memory-pack.json",
 		ItemCount:     1,
-		Artifact: skillpackservice.MemoryPackArtifact{
-			Evidence:         []skillpackservice.MemoryPackEvidence{{EvidenceID: "evidence-1"}},
-			EvidenceSupports: []skillpackservice.MemoryPackEvidenceSupport{{EvidenceID: "evidence-1"}},
+		Artifact: memorypack.MemoryPackArtifact{
+			Evidence:         []memorypack.MemoryPackEvidence{{EvidenceID: "evidence-1"}},
+			EvidenceSupports: []memorypack.MemoryPackEvidenceSupport{{EvidenceID: "evidence-1"}},
 		},
 	})
 	if err := ValidateInput(Tool{InputSchema: exportMemoryPackOutputSchema()}, output); err != nil {

--- a/internal/tools/registry/contract_outputs.go
+++ b/internal/tools/registry/contract_outputs.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/dream"
+	"github.com/markhuangai/dense-mem/internal/graph/contract"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 	"github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
 )
 
-func rememberRequestFromContractInput(input map[string]any) (memoryservice.RememberRequest, error) {
-	var req memoryservice.RememberRequest
+func rememberRequestFromContractInput(input map[string]any) (rememberapp.RememberRequest, error) {
+	var req rememberapp.RememberRequest
 	if err := remapInput(input, &req); err != nil {
 		return req, err
 	}
@@ -110,9 +110,9 @@ func recallContractOutput(res *recall.RecallResult) map[string]any {
 	}
 }
 
-func traceContractOutput(trace *contextservice.SemanticTrace) (map[string]any, error) {
+func traceContractOutput(trace *traceapp.SemanticTrace) (map[string]any, error) {
 	if trace == nil {
-		trace = &contextservice.SemanticTrace{}
+		trace = &traceapp.SemanticTrace{}
 	}
 	stoppedReason := any(nil)
 	if strings.TrimSpace(trace.StoppedReason) != "" {
@@ -138,14 +138,14 @@ func traceContractOutput(trace *contextservice.SemanticTrace) (map[string]any, e
 	}, nil
 }
 
-func traceRelationshipOutput(record *repository.RelationshipTraceRecord) map[string]any {
+func traceRelationshipOutput(record *tracecontract.RelationshipTraceRecord) map[string]any {
 	if record == nil {
 		return nil
 	}
 	return traceRelationshipRecordOutput(*record)
 }
 
-func traceRelationshipLineageOutputs(records []repository.RelationshipTraceRecord) []map[string]any {
+func traceRelationshipLineageOutputs(records []tracecontract.RelationshipTraceRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		out = append(out, traceRelationshipRecordOutput(record))
@@ -153,7 +153,7 @@ func traceRelationshipLineageOutputs(records []repository.RelationshipTraceRecor
 	return out
 }
 
-func traceRelationshipRecordOutput(record repository.RelationshipTraceRecord) map[string]any {
+func traceRelationshipRecordOutput(record tracecontract.RelationshipTraceRecord) map[string]any {
 	out := map[string]any{
 		"relationship_id": record.RelationshipID,
 	}
@@ -174,7 +174,7 @@ func traceRelationshipRecordOutput(record repository.RelationshipTraceRecord) ma
 	return out
 }
 
-func traceObservationOutputs(records []repository.RelationshipObservationRecord) []map[string]any {
+func traceObservationOutputs(records []tracecontract.RelationshipObservationRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -192,7 +192,7 @@ func traceObservationOutputs(records []repository.RelationshipObservationRecord)
 	return out
 }
 
-func traceEvidenceSupportOutputs(records []repository.RelationshipEvidenceSupportRecord) []map[string]any {
+func traceEvidenceSupportOutputs(records []tracecontract.RelationshipEvidenceSupportRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -215,7 +215,7 @@ func traceEvidenceSupportOutputs(records []repository.RelationshipEvidenceSuppor
 	return out
 }
 
-func traceSupportDecisionOutputs(records []repository.RelationshipSupportDecisionEvent) []map[string]any {
+func traceSupportDecisionOutputs(records []tracecontract.RelationshipSupportDecisionEvent) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -232,7 +232,7 @@ func traceSupportDecisionOutputs(records []repository.RelationshipSupportDecisio
 	return out
 }
 
-func traceEvidenceOutputs(records []repository.TraceEvidenceFragment) []map[string]any {
+func traceEvidenceOutputs(records []tracecontract.TraceEvidenceFragment) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -252,7 +252,7 @@ func traceEvidenceOutputs(records []repository.TraceEvidenceFragment) []map[stri
 	return out
 }
 
-func traceEvidenceLifecycleEventOutputs(records []repository.TraceEvidenceLifecycleEvent) []map[string]any {
+func traceEvidenceLifecycleEventOutputs(records []tracecontract.TraceEvidenceLifecycleEvent) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -269,7 +269,7 @@ func traceEvidenceLifecycleEventOutputs(records []repository.TraceEvidenceLifecy
 	return out
 }
 
-func traceVerificationOutputs(records []repository.RelationshipVerificationEvent) []map[string]any {
+func traceVerificationOutputs(records []tracecontract.RelationshipVerificationEvent) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -287,7 +287,7 @@ func traceVerificationOutputs(records []repository.RelationshipVerificationEvent
 	return out
 }
 
-func traceTransitionOutputs(records []repository.RelationshipTransitionEvent) []map[string]any {
+func traceTransitionOutputs(records []tracecontract.RelationshipTransitionEvent) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -303,7 +303,7 @@ func traceTransitionOutputs(records []repository.RelationshipTransitionEvent) []
 	return out
 }
 
-func traceConflictOutputs(records []repository.RelationshipConflictCaseRecord) []map[string]any {
+func traceConflictOutputs(records []tracecontract.RelationshipConflictCaseRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		positions := traceConflictPositionOutputs(record.Positions)
@@ -333,7 +333,7 @@ const (
 	traceConflictResultEvidenceIDLimit = 50
 )
 
-func traceConflictPositionOutputs(records []repository.RelationshipConflictPositionRecord) []map[string]any {
+func traceConflictPositionOutputs(records []domain.RelationshipConflictPositionRecord) []map[string]any {
 	if len(records) > traceConflictPositionLimit {
 		records = records[:traceConflictPositionLimit]
 	}
@@ -354,7 +354,7 @@ func traceConflictPositionOutputs(records []repository.RelationshipConflictPosit
 	return out
 }
 
-func traceConflictSupporterOutputs(records []repository.RelationshipConflictSupporterRecord) []map[string]any {
+func traceConflictSupporterOutputs(records []domain.RelationshipConflictSupporterRecord) []map[string]any {
 	if len(records) > traceConflictSupporterLimit {
 		records = records[:traceConflictSupporterLimit]
 	}
@@ -378,7 +378,7 @@ func traceBoundedStringArray(values []string, limit int) []string {
 	return traceStringArray(values)
 }
 
-func traceCrossProfileReferenceOutputs(records []repository.RelationshipCrossReferenceRecord) []map[string]any {
+func traceCrossProfileReferenceOutputs(records []tracecontract.RelationshipCrossReferenceRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		out = append(out, map[string]any{
@@ -391,7 +391,7 @@ func traceCrossProfileReferenceOutputs(records []repository.RelationshipCrossRef
 	return out
 }
 
-func traceIdentityCorrectionOutputs(records []repository.EntityCorrectionEventRecord) []map[string]any {
+func traceIdentityCorrectionOutputs(records []tracecontract.EntityCorrectionEventRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		item := map[string]any{
@@ -408,7 +408,7 @@ func traceIdentityCorrectionOutputs(records []repository.EntityCorrectionEventRe
 	return out
 }
 
-func traceSemanticNodeOutputs(records []repository.SemanticGraphNode) []map[string]any {
+func traceSemanticNodeOutputs(records []contract.Node) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		out = append(out, map[string]any{
@@ -420,7 +420,7 @@ func traceSemanticNodeOutputs(records []repository.SemanticGraphNode) []map[stri
 	return out
 }
 
-func traceSemanticEdgeOutputs(records []repository.SemanticGraphEdge) []map[string]any {
+func traceSemanticEdgeOutputs(records []contract.Edge) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		out = append(out, map[string]any{
@@ -548,7 +548,7 @@ func resolveDreamTerminalOutcome(res *dream.ResolveFeedbackResult) (map[string]a
 	return output, true, nil
 }
 
-func exportMemoryPackContractOutput(res *skillpackservice.ExportResult) map[string]any {
+func exportMemoryPackContractOutput(res *memorypack.ExportResult) map[string]any {
 	if res == nil {
 		return map[string]any{
 			"artifact_json":  "",

--- a/internal/tools/registry/contract_outputs_test.go
+++ b/internal/tools/registry/contract_outputs_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	recallapp "github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/repository"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
 	"github.com/stretchr/testify/require"
 )
 
@@ -136,7 +136,7 @@ func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 	dueAt := time.Date(2026, 7, 25, 4, 0, 0, 0, time.UTC)
 	effectiveAt := dueAt.Add(time.Hour)
 	acceptedAt := dueAt.Add(-time.Hour)
-	out := traceConflictOutputs([]repository.RelationshipConflictCaseRecord{{
+	out := traceConflictOutputs([]tracecontract.RelationshipConflictCaseRecord{{
 		ConflictID:          "00000000-0000-0000-0000-000000000101",
 		Version:             2,
 		Kind:                "cross_profile_current_state",
@@ -146,11 +146,11 @@ func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 		EffectiveAt:         &effectiveAt,
 		EffectiveTimeBasis:  "valid_from",
 		PreferredPositionID: "00000000-0000-0000-0000-000000000201",
-		Positions: []repository.RelationshipConflictPositionRecord{{
+		Positions: []domain.RelationshipConflictPositionRecord{{
 			PositionID:     "00000000-0000-0000-0000-000000000201",
 			Disposition:    "preferred",
 			SupporterCount: 1,
-			Supporters: []repository.RelationshipConflictSupporterRecord{{
+			Supporters: []domain.RelationshipConflictSupporterRecord{{
 				ProfileID:          "00000000-0000-0000-0000-000000000401",
 				ProfileName:        "Profile A",
 				StrongestAuthority: "authoritative",
@@ -206,18 +206,18 @@ func TestTraceConflictOutputsIncludePositionsAndResolution(t *testing.T) {
 }
 
 func TestTraceConflictOutputsEnforcePositionBounds(t *testing.T) {
-	positions := make([]repository.RelationshipConflictPositionRecord, 0, 11)
+	positions := make([]domain.RelationshipConflictPositionRecord, 0, 11)
 	for i := 0; i < 11; i++ {
-		positions = append(positions, repository.RelationshipConflictPositionRecord{
+		positions = append(positions, domain.RelationshipConflictPositionRecord{
 			PositionID:      "00000000-0000-0000-0000-000000000201",
 			Disposition:     "candidate",
-			Supporters:      make([]repository.RelationshipConflictSupporterRecord, 21),
+			Supporters:      make([]domain.RelationshipConflictSupporterRecord, 21),
 			RelationshipIDs: make([]string, 21),
 			OwnerProfileIDs: make([]string, 21),
 			EvidenceIDs:     make([]string, 51),
 		})
 	}
-	out := traceConflictOutputs([]repository.RelationshipConflictCaseRecord{{
+	out := traceConflictOutputs([]tracecontract.RelationshipConflictCaseRecord{{
 		ConflictID:  "00000000-0000-0000-0000-000000000101",
 		Version:     1,
 		Kind:        "cross_profile_current_state",

--- a/internal/tools/registry/contract_outputs_trace_test.go
+++ b/internal/tools/registry/contract_outputs_trace_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
+	graphcontract "github.com/markhuangai/dense-mem/internal/graph/contract"
 )
 
 func TestTraceContractOutputPreservesPublicSubmissionAndLineageIDs(t *testing.T) {
@@ -13,41 +14,41 @@ func TestTraceContractOutputPreservesPublicSubmissionAndLineageIDs(t *testing.T)
 	validFrom := now.Add(-time.Hour)
 	validTo := now.Add(time.Hour)
 	confidence := 0.9
-	trace, err := traceContractOutput(&contextservice.SemanticTrace{
-		Relationship: &repository.RelationshipTraceRecord{
+	trace, err := traceContractOutput(&traceapp.SemanticTrace{
+		Relationship: &tracecontract.RelationshipTraceRecord{
 			RelationshipID: "relationship-1", OwnerProfileID: "profile-1", SubjectEntityID: "entity-1", SubjectName: "Dense-Mem",
 			PredicateKey: "uses", PredicateVersion: 1, ObjectEntityID: "entity-2", Polarity: "+", Status: "active", Version: 2,
 			ValidFrom: &validFrom, ValidTo: &validTo, CreatedAt: now, UpdatedAt: now,
 		},
-		Observations: []repository.RelationshipObservationRecord{{
+		Observations: []tracecontract.RelationshipObservationRecord{{
 			ObservationID: "observation-1", IngestID: "submission-1", RelationshipID: "relationship-1",
 			SubjectRef: "subject", OriginalPredicate: "uses", ObjectRef: "object", Polarity: "+", CreatedAt: now,
 		}},
-		EvidenceSupports: []repository.RelationshipEvidenceSupportRecord{{
+		EvidenceSupports: []tracecontract.RelationshipEvidenceSupportRecord{{
 			SupportID: "support-1", RelationshipID: "relationship-1", ObservationID: "observation-1", FragmentID: "evidence-1", OccurrenceID: "occurrence-1",
 			SpanStart: 0, SpanEnd: 4, Quote: "Dense", Authority: "primary", CreatedAt: now,
 		}},
-		EvidenceSupportDecisionEvents: []repository.RelationshipSupportDecisionEvent{{
+		EvidenceSupportDecisionEvents: []tracecontract.RelationshipSupportDecisionEvent{{
 			SupportDecisionID: "decision-1", SupportID: "support-1", RelationshipID: "relationship-1", Decision: "accepted", CreatedAt: now,
 		}},
-		Evidence: []repository.TraceEvidenceFragment{{
+		Evidence: []tracecontract.TraceEvidenceFragment{{
 			FragmentID: "evidence-1", OccurrenceID: "occurrence-1", IngestID: "submission-1", Content: "Dense-Mem uses PostgreSQL", SourceType: "manual", Authority: "primary", CreatedAt: now,
 		}},
-		EvidenceLifecycleEvents: []repository.TraceEvidenceLifecycleEvent{{
+		EvidenceLifecycleEvents: []tracecontract.TraceEvidenceLifecycleEvent{{
 			LifecycleEventID: "lifecycle-1", TargetFragmentID: "evidence-1", Action: "accepted", CreatedAt: now,
 		}},
-		VerificationEvents: []repository.RelationshipVerificationEvent{{
+		VerificationEvents: []tracecontract.RelationshipVerificationEvent{{
 			VerificationEventID: "verification-1", ObservationID: "observation-1", EvidenceVerdict: "entailed", Confidence: &confidence, CreatedAt: now,
 		}},
-		Transitions: []repository.RelationshipTransitionEvent{{
+		Transitions: []tracecontract.RelationshipTransitionEvent{{
 			TransitionID: "transition-1", RelationshipID: "relationship-1", FromStatus: "candidate", ToStatus: "active", CreatedAt: now,
 		}},
-		IdentityCorrections: []repository.EntityCorrectionEventRecord{{
+		IdentityCorrections: []tracecontract.EntityCorrectionEventRecord{{
 			CorrectionEventID: "correction-1", Action: "merge", SurvivorEntityID: "entity-1", NewEntityID: "entity-2", SelectedObservationIDs: []string{"observation-1"}, CreatedAt: now,
 		}},
-		SupersessionLineage: []repository.RelationshipTraceRecord{{RelationshipID: "relationship-0", Status: "superseded"}},
-		SemanticNodes:       []repository.SemanticGraphNode{{ID: "entity-1", Type: "entity", Title: "Dense-Mem"}},
-		SemanticEdges:       []repository.SemanticGraphEdge{{RelationshipID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "uses"}},
+		SupersessionLineage: []tracecontract.RelationshipTraceRecord{{RelationshipID: "relationship-0", Status: "superseded"}},
+		SemanticNodes:       []graphcontract.Node{{ID: "entity-1", Type: "entity", Title: "Dense-Mem"}},
+		SemanticEdges:       []graphcontract.Edge{{RelationshipID: "relationship-1", Source: "entity:entity-1", Target: "value:value-1", Relationship: "uses"}},
 		VisitedEntityIDs:    []string{"entity-1"},
 		StoppedReason:       "bounded",
 	})

--- a/internal/tools/registry/contract_result_errors.go
+++ b/internal/tools/registry/contract_result_errors.go
@@ -12,12 +12,13 @@ import (
 	"github.com/markhuangai/dense-mem/internal/dream"
 	dreamcontract "github.com/markhuangai/dense-mem/internal/dream/contract"
 	"github.com/markhuangai/dense-mem/internal/httperr"
+	"github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 	"github.com/markhuangai/dense-mem/internal/modelprovider"
-	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
 	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
 )
 
 const (
@@ -53,11 +54,11 @@ func ActionableErrorData(ctx context.Context, tool string, err error) map[string
 		code, reasonCode, message, retryable, nextAction, remediation = domain.ErrorProviderUnavailable, "request_timeout", "The "+tool+" operation exceeded its bounded deadline.", true, actionRetrySameRequest, actionableTimeoutRemediation(tool)
 	case errors.Is(err, ErrToolUnavailable):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorDegraded, "tool_unavailable", "The "+tool+" operation is not available on this server.", actionContactOperator, "Contact an operator to enable the required server capability, then retry."
-	case errors.Is(err, rememberapp.ErrRememberAuthContext), errors.Is(err, memoryservice.ErrLifecycleAuthContext), errors.Is(err, contextservice.ErrTraceAuthContext), errors.Is(err, dream.ErrDreamAuthContext), errors.Is(err, skillpackservice.ErrMemoryPackAuthContext):
+	case errors.Is(err, rememberapp.ErrRememberAuthContext), errors.Is(err, lifecycle.ErrLifecycleAuthContext), errors.Is(err, traceapp.ErrTraceAuthContext), errors.Is(err, dream.ErrDreamAuthContext), errors.Is(err, memorypack.ErrMemoryPackAuthContext):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorUnauthorizedScope, "authenticated_context_required", "Dense-Mem could not authorize the "+tool+" operation.", actionAuthorization, "Authenticate with a credential that has access to this tool and retry."
-	case errors.Is(err, repository.ErrTraceRelationshipNotFound), errors.Is(err, contextservice.ErrTraceRelationshipNotFound), errors.Is(err, dream.ErrDreamNotFound), errors.Is(err, dreamcontract.ErrDreamHypothesisNotFound):
+	case errors.Is(err, tracecontract.ErrRelationshipNotFound), errors.Is(err, traceapp.ErrTraceRelationshipNotFound), errors.Is(err, dream.ErrDreamNotFound), errors.Is(err, dreamcontract.ErrDreamHypothesisNotFound):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "reference_not_found", "The reference supplied to "+tool+" was not found or is no longer available.", actionRefreshState, "Refresh authorized state, then retry with a current reference."
-	case errors.Is(err, repository.ErrTraceRelationshipIDInvalid):
+	case errors.Is(err, tracecontract.ErrRelationshipIDInvalid):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "invalid_request", "The relationship_id supplied to "+tool+" must be a valid UUID.", actionCorrectInput, "Use a relationship_id returned by recall_memory and submit the corrected request again."
 		failureDetails["component"] = "trace.relationship_id"
 		failureDetails["client_controlled"] = true
@@ -65,11 +66,11 @@ func ActionableErrorData(ctx context.Context, tool string, err error) map[string
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "invalid_request", "The hypothesis_id supplied to "+tool+" must be a valid UUID.", actionCorrectInput, "Use a hypothesis_id returned by list_dreams or recall_memory and submit the corrected request again."
 		failureDetails["component"] = "dream.hypothesis_id"
 		failureDetails["client_controlled"] = true
-	case errors.Is(err, repository.ErrEvidenceLifecycleIDInvalid):
+	case errors.Is(err, contract.ErrEvidenceLifecycleIDInvalid):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "invalid_request", "The evidence_ids supplied to "+tool+" must contain valid UUIDs.", actionCorrectInput, "Use evidence IDs returned by remember or recall_memory and submit the corrected request again."
 		failureDetails["component"] = "retract_evidence.evidence_ids"
 		failureDetails["client_controlled"] = true
-	case errors.Is(err, skillpackservice.ErrMemoryPackRelationshipNotActive):
+	case errors.Is(err, memorypack.ErrMemoryPackRelationshipNotActive):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "relationship_not_active", "The selected relationship for "+tool+" is no longer active.", actionRefreshState, "Refresh authorized relationships, remove inactive references, and submit the export again."
 		failureDetails["component"] = "memory_pack.relationship"
 		failureDetails["client_controlled"] = true
@@ -77,11 +78,11 @@ func ActionableErrorData(ctx context.Context, tool string, err error) map[string
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "invalid_request", "The evidence field for "+tool+" must contain independent evidence rather than the hypothesis text.", actionCorrectInput, "Provide independent evidence in the evidence field, then submit the corrected Dream feedback request."
 		failureDetails["component"] = "dream_feedback.evidence"
 		failureDetails["client_controlled"] = true
-	case errors.Is(err, repository.ErrSearchContractMismatch):
+	case errors.Is(err, contract.ErrSearchContractMismatch):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorDegraded, "search_not_ready", "Dense-Mem search is not ready for the "+tool+" operation.", actionContactOperator, "Contact an operator to restore the configured search contract, then retry."
 	case errors.Is(err, rememberapp.ErrRememberInputBudgetExceeded):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "input_budget_exceeded", "The assessor input for "+tool+" exceeds the configured server budget.", actionContactOperator, "Ask an operator to review the configured assessor budget and selected server context before retrying."
-		if measuredReason, measured := memoryservice.SynchronousAssessmentFailureDetails(err); measuredReason != "" {
+		if measuredReason, measured := rememberapp.SynchronousAssessmentFailureDetails(err); measuredReason != "" {
 			reasonCode = measuredReason
 			for key, value := range measured {
 				failureDetails[key] = value
@@ -98,11 +99,11 @@ func ActionableErrorData(ctx context.Context, tool string, err error) map[string
 		code, reasonCode, message, retryable, nextAction, remediation = domain.ErrorProviderUnavailable, "request_timeout", "The "+tool+" operation exceeded its bounded deadline.", true, actionRetrySameRequest, actionableTimeoutRemediation(tool)
 	case errors.Is(err, rememberapp.ErrRememberRequestCancelled):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorConflict, "request_cancelled", "The "+tool+" operation was cancelled before completion.", actionStop, "Stop this operation; retry only if the caller still needs it."
-	case errors.Is(err, rememberapp.ErrRememberConflict), errors.Is(err, repository.ErrIdempotencyConflict):
+	case errors.Is(err, rememberapp.ErrRememberConflict), errors.Is(err, contract.ErrIdempotencyConflict):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorConflict, "idempotency_conflict", "The idempotency key for "+tool+" is already bound to a different request.", actionRefreshState, "Reuse the key only for the original request; otherwise submit the changed request with a new key."
 	case actionableInputBudgetError(err):
 		code, reasonCode, message, nextAction, remediation = domain.ErrorInvalidInput, "assessor_input_budget_exceeded", "The server could not fit the assessor conversation within its configured input budget.", actionContactOperator, "Ask an operator to review the configured assessor budget and server-owned context before retrying."
-		if _, measured := memoryservice.SynchronousAssessmentFailureDetails(err); measured != nil {
+		if _, measured := rememberapp.SynchronousAssessmentFailureDetails(err); measured != nil {
 			for key, value := range measured {
 				failureDetails[key] = value
 			}
@@ -290,7 +291,7 @@ func rememberToolResultError(ctx context.Context, err error) error {
 	if processErr != nil && processErr.Status != nil && len(processErr.Status.Errors) > 0 {
 		code = rememberapp.SubmissionErrorCode(rememberapp.StatusErrorForCode(processErr.Status.Errors[0].Code, processErr.Status.ProcessingState).Code)
 	}
-	reasonCode, details := memoryservice.SynchronousAssessmentFailureDetails(err)
+	reasonCode, details := rememberapp.SynchronousAssessmentFailureDetails(err)
 	if reasonCode == "" {
 		reasonCode = "remember_failure"
 		details = map[string]any{"component": "remember", "server_owned": true}
@@ -317,7 +318,7 @@ func rememberToolResultError(ctx context.Context, err error) error {
 
 func rememberErrorCode(err error) rememberapp.SubmissionErrorCode {
 	switch {
-	case errors.Is(err, memoryservice.ErrRememberConflict), errors.Is(err, rememberapp.ErrRememberConflict):
+	case errors.Is(err, rememberapp.ErrRememberConflict):
 		return rememberapp.SubmissionErrorIdempotencyConflict
 	case errors.Is(err, rememberapp.ErrRememberPolicyRejected), errors.Is(err, rememberapp.ErrEvidenceSecurityRejected), errors.Is(err, rememberapp.ErrEncodedEvidenceNotAllowed):
 		return rememberapp.SubmissionErrorPolicyRejected
@@ -355,13 +356,13 @@ func correctionToolResultError(ctx context.Context, submissionID string, err err
 	reasonCode := "relationship_correction_failed"
 	processingState := "failed"
 	switch {
-	case errors.Is(err, memoryservice.ErrLifecycleEmbeddingUnavailable):
+	case errors.Is(err, lifecycle.ErrLifecycleEmbeddingUnavailable):
 		code = rememberapp.SubmissionErrorEmbeddingUnavailable
 		reasonCode = "embedding_unavailable"
-	case errors.Is(err, memoryservice.ErrLifecycleEmbeddingInvalid):
+	case errors.Is(err, lifecycle.ErrLifecycleEmbeddingInvalid):
 		code = rememberapp.SubmissionErrorEmbeddingResponseInvalid
 		reasonCode = "embedding_response_invalid"
-	case errors.Is(err, memoryservice.ErrLifecycleEmbeddingTimeout):
+	case errors.Is(err, lifecycle.ErrLifecycleEmbeddingTimeout):
 		code = rememberapp.SubmissionErrorRequestTimeout
 		reasonCode = "embedding_timeout"
 	case errors.Is(err, context.DeadlineExceeded):

--- a/internal/tools/registry/contract_result_errors_test.go
+++ b/internal/tools/registry/contract_result_errors_test.go
@@ -16,11 +16,12 @@ import (
 	"github.com/markhuangai/dense-mem/internal/dream"
 	dreamcontract "github.com/markhuangai/dense-mem/internal/dream/contract"
 	"github.com/markhuangai/dense-mem/internal/httperr"
+	knowledgecontract "github.com/markhuangai/dense-mem/internal/knowledge/contract"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 	"github.com/markhuangai/dense-mem/internal/modelprovider"
-	"github.com/markhuangai/dense-mem/internal/repository"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
 )
 
 func TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance(t *testing.T) {
@@ -39,11 +40,11 @@ func TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance(t *testing.T
 		{name: "deadline read", tool: ToolRecallMemory, err: context.DeadlineExceeded, code: string(domain.ErrorProviderUnavailable), reasonCode: "request_timeout", nextAction: actionRetrySameRequest, retryable: true},
 		{name: "unavailable", tool: ToolRecallMemory, err: ErrToolUnavailable, code: string(domain.ErrorDegraded), reasonCode: "tool_unavailable", nextAction: actionContactOperator},
 		{name: "authorization", tool: ToolRemember, err: rememberapp.ErrRememberAuthContext, code: string(domain.ErrorUnauthorizedScope), reasonCode: "authenticated_context_required", nextAction: actionAuthorization},
-		{name: "reference", tool: ToolTraceMemory, err: repository.ErrTraceRelationshipNotFound, code: string(domain.ErrorInvalidInput), reasonCode: "reference_not_found", nextAction: actionRefreshState},
-		{name: "invalid trace id", tool: ToolTraceMemory, err: repository.ErrTraceRelationshipIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
+		{name: "reference", tool: ToolTraceMemory, err: tracecontract.ErrRelationshipNotFound, code: string(domain.ErrorInvalidInput), reasonCode: "reference_not_found", nextAction: actionRefreshState},
+		{name: "invalid trace id", tool: ToolTraceMemory, err: tracecontract.ErrRelationshipIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
 		{name: "invalid dream id", tool: ToolGetDream, err: dreamcontract.ErrDreamHypothesisIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
 		{name: "invalid dream feedback id", tool: ToolResolveDreamFeedback, err: dreamcontract.ErrDreamHypothesisIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
-		{name: "invalid retract evidence id", tool: ToolRetractEvidence, err: repository.ErrEvidenceLifecycleIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
+		{name: "invalid retract evidence id", tool: ToolRetractEvidence, err: knowledgecontract.ErrEvidenceLifecycleIDInvalid, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
 		{name: "dream feedback input", tool: ToolResolveDreamFeedback, err: dream.ErrDreamFeedbackInvalidInput, code: string(domain.ErrorInvalidInput), reasonCode: "invalid_request", nextAction: actionCorrectInput},
 		{name: "read repository", tool: ToolRecallMemory, err: errors.New("database unavailable"), code: string(domain.ErrorProviderUnavailable), reasonCode: "read_unavailable", nextAction: actionRetrySameRequest, retryable: true},
 		{name: "retract repository", tool: ToolRetractEvidence, err: errors.New("database unavailable"), code: string(domain.ErrorProviderUnavailable), reasonCode: "write_unavailable", nextAction: actionRetrySameRequest, retryable: true},
@@ -82,7 +83,7 @@ func TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance(t *testing.T
 		})
 	}
 	longCorrelation := strings.Repeat("界", 129)
-	bounded := ActionableErrorData(correlation.WithID(context.Background(), longCorrelation), ToolTraceMemory, repository.ErrTraceRelationshipNotFound)
+	bounded := ActionableErrorData(correlation.WithID(context.Background(), longCorrelation), ToolTraceMemory, tracecontract.ErrRelationshipNotFound)
 	require.LessOrEqual(t, len([]rune(bounded["correlation_id"].(string))), 128)
 	require.NotEqual(t, longCorrelation, bounded["correlation_id"])
 	serverMessage := ActionableErrorData(ctx, ToolRecallMemory, httperr.New(httperr.SERVICE_UNAVAILABLE, "internal database password"))
@@ -92,7 +93,7 @@ func TestActionableErrorDataMapsSupportedFailuresToRecoveryGuidance(t *testing.T
 	dreamDetails := dreamInput["details"].(map[string]any)
 	require.Equal(t, "dream_feedback.evidence", dreamDetails["component"])
 	require.Equal(t, true, dreamDetails["client_controlled"])
-	inactiveExport := ActionableErrorData(ctx, ToolExportMemoryPack, fmt.Errorf("%w: relationship-1", skillpackservice.ErrMemoryPackRelationshipNotActive))
+	inactiveExport := ActionableErrorData(ctx, ToolExportMemoryPack, fmt.Errorf("%w: relationship-1", memorypack.ErrMemoryPackRelationshipNotActive))
 	require.Equal(t, string(domain.ErrorInvalidInput), inactiveExport["code"])
 	require.Equal(t, "relationship_not_active", inactiveExport["reason_code"])
 	require.Equal(t, actionRefreshState, inactiveExport["next_action"])
@@ -150,7 +151,7 @@ func TestActionableErrorDataMapsHTTPStatusesAndBudgetMeasurements(t *testing.T) 
 	require.Equal(t, 12, details["observed"])
 	require.Equal(t, 10, details["limit"])
 	require.Equal(t, true, details["server_owned"])
-	invalidTrace := ActionableErrorData(ctx, ToolTraceMemory, repository.ErrTraceRelationshipIDInvalid)
+	invalidTrace := ActionableErrorData(ctx, ToolTraceMemory, tracecontract.ErrRelationshipIDInvalid)
 	require.Equal(t, "trace.relationship_id", invalidTrace["details"].(map[string]any)["component"])
 	require.Equal(t, true, invalidTrace["details"].(map[string]any)["client_controlled"])
 
@@ -258,7 +259,7 @@ func TestRememberErrorCodeCoversSupportedFailureClasses(t *testing.T) {
 		err  error
 		want rememberapp.SubmissionErrorCode
 	}{
-		{name: "conflict", err: memoryservice.ErrRememberConflict, want: rememberapp.SubmissionErrorIdempotencyConflict},
+		{name: "conflict", err: rememberapp.ErrRememberConflict, want: rememberapp.SubmissionErrorIdempotencyConflict},
 		{name: "stale", err: rememberapp.ErrRememberStaleInput, want: rememberapp.SubmissionErrorStaleInput},
 		{name: "embedding unavailable", err: rememberapp.ErrRememberEmbeddingUnavailable, want: rememberapp.SubmissionErrorEmbeddingUnavailable},
 		{name: "provider unavailable", err: rememberapp.ErrRememberProviderUnavailable, want: rememberapp.SubmissionErrorProviderUnavailable},
@@ -286,9 +287,9 @@ func TestCorrectionToolResultErrorMapsLifecycleAndHTTPFailures(t *testing.T) {
 		err  error
 		want rememberapp.SubmissionErrorCode
 	}{
-		{name: "embedding unavailable", err: memoryservice.ErrLifecycleEmbeddingUnavailable, want: rememberapp.SubmissionErrorEmbeddingUnavailable},
-		{name: "embedding invalid", err: memoryservice.ErrLifecycleEmbeddingInvalid, want: rememberapp.SubmissionErrorEmbeddingResponseInvalid},
-		{name: "embedding timeout", err: memoryservice.ErrLifecycleEmbeddingTimeout, want: rememberapp.SubmissionErrorRequestTimeout},
+		{name: "embedding unavailable", err: lifecycle.ErrLifecycleEmbeddingUnavailable, want: rememberapp.SubmissionErrorEmbeddingUnavailable},
+		{name: "embedding invalid", err: lifecycle.ErrLifecycleEmbeddingInvalid, want: rememberapp.SubmissionErrorEmbeddingResponseInvalid},
+		{name: "embedding timeout", err: lifecycle.ErrLifecycleEmbeddingTimeout, want: rememberapp.SubmissionErrorRequestTimeout},
 		{name: "request deadline", err: context.DeadlineExceeded, want: rememberapp.SubmissionErrorRequestTimeout},
 		{name: "translated embedding unavailable", err: httperr.New(httperr.ErrEmbeddingUnavailable, "embedding provider unavailable"), want: rememberapp.SubmissionErrorEmbeddingUnavailable},
 		{name: "translated embedding invalid", err: httperr.New(httperr.ErrEmbeddingResponseInvalid, "embedding provider response invalid"), want: rememberapp.SubmissionErrorEmbeddingResponseInvalid},
@@ -359,7 +360,7 @@ func TestCorrectionToolResultErrorPreservesTypedConflictReasons(t *testing.T) {
 			wantNextAction: string(rememberapp.SubmissionNextActionRetrySameRequest), wantClient: false,
 		},
 		{
-			name: "invalid confirmation", reason: memoryservice.CorrectionConfirmationInvalidReason,
+			name: "invalid confirmation", reason: lifecycle.CorrectionConfirmationInvalidReason,
 			wantCode: rememberapp.SubmissionErrorRelationshipChanged, wantState: "failed",
 			wantNextAction: string(rememberapp.SubmissionNextActionRetryCorrection), wantClient: true,
 		},

--- a/internal/tools/registry/contract_schema_helpers.go
+++ b/internal/tools/registry/contract_schema_helpers.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
 )
 
 const (
@@ -224,10 +224,10 @@ func submissionStatusErrorSchema() map[string]any {
 	return closedObject(
 		[]string{"code", "message", "retryable", "next_action", "remediation"},
 		map[string]any{
-			"code":        schemaEnum(memoryservice.SubmissionErrorCodes()),
+			"code":        schemaEnum(rememberapp.SubmissionErrorCodes()),
 			"message":     schemaString("Bounded safe submission error.", 512),
 			"retryable":   map[string]any{"type": "boolean"},
-			"next_action": schemaEnum(memoryservice.SubmissionNextActions()),
+			"next_action": schemaEnum(rememberapp.SubmissionNextActions()),
 			"remediation": schemaString("Bounded action the caller can take next.", 512),
 			"reason_code": schemaString("Code-specific bounded reason.", 128),
 			"details":     actionableErrorDetailsSchema(),

--- a/internal/tools/registry/contract_test.go
+++ b/internal/tools/registry/contract_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/embedding"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
 )
 
 type contractFixture struct {
@@ -731,7 +731,7 @@ func TestOutputSchemasAreClosed(t *testing.T) {
 
 func TestRememberEvidenceErrorsUseTheClosedCodeEnum(t *testing.T) {
 	schema := rememberOutputSchema()
-	expectedCodes := append([]string(nil), memoryservice.SubmissionErrorCodes()...)
+	expectedCodes := append([]string(nil), rememberapp.SubmissionErrorCodes()...)
 	slices.Sort(expectedCodes)
 	assertExactCodeEnum := func(label string, codeSchema map[string]any) {
 		t.Helper()
@@ -759,7 +759,7 @@ func TestRememberEvidenceErrorsUseTheClosedCodeEnum(t *testing.T) {
 	)
 	nextActions, ok := schemaProperties(topLevelErrors)["next_action"]["enum"].([]string)
 	require.True(t, ok)
-	require.ElementsMatch(t, memoryservice.SubmissionNextActions(), nextActions)
+	require.ElementsMatch(t, rememberapp.SubmissionNextActions(), nextActions)
 }
 
 func sortedStrings(raw any) []string {

--- a/internal/tools/registry/contract_test_helpers_test.go
+++ b/internal/tools/registry/contract_test_helpers_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/repository"
 	"github.com/markhuangai/dense-mem/internal/requestctx"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
+	tracecontract "github.com/markhuangai/dense-mem/internal/trace/contract"
 )
 
 func toolMap(t *testing.T) map[string]Tool {
@@ -50,12 +50,12 @@ func contractInvokeContext(scopes ...string) context.Context {
 }
 
 type stubRememberService struct {
-	req            memoryservice.RememberRequest
+	req            rememberapp.RememberRequest
 	err            error
 	inspectContext func(context.Context)
 }
 
-func (s *stubRememberService) Remember(ctx context.Context, req memoryservice.RememberRequest) (*memoryservice.RememberResult, error) {
+func (s *stubRememberService) Remember(ctx context.Context, req rememberapp.RememberRequest) (*rememberapp.RememberResult, error) {
 	s.req = req
 	if s.inspectContext != nil {
 		s.inspectContext(ctx)
@@ -63,15 +63,15 @@ func (s *stubRememberService) Remember(ctx context.Context, req memoryservice.Re
 	if s.err != nil {
 		return nil, s.err
 	}
-	return &memoryservice.RememberResult{
+	return &rememberapp.RememberResult{
 		ContractVersion:     domain.ContractVersion,
 		SubmissionID:        "ingest-canonical",
 		SubmissionKind:      "remember",
 		ProcessingState:     "completed",
 		SearchState:         string(domain.SearchProjectionCurrent),
-		Evidence:            []memoryservice.SubmissionEvidenceStatus{},
-		Errors:              []memoryservice.SubmissionStatusError{},
-		RelationshipResults: []memoryservice.SubmissionRelationshipResult{},
+		Evidence:            []rememberapp.SubmissionEvidenceStatus{},
+		Errors:              []rememberapp.SubmissionStatusError{},
+		RelationshipResults: []rememberapp.SubmissionRelationshipResult{},
 		CorrelationID:       "corr-canonical",
 		Kind:                "terminal",
 		IngestID:            "ingest-canonical",
@@ -102,28 +102,28 @@ func (s *stubRecallService) Recall(_ context.Context, req recall.RecallRequest) 
 }
 
 type stubTraceContext struct {
-	req contextservice.TraceRequest
+	req traceapp.TraceRequest
 }
 
-func (s *stubTraceContext) Trace(_ context.Context, _ string, req contextservice.TraceRequest) (*contextservice.TraceResult, error) {
+func (s *stubTraceContext) Trace(_ context.Context, _ string, req traceapp.TraceRequest) (*traceapp.TraceResult, error) {
 	s.req = req
-	return &contextservice.TraceResult{
-		Semantic: &contextservice.SemanticTrace{
-			Relationship: &repository.RelationshipTraceRecord{
+	return &traceapp.TraceResult{
+		Semantic: &traceapp.SemanticTrace{
+			Relationship: &tracecontract.RelationshipTraceRecord{
 				RelationshipID:   "relationship-canonical",
 				TeamID:           "team-canonical",
 				SemanticGroupKey: "group-canonical",
 				PredicateKey:     "works_on",
 				Status:           string(domain.RelationshipStatusActive),
 			},
-			EvidenceSupports: []repository.RelationshipEvidenceSupportRecord{{
+			EvidenceSupports: []tracecontract.RelationshipEvidenceSupportRecord{{
 				SupportID:      "support-canonical",
 				RelationshipID: "relationship-canonical",
 				FragmentID:     "fragment-canonical",
 				SpanStart:      0,
 				SpanEnd:        12,
 			}},
-			SearchDocuments: []repository.TraceSearchDocument{{
+			SearchDocuments: []tracecontract.TraceSearchDocument{{
 				SearchDocumentID: "search-doc-canonical",
 			}},
 			StoppedReason: "max_edges",

--- a/internal/tools/registry/contract_uat_test.go
+++ b/internal/tools/registry/contract_uat_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/observability"
 	recallapp "github.com/markhuangai/dense-mem/internal/recall"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
 )
 
 func TestBuildActiveWiresExecutableRemember(t *testing.T) {

--- a/internal/tools/registry/dream_tools_test.go
+++ b/internal/tools/registry/dream_tools_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/dream"
-	rememberapp "github.com/markhuangai/dense-mem/internal/service/remember"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/tools/registry/evaluation_bindings_test.go
+++ b/internal/tools/registry/evaluation_bindings_test.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"testing"
 
+	communitycontract "github.com/markhuangai/dense-mem/internal/community/contract"
 	dreamcontract "github.com/markhuangai/dense-mem/internal/dream/contract"
-	"github.com/markhuangai/dense-mem/internal/repository"
 )
 
 type evaluationBindingsRepository struct{}
+
+// evaluationCommunityRepositoryStub only needs the native repository method
+// set because these tests exercise dependency precedence, not repository I/O.
+type evaluationCommunityRepositoryStub struct {
+	communitycontract.CommunityRepository
+}
 
 func (*evaluationBindingsRepository) ListEvaluationRefs(context.Context, dreamcontract.EvaluationListInput) (*dreamcontract.EvaluationPage, error) {
 	return nil, nil
@@ -31,8 +37,8 @@ func TestEvaluationFacetSuppliesAuditAppender(t *testing.T) {
 func TestEvaluationBindingsPreserveFlatCoreAndFacetPrecedence(t *testing.T) {
 	flatEval := &evaluationBindingsRepository{}
 	facetEval := &evaluationBindingsRepository{}
-	flatCommunity := repository.NewSemanticRepository(nil, nil)
-	facetCommunity := repository.NewSemanticRepository(nil, nil)
+	flatCommunity := &evaluationCommunityRepositoryStub{}
+	facetCommunity := &evaluationCommunityRepositoryStub{}
 	flatAudit := &evaluationAuditStub{}
 	coreAudit := &evaluationAuditStub{}
 	facetAudit := &evaluationAuditStub{}

--- a/internal/tools/registry/toolset.go
+++ b/internal/tools/registry/toolset.go
@@ -9,11 +9,11 @@ import (
 	"github.com/markhuangai/dense-mem/internal/domain"
 	"github.com/markhuangai/dense-mem/internal/dream"
 	"github.com/markhuangai/dense-mem/internal/lifecycle"
-	"github.com/markhuangai/dense-mem/internal/observability"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 	"github.com/markhuangai/dense-mem/internal/recall"
-	"github.com/markhuangai/dense-mem/internal/service/contextservice"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	recallcontract "github.com/markhuangai/dense-mem/internal/recall/contract"
+	rememberapp "github.com/markhuangai/dense-mem/internal/remember/service"
+	traceapp "github.com/markhuangai/dense-mem/internal/trace"
 )
 
 // Dependencies is the wiring bundle used to construct the active tool catalog.
@@ -27,20 +27,20 @@ type Dependencies struct {
 	MemoryPackBindings MemoryPackBindings
 	EvaluationBindings EvaluationBindings
 
-	Metrics observability.DiscoverabilityMetrics
+	Metrics recallcontract.FeedbackMetrics
 
 	RecallFeedbackConfig RecallFeedbackConfigProvider
 	RecallFeedbackEvents RecallFeedbackEventRecorder
 	EvaluationAudit      EvaluationAuditAppender
 
-	Context        contextservice.Service
-	Remember       memoryservice.RememberService
+	Context        traceapp.Service
+	Remember       rememberapp.Service
 	Recall         recall.RecallService
 	Lifecycle      lifecycle.LifecycleService
 	RecallDreaming DreamingConfigProvider
 	Evaluation     EvaluationRepository
 	Communities    CommunityRepository
-	MemoryPack     skillpackservice.MemoryPackService
+	MemoryPack     memorypack.MemoryPackService
 	Dreams         dream.Service
 }
 type RecallFeedbackEventRecorder interface {

--- a/internal/tools/registry/uat_lifecycle_test.go
+++ b/internal/tools/registry/uat_lifecycle_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/markhuangai/dense-mem/internal/domain"
-	"github.com/markhuangai/dense-mem/internal/service/memoryservice"
+	"github.com/markhuangai/dense-mem/internal/lifecycle"
 )
 
 func TestBuildActiveWiresExecutableRetractEvidence(t *testing.T) {
@@ -151,33 +151,33 @@ func TestBuildActiveCorrectRelationshipRejectsTenantOverride(t *testing.T) {
 }
 
 type stubLifecycleService struct {
-	correctReq memoryservice.CorrectRelationshipRequest
-	retractReq memoryservice.RetractEvidenceRequest
+	correctReq lifecycle.CorrectRelationshipRequest
+	retractReq lifecycle.RetractEvidenceRequest
 	retractErr error
 }
 
 func (s *stubLifecycleService) CorrectRelationship(
 	_ context.Context,
-	req memoryservice.CorrectRelationshipRequest,
-) (*memoryservice.CorrectRelationshipReceipt, error) {
+	req lifecycle.CorrectRelationshipRequest,
+) (*lifecycle.CorrectRelationshipReceipt, error) {
 	s.correctReq = req
-	return &memoryservice.CorrectRelationshipReceipt{
+	return &lifecycle.CorrectRelationshipReceipt{
 		ContractVersion: domain.ContractVersion,
 		SubmissionID:    "correction-canonical", SubmissionKind: "relationship_correction",
 		ProcessingState: "completed", SearchState: "current", CorrelationID: "correlation-canonical",
-		Errors: []memoryservice.SubmissionStatusError{},
+		Errors: []lifecycle.SubmissionStatusError{},
 	}, nil
 }
 
 func (s *stubLifecycleService) RetractEvidence(
 	_ context.Context,
-	req memoryservice.RetractEvidenceRequest,
-) (*memoryservice.RetractEvidenceResult, error) {
+	req lifecycle.RetractEvidenceRequest,
+) (*lifecycle.RetractEvidenceResult, error) {
 	s.retractReq = req
 	if s.retractErr != nil {
 		return nil, s.retractErr
 	}
-	return &memoryservice.RetractEvidenceResult{
+	return &lifecycle.RetractEvidenceResult{
 		DecisionID:                      "evidence-decision-canonical",
 		ProcessingState:                 "completed",
 		RetractedEvidenceIDs:            append([]string(nil), req.EvidenceIDs...),

--- a/internal/tools/registry/uat_memory_pack_test.go
+++ b/internal/tools/registry/uat_memory_pack_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/markhuangai/dense-mem/internal/service/skillpackservice"
+	"github.com/markhuangai/dense-mem/internal/memorypack"
 )
 
 func TestBuildActiveWiresExportMemoryPackOnly(t *testing.T) {
@@ -47,13 +47,13 @@ func TestBuildActiveDoesNotRegisterMemoryPackImportTools(t *testing.T) {
 }
 
 type exportOnlyMemoryPackStub struct {
-	req skillpackservice.ExportRequest
+	req memorypack.ExportRequest
 }
 
-func (s *exportOnlyMemoryPackStub) Export(_ context.Context, req skillpackservice.ExportRequest) (*skillpackservice.ExportResult, error) {
+func (s *exportOnlyMemoryPackStub) Export(_ context.Context, req memorypack.ExportRequest) (*memorypack.ExportResult, error) {
 	s.req = req
-	return &skillpackservice.ExportResult{
-		CanonicalJSON: `{"format":"` + skillpackservice.MemoryPackFormat + `","relationships":[]}`,
+	return &memorypack.ExportResult{
+		CanonicalJSON: `{"format":"` + memorypack.MemoryPackFormat + `","relationships":[]}`,
 		SHA256:        strings.Repeat("a", 64),
 		ItemCount:     0,
 		Filename:      "postgresql-pack.memory-pack.json",
@@ -61,4 +61,4 @@ func (s *exportOnlyMemoryPackStub) Export(_ context.Context, req skillpackservic
 	}, nil
 }
 
-var _ skillpackservice.MemoryPackService = (*exportOnlyMemoryPackStub)(nil)
+var _ memorypack.MemoryPackService = (*exportOnlyMemoryPackStub)(nil)

--- a/tests/uat/architecture_conformance.test.mjs
+++ b/tests/uat/architecture_conformance.test.mjs
@@ -487,7 +487,7 @@ test("enforces private visibility and narrow PostgreSQL infrastructure reuse", (
 
 test("retains precise replacement owners and lifecycle obligations", () => {
   const exceptionOwners = [...new Set(productionManifest.exceptions.map((entry) => entry.removal_issue))].sort((a, b) => a - b);
-  assert.deepEqual(exceptionOwners, [367, 379, 380, 382]);
+  assert.deepEqual(exceptionOwners, [367, 379, 382]);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 276), false);
   assert.equal(productionManifest.exceptions.some((entry) => entry.removal_issue === 280), false);
   assert.ok(productionManifest.workers.every((entry) => entry.lifecycle_issue === 381));


### PR DESCRIPTION
## Goal

Finish MCP protocol and registry isolation for #380 while preserving the versioned MCP contract, exact production/evaluation catalogs, strict schemas, feature and scope gating, bounded errors, cancellation, and capability ownership.

Closes #380

## What changed

- Added native capability bindings for Remember, Lifecycle, Trace, and Memory Pack services and moved registry projections/error classification to their capability contracts.
- Added a narrow MCP logger port and HTTP composition adapter so `internal/mcp` no longer depends on the shared observability implementation.
- Moved the Recall feedback metrics port into `internal/recall/contract`, retaining contextual attribution without widening the required interface.
- Added production/evaluation conformance coverage for exact 10/13 catalogs, one-registry list/call parity, scope and feature visibility, strict inputs, bounded errors, and request cancellation through the SDK transport.
- Removed the exhausted #380 compatibility exceptions and updated the #382 ledgers and architecture conformance expectations.

## Plan audit

```yaml
verdict: conformant
auditor: gpt-5.6-terra
reasoning_effort: max
base_sha: 0d59434251b4e0667739ff9945f9533bf30a6901
audited_state: "35 modified tracked files and 6 untracked source files before commit"
findings: []
```

The audit confirmed no production MCP/registry imports of legacy repository, storage/provider implementation, or shared observability packages; native bindings, bounded compatibility records, shared list/call gating, exact catalog fixtures, strict input rejection, and cancellation remain aligned with the frozen issue plan.

## Risk and mitigation

- List and call visibility could diverge after the registry extraction. The production and evaluation conformance harnesses exercise both surfaces through the same registry across scope and feature gates.
- A transport logger or registry error projection could leak identity or backend details. The MCP logger adapter preserves the sanitized sink, while strict-input, bounded-error, and redaction tests cover the public failure paths.
- Cancellation could stop transport handling without stopping the invoker. The SDK transport cancellation scenario proves context propagation and handler completion.

## Validation

- `go test ./internal/mcp/... ./internal/tools/... -count=1` — passed.
- `go test -tags evaluation ./internal/mcp/... ./internal/tools/... -count=1` — passed.
- `go test ./internal/http/handler/... ./internal/recall/... ./internal/observability/... -count=1` — passed.
- `./scripts/ci-check.sh` — passed, including architecture conformance and the 90.0% aggregate coverage gate.
- `./scripts/e2e.sh mcp_boundaries` — passed.
- `./scripts/e2e.sh mcp_sdk_parity` — passed.
- `./scripts/e2e.sh mcp_sdk_transport` — passed.
- Pre-push checks reran the repository architecture, Go, coverage, browser, and E2E-harness gates successfully.

The final-head production-image full-matrix E2E gate and configured automated reviewer outcomes remain required on this PR before merge. No automatic merge is authorized.

Base: `0d59434251b4e0667739ff9945f9533bf30a6901`
Head: `53d5594a506df5ed63657314f14846edaa14bb3a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured logging support for MCP requests, including safer handling of sensitive values.
  - Added recall feedback metrics support with optional request-scoped attribution.
  - Added expanded MCP conformance coverage for tool discovery, execution, authorization, invalid requests, and cancellation.

- **Bug Fixes**
  - Updated service integrations and contract handling to preserve existing error messages, response formats, and validation behavior during ongoing architecture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->